### PR TITLE
Nullifiers + SCT validation

### DIFF
--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -4,9 +4,12 @@ import {
   base64ToUint8Array,
   IndexedDbInterface,
   NewNoteRecord,
+  uint8ArrayToBase64,
   ViewServerInterface,
 } from 'penumbra-types';
 import { CompactBlock } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/chain/v1alpha1/chain_pb';
+import { Nullifier } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb';
+import { decodeNctRoot, generateMetadata } from 'penumbra-wasm-ts/src/sct';
 
 interface QueryClientProps {
   oblQuerier: ObliviousQuerier;
@@ -49,41 +52,41 @@ export class BlockProcessor {
         const metadata = await this.specQuerier.denomMetadata(n.note.value.assetId.inner);
         if (metadata) {
           await this.indexedDb.saveAssetsMetadata(metadata);
-        } // TODO: add base64_to_bech32 to store
+        } else {
+          const denomMetadata = generateMetadata(assetId);
+          await this.indexedDb.saveAssetsMetadata(denomMetadata);
+        }
       }
     }
   }
 
-  // TODO: Next PR
   // Each nullifier has a corresponding note stored. This marks them as spent at a specific block height.
-  // async markNotesSpent(nullifiers: Nullifier[], blockHeight: bigint) {
-  //   for (const nullifier of nullifiers) {
-  //     const stringId = uint8ArrayToBase64(nullifier.inner);
-  //     const matchingNote = await this.indexedDb.getNoteByNullifier(stringId);
-  //     if (!matchingNote)
-  //       throw new Error(`No corresponding note for nullifier: ${nullifier.inner.toString()}`);
-  //
-  //     matchingNote.heightSpent = blockHeight;
-  //     await this.indexedDb.saveSpendableNote(matchingNote);
-  //   }
-  // }
+  async markNotesSpent(nullifiers: Nullifier[], blockHeight: bigint) {
+    for (const nullifier of nullifiers) {
+      const stringId = uint8ArrayToBase64(nullifier.inner);
+      const matchingNote = await this.indexedDb.getNoteByNullifier(stringId);
+      if (matchingNote) {
+        matchingNote.heightSpent = blockHeight;
+        await this.indexedDb.saveSpendableNote(matchingNote);
+      }
+    }
+  }
 
   async saveSyncProgress(height: bigint) {
     const updates = await this.viewServer.updatesSinceCheckpoint();
     await this.indexedDb.updateStateCommitmentTree(updates, height);
   }
 
-  // TODO: Put behind debugger flag
-  // private async assertRootValid(blockHeight: bigint): Promise<void> {
-  //   const sourceOfTruth = await this.specQuerier.keyValue(`sct/anchor/${blockHeight}`);
-  //   const inMemoryRoot = this.viewServer.getNctRoot();
-  //
-  //   if (decodeNctRoot(sourceOfTruth) !== inMemoryRoot) {
-  //     throw new Error(
-  //       `Block height: ${blockHeight}. Wasm root does not match remote source of truth. Programmer error.`,
-  //     );
-  //   }
-  // }
+  private async assertRootValid(blockHeight: bigint): Promise<void> {
+    const sourceOfTruth = await this.specQuerier.keyValue(`sct/anchor/${blockHeight}`);
+    const inMemoryRoot = this.viewServer.getNctRoot();
+
+    if (decodeNctRoot(sourceOfTruth) !== inMemoryRoot) {
+      throw new Error(
+        `Block height: ${blockHeight}. Wasm root does not match remote source of truth. Programmer error.`,
+      );
+    }
+  }
 
   private async syncAndStore() {
     const lastBlockSynced = await this.indexedDb.getLastBlockSynced();
@@ -100,9 +103,9 @@ export class BlockProcessor {
       // TODO: We should not store new blocks as we find them, but only when sync progress is saved: https://github.com/penumbra-zone/web/issues/34
       //       However, the current wasm crate discards the new notes on every block scan.
       await this.storeNewNotes(scanResult.new_notes);
-      // await this.markNotesSpent(res.compactBlock.nullifiers, res.compactBlock.height);
+      await this.markNotesSpent(res.compactBlock.nullifiers, res.compactBlock.height);
 
-      // await this.assertRootValid(res.compactBlock.height); // TODO: Put behind debug flag
+      await this.assertRootValid(res.compactBlock.height); // TODO: Put behind debug flag
 
       if (shouldStoreProgress(res.compactBlock, lastBlockHeight)) {
         await this.saveSyncProgress(res.compactBlock.height);

--- a/packages/wasm/src/sct.test.ts
+++ b/packages/wasm/src/sct.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { decodeNctRoot } from './sct';
+import { base64ToBech32, decodeNctRoot } from './sct';
 
 // Replace the wasm-pack import with the nodejs version so tests can run
 vi.mock('@penumbra-zone/wasm-bundler', () => vi.importActual('@penumbra-zone/wasm-nodejs'));
@@ -14,6 +14,14 @@ describe('tct', () => {
 
       expect(() => {
         decodeNctRoot(root);
+      }).not.toThrow();
+    });
+  });
+
+  describe('base64ToBech32()', () => {
+    it('does not raise zod validation error', () => {
+      expect(() => {
+        base64ToBech32('6KBVsPINa8gWSHhfH+kAFJC4afEJA3EtuB2HyCqJUws=');
       }).not.toThrow();
     });
   });

--- a/packages/wasm/src/sct.ts
+++ b/packages/wasm/src/sct.ts
@@ -1,9 +1,33 @@
 import { uint8ArrayToHex } from './utils';
-import { decode_nct_root } from '@penumbra-zone/wasm-bundler';
-import { InnerBase64Schema, validateSchema } from 'penumbra-types';
+import { base64_to_bech32, decode_nct_root } from '@penumbra-zone/wasm-bundler';
+import {
+  Base64StringSchema,
+  InnerBase64Schema,
+  uint8ArrayToBase64,
+  validateSchema,
+} from 'penumbra-types';
+import { z } from 'zod';
+import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/crypto/v1alpha1/crypto_pb';
 
 export const decodeNctRoot = (hash: Uint8Array): string => {
   const hexString = uint8ArrayToHex(hash);
   const result = validateSchema(InnerBase64Schema, decode_nct_root(hexString));
   return result.inner;
+};
+
+export const generateMetadata = (assetId: Uint8Array): DenomMetadata => {
+  const denom = base64ToBech32(uint8ArrayToBase64(assetId));
+  return new DenomMetadata({
+    base: denom,
+    denomUnits: [{ aliases: [], denom, exponent: 0 }],
+    display: denom,
+    penumbraAssetId: { inner: assetId },
+  });
+};
+
+export const UNNAMED_ASSET_PREFIX = 'unnamed_asset';
+
+export const base64ToBech32 = (base64Str: string): string => {
+  const validated = validateSchema(Base64StringSchema, base64Str);
+  return validateSchema(z.string(), base64_to_bech32(UNNAMED_ASSET_PREFIX, validated));
 };


### PR DESCRIPTION
- Enables marking notes as spent via nullifiers
- Validates SCT tree (need to add debug flag)
- Adds generated metadata to storage if no metadata in remote