### PR TITLE
don't remove init listener after activation

### DIFF
--- a/apps/extension/src/injected-penumbra-global.ts
+++ b/apps/extension/src/injected-penumbra-global.ts
@@ -25,7 +25,6 @@ const initPenumbra = (ev: MessageEvent<unknown>) => {
       ...Object.fromEntries(services.map((s: string) => [s, port])),
     };
   }
-  window.removeEventListener('message', initPenumbra);
 };
 
 window.addEventListener('message', initPenumbra);


### PR DESCRIPTION
[Bug] Other wallet extensions block transport between the webapp and extension
Fixes #297

obviously intended to be inside the conditional, but i guess there is not really any reason to deactivate it