### PR TITLE
252 need to clear indexed db during version migration

### DIFF
--- a/packages/storage/src/chrome/syncer.ts
+++ b/packages/storage/src/chrome/syncer.ts
@@ -4,6 +4,9 @@ import { IndexedDb } from '../indexed-db';
 // Syncs the IndexedDb last block number with chrome.storage.local
 // Later used to synchronize with Zustand store
 export const syncLastBlockWithLocal = async (indexedDb: IndexedDb) => {
+  const lastBlockSyncedDb = await indexedDb.getLastBlockSynced();
+  await localExtStorage.set('lastBlockSynced', Number(lastBlockSyncedDb));
+
   const subscription = indexedDb.subscribe('LAST_BLOCK_SYNCED');
   for await (const update of subscription) {
     await localExtStorage.set('lastBlockSynced', Number(update.value));

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -42,6 +42,13 @@ export class IndexedDb implements IndexedDbInterface {
 
     const db = await openDB<PenumbraDb>(dbName, dbVersion, {
       upgrade(db: IDBPDatabase<PenumbraDb>) {
+
+        // delete existing ObjectStores before re-creating them
+        // all existing indexed-db data will be deleted when version is increased
+        for (const objectStoreName of db.objectStoreNames) {
+          db.deleteObjectStore(objectStoreName)
+        }
+
         db.createObjectStore('LAST_BLOCK_SYNCED');
         db.createObjectStore('ASSETS', { keyPath: 'penumbraAssetId.inner' });
         db.createObjectStore('SPENDABLE_NOTES', {

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -23,7 +23,7 @@ import {
   AssetId,
   DenomMetadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
-import {localExtStorage} from "../chrome";
+import { localExtStorage } from '../chrome';
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
@@ -43,15 +43,13 @@ export class IndexedDb implements IndexedDbInterface {
 
     const db = await openDB<PenumbraDb>(dbName, dbVersion, {
       upgrade(db: IDBPDatabase<PenumbraDb>) {
-
         // delete existing ObjectStores before re-creating them
         // all existing indexed-db data will be deleted when version is increased
         for (const objectStoreName of db.objectStoreNames) {
-          db.deleteObjectStore(objectStoreName)
+          db.deleteObjectStore(objectStoreName);
         }
 
         void localExtStorage.set('lastBlockSynced', 0);
-
 
         db.createObjectStore('LAST_BLOCK_SYNCED');
         db.createObjectStore('ASSETS', { keyPath: 'penumbraAssetId.inner' });

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -23,6 +23,7 @@ import {
   AssetId,
   DenomMetadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import {localExtStorage} from "../chrome";
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
@@ -48,6 +49,9 @@ export class IndexedDb implements IndexedDbInterface {
         for (const objectStoreName of db.objectStoreNames) {
           db.deleteObjectStore(objectStoreName)
         }
+
+        void localExtStorage.set('lastBlockSynced', 0);
+
 
         db.createObjectStore('LAST_BLOCK_SYNCED');
         db.createObjectStore('ASSETS', { keyPath: 'penumbraAssetId.inner' });

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -23,7 +23,6 @@ import {
   AssetId,
   DenomMetadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
-import { localExtStorage } from '../chrome';
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
@@ -48,8 +47,6 @@ export class IndexedDb implements IndexedDbInterface {
         for (const objectStoreName of db.objectStoreNames) {
           db.deleteObjectStore(objectStoreName);
         }
-
-        void localExtStorage.set('lastBlockSynced', 0);
 
         db.createObjectStore('LAST_BLOCK_SYNCED');
         db.createObjectStore('ASSETS', { keyPath: 'penumbraAssetId.inner' });

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -62,6 +62,22 @@ describe('IndexedDb', () => {
         denomMetadataA.name,
       );
     });
+
+    it('increasing version should re-create object stores', async () => {
+      const version1Props = generateInitialProps();
+      const dbA = await IndexedDb.initialize(version1Props);
+      await dbA.saveAssetsMetadata(denomMetadataA);
+
+      const version2Props = {
+        chainId: 'test',
+        accountAddr: 'penumbra123xyz',
+        dbVersion: 2,
+        walletId: `walletid${Math.random()}`,
+      };
+
+      const dbB = await IndexedDb.initialize(version2Props);
+      expect((await dbB.getAssetsMetadata(denomMetadataA.penumbraAssetId!))?.name).toBeUndefined();
+    });
   });
 
   describe('Updater', () => {


### PR DESCRIPTION
We'll get a display bug if we don't execute 
```typescript
void localExtStorage.set('lastBlockSynced', 0); 
``` 
The synс progress bar will display the old value of `lastBlockSynced`, while in fact sync started from 0 block


