### PR TITLE
Skip waiting in dev

### DIFF
--- a/apps/extension/src/services/index.ts
+++ b/apps/extension/src/services/index.ts
@@ -5,8 +5,6 @@ import { IndexedDb, localExtStorage, syncLastBlockWithLocal } from 'penumbra-sto
 import { ViewServer } from 'penumbra-wasm-ts';
 import { BlockProcessor } from 'penumbra-query';
 
-const sw = self as unknown as ServiceWorkerGlobalScope & typeof globalThis;
-
 interface WalletServices {
   viewServer: ViewServer;
   blockProcessor: BlockProcessor;
@@ -31,10 +29,6 @@ export class Services {
 
   async onServiceWorkerInit(): Promise<void> {
     try {
-      // Forces the waiting service worker to become the active service worker
-      await sw.skipWaiting();
-      await sw.clients.claim();
-
       const grpcEndpoint = await localExtStorage.get('grpcEndpoint');
       this._querier = new RootQuerier({ grpcEndpoint });
 

--- a/apps/extension/webpack/webpack.dev.js
+++ b/apps/extension/webpack/webpack.dev.js
@@ -1,7 +1,27 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const webpack = require('webpack');
 
 module.exports = merge(common, {
   devtool: 'inline-source-map',
   mode: 'development',
+  plugins: [
+    // Our current webpack config wraps `service-worker.ts` in a function.
+    // This makes registering top-level listeners render errors.
+    // If someone figures this one out, move this to `service-worker.ts`.
+    // Just for dev env so service worker hand-offs are immediate.
+    new webpack.BannerPlugin({
+      banner: `
+           self.addEventListener('install', () => {
+              self.skipWaiting();
+           });
+
+          self.addEventListener('activate', event => {
+            event.waitUntil(self.clients.claim());
+          });
+      `,
+      include: 'service-worker.js',
+      raw: true,
+    }),
+  ],
 });


### PR DESCRIPTION
closes #67

Realized we probably should not be overriding the default service worker lifecycle for installing and taking over. In production, the old service worker should be able to transition to the new when it's ready to. However, in dev mode, we want to rapidly transition and not wait.

Had to add this code as a banner given our webpack config prevents top level listeners.