### PR TITLE
Service worker forced handover

### DIFF
--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -1,7 +1,4 @@
-import { swMessageHandler } from './routes/service-worker/message-handler';
 import { Services } from './controllers/services';
 
 export const services = new Services();
 await services.onServiceWorkerInit();
-
-chrome.runtime.onMessage.addListener(swMessageHandler);


### PR DESCRIPTION
When re-building and deploying new code, the new service worker "waits" to take over the old one. This appears to cause the messaging connection to break. The error reads:
```
could not establish connection. receiving end does not exist
```

This PR mitigates this by forcing the new service worker to replace the old one as soon as it's installed.