### PR TITLE
ci: install deps prior to running turbo

### DIFF
--- a/.github/workflows/deploy-firebase-dapp.yml
+++ b/.github/workflows/deploy-firebase-dapp.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           version: 8
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Build static site
         run: pnpm build
 


### PR DESCRIPTION
Follow up to [0]. Post merge of the new Firebase deploy config, the GHA failed [1], not able to find `turbo`. Makes sense: we didn't install it! Let's run the `pnpm install` command, same as used in the other workflows.

[0] https://github.com/penumbra-zone/web/pull/48
[1] https://github.com/penumbra-zone/web/actions/runs/6404599868/job/17385485760#step:5:14