### PR TITLE
wrap impls to rethrow

### DIFF
--- a/packages/transport/src/chrome-runtime/adapter.ts
+++ b/packages/transport/src/chrome-runtime/adapter.ts
@@ -134,12 +134,7 @@ export const connectChromeRuntimeAdapter = (
         Object.entries(handler) as [keyof UniversalHandler, unknown][],
       ) as { [k in keyof UniversalHandler]: UniversalHandler[k] };
       // wrap the handler function to generate and apply context
-      const wrappedFn: UniversalHandlerFn = req =>
-        opt.createRequestContext(req).then(handlerFn, error => {
-          // it's convenient to log and rethrow as ConnectError here
-          console.warn('Handler Error', handler.name, error);
-          throw ConnectError.from(error);
-        });
+      const wrappedFn: UniversalHandlerFn = req => opt.createRequestContext(req).then(handlerFn);
       // replace attributes onto the wrapped handler
       return Object.assign(wrappedFn, handlerMeta);
     }),


### PR DESCRIPTION
this is a temp workaround. we could also 

1) do nothing. it's not the end of the world to default to concealed errors
2) manually try/catch in impls
3) [PR connectrpc](https://github.com/connectrpc/connect-es/compare/main...turbocrime:connect-es:internal-errors)