### PR TITLE
view service:  impl witness

### DIFF
--- a/packages/router/src/grpc/view-protocol-server/index.ts
+++ b/packages/router/src/grpc/view-protocol-server/index.ts
@@ -22,10 +22,11 @@ import { transactionPlanner } from './transaction-planner';
 import { unclaimedSwaps } from './unclaimed-swaps';
 import { walletId } from './wallet-id';
 import { witnessAndBuild } from './witness-and-build';
+import { witness } from './witness';
 
 export const viewImpl: Omit<
   Impl,
-  'authorizeAndBuild' | 'gasPrices' | 'notesForVoting' | 'ownedPositionIds' | 'witness'
+  'authorizeAndBuild' | 'gasPrices' | 'notesForVoting' | 'ownedPositionIds'
 > = {
   addressByIndex,
   appParameters,
@@ -47,4 +48,5 @@ export const viewImpl: Omit<
   unclaimedSwaps,
   walletId,
   witnessAndBuild,
+  witness,
 };

--- a/packages/router/src/grpc/view-protocol-server/witness-and-build.ts
+++ b/packages/router/src/grpc/view-protocol-server/witness-and-build.ts
@@ -3,7 +3,7 @@ import { servicesCtx } from '../../ctx';
 
 import { offscreenClient } from '../offscreen-client';
 
-import { buildParallel, witness } from '@penumbra-zone/wasm-ts';
+import { buildParallel, getWitness } from '@penumbra-zone/wasm-ts';
 
 import { ConnectError, Code } from '@connectrpc/connect';
 
@@ -19,7 +19,7 @@ export const witnessAndBuild: Impl['witnessAndBuild'] = async (req, ctx) => {
   } = await services.getWalletServices();
   const sct = await indexedDb.getStateCommitmentTree();
 
-  const witnessData = witness(req.transactionPlan, sct);
+  const witnessData = getWitness(req.transactionPlan, sct);
 
   const batchActions = await offscreenClient.buildAction(req, witnessData, fullViewingKey);
 

--- a/packages/router/src/grpc/view-protocol-server/witness.ts
+++ b/packages/router/src/grpc/view-protocol-server/witness.ts
@@ -1,0 +1,19 @@
+import type { Impl } from '.';
+import { servicesCtx } from '../../ctx';
+
+import { getWitness } from '@penumbra-zone/wasm-ts';
+
+import { ConnectError, Code } from '@connectrpc/connect';
+
+export const witness: Impl['witness'] = async (req, ctx) => {
+  const services = ctx.values.get(servicesCtx);
+
+  if (!req.transactionPlan) throw new ConnectError('No tx plan in request', Code.InvalidArgument);
+
+  const { indexedDb } = await services.getWalletServices();
+  const sct = await indexedDb.getStateCommitmentTree();
+
+  const witnessData = getWitness(req.transactionPlan, sct);
+
+  return { witnessData };
+};

--- a/packages/wasm/src/build.ts
+++ b/packages/wasm/src/build.ts
@@ -26,7 +26,7 @@ export const authorizePlan = (spendKey: string, txPlan: TransactionPlan): Author
   return AuthorizationData.fromJsonString(JSON.stringify(result));
 };
 
-export const witness = (txPlan: TransactionPlan, sct: StateCommitmentTree): WitnessData => {
+export const getWitness = (txPlan: TransactionPlan, sct: StateCommitmentTree): WitnessData => {
   const result = validateSchema(WasmWitnessDataSchema, wasmWitness(txPlan.toJson(), sct));
   return WitnessData.fromJsonString(JSON.stringify(result));
 };


### PR DESCRIPTION
- `note_commitments` will be removed from `WitnessRequest`, so I just ignored this field 
ref: https://discord.com/channels/824484045370818580/979785365437165658/1193954469201838101
- just renamed the wasm wrapper `witness()` to `getWitness()` so as not to conflict with the rpc method