### PR TITLE
Add wallet id to popup

### DIFF
--- a/apps/extension/src/routes/popup/home/index.tsx
+++ b/apps/extension/src/routes/popup/home/index.tsx
@@ -40,8 +40,21 @@ export const PopupIndex = () => {
     <div className='relative flex h-full flex-col items-stretch justify-start bg-left-bottom px-[30px]'>
       <div className='absolute bottom-[50px] left-[-10px] -z-10 h-[715px] w-[900px] overflow-hidden bg-logo opacity-10' />
       <IndexHeader />
-      <div className='mb-[150px] flex w-full flex-col'>
-        <div className='mt-24 flex justify-between'>
+      <div className='my-16 flex w-full flex-col'>
+        <p className='mb-4 select-none text-center font-headline text-xl font-semibold leading-[30px]'>
+          Wallet id
+        </p>
+        <div className='flex items-center justify-between gap-1 break-all rounded-lg border bg-background px-3 py-4'>
+          <div className='flex items-center gap-[6px]'>
+            <Identicon name={account?.walletId ?? ''} className='h-5 w-5' />
+            <p className='select-none text-center text-[12px] font-bold leading-[18px] text-muted-foreground'>
+              {account?.walletId.slice(0, 42)}...
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className='mb-16 flex w-full flex-col'>
+        <div className='flex justify-between'>
           {account?.index !== 0 ? (
             <ArrowLeftIcon onClick={previous} className='h-6 w-6 hover:cursor-pointer' />
           ) : (

--- a/apps/extension/src/state/accounts.ts
+++ b/apps/extension/src/state/accounts.ts
@@ -1,8 +1,9 @@
 import { AllSlices, SliceCreator } from './index';
-import { getAddressByIndex, getShortAddressByIndex } from 'penumbra-wasm-ts';
+import { getAddressByIndex, getShortAddressByIndex, getWalletId } from 'penumbra-wasm-ts';
 import { getActiveWallet } from './wallets';
 
 interface Account {
+  walletId: string;
   address: string;
   preview: string;
   index: number;
@@ -44,5 +45,6 @@ export const activeAccount = (state: AllSlices): Account | undefined => {
     address: getAddressByIndex(active.fullViewingKey, state.accounts.index),
     preview: getShortAddressByIndex(active.fullViewingKey, state.accounts.index),
     index: state.accounts.index,
+    walletId: getWalletId(active.fullViewingKey),
   };
 };

--- a/packages/ui/components/ui/identicon/index.tsx
+++ b/packages/ui/components/ui/identicon/index.tsx
@@ -9,6 +9,7 @@ export interface IdenticonProps {
 
 export const Identicon = ({ name, size = 120, className }: IdenticonProps) => {
   const gradient = useMemo(() => generateGradient(name), [name]);
+  const gradientId = useMemo(() => `gradient-${name}`, [name]);
 
   return (
     <svg
@@ -21,12 +22,12 @@ export const Identicon = ({ name, size = 120, className }: IdenticonProps) => {
     >
       <g>
         <defs>
-          <linearGradient id='gradient' x1='0' y1='0' x2='1' y2='1'>
+          <linearGradient id={gradientId} x1='0' y1='0' x2='1' y2='1'>
             <stop offset='0%' stopColor={gradient.fromColor} />
             <stop offset='100%' stopColor={gradient.toColor} />
           </linearGradient>
         </defs>
-        <rect fill='url(#gradient)' x='0' y='0' width={size} height={size} />
+        <rect fill={`url(#${gradientId})`} x='0' y='0' width={size} height={size} />
       </g>
     </svg>
   );


### PR DESCRIPTION
Closes #76

I'm not entirely the biggest fan (design wise) of the double bar/identicon. But we need a way to communicate the wallet id as this will be the address/identicon that shows when you are connected to the web app. 

<img width="389" alt="Screenshot 2023-10-11 at 4 09 33 PM" src="https://github.com/penumbra-zone/web/assets/16624263/39e313e6-3315-4878-ab9a-e9e3f675a51a">


