### PR TITLE
Send form work

### DIFF
--- a/apps/webapp/app/send/send-form.tsx
+++ b/apps/webapp/app/send/send-form.tsx
@@ -7,7 +7,7 @@ import { amountToBig, sendSelector, sendValidationErrors } from '../../state/sen
 import { useToast } from '@penumbra-zone/ui/components/ui/use-toast';
 import { isPenumbraAddr } from '@penumbra-zone/types';
 import { useSendBalance } from '../../hooks/send-balance';
-import { useAddress, useEphemeralAddress, } from '../../hooks/address';
+import { useAddress, useEphemeralAddress } from '../../hooks/address';
 import { bech32Address } from '@penumbra-zone/types';
 import { useEffect, useMemo, useState } from 'react';
 import { cn } from '@penumbra-zone/ui/lib/utils';
@@ -20,7 +20,7 @@ const Send = () => {
     asset,
     recipient,
     memoText,
-    memoSender,
+    //memoSender,
     setAmount,
     setAsset,
     setRecipient,
@@ -36,7 +36,7 @@ const Send = () => {
 
   // TODO: enable address selection
   const defaultSender = useAddress(0);
-  const ephemeralSender = useEphemeralAddress(0, { enabled: hidden })
+  const ephemeralSender = useEphemeralAddress(0, { enabled: hidden });
 
   const sender = useMemo(() => {
     if (!hidden && defaultSender.data) return bech32Address(defaultSender.data);

--- a/apps/webapp/app/send/send-form.tsx
+++ b/apps/webapp/app/send/send-form.tsx
@@ -9,7 +9,7 @@ import { isPenumbraAddr } from '@penumbra-zone/types';
 import { useSendBalance } from '../../hooks/send-balance';
 import { useAddress, useEphemeralAddress, } from '../../hooks/address';
 import { bech32Address } from '@penumbra-zone/types';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { cn } from '@penumbra-zone/ui/lib/utils';
 import InputToken from '../../shared/input-token';
 
@@ -20,10 +20,12 @@ const Send = () => {
     asset,
     recipient,
     memoText,
+    memoSender,
     setAmount,
     setAsset,
     setRecipient,
     setMemoText,
+    setMemoSender,
     sendTx,
     txInProgress,
   } = useStore(sendSelector);
@@ -41,6 +43,10 @@ const Send = () => {
     if (hidden && ephemeralSender.data) return bech32Address(ephemeralSender.data);
     return '';
   }, [hidden, defaultSender, ephemeralSender]);
+
+  useEffect(() => {
+    setMemoSender(sender);
+  }, [sender, setMemoSender]);
 
   return (
     <form

--- a/apps/webapp/app/send/send-form.tsx
+++ b/apps/webapp/app/send/send-form.tsx
@@ -15,12 +15,12 @@ const Send = () => {
     amount,
     asset,
     recipient,
-    memo,
+    memoText,
     hidden,
     setAmount,
     setAsset,
     setRecipient,
-    setMemo,
+    setMemoText,
     setHidden,
     sendTx,
     txInProgress,
@@ -73,8 +73,8 @@ const Send = () => {
       <InputBlock
         label='Memo'
         placeholder='Optional message'
-        value={memo}
-        onChange={e => setMemo(e.target.value)}
+        value={memoText}
+        onChange={e => setMemoText(e.target.value)}
       />
       <div className='flex items-center justify-between'>
         <div className='flex items-start gap-2'>

--- a/apps/webapp/hooks/address.ts
+++ b/apps/webapp/hooks/address.ts
@@ -35,3 +35,24 @@ export const useAddresses = (accounts: (number | undefined)[]) => {
     },
   });
 };
+
+export const useAddress = (account = 0) =>
+  useQuery({
+    queryKey: ['get-addr-index', account],
+    queryFn: async () => {
+      const res = await viewClient.addressByIndex({ addressIndex: new AddressIndex({ account }) });
+      return res.address!;
+    },
+  });
+
+export const useEphemeralAddress = (account = 0, options?: { enabled: boolean }) =>
+  useQuery({
+    queryKey: ['get-addr-ephem', account],
+    queryFn: async () => {
+      const res = await viewClient.ephemeralAddress({
+        addressIndex: new AddressIndex({ account }),
+      });
+      return res.address!;
+    },
+    enabled: Boolean(options?.enabled),
+  });

--- a/apps/webapp/state/send.test.ts
+++ b/apps/webapp/state/send.test.ts
@@ -18,9 +18,9 @@ describe('Send Slice', () => {
   });
 
   test('the default is empty, false or undefined', () => {
-    const { amount, memo, recipient, hidden, asset, txInProgress } = useStore.getState().send;
+    const { amount, memoText, recipient, hidden, asset, txInProgress } = useStore.getState().send;
     expect(amount).toBe('');
-    expect(memo).toBe('');
+    expect(memoText).toBe('');
     expect(recipient).toBe('');
     expect(hidden).toBeFalsy();
     expect(asset).toBeTruthy();
@@ -63,8 +63,8 @@ describe('Send Slice', () => {
 
   describe('setMemo', () => {
     test('memo can be set', () => {
-      useStore.getState().send.setMemo('memo-test');
-      expect(useStore.getState().send.memo).toBe('memo-test');
+      useStore.getState().send.setMemoText('memo-test');
+      expect(useStore.getState().send.memoText).toBe('memo-test');
     });
   });
 

--- a/apps/webapp/state/send.test.ts
+++ b/apps/webapp/state/send.test.ts
@@ -18,11 +18,12 @@ describe('Send Slice', () => {
   });
 
   test('the default is empty, false or undefined', () => {
-    const { amount, memoText, recipient, hidden, asset, txInProgress } = useStore.getState().send;
+    const { amount, memoText, memoSender, recipient, asset, txInProgress } =
+      useStore.getState().send;
     expect(amount).toBe('');
     expect(memoText).toBe('');
+    expect(memoSender).toBe('');
     expect(recipient).toBe('');
-    expect(hidden).toBeFalsy();
     expect(asset).toBeTruthy();
     expect(txInProgress).toBeFalsy();
 
@@ -65,20 +66,6 @@ describe('Send Slice', () => {
     test('memo can be set', () => {
       useStore.getState().send.setMemoText('memo-test');
       expect(useStore.getState().send.memoText).toBe('memo-test');
-    });
-  });
-
-  describe('setHidden', () => {
-    test('hidden after click has true value', () => {
-      useStore.getState().send.setHidden(true);
-      expect(useStore.getState().send.hidden).toBeTruthy();
-    });
-
-    test('false value after 2 click', () => {
-      useStore.getState().send.setHidden(true);
-      expect(useStore.getState().send.hidden).toBeTruthy();
-      useStore.getState().send.setHidden(false);
-      expect(useStore.getState().send.hidden).toBeFalsy();
     });
   });
 

--- a/apps/webapp/state/send.ts
+++ b/apps/webapp/state/send.ts
@@ -36,6 +36,7 @@ export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
     asset: assets[0]!,
     recipient: '',
     memoText: '',
+    memoSender: '',
     hidden: false,
     txInProgress: false,
     setAmount: amount => {

--- a/apps/webapp/state/send.ts
+++ b/apps/webapp/state/send.ts
@@ -97,9 +97,15 @@ const getExponent = (asset: TempAsset): number => {
   return match?.exponent ?? 0;
 };
 
-const planWitnessBuildBroadcast = async ({ amount, memoText, recipient, asset }: SendSlice) => {
+const planWitnessBuildBroadcast = async ({
+  amount,
+  memoSender,
+  memoText,
+  recipient,
+  asset,
+}: SendSlice) => {
   const req = new TransactionPlannerRequest({
-    memo: { text: memoText },
+    memo: { sender: { altBech32m: memoSender }, text: memoText },
     outputs: [
       {
         address: { altBech32m: recipient },

--- a/apps/webapp/state/send.ts
+++ b/apps/webapp/state/send.ts
@@ -24,6 +24,8 @@ export interface SendSlice {
   setRecipient: (addr: string) => void;
   memoText: string;
   setMemoText: (txt: string) => void;
+  memoSender: string;
+  setMemoSender: (addr: string) => void;
   sendTx: (toastFn: typeof toast) => Promise<void>;
   txInProgress: boolean;
 }
@@ -57,9 +59,9 @@ export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
         state.send.memoText = txt;
       });
     },
-    setHidden: (checked: boolean) => {
+    setMemoSender: addr => {
       set(state => {
-        state.send.hidden = checked;
+        state.send.memoSender = addr;
       });
     },
     sendTx: async toastFn => {

--- a/apps/webapp/state/send.ts
+++ b/apps/webapp/state/send.ts
@@ -22,8 +22,8 @@ export interface SendSlice {
   setAmount: (amount: string) => void;
   recipient: string;
   setRecipient: (addr: string) => void;
-  memo: string;
-  setMemo: (txt: string) => void;
+  memoText: string;
+  setMemoText: (txt: string) => void;
   hidden: boolean;
   setHidden: (checked: boolean) => void;
   sendTx: (toastFn: typeof toast) => Promise<void>;
@@ -35,7 +35,7 @@ export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
     amount: '',
     asset: assets[0]!,
     recipient: '',
-    memo: '',
+    memoText: '',
     hidden: false,
     txInProgress: false,
     setAmount: amount => {
@@ -54,9 +54,9 @@ export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
         state.send.recipient = addr;
       });
     },
-    setMemo: txt => {
+    setMemoText: txt => {
       set(state => {
-        state.send.memo = txt;
+        state.send.memoText = txt;
       });
     },
     setHidden: (checked: boolean) => {
@@ -97,8 +97,9 @@ const getExponent = (asset: TempAsset): number => {
   return match?.exponent ?? 0;
 };
 
-const planWitnessBuildBroadcast = async ({ amount, recipient, asset }: SendSlice) => {
+const planWitnessBuildBroadcast = async ({ amount, memoText, recipient, asset }: SendSlice) => {
   const req = new TransactionPlannerRequest({
+    memo: { text: memoText },
     outputs: [
       {
         address: { altBech32m: recipient },

--- a/apps/webapp/state/send.ts
+++ b/apps/webapp/state/send.ts
@@ -24,8 +24,6 @@ export interface SendSlice {
   setRecipient: (addr: string) => void;
   memoText: string;
   setMemoText: (txt: string) => void;
-  hidden: boolean;
-  setHidden: (checked: boolean) => void;
   sendTx: (toastFn: typeof toast) => Promise<void>;
   txInProgress: boolean;
 }

--- a/packages/router/src/grpc/view-protocol-server/tx-planner.ts
+++ b/packages/router/src/grpc/view-protocol-server/tx-planner.ts
@@ -26,7 +26,6 @@ export const handleTxPlannerReq = async (
   req: TransactionPlannerRequest,
   services: ServicesInterface,
 ): Promise<TransactionPlannerResponse> => {
-  const refundAddr = await getDefaultAddress(req);
   const { indexedDb } = await services.getWalletServices();
   const chainParams = await services.querier.app.chainParams();
   const fmdParams = await indexedDb.getFmdParams();
@@ -43,7 +42,6 @@ export const handleTxPlannerReq = async (
   }
 
   if (req.memo) {
-    req.memo.sender ??= refundAddr;
     planner.memo(req.memo);
   }
 
@@ -56,6 +54,7 @@ export const handleTxPlannerReq = async (
     planner.output(o.value, o.address);
   }
 
+  const refundAddr = await getDefaultAddress(req);
   const plan = await planner.plan(refundAddr);
   return new TransactionPlannerResponse({ plan });
 };

--- a/packages/router/src/grpc/view-protocol-server/tx-planner.ts
+++ b/packages/router/src/grpc/view-protocol-server/tx-planner.ts
@@ -26,6 +26,7 @@ export const handleTxPlannerReq = async (
   req: TransactionPlannerRequest,
   services: ServicesInterface,
 ): Promise<TransactionPlannerResponse> => {
+  const refundAddr = await getRefundAddress(req);
   const { indexedDb } = await services.getWalletServices();
   const chainParams = await services.querier.app.chainParams();
   const fmdParams = await indexedDb.getFmdParams();
@@ -42,6 +43,7 @@ export const handleTxPlannerReq = async (
   }
 
   if (req.memo) {
+    req.memo.sender ??= refundAddr;
     planner.memo(req.memo);
   }
 
@@ -54,7 +56,6 @@ export const handleTxPlannerReq = async (
     planner.output(o.value, o.address);
   }
 
-  const refundAddr = await getRefundAddress(req);
   const plan = await planner.plan(refundAddr);
   return new TransactionPlannerResponse({ plan });
 };

--- a/packages/router/src/grpc/view-protocol-server/tx-planner.ts
+++ b/packages/router/src/grpc/view-protocol-server/tx-planner.ts
@@ -16,7 +16,7 @@ export const isTxPlannerRequest = (msg: ViewReqMessage): msg is TransactionPlann
 };
 
 // If there are any balances left over, refund back to source. Default to account 0.
-const getRefundAddress = async (req: TransactionPlannerRequest): Promise<Address> => {
+const getDefaultAddress = async (req: TransactionPlannerRequest): Promise<Address> => {
   const refundAddrIndex = req.source ?? new AddressIndex({ account: 0 });
   const wallets = await localExtStorage.get('wallets');
   return getAddressByIndex(wallets[0]!.fullViewingKey, refundAddrIndex.account);
@@ -26,7 +26,7 @@ export const handleTxPlannerReq = async (
   req: TransactionPlannerRequest,
   services: ServicesInterface,
 ): Promise<TransactionPlannerResponse> => {
-  const refundAddr = await getRefundAddress(req);
+  const refundAddr = await getDefaultAddress(req);
   const { indexedDb } = await services.getWalletServices();
   const chainParams = await services.querier.app.chainParams();
   const fmdParams = await indexedDb.getFmdParams();


### PR DESCRIPTION
edit: updated with some more work that was closely aligned
 
fixes #160 but i don't think this is ready

initially, the send page provided undefined memo fields to the planner request. the page didn't send it, and handleTxPlannerReq just skipped the memo plan step. this is apparently a valid way to plan a transaction. i don't have a good wasm/rust debug flow yet but i believe this results in a zeroed MemoPlaintext.sender and zero-length MemoPlaintext.text in the final transaction on the chain.

the send form now always supplies a return address, and at least an empty-string memo.

ephemeraladdressrequest is unimplemented #181 so that part doesn't work, but it's on the way to also addressing parts of #162