### PR TITLE
json serialize indexdb

### DIFF
--- a/apps/webapp/hooks/sorted-asset.ts
+++ b/apps/webapp/hooks/sorted-asset.ts
@@ -89,7 +89,6 @@ interface SortedAssetsReturnVal {
   error: unknown;
 }
 
-// TODO: Are there react-specific optimizations missing here?
 export const useBalancesWithMetadata = (
   sortBy: keyof AssetBalance,
   search?: string,

--- a/apps/webapp/shared/select-token-modal.tsx
+++ b/apps/webapp/shared/select-token-modal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
-import { assets } from 'penumbra-constants';
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogPrimitive, DialogTrigger, Input } from 'ui';
 import { useBalancesWithMetadata } from '../hooks/sorted-asset';
@@ -21,7 +20,7 @@ export default function SelectTokenModal({ asset, setAsset }: SelectTokenModalPr
 
   return (
     <Dialog>
-      <DialogTrigger disabled={!assets.length}>
+      <DialogTrigger disabled={!sortedAssets.length}>
         <div className='flex h-9 w-[100px] items-center justify-center gap-2 rounded-lg bg-light-brown'>
           <p className='text-base font-bold text-light-grey'>{asset.display}</p>
         </div>
@@ -46,20 +45,20 @@ export default function SelectTokenModal({ asset, setAsset }: SelectTokenModalPr
               <p>Balance</p>
             </div>
             <div className='flex flex-col gap-2'>
-              {sortedAssets.map(i => (
-                <DialogPrimitive.Close key={i.denomMetadata.display}>
+              {sortedAssets.map((a, i) => (
+                <DialogPrimitive.Close key={i}>
                   <div
                     className={cn(
                       'flex justify-between items-center py-[10px] cursor-pointer hover:bg-light-brown hover:px-2',
-                      asset.penumbraAssetId.inner === i.assetId && 'bg-light-brown px-2',
+                      asset.penumbraAssetId.inner === a.assetId && 'bg-light-brown px-2',
                     )}
-                    onClick={() => setAsset({ inner: i.assetId, altBaseDenom: '', altBech32: '' })}
+                    onClick={() => setAsset({ inner: a.assetId, altBaseDenom: '', altBech32: '' })}
                   >
                     <div className='flex items-start gap-[6px]'>
-                      <p className='font-bold text-muted-foreground'>{i.denomMetadata.display}</p>
+                      <p className='font-bold text-muted-foreground'>{a.denomMetadata.display}</p>
                     </div>
                     <p className='font-bold text-muted-foreground'>
-                      {formatNumber(i.balance.amount)}
+                      {formatNumber(a.balance.amount)}
                     </p>
                   </div>
                 </DialogPrimitive.Close>

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -8,10 +8,11 @@ export interface Constants {
 
 export const testnetConstants: Constants = {
   grpcEndpoint: 'https://grpc.testnet.penumbra.zone',
-  indexedDbVersion: 14,
+  indexedDbVersion: 15,
   usdcAssetId: 'reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg=',
 };
 
+// TODO: This should only have things like icon or other fields not available in assets indexedb
 export const assets: Asset[] = [
   {
     base: 'ugm',

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@buf/penumbra-zone_penumbra.bufbuild_es": "1.3.3-20231012162011-1913ee1cd78e.1",
+    "@bufbuild/protobuf": "^1.3.3",
     "eslint": "^8.51.0",
     "eslint-config-custom": "workspace:*",
     "idb": "^7.1.1",

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -10,8 +10,8 @@ import {
   SpendableNoteRecord,
   TransactionInfo,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
-import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1alpha1/tct_pb';
 import { FmdParameters } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/chain/v1alpha1/chain_pb';
+import { JsonValue } from '@bufbuild/protobuf';
 
 const denomMetadataA = new DenomMetadata({
   symbol: 'usdc',
@@ -89,12 +89,9 @@ describe('IndexedDb', () => {
       await db.saveSpendableNote(newNote);
 
       expect(mockNotifier).toHaveBeenCalledOnce();
-      const [value, key] = mockNotifier.mock.lastCall as [
-        SpendableNoteRecord,
-        StateCommitment['inner'],
-      ];
-      expect(value).toBe(newNote);
-      expect(key).toBe(newNote.noteCommitment!.inner);
+      const [value, key] = mockNotifier.mock.lastCall as [JsonValue, undefined];
+      expect(value).toStrictEqual(newNote.toJson());
+      expect(key).toBeUndefined();
     });
 
     it('does not call function if not subscribed', async () => {
@@ -170,7 +167,7 @@ describe('IndexedDb', () => {
   });
 
   describe('fmd params', () => {
-    it('object store should be empty after clear', async () => {
+    it('should be able to set/get', async () => {
       const db = await IndexedDb.initialize({ ...generateInitialProps() });
 
       const fmdParams = new FmdParameters({ asOfBlockHeight: 1n, precisionBits: 0 });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@buf/penumbra-zone_penumbra.bufbuild_es": "1.3.3-20231012162011-1913ee1cd78e.1",
+    "@bufbuild/protobuf": "^1.3.3",
     "@types/chrome": "0.0.248",
     "bech32": "^2.0.0",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@buf/penumbra-zone_penumbra.bufbuild_es':
         specifier: 1.3.3-20231012162011-1913ee1cd78e.1
         version: 1.3.3-20231012162011-1913ee1cd78e.1(@bufbuild/protobuf@1.3.3)
+      '@bufbuild/protobuf':
+        specifier: ^1.3.3
+        version: 1.3.3
       eslint:
         specifier: ^8.51.0
         version: 8.51.0
@@ -495,6 +498,9 @@ importers:
       '@buf/penumbra-zone_penumbra.bufbuild_es':
         specifier: 1.3.3-20231012162011-1913ee1cd78e.1
         version: 1.3.3-20231012162011-1913ee1cd78e.1(@bufbuild/protobuf@1.3.3)
+      '@bufbuild/protobuf':
+        specifier: ^1.3.3
+        version: 1.3.3
       '@types/chrome':
         specifier: 0.0.248
         version: 0.0.248


### PR DESCRIPTION
At the moment, the proto values are being saved directly to the database. This poses a problem when the wasm crate attempts to deserialize these values. For that reason, those indexdb values should be json-serialized. 