### PR TITLE
Re-initialization of wallet services [bug fix]

### DIFF
--- a/apps/extension/src/routes/popup/home/block-sync.tsx
+++ b/apps/extension/src/routes/popup/home/block-sync.tsx
@@ -13,7 +13,7 @@ export const BlockSync = () => {
       animate={{ opacity: 1, transition: { duration: 0.5, ease: 'easeOut' } }}
       exit={{ opacity: 0 }}
     >
-      {lastBlockSynced && lastBlockHeight ? (
+      {lastBlockHeight ? (
         // Is syncing ⏳
         lastBlockHeight - lastBlockSynced > 10 ? (
           <>

--- a/apps/extension/src/services/index.ts
+++ b/apps/extension/src/services/index.ts
@@ -69,7 +69,11 @@ export class Services {
   // they'll all wait for the same promise rather than each starting their own initialization process.
   async getWalletServices(): Promise<WalletServices> {
     if (!this.walletServicesPromise) {
-      this.walletServicesPromise = this.initializeWalletServices();
+      this.walletServicesPromise = this.initializeWalletServices().catch(e => {
+        // If promise rejected, reset promise to `undefined` so next caller can try again
+        this.walletServicesPromise = undefined;
+        throw e;
+      });
     }
     return this.walletServicesPromise;
   }


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/62

- Allows for retries of `getWalletServices()` on subsequent calls instead of settling on a reject promise
- Makes `syncBlocks()` not spin up more instances if called twice
- Popup on init sends "SYNC-BLOCKS" request on startup to wake the service worker up