### PR TITLE
use Transaction.toBinary instead of wasm encodeTx

### DIFF
--- a/packages/query/src/block-processor/index.ts
+++ b/packages/query/src/block-processor/index.ts
@@ -15,8 +15,11 @@ import {
 import { RootQuerier } from '../root-querier';
 import { generateMetadata } from './metadata';
 import { Transactions } from './transactions';
-import { decodeSctRoot, decodeTx, transactionInfo } from '@penumbra-zone/wasm-ts';
-import { Id } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
+import { decodeSctRoot, transactionInfo } from '@penumbra-zone/wasm-ts';
+import {
+  Id,
+  Transaction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 
 interface QueryClientProps {
   fullViewingKey: string;
@@ -173,7 +176,7 @@ export class BlockProcessor implements BlockProcessorInterface {
 
     if (!txResponse) return undefined;
 
-    const tx = decodeTx(txResponse.tx);
+    const tx = Transaction.fromBinary(txResponse.tx);
     const { txp, txv } = await transactionInfo(this.fullViewingKey, tx, this.indexedDb.constants());
 
     return new TransactionInfo({

--- a/packages/query/src/block-processor/transactions.ts
+++ b/packages/query/src/block-processor/transactions.ts
@@ -4,7 +4,7 @@ import {
   ParsedNoteSource,
   ViewServerInterface,
 } from '@penumbra-zone/types';
-import { encodeTx, transactionInfo } from '@penumbra-zone/wasm-ts/src/transaction';
+import { transactionInfo } from '@penumbra-zone/wasm-ts/src/transaction';
 import { sha256Hash } from '@penumbra-zone/crypto-web';
 import { NoteSource } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/chain/v1alpha1/chain_pb';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
@@ -52,7 +52,7 @@ export class Transactions {
     const { transactions } = await this.querier.txsByHeight(this.blockHeight);
 
     for (const tx of transactions) {
-      const hash = await sha256Hash(encodeTx(tx));
+      const hash = await sha256Hash(tx.toBinary());
       const noteSource = new NoteSource({ inner: hash });
 
       if (noteSourcePresent(this.all, noteSource)) {

--- a/packages/router/src/grpc/view-protocol-server/broadcast-transaction.ts
+++ b/packages/router/src/grpc/view-protocol-server/broadcast-transaction.ts
@@ -1,8 +1,6 @@
 import type { Impl } from '.';
 import { servicesCtx } from '../../ctx';
 
-import { encodeTx } from '@penumbra-zone/wasm-ts';
-
 import { NoteSource } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/chain/v1alpha1/chain_pb';
 import { SpendableNoteRecord } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
 
@@ -15,7 +13,7 @@ export const broadcastTransaction: Impl['broadcastTransaction'] = async (req, ct
   if (!req.transaction)
     throw new ConnectError('No transaction provided in request', Code.InvalidArgument);
 
-  const encodedTx = encodeTx(req.transaction);
+  const encodedTx = req.transaction.toBinary();
 
   // start subscription early to prevent race condition
   const subscription = indexedDb.subscribe('SPENDABLE_NOTES');

--- a/packages/wasm/src/transaction.ts
+++ b/packages/wasm/src/transaction.ts
@@ -1,27 +1,15 @@
 import {
   IdbConstants,
-  uint8ArrayToBase64,
   validateSchema,
   WasmTransactionInfo,
   WasmTransactionInfoSchema,
 } from '@penumbra-zone/types';
-import { decode_tx, encode_tx, transaction_info } from '@penumbra-zone/wasm-bundler';
+import { transaction_info } from '@penumbra-zone/wasm-bundler';
 import {
   Transaction,
   TransactionPerspective,
   TransactionView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
-import { z } from 'zod';
-
-export const decodeTx = (txBytes: Uint8Array): Transaction => {
-  const base64Bytes = uint8ArrayToBase64(txBytes);
-  return Transaction.fromJsonString(JSON.stringify(decode_tx(base64Bytes)));
-};
-
-export const encodeTx = (tx: Transaction): Uint8Array => {
-  const result = validateSchema(z.array(z.number()), encode_tx(tx.toJson()));
-  return new Uint8Array(result);
-};
 
 export const transactionInfo = async (
   fullViewingKey: string,


### PR DESCRIPTION
wasm just uses `pbt::Transaction::encode_to_vec`, which is byte-for-byte identical to bufbuild's `Transaction.toBinary`

https://github.com/penumbra-zone/penumbra/blob/4d4ae0197a1315fdb02bda6d40b044e35c838fe8/crates/wasm/src/tx.rs#L44-L52

https://github.com/penumbra-zone/penumbra//blob/1c957b5e1fc68cb2d26a63135b5392cd9357d2a9/transaction/src/transaction.rs#L306-L318