### PR TITLE
Re-enable wasm test

### DIFF
--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -18,6 +18,7 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
+    "fake-indexeddb": "^4.0.2",
     "vitest": "^0.34.5"
   }
 }

--- a/packages/wasm/src/view-server.test.ts
+++ b/packages/wasm/src/view-server.test.ts
@@ -1,37 +1,38 @@
+import 'fake-indexeddb/auto'; // Instanitating ViewServer requires opening up IndexedDb connection
 import { describe, expect, it, vi } from 'vitest';
+import { generateSpendKey, getFullViewingKey } from './keys';
+import { ViewServer } from '@penumbra-zone/wasm-nodejs';
 
 // Replace the wasm-pack import with the nodejs version so tests can run
 vi.mock('@penumbra-zone/wasm-bundler', () => vi.importActual('@penumbra-zone/wasm-nodejs'));
 
 describe('wasmViewServer', () => {
-  it('does not raise zod validation error', () => {
-    // const seedPhrase =
-    //   'benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain';
-    //
-    // const spendKey = generateSpendKey(seedPhrase);
-    // const fullViewingKey = getFullViewingKey(spendKey);
-    //
-    // const storedTree = {
-    //   hashes: [],
-    //   commitments: [],
-    //   last_forgotten: 0,
-    //   last_position: {
-    //     Position: {
-    //       epoch: 0,
-    //       block: 0,
-    //       commitment: 0,
-    //     },
-    //   },
-    // };
+  it('does not raise zod validation error', async () => {
+    const seedPhrase =
+      'benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain';
 
-    // TODO: Unreachable errors. Could be caused by async constructor? Need to investigate.
+    const spendKey = generateSpendKey(seedPhrase);
+    const fullViewingKey = getFullViewingKey(spendKey);
+
+    const storedTree = {
+      hashes: [],
+      commitments: [],
+      last_forgotten: 0,
+      last_position: {
+        Position: {
+          epoch: 0,
+          block: 0,
+          commitment: 0,
+        },
+      },
+    };
+
     // The constructor is an async fn. Should consider a `new()` function instead of a constructor.
-    // const vsServer = new ViewServer(
-    //   fullViewingKey,
-    //   719n,
-    //   storedTree,
-    // ) as unknown as Promise<ViewServer>;
-    // const wasmViewServer = await vsServer;
-    expect(true).toBe(true);
+    const vsServer = new ViewServer(
+      fullViewingKey,
+      719n,
+      storedTree,
+    ) as unknown as Promise<ViewServer>;
+    await expect(vsServer).resolves.not.toThrow();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,9 @@ importers:
         specifier: ^3.22.2
         version: 3.22.2
     devDependencies:
+      fake-indexeddb:
+        specifier: ^4.0.2
+        version: 4.0.2
       vitest:
         specifier: ^0.34.5
         version: 0.34.5
@@ -1830,8 +1833,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@rushstack/eslint-patch@1.4.0:
-    resolution: {integrity: sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg==}
+  /@rushstack/eslint-patch@1.5.0:
+    resolution: {integrity: sha512-EF3948ckf3f5uPgYbQ6GhyA56Dmv8yg0+ir+BroRjwdxyZJsekhZzawOecC2rOTPCz173t7ZcR1HHZu0dZgOCw==}
     dev: false
 
   /@sinclair/typebox@0.27.8:
@@ -2759,7 +2762,7 @@ packages:
       assertion-error: 1.1.0
       check-error: 1.0.2
       deep-eql: 4.1.3
-      get-func-name: 2.0.0
+      get-func-name: 2.0.2
       loupe: 2.3.6
       pathval: 1.1.1
       type-detect: 4.0.8
@@ -3355,7 +3358,7 @@ packages:
         optional: true
     dependencies:
       '@next/eslint-plugin-next': 13.5.3
-      '@rushstack/eslint-patch': 1.4.0
+      '@rushstack/eslint-patch': 1.5.0
       '@typescript-eslint/parser': 6.7.3(eslint@8.50.0)(typescript@5.2.2)
       eslint: 8.50.0
       eslint-import-resolver-node: 0.3.9
@@ -3870,8 +3873,8 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
-  /get-func-name@2.0.0:
-    resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
@@ -4651,7 +4654,7 @@ packages:
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
     dependencies:
-      get-func-name: 2.0.0
+      get-func-name: 2.0.2
 
   /lower-case-first@1.0.2:
     resolution: {integrity: sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==}


### PR DESCRIPTION
Turns out the new `ViewServer` has a requirement to open up a IndexedDb connection. On web, that's fine. But for our nodejs tests, we have to import a faux indexed db or it will throw.