### PR TITLE
Add a feedback button to the header of the web app

### DIFF
--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -14,8 +14,9 @@ import Notifications from './notifications.tsx';
 import { PagePath } from '../metadata/paths.ts';
 import { TabletNavMenu } from './tablet-nav-menu.tsx';
 
-// Infinite-expiry invite link, provided by Henry, to the #web-ext-feedback
-// channel.
+// Infinite-expiry invite link to the #web-ext-feedback channel. Provided by
+// Henry (@hdevalence) and thus tied to his Discord account, so reach out to him
+// if there are any problems with this link.
 const WEB_EXT_FEEDBACK_DISCORD_CHANNEL = 'https://discord.gg/XDNcrhKVwV';
 
 export const Header = () => {

--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -5,6 +5,7 @@ import Notifications from './notifications.tsx';
 import { TabletNavMenu } from './tablet-nav-menu.tsx';
 import { LayoutLoaderResult } from '../layout.tsx';
 import { NetworksPopover } from '@penumbra-zone/ui';
+import { MessageWarningIcon } from '../../icons/message-warning.tsx';
 import { MobileNavMenu } from './mobile-nav-menu.tsx';
 
 export const Header = () => {
@@ -27,18 +28,22 @@ export const Header = () => {
         </Link>
       </div>
       <Navbar />
-      <div className='flex w-full items-center justify-between md:w-auto md:gap-6 xl:gap-4'>
+      <div className='flex w-full items-center justify-between gap-4 md:w-auto md:gap-6 xl:gap-4'>
         <div className='order-1 block md:hidden'>
           <MobileNavMenu />
         </div>
         <TabletNavMenu />
+
+        <div className='order-3 flex items-center justify-center md:order-none'>
+          <MessageWarningIcon />
+        </div>
 
         {result.isInstalled ? (
           <>
             <div className='order-3 flex items-center justify-center md:order-none'>
               <Notifications />
             </div>
-            <div className='order-2 md:order-none'>
+            <div className='order-2 flex grow justify-center md:order-none'>
               <NetworksPopover name={result.chainId} />
             </div>
           </>

--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -21,7 +21,7 @@ export const Header = () => {
   const result = useLoaderData() as LayoutLoaderResult;
 
   return (
-    <header className='z-10 flex w-full flex-col items-center justify-between px-6 md:h-[82px] md:flex-row md:px-12'>
+    <header className='z-10 flex w-full flex-col items-center justify-between px-6 md:h-[82px] md:flex-row md:gap-12 md:px-12'>
       <div className='mb-[30px] md:mb-0'>
         <img
           src='/penumbra-logo.svg'

--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -8,6 +8,9 @@ import { NetworksPopover } from '@penumbra-zone/ui';
 import { MessageWarningIcon } from '../../icons/message-warning.tsx';
 import { MobileNavMenu } from './mobile-nav-menu.tsx';
 
+const WEB_EXT_FEEDBACK_DISCORD_CHANNEL =
+  'https://discord.com/channels/824484045370818580/1077672871251415141';
+
 export const Header = () => {
   const result = useLoaderData() as LayoutLoaderResult;
 
@@ -35,7 +38,14 @@ export const Header = () => {
         <TabletNavMenu />
 
         <div className='order-3 flex items-center justify-center md:order-none'>
-          <MessageWarningIcon />
+          <a
+            href={WEB_EXT_FEEDBACK_DISCORD_CHANNEL}
+            target='_blank'
+            rel='noreferrer'
+            aria-label='Send feedback via our Discord channel'
+          >
+            <MessageWarningIcon />
+          </a>
         </div>
 
         {result.isInstalled ? (

--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -1,12 +1,18 @@
-import { Navbar } from './navbar';
-import { Link, useLoaderData } from 'react-router-dom';
-import { PagePath } from '../metadata/paths.ts';
-import Notifications from './notifications.tsx';
-import { TabletNavMenu } from './tablet-nav-menu.tsx';
 import { LayoutLoaderResult } from '../layout.tsx';
-import { NetworksPopover } from '@penumbra-zone/ui';
+import { Link, useLoaderData } from 'react-router-dom';
 import { MessageWarningIcon } from '../../icons/message-warning.tsx';
 import { MobileNavMenu } from './mobile-nav-menu.tsx';
+import { Navbar } from './navbar';
+import {
+  NetworksPopover,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@penumbra-zone/ui';
+import Notifications from './notifications.tsx';
+import { PagePath } from '../metadata/paths.ts';
+import { TabletNavMenu } from './tablet-nav-menu.tsx';
 
 const WEB_EXT_FEEDBACK_DISCORD_CHANNEL =
   'https://discord.com/channels/824484045370818580/1077672871251415141';
@@ -38,14 +44,21 @@ export const Header = () => {
         <TabletNavMenu />
 
         <div className='order-3 flex items-center justify-center md:order-none'>
-          <a
-            href={WEB_EXT_FEEDBACK_DISCORD_CHANNEL}
-            target='_blank'
-            rel='noreferrer'
-            aria-label='Send feedback via our Discord channel'
-          >
-            <MessageWarningIcon />
-          </a>
+          <TooltipProvider>
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger>
+                <a
+                  href={WEB_EXT_FEEDBACK_DISCORD_CHANNEL}
+                  target='_blank'
+                  rel='noreferrer'
+                  aria-label='Send feedback via our Discord channel'
+                >
+                  <MessageWarningIcon />
+                </a>
+              </TooltipTrigger>
+              <TooltipContent>Send feedback via our Discord channel</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
 
         {result.isInstalled ? (

--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -14,8 +14,9 @@ import Notifications from './notifications.tsx';
 import { PagePath } from '../metadata/paths.ts';
 import { TabletNavMenu } from './tablet-nav-menu.tsx';
 
-const WEB_EXT_FEEDBACK_DISCORD_CHANNEL =
-  'https://discord.com/channels/824484045370818580/1077672871251415141';
+// Infinite-expiry invite link, provided by Henry, to the #web-ext-feedback
+// channel.
+const WEB_EXT_FEEDBACK_DISCORD_CHANNEL = 'https://discord.gg/XDNcrhKVwV';
 
 export const Header = () => {
   const result = useLoaderData() as LayoutLoaderResult;

--- a/apps/webapp/src/components/header/navbar.tsx
+++ b/apps/webapp/src/components/header/navbar.tsx
@@ -7,7 +7,7 @@ export const Navbar = () => {
   const pathname = usePagePath();
 
   return (
-    <nav className='hidden gap-4 xl:flex xl:grow xl:justify-between max-w-2xl'>
+    <nav className='hidden max-w-2xl gap-4 xl:flex xl:grow xl:justify-between'>
       {headerLinks.map(link =>
         link.active ? (
           <Link

--- a/apps/webapp/src/components/header/navbar.tsx
+++ b/apps/webapp/src/components/header/navbar.tsx
@@ -7,17 +7,17 @@ export const Navbar = () => {
   const pathname = usePagePath();
 
   return (
-    <nav className='hidden gap-4 xl:flex'>
+    <nav className='hidden gap-4 xl:flex xl:grow xl:justify-between max-w-2xl'>
       {headerLinks.map(link =>
         link.active ? (
           <Link
             key={link.href}
             to={link.href}
             className={cn(
-              'font-bold py-[10px] px-[30px] select-none',
+              'font-bold py-[10px] select-none',
               link.subLinks &&
                 link.subLinks.includes(pathname) &&
-                'bg-button-gradient-secondary rounded-lg',
+                'bg-button-gradient-secondary px-[30px] rounded-lg',
             )}
           >
             {link.label}
@@ -25,7 +25,7 @@ export const Navbar = () => {
         ) : (
           <div
             key={link.href}
-            className='cursor-not-allowed select-none px-[30px] py-[10px] font-bold text-gray-600'
+            className='cursor-not-allowed select-none py-[10px] font-bold text-gray-600'
           >
             {link.label}
           </div>

--- a/apps/webapp/src/icons/index.tsx
+++ b/apps/webapp/src/icons/index.tsx
@@ -1,3 +1,4 @@
-export * from './bell.tsx';
+export * from './bell';
 export * from './box';
+export * from './message-warning';
 export * from './swap';

--- a/apps/webapp/src/icons/message-warning.tsx
+++ b/apps/webapp/src/icons/message-warning.tsx
@@ -1,0 +1,14 @@
+export const MessageWarningIcon = ({ stroke = '#BDB8B8' }: { stroke?: string }) => {
+  return (
+    <svg width='30' height='30' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path d='M12 7V11' stroke={stroke} strokeLinecap='round' />
+      <path
+        fillRule='evenodd'
+        clipRule='evenodd'
+        d='M12 15C12.5523 15 13 14.5523 13 14C13 13.4477 12.5523 13 12 13C11.4477 13 11 13.4477 11 14C11 14.5523 11.4477 15 12 15Z'
+        fill={stroke}
+      />
+      <path d='M21 4V17H13L7 21V17H3V4H21Z' stroke={stroke} strokeLinejoin='round' />
+    </svg>
+  );
+};

--- a/packages/ui/components/ui/networks-popover.tsx
+++ b/packages/ui/components/ui/networks-popover.tsx
@@ -25,7 +25,7 @@ const NetworksPopover = ({
         {connectIndicator && (
           <div className='-mx-1 h-4 w-1 rounded-sm bg-gradient-to-b from-cyan-400 to-emerald-400'></div>
         )}
-        <p>{name}</p>
+        <p className='whitespace-nowrap'>{name}</p>
       </PopoverTrigger>
       <PopoverContent></PopoverContent>
     </Popover>


### PR DESCRIPTION
## In this PR
- Add a feedback button to the web app, which links to an invite the `#web-ext-feedback` Discord channel.
- Tweak the layout of the header so that, instead of having a fixed gap between header links, it is responsive to the width of the window.

![screencap](https://github.com/penumbra-zone/web/assets/1121544/9721947f-c900-4325-9306-8aa64d0d3c09)


Closes #221 