### PR TITLE
Do not emit declaration map

### DIFF
--- a/packages/tsconfig/vite.json
+++ b/packages/tsconfig/vite.json
@@ -11,6 +11,8 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "declarationMap": false,
+    "declaration": false
   }
 }


### PR DESCRIPTION
Removes the necessity for declaration files to be emit with the vite app. It's not necessary and causing IDE warnings.