### PR TITLE
Extract several shared components related to rendering addresses

### DIFF
--- a/apps/extension/src/state/wallets.ts
+++ b/apps/extension/src/state/wallets.ts
@@ -4,7 +4,6 @@ import {
   getAddressByIndex,
   getEphemeralByIndex,
   getFullViewingKey,
-  getShortAddressByIndex,
   getWalletId,
 } from '@penumbra-zone/wasm-ts';
 import { Key } from '@penumbra-zone/crypto-web';
@@ -86,9 +85,6 @@ export const accountAddrSelector = (state: AllSlices) => (index: number, ephemer
 
   return {
     address: bech32Addr,
-    preview: ephemeral
-      ? bech32Addr.slice(0, 33) + '…'
-      : getShortAddressByIndex(active.fullViewingKey, index),
     index,
   };
 };

--- a/apps/webapp/src/components/dashboard/assets-table.tsx
+++ b/apps/webapp/src/components/dashboard/assets-table.tsx
@@ -1,17 +1,10 @@
-import {
-  Identicon,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@penumbra-zone/ui';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@penumbra-zone/ui';
 import { displayUsd, fromBaseUnitAmount, shortenAddress } from '@penumbra-zone/types';
 import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { throwIfExtNotInstalled } from '../../fetchers/is-connected.ts';
 import { AccountBalance, getBalancesByAccount } from '../../fetchers/balances.ts';
 import { AssetIcon } from '../shared/asset-icon.tsx';
+import { AddressIcon } from '@penumbra-zone/ui/components/ui/address-icon';
 
 export const AssetsLoader: LoaderFunction = async (): Promise<AccountBalance[]> => {
   throwIfExtNotInstalled();
@@ -43,7 +36,7 @@ export default function AssetsTable() {
             <div className='flex flex-col items-center justify-center'>
               <div className='flex flex-col items-center justify-center gap-2 md:flex-row'>
                 <div className='flex items-center gap-2'>
-                  <Identicon name={a.address} size={20} className='rounded-full' type='gradient' />
+                  <AddressIcon address={a.address} size={20} />
                   <h2 className='font-bold md:text-base xl:text-xl'>Account #{a.index}</h2>{' '}
                 </div>
                 <div className='font-mono text-sm italic text-foreground'>

--- a/apps/webapp/src/components/dashboard/assets-table.tsx
+++ b/apps/webapp/src/components/dashboard/assets-table.tsx
@@ -1,10 +1,11 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@penumbra-zone/ui';
-import { displayUsd, fromBaseUnitAmount, shortenAddress } from '@penumbra-zone/types';
+import { displayUsd, fromBaseUnitAmount } from '@penumbra-zone/types';
 import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { throwIfExtNotInstalled } from '../../fetchers/is-connected.ts';
 import { AccountBalance, getBalancesByAccount } from '../../fetchers/balances.ts';
 import { AssetIcon } from '../shared/asset-icon.tsx';
 import { AddressIcon } from '@penumbra-zone/ui/components/ui/address-icon';
+import { Address } from '@penumbra-zone/ui/components/ui/address.tsx';
 
 export const AssetsLoader: LoaderFunction = async (): Promise<AccountBalance[]> => {
   throwIfExtNotInstalled();
@@ -39,9 +40,8 @@ export default function AssetsTable() {
                   <AddressIcon address={a.address} size={20} />
                   <h2 className='font-bold md:text-base xl:text-xl'>Account #{a.index}</h2>{' '}
                 </div>
-                <div className='font-mono text-sm italic text-foreground'>
-                  {shortenAddress(a.address)}
-                </div>
+
+                <Address address={a.address} />
               </div>
             </div>
             <div className='flex flex-col gap-[34px] md:hidden'>

--- a/apps/webapp/src/fetchers/address.ts
+++ b/apps/webapp/src/fetchers/address.ts
@@ -6,7 +6,7 @@ import {
   AddressByIndexRequest,
   EphemeralAddressRequest,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
-import { bech32Address, shortenAddress } from '@penumbra-zone/types';
+import { bech32Address } from '@penumbra-zone/types';
 import { viewClient } from '../clients/grpc';
 
 type Index = number;
@@ -50,7 +50,6 @@ export const getAccountAddr = async (index: number, ephemeral: boolean) => {
 
   return {
     address: bech32,
-    preview: shortenAddress(bech32),
     index,
   };
 };

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -1,5 +1,4 @@
 export interface Account {
   address: string;
-  preview: string;
   index: number;
 }

--- a/packages/ui/components/ui/address-icon.tsx
+++ b/packages/ui/components/ui/address-icon.tsx
@@ -1,0 +1,8 @@
+import { Identicon } from './identicon';
+
+/**
+ * A simple component to display a consistently styled icon for a given address.
+ */
+export const AddressIcon = ({ address, size }: { address: string; size: number }) => (
+  <Identicon name={address} size={size} className='rounded-full' type='gradient' />
+);

--- a/packages/ui/components/ui/address.test.tsx
+++ b/packages/ui/components/ui/address.test.tsx
@@ -1,0 +1,27 @@
+import { Address } from './address';
+import { describe, expect, test } from 'vitest';
+import { render } from '@testing-library/react';
+import { shortenAddress } from '@penumbra-zone/types';
+
+describe('<Address />', () => {
+  const address =
+    'penumbra1nzxd3wqautgr8hmwwvvgwnsgtpnl3rexwyj0srpcyaf75968mq3wseftwzwcsx458la09m3am7x2qlk7jfchuvpv6uvw79ctzpnrt7c2wd6n9j9xgk8regdwkrjple9uh2tekf';
+
+  test('renders the shortened address', () => {
+    const { baseElement } = render(<Address address={address} />);
+
+    expect(baseElement).toHaveTextContent(shortenAddress(address));
+  });
+
+  test('uses text-muted-foreground for non-ephemeral addresses', () => {
+    const { getByText } = render(<Address address={address} />);
+
+    expect(getByText(shortenAddress(address))).toHaveClass('text-muted-foreground');
+  });
+
+  test('uses colored text for ephemeral addresses', () => {
+    const { getByText } = render(<Address address={address} ephemeral />);
+
+    expect(getByText(shortenAddress(address))).toHaveClass('text-[#8D5728]');
+  });
+});

--- a/packages/ui/components/ui/address.tsx
+++ b/packages/ui/components/ui/address.tsx
@@ -1,0 +1,19 @@
+import { shortenAddress } from '@penumbra-zone/types';
+
+/**
+ * Displays an address. The address is truncated to the prefix plus 24
+ * characters, and rendered in color when it is ephemeral.
+ */
+export const Address = ({
+  address,
+  ephemeral = false,
+}: {
+  address: string;
+  ephemeral?: boolean;
+}) => (
+  <span
+    className={'font-mono text-[12px]' + (ephemeral ? ' text-[#8D5728]' : ' text-muted-foreground')}
+  >
+    {shortenAddress(address)}
+  </span>
+);

--- a/packages/ui/components/ui/copy-address-button.tsx
+++ b/packages/ui/components/ui/copy-address-button.tsx
@@ -1,0 +1,16 @@
+import { CopyIcon } from 'lucide-react';
+import { CopyToClipboard } from './copy-to-clipboard';
+
+export const CopyAddressButton = ({ address }: { address: string }) => {
+  return (
+    <CopyToClipboard
+      text={address}
+      label={
+        <div>
+          <CopyIcon className='text-muted-foreground h-4 w-4 hover:opacity-50' />
+        </div>
+      }
+      className='w-4'
+    />
+  );
+};

--- a/packages/ui/components/ui/copy-address-button.tsx
+++ b/packages/ui/components/ui/copy-address-button.tsx
@@ -1,6 +1,9 @@
 import { CopyIcon } from 'lucide-react';
 import { CopyToClipboard } from './copy-to-clipboard';
 
+/**
+ * A little copy icon button for copying an address to the clipboard.
+ */
 export const CopyAddressButton = ({ address }: { address: string }) => {
   return (
     <CopyToClipboard

--- a/packages/ui/components/ui/copy-address-button.tsx
+++ b/packages/ui/components/ui/copy-address-button.tsx
@@ -5,12 +5,8 @@ export const CopyAddressButton = ({ address }: { address: string }) => {
   return (
     <CopyToClipboard
       text={address}
-      label={
-        <div>
-          <CopyIcon className='text-muted-foreground h-4 w-4 hover:opacity-50' />
-        </div>
-      }
-      className='w-4'
+      label={<CopyIcon className='text-muted-foreground h-4 w-4 hover:opacity-50' />}
+      className='h-4 w-4'
     />
   );
 };

--- a/packages/ui/components/ui/copy-to-clipboard-icon-button.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard-icon-button.tsx
@@ -8,7 +8,12 @@ export const CopyToClipboardIconButton = ({ text }: { text: string }) => {
   return (
     <CopyToClipboard
       text={text}
-      label={<CopyIcon className='text-muted-foreground h-4 w-4 hover:opacity-50' />}
+      label={
+        <CopyIcon
+          className='text-muted-foreground h-4 w-4 hover:opacity-50'
+          data-testid='CopyToClipboardIconButton__icon'
+        />
+      }
       className='h-4 w-4'
     />
   );

--- a/packages/ui/components/ui/copy-to-clipboard-icon-button.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard-icon-button.tsx
@@ -2,12 +2,12 @@ import { CopyIcon } from 'lucide-react';
 import { CopyToClipboard } from './copy-to-clipboard';
 
 /**
- * A little copy icon button for copying an address to the clipboard.
+ * Wraps `CopyToClipboard` and passes in a `CopyIcon` as the label.
  */
-export const CopyAddressButton = ({ address }: { address: string }) => {
+export const CopyToClipboardIconButton = ({ text }: { text: string }) => {
   return (
     <CopyToClipboard
-      text={address}
+      text={text}
       label={<CopyIcon className='text-muted-foreground h-4 w-4 hover:opacity-50' />}
       className='h-4 w-4'
     />

--- a/packages/ui/components/ui/copy-to-clipboard-icon-button.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard-icon-button.tsx
@@ -10,7 +10,7 @@ export const CopyToClipboardIconButton = ({ text }: { text: string }) => {
       text={text}
       label={
         <CopyIcon
-          className='text-muted-foreground h-4 w-4 hover:opacity-50'
+          className='h-4 w-4 hover:opacity-50'
           data-testid='CopyToClipboardIconButton__icon'
         />
       }

--- a/packages/ui/components/ui/copy-to-clipboard.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard.tsx
@@ -18,7 +18,11 @@ const CopyToClipboard = React.forwardRef<HTMLButtonElement, CopyToClipboardProps
 
     return (
       <Button
-        className={cn(copied && 'cursor-default text-teal-500 hover:no-underline', className)}
+        className={cn(
+          copied && 'cursor-default text-teal-500 hover:no-underline',
+          'block',
+          className,
+        )}
         variant='link'
         ref={ref}
         size='sm'

--- a/packages/ui/components/ui/copy-to-clipboard.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard.tsx
@@ -10,10 +10,11 @@ export interface CopyToClipboardProps extends React.ButtonHTMLAttributes<HTMLBut
   text: string;
   labelType?: 'text' | 'icon';
   label: React.ReactElement;
+  isSuccessCopyText?: boolean;
 }
 
 const CopyToClipboard = React.forwardRef<HTMLButtonElement, CopyToClipboardProps>(
-  ({ text, className, label, ...props }, ref) => {
+  ({ text, className, label, isSuccessCopyText, ...props }, ref) => {
     const [copied, setCopied] = useState(false);
 
     return (
@@ -35,7 +36,14 @@ const CopyToClipboard = React.forwardRef<HTMLButtonElement, CopyToClipboardProps
         }}
         {...props}
       >
-        {copied ? <CheckCircledIcon /> : label}
+        {copied ? (
+          <span className={cn(isSuccessCopyText && 'flex items-center gap-2')}>
+            {isSuccessCopyText && <span>Copied</span>}
+            <CheckCircledIcon />
+          </span>
+        ) : (
+          label
+        )}
       </Button>
     );
   },

--- a/packages/ui/components/ui/copy-to-clipboard.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard.tsx
@@ -10,11 +10,10 @@ export interface CopyToClipboardProps extends React.ButtonHTMLAttributes<HTMLBut
   text: string;
   labelType?: 'text' | 'icon';
   label: React.ReactElement;
-  isSuccessCopyText?: boolean;
 }
 
 const CopyToClipboard = React.forwardRef<HTMLButtonElement, CopyToClipboardProps>(
-  ({ text, className, label, isSuccessCopyText, ...props }, ref) => {
+  ({ text, className, label, ...props }, ref) => {
     const [copied, setCopied] = useState(false);
 
     return (
@@ -32,14 +31,7 @@ const CopyToClipboard = React.forwardRef<HTMLButtonElement, CopyToClipboardProps
         }}
         {...props}
       >
-        {copied ? (
-          <span className={cn(isSuccessCopyText && 'flex items-center gap-2')}>
-            {isSuccessCopyText && <span>Copied</span>}
-            <CheckCircledIcon />
-          </span>
-        ) : (
-          label
-        )}
+        {copied ? <CheckCircledIcon /> : label}
       </Button>
     );
   },

--- a/packages/ui/components/ui/select-account.tsx
+++ b/packages/ui/components/ui/select-account.tsx
@@ -1,4 +1,5 @@
 import { Account } from '@penumbra-zone/types';
+import { AddressIcon } from './address-icon';
 import { ArrowLeftIcon, ArrowRightIcon, InfoIcon } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { CopyToClipboardIconButton } from './copy-to-clipboard-icon-button';
@@ -7,7 +8,6 @@ import { IncognitoIcon } from './icons/incognito';
 import { Input } from './input';
 import { Switch } from './switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
-import { Identicon } from './identicon';
 import { useEffect, useState } from 'react';
 
 interface SelectAccountProps {
@@ -100,7 +100,8 @@ export const SelectAccount = ({ getAccount }: SelectAccountProps) => {
           </div>
           <div className='mt-4 flex items-center justify-between gap-1 break-all rounded-lg border bg-background px-3 py-4'>
             <div className='flex items-center gap-[6px]'>
-              <Identicon name={account.address} className='h-6 w-6 rounded-full' type='gradient' />
+              <AddressIcon address={account.address} size={24} />
+
               <p
                 className={cn(
                   'select-none text-center font-mono text-[12px] leading-[18px] text-muted-foreground',

--- a/packages/ui/components/ui/select-account.tsx
+++ b/packages/ui/components/ui/select-account.tsx
@@ -1,4 +1,5 @@
 import { Account } from '@penumbra-zone/types';
+import { Address } from './address';
 import { AddressIcon } from './address-icon';
 import { ArrowLeftIcon, ArrowRightIcon, InfoIcon } from 'lucide-react';
 import { cn } from '../../lib/utils';
@@ -102,13 +103,8 @@ export const SelectAccount = ({ getAccount }: SelectAccountProps) => {
             <div className='flex items-center gap-[6px]'>
               <AddressIcon address={account.address} size={24} />
 
-              <p
-                className={cn(
-                  'select-none text-center font-mono text-[12px] leading-[18px] text-muted-foreground',
-                  ephemeral && 'text-[#8D5728]',
-                )}
-              >
-                {account.preview}
+              <p>
+                <Address address={account.address} ephemeral={ephemeral} />
               </p>
             </div>
             <CopyToClipboardIconButton text={account.address} />

--- a/packages/ui/components/ui/select-account.tsx
+++ b/packages/ui/components/ui/select-account.tsx
@@ -1,7 +1,7 @@
 import { Account } from '@penumbra-zone/types';
 import { ArrowLeftIcon, ArrowRightIcon, InfoIcon } from 'lucide-react';
 import { cn } from '../../lib/utils';
-import { CopyAddressButton } from './copy-address-button';
+import { CopyToClipboardIconButton } from './copy-to-clipboard-icon-button';
 import { Button } from './button';
 import { IncognitoIcon } from './icons/incognito';
 import { Input } from './input';
@@ -110,7 +110,7 @@ export const SelectAccount = ({ getAccount }: SelectAccountProps) => {
                 {account.preview}
               </p>
             </div>
-            <CopyAddressButton address={account.address} />
+            <CopyToClipboardIconButton text={account.address} />
           </div>
           <div className='mt-2 flex items-center justify-between'>
             <div className='flex items-center gap-2'>

--- a/packages/ui/components/ui/select-account.tsx
+++ b/packages/ui/components/ui/select-account.tsx
@@ -1,14 +1,14 @@
 import { Account } from '@penumbra-zone/types';
-import { ArrowLeftIcon, ArrowRightIcon, CopyIcon, InfoIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { ArrowLeftIcon, ArrowRightIcon, InfoIcon } from 'lucide-react';
 import { cn } from '../../lib/utils';
+import { CopyAddressButton } from './copy-address-button';
 import { Button } from './button';
-import { CopyToClipboard } from './copy-to-clipboard';
 import { IncognitoIcon } from './icons/incognito';
 import { Input } from './input';
 import { Switch } from './switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 import { Identicon } from './identicon';
+import { useEffect, useState } from 'react';
 
 interface SelectAccountProps {
   getAccount: (index: number, ephemeral: boolean) => Promise<Account> | Account | undefined;
@@ -110,15 +110,7 @@ export const SelectAccount = ({ getAccount }: SelectAccountProps) => {
                 {account.preview}
               </p>
             </div>
-            <CopyToClipboard
-              text={account.address}
-              label={
-                <div>
-                  <CopyIcon className='h-4 w-4 text-muted-foreground hover:opacity-50' />
-                </div>
-              }
-              className='w-4'
-            />
+            <CopyAddressButton address={account.address} />
           </div>
           <div className='mt-2 flex items-center justify-between'>
             <div className='flex items-center gap-2'>

--- a/packages/ui/components/ui/tx/view/address-view.test.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.test.tsx
@@ -45,7 +45,7 @@ describe('<AddressViewComponent />', () => {
         <AddressViewComponent view={addressViewWithOneTimeAddress} copyable />,
       );
 
-      expect(queryByTestId('AddressView__CopyIcon')).toBeNull();
+      expect(queryByTestId('CopyToClipboardIconButton__icon')).toBeNull();
     });
 
     test('shows the copy icon when the address is not a one-time address', () => {
@@ -53,7 +53,7 @@ describe('<AddressViewComponent />', () => {
         <AddressViewComponent view={addressViewWithNormalAddress} copyable />,
       );
 
-      expect(queryByTestId('AddressView__CopyIcon')).not.toBeNull();
+      expect(queryByTestId('CopyToClipboardIconButton__icon')).not.toBeNull();
     });
   });
 
@@ -63,7 +63,7 @@ describe('<AddressViewComponent />', () => {
         <AddressViewComponent view={addressViewWithOneTimeAddress} copyable={false} />,
       );
 
-      expect(queryByTestId('AddressView__CopyIcon')).toBeNull();
+      expect(queryByTestId('CopyToClipboardIconButton__icon')).toBeNull();
     });
 
     test('does not show the copy icon when the address is not a one-time address', () => {
@@ -71,7 +71,7 @@ describe('<AddressViewComponent />', () => {
         <AddressViewComponent view={addressViewWithNormalAddress} copyable={false} />,
       );
 
-      expect(queryByTestId('AddressView__CopyIcon')).toBeNull();
+      expect(queryByTestId('CopyToClipboardIconButton__icon')).toBeNull();
     });
   });
 });

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -7,20 +7,15 @@ import { Identicon } from '../../identicon';
 interface AddressViewProps {
   view: AddressView | undefined;
   copyable?: boolean;
-  short_form?: boolean;
 }
 
 // Renders an address or an address view.
 // If the view is given and is "visible", the account information will be displayed instead.
-export const AddressViewComponent = ({
-  view,
-  copyable = true,
-  short_form = true,
-}: AddressViewProps) => {
+export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps) => {
   if (!view?.addressView.value?.address) return <></>;
 
   const encoded = bech32Address(view.addressView.value.address);
-  const display = short_form ? shortenAddress(encoded) : encoded;
+  const display = shortenAddress(encoded);
 
   const accountIndex =
     view.addressView.case === 'visible' ? view.addressView.value.index?.account : undefined;

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -26,25 +26,21 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
   copyable = isOneTimeAddress ? false : copyable;
 
   return (
-    <div className='flex'>
+    <div className='flex items-center gap-2'>
       {accountIndex !== undefined ? (
-        <div className='flex items-baseline gap-2'>
+        <>
           <Identicon name={encoded} size={14} className='rounded-full' type='gradient' />
           {isOneTimeAddress ? (
             <span className='font-bold'>One-time Address for Account #{accountIndex}</span>
           ) : (
             <span className='font-bold'>Account #{accountIndex}</span>
           )}
-        </div>
+        </>
       ) : (
         <div className='font-mono text-sm italic text-foreground'>{display}</div>
       )}
 
-      {copyable && (
-        <div className='pl-2'>
-          <CopyToClipboardIconButton text={encoded} />
-        </div>
-      )}
+      {copyable && <CopyToClipboardIconButton text={encoded} />}
     </div>
   );
 };

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -23,6 +23,8 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
       ? !view.addressView.value.index?.randomizer.every(v => v === 0) // Randomized (and thus, a one-time address) if the randomizer is not all zeros.
       : undefined;
 
+  const addressIndexLabel = isOneTimeAddress ? 'One-time Address for Account #' : 'Account #';
+
   copyable = isOneTimeAddress ? false : copyable;
 
   return (
@@ -31,11 +33,10 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
         <>
           <AddressIcon address={encoded} size={14} />
 
-          {isOneTimeAddress ? (
-            <span className='font-bold'>One-time Address for Account #{accountIndex}</span>
-          ) : (
-            <span className='font-bold'>Account #{accountIndex}</span>
-          )}
+          <span className='font-bold'>
+            {addressIndexLabel}
+            {accountIndex}
+          </span>
         </>
       ) : (
         <div className='font-mono text-sm italic text-foreground'>{display}</div>

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -1,7 +1,7 @@
+import { AddressIcon } from '../../address-icon';
 import { AddressView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1alpha1/keys_pb';
 import { bech32Address, shortenAddress } from '@penumbra-zone/types';
 import { CopyToClipboardIconButton } from '../../copy-to-clipboard-icon-button';
-import { Identicon } from '../../identicon';
 
 interface AddressViewProps {
   view: AddressView | undefined;
@@ -29,7 +29,8 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
     <div className='flex items-center gap-2'>
       {accountIndex !== undefined ? (
         <>
-          <Identicon name={encoded} size={14} className='rounded-full' type='gradient' />
+          <AddressIcon address={encoded} size={14} />
+
           {isOneTimeAddress ? (
             <span className='font-bold'>One-time Address for Account #{accountIndex}</span>
           ) : (

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -1,7 +1,6 @@
 import { AddressView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1alpha1/keys_pb';
 import { bech32Address, shortenAddress } from '@penumbra-zone/types';
-import { CopyIcon } from '@radix-ui/react-icons';
-import { CopyToClipboard } from '../../copy-to-clipboard';
+import { CopyToClipboardIconButton } from '../../copy-to-clipboard-icon-button';
 import { Identicon } from '../../identicon';
 
 interface AddressViewProps {
@@ -40,16 +39,11 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
       ) : (
         <div className='font-mono text-sm italic text-foreground'>{display}</div>
       )}
+
       {copyable && (
-        <CopyToClipboard
-          text={encoded}
-          label={
-            <div data-testid='AddressView__CopyIcon'>
-              <CopyIcon className='h-4 w-4 text-muted-foreground hover:opacity-50' />
-            </div>
-          }
-          className='w-4 px-4'
-        />
+        <div className='pl-2'>
+          <CopyToClipboardIconButton text={encoded} />
+        </div>
       )}
     </div>
   );

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -1,6 +1,7 @@
+import { Address } from '../../address';
 import { AddressIcon } from '../../address-icon';
 import { AddressView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1alpha1/keys_pb';
-import { bech32Address, shortenAddress } from '@penumbra-zone/types';
+import { bech32Address } from '@penumbra-zone/types';
 import { CopyToClipboardIconButton } from '../../copy-to-clipboard-icon-button';
 
 interface AddressViewProps {
@@ -13,8 +14,7 @@ interface AddressViewProps {
 export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps) => {
   if (!view?.addressView.value?.address) return <></>;
 
-  const encoded = bech32Address(view.addressView.value.address);
-  const display = shortenAddress(encoded);
+  const encodedAddress = bech32Address(view.addressView.value.address);
 
   const accountIndex =
     view.addressView.case === 'visible' ? view.addressView.value.index?.account : undefined;
@@ -31,7 +31,7 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
     <div className='flex items-center gap-2'>
       {accountIndex !== undefined ? (
         <>
-          <AddressIcon address={encoded} size={14} />
+          <AddressIcon address={encodedAddress} size={14} />
 
           <span className='font-bold'>
             {addressIndexLabel}
@@ -39,10 +39,10 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
           </span>
         </>
       ) : (
-        <div className='font-mono text-sm italic text-foreground'>{display}</div>
+        <Address address={encodedAddress} />
       )}
 
-      {copyable && <CopyToClipboardIconButton text={encoded} />}
+      {copyable && <CopyToClipboardIconButton text={encodedAddress} />}
     </div>
   );
 };

--- a/packages/ui/components/ui/tx/view/output.tsx
+++ b/packages/ui/components/ui/tx/view/output.tsx
@@ -10,9 +10,9 @@ export const OutputViewComponent = ({ value }: { value: OutputView }) => {
       <ViewBox
         label='Output'
         visibleContent={
-          <div className='flex items-baseline justify-between md:flex-col lg:flex-row'>
+          <div className='flex justify-between md:flex-col lg:flex-row'>
             <ValueViewComponent view={note.value} />
-            <div className='flex items-baseline gap-2'>
+            <div className='flex gap-2'>
               <span className='font-mono text-sm italic text-foreground'>to</span>
               <AddressViewComponent view={note.address} />
             </div>

--- a/packages/ui/components/ui/tx/view/spend.tsx
+++ b/packages/ui/components/ui/tx/view/spend.tsx
@@ -10,9 +10,9 @@ export const SpendViewComponent = ({ value }: { value: SpendView }) => {
       <ViewBox
         label='Spend'
         visibleContent={
-          <div className='flex items-baseline justify-between'>
+          <div className='flex justify-between'>
             <ValueViewComponent view={note.value} />
-            <div className='flex items-baseline gap-2'>
+            <div className='flex gap-2'>
               <span className='font-mono text-sm italic text-foreground'>from</span>
               <AddressViewComponent view={note.address} />
             </div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.7",
+    "@testing-library/jest-dom": "^6.2.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "djb2a": "^2.0.0",

--- a/packages/ui/tests-setup.ts
+++ b/packages/ui/tests-setup.ts
@@ -1,6 +1,8 @@
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
+import '@testing-library/jest-dom/vitest';
+
 afterEach(() => {
   // Clear anything rendered by jsdom. (Without this, previous tests can leave
   // React nodes in the DOM, which can interfere with subsequent tests.)

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "tsconfig/react-library.json",
-  "include": ["."],
+  "include": [".", "./tests-setup.ts"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    setupFiles: ['./tests-setup.js'],
+    setupFiles: ['./tests-setup.ts'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,6 +694,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.0.7
         version: 1.0.7(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@testing-library/jest-dom':
+        specifier: ^6.2.0
+        version: 6.2.0(vitest@0.34.6)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -822,6 +825,10 @@ packages:
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  /@adobe/css-tools@4.3.2:
+    resolution: {integrity: sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==}
+    dev: false
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1547,7 +1554,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.19.9:
@@ -1564,7 +1570,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.19.9:
@@ -1581,7 +1586,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.19.9:
@@ -1598,7 +1602,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.19.9:
@@ -1615,7 +1618,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.9:
@@ -1632,7 +1634,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.9:
@@ -1649,7 +1650,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.9:
@@ -1666,7 +1666,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.19.9:
@@ -1683,7 +1682,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.19.9:
@@ -1700,7 +1698,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.19.9:
@@ -1717,7 +1714,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.9:
@@ -1734,7 +1730,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.19.9:
@@ -1751,7 +1746,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.9:
@@ -1768,7 +1762,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.19.9:
@@ -1785,7 +1778,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.9:
@@ -1802,7 +1794,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.19.9:
@@ -1819,7 +1810,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.9:
@@ -1836,7 +1826,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.19.9:
@@ -1853,7 +1842,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.9:
@@ -1870,7 +1858,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.19.9:
@@ -1887,7 +1874,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.19.9:
@@ -1904,7 +1890,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.19.9:
@@ -2079,7 +2064,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.27.8
-    dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -2133,7 +2117,6 @@ packages:
 
   /@jspm/core@2.0.1:
     resolution: {integrity: sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==}
-    dev: true
 
   /@next/env@14.0.4:
     resolution: {integrity: sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==}
@@ -2321,7 +2304,6 @@ packages:
 
   /@polka/url@1.0.0-next.24:
     resolution: {integrity: sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==}
-    dev: true
 
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3169,7 +3151,6 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    dev: true
 
   /@rollup/rollup-android-arm-eabi@4.8.0:
     resolution: {integrity: sha512-zdTObFRoNENrdPpnTNnhOljYIcOX7aI7+7wyrSpPFFIOf/nRdedE6IYsjaBE7tjukphh1tMTojgJ7p3lKY8x6Q==}
@@ -3268,7 +3249,6 @@ packages:
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
-    dev: true
 
   /@swc/core-darwin-arm64@1.3.100:
     resolution: {integrity: sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==}
@@ -3416,6 +3396,35 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@testing-library/jest-dom@6.2.0(vitest@0.34.6):
+    resolution: {integrity: sha512-+BVQlJ9cmEn5RDMUS8c2+TU6giLvzaHZ8sU/x0Jj7fk+6/46wPdwlgOPcpxS17CjcanBi/3VmGMqVr2rmbUmNw==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@jest/globals': '>= 28'
+      '@types/jest': '>= 28'
+      jest: '>= 28'
+      vitest: '>= 0.32'
+    peerDependenciesMeta:
+      '@jest/globals':
+        optional: true
+      '@types/jest':
+        optional: true
+      jest:
+        optional: true
+      vitest:
+        optional: true
+    dependencies:
+      '@adobe/css-tools': 4.3.2
+      '@babel/runtime': 7.23.6
+      aria-query: 5.3.0
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+    dev: false
+
   /@testing-library/react@14.1.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==}
     engines: {node: '>=14'}
@@ -3499,11 +3508,9 @@ packages:
     resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
     dependencies:
       '@types/chai': 4.3.11
-    dev: true
 
   /@types/chai@4.3.11:
     resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
-    dev: true
 
   /@types/chrome@0.0.254:
     resolution: {integrity: sha512-svkOGKwA+6ZZuk9xtrYun8MYpNY/9hD17rgZ19v3KunhsK1ZOKaMESw12/1AXLh1u3UPA8jQIRi2370DXv9wgw==}
@@ -3537,7 +3544,6 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-    dev: true
 
   /@types/filesystem@0.0.35:
     resolution: {integrity: sha512-1eKvCaIBdrD2mmMgy5dwh564rVvfEhZTWVQQGRNn0Nt4ZEnJ0C8oSUCzvMKRA4lGde5oEVo+q2MrTTbV/GHDCQ==}
@@ -3812,7 +3818,6 @@ packages:
     transitivePeerDependencies:
       - esbuild
       - rollup
-    dev: true
 
   /@vitest/expect@0.34.6:
     resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
@@ -3820,7 +3825,6 @@ packages:
       '@vitest/spy': 0.34.6
       '@vitest/utils': 0.34.6
       chai: 4.3.10
-    dev: true
 
   /@vitest/runner@0.34.6:
     resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
@@ -3828,7 +3832,6 @@ packages:
       '@vitest/utils': 0.34.6
       p-limit: 4.0.0
       pathe: 1.1.1
-    dev: true
 
   /@vitest/snapshot@0.34.6:
     resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
@@ -3836,13 +3839,11 @@ packages:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
-    dev: true
 
   /@vitest/spy@0.34.6:
     resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
     dependencies:
       tinyspy: 2.2.0
-    dev: true
 
   /@vitest/utils@0.34.6:
     resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
@@ -3850,7 +3851,6 @@ packages:
       diff-sequences: 29.6.3
       loupe: 2.3.7
       pretty-format: 29.7.0
-    dev: true
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -4043,7 +4043,6 @@ packages:
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
@@ -4066,7 +4065,6 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -4168,7 +4166,6 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-    dev: true
 
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -4369,7 +4366,6 @@ packages:
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-    dev: true
 
   /ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -4404,7 +4400,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /autoprefixer@10.4.16(postcss@8.4.32):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
@@ -4640,7 +4635,6 @@ packages:
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /cacache@18.0.1:
     resolution: {integrity: sha512-g4Uf2CFZPaxtJKre6qr4zqLDOOPU7bNVhWjlNhvzc51xaTOx2noMOLhfFkTAqwtrAZAKQUuDfyjitzilpA8WsQ==}
@@ -4726,7 +4720,6 @@ packages:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
-    dev: true
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -4742,7 +4735,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4787,7 +4779,6 @@ packages:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
     dependencies:
       get-func-name: 2.0.2
-    dev: true
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -4960,7 +4951,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -5213,6 +5203,10 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
+  /css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: false
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -5223,7 +5217,6 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       rrweb-cssom: 0.6.0
-    dev: true
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -5252,7 +5245,6 @@ packages:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-    dev: true
 
   /debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -5305,14 +5297,12 @@ packages:
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
-    dev: true
 
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
     dependencies:
       type-detect: 4.0.8
-    dev: true
 
   /deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -5398,7 +5388,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -5425,7 +5414,6 @@ packages:
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -5462,6 +5450,10 @@ packages:
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
+
+  /dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+    dev: false
 
   /dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
@@ -5554,7 +5546,6 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-    dev: true
 
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -5715,7 +5706,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-    dev: true
 
   /esbuild@0.19.9:
     resolution: {integrity: sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==}
@@ -6146,13 +6136,11 @@ packages:
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
       '@types/estree': 1.0.5
-    dev: true
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -6557,7 +6545,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -6644,7 +6631,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /fsevents@2.3.3:
@@ -6731,7 +6717,6 @@ packages:
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-    dev: true
 
   /get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
@@ -7121,7 +7106,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       whatwg-encoding: 3.1.1
-    dev: true
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -7148,7 +7132,6 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -7168,7 +7151,6 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -7188,7 +7170,6 @@ packages:
     requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /icss-utils@5.1.0(postcss@8.4.32):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -7243,7 +7224,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
     requiresBuild: true
-    dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -7517,7 +7497,6 @@ packages:
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-    dev: true
 
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -7778,7 +7757,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -7834,7 +7812,6 @@ packages:
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: true
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -7999,7 +7976,6 @@ packages:
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
-    dev: true
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -8135,7 +8111,6 @@ packages:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
     dependencies:
       get-func-name: 2.0.2
-    dev: true
 
   /lower-case-first@1.0.2:
     resolution: {integrity: sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==}
@@ -8189,7 +8164,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -8301,14 +8275,12 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -8326,6 +8298,11 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
+
+  /min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+    dev: false
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -8452,7 +8429,6 @@ packages:
       pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.3.2
-    dev: true
 
   /modern-node-polyfills@1.0.0(esbuild@0.18.20):
     resolution: {integrity: sha512-w1yb6ae5qSUJJ2u41krkUAxs+L7i9143Qam8EuXwDMeZHxl1JN8RfTSXG4S2bt0RHIRMeoWm/HCeO0pNIHmIYQ==}
@@ -8466,7 +8442,6 @@ packages:
       local-pkg: 0.4.3
     transitivePeerDependencies:
       - rollup
-    dev: true
 
   /morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
@@ -8484,7 +8459,6 @@ packages:
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
     engines: {node: '>=10'}
-    dev: true
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -8690,7 +8664,6 @@ packages:
 
   /nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
-    dev: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -8897,7 +8870,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       yocto-queue: 1.0.0
-    dev: true
 
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -8984,7 +8956,6 @@ packages:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
       entities: 4.5.0
-    dev: true
 
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -9050,11 +9021,9 @@ packages:
 
   /pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
-    dev: true
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
-    dev: true
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -9084,13 +9053,11 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.4.2
       pathe: 1.1.1
-    dev: true
 
   /playwright-core@1.40.1:
     resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
     engines: {node: '>=16'}
     hasBin: true
-    dev: true
 
   /playwright@1.40.1:
     resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
@@ -9100,7 +9067,6 @@ packages:
       playwright-core: 1.40.1
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
@@ -9273,7 +9239,6 @@ packages:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
-    dev: true
 
   /proc-log@3.0.0:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
@@ -9399,7 +9364,6 @@ packages:
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
-    dev: true
 
   /pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
@@ -9443,7 +9407,6 @@ packages:
 
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-    dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9741,6 +9704,14 @@ packages:
       resolve: 1.22.8
     dev: true
 
+  /redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+    dev: false
+
   /redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
     dependencies:
@@ -9810,7 +9781,6 @@ packages:
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-    dev: true
 
   /requizzle@0.2.4:
     resolution: {integrity: sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==}
@@ -9931,7 +9901,6 @@ packages:
 
   /rrweb-cssom@0.6.0:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
-    dev: true
 
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -9989,14 +9958,12 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
     dependencies:
       xmlchars: 2.2.0
-    dev: true
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -10158,7 +10125,6 @@ packages:
 
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-    dev: true
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -10184,7 +10150,6 @@ packages:
       '@polka/url': 1.0.0-next.24
       mrmime: 1.0.1
       totalist: 3.0.1
-    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -10266,7 +10231,6 @@ packages:
 
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-    dev: true
 
   /statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -10280,7 +10244,6 @@ packages:
 
   /std-env@3.6.0:
     resolution: {integrity: sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==}
-    dev: true
 
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
@@ -10405,6 +10368,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      min-indent: 1.0.1
+    dev: false
+
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -10418,7 +10388,6 @@ packages:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
       acorn: 8.11.2
-    dev: true
 
   /style-loader@3.3.3(webpack@5.89.0):
     resolution: {integrity: sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==}
@@ -10558,7 +10527,6 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-    dev: true
 
   /tailwind-merge@2.1.0:
     resolution: {integrity: sha512-l11VvI4nSwW7MtLSLYT4ldidDEUwQAMWuSHk7l4zcXZDgnCRa0V3OdCwFfM7DCzakVXMNRwAeje9maFFXT71dQ==}
@@ -10699,7 +10667,6 @@ packages:
 
   /tinybench@2.5.1:
     resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
-    dev: true
 
   /tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
@@ -10714,12 +10681,10 @@ packages:
   /tinypool@0.7.0:
     resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
-    dev: true
 
   /tinyspy@2.2.0:
     resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
     engines: {node: '>=14.0.0'}
-    dev: true
 
   /title-case@2.1.1:
     resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
@@ -10760,7 +10725,6 @@ packages:
   /totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /tough-cookie@4.1.3:
     resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
@@ -10770,7 +10734,6 @@ packages:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
-    dev: true
 
   /toxic@1.0.1:
     resolution: {integrity: sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==}
@@ -10786,7 +10749,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       punycode: 2.3.1
-    dev: true
 
   /triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
@@ -10954,7 +10916,6 @@ packages:
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
-    dev: true
 
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -11037,7 +10998,6 @@ packages:
 
   /ufo@1.3.2:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
-    dev: true
 
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
@@ -11104,7 +11064,6 @@ packages:
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
-    dev: true
 
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -11181,7 +11140,6 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-    dev: true
 
   /use-callback-ref@1.3.0(@types/react@18.2.43)(react@18.2.0):
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
@@ -11321,7 +11279,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
   /vite@5.0.7(@types/node@20.10.4):
     resolution: {integrity: sha512-B4T4rJCDPihrQo2B+h1MbeGL/k/GMAHzhQ8S0LjQ142s6/+l3hHTT095ORvsshj4QCkoWu3Xtmob5mazvakaOw==}
@@ -11424,14 +11381,12 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
   /w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
     dependencies:
       xml-name-validator: 5.0.0
-    dev: true
 
   /watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
@@ -11457,7 +11412,6 @@ packages:
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
-    dev: true
 
   /webpack-cli@5.1.4(webpack@5.89.0):
     resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
@@ -11552,7 +11506,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       iconv-lite: 0.6.3
-    dev: true
 
   /whatwg-fetch@3.6.19:
     resolution: {integrity: sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw==}
@@ -11561,7 +11514,6 @@ packages:
   /whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
-    dev: true
 
   /whatwg-url@14.0.0:
     resolution: {integrity: sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==}
@@ -11569,7 +11521,6 @@ packages:
     dependencies:
       tr46: 5.0.0
       webidl-conversions: 7.0.0
-    dev: true
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -11653,7 +11604,6 @@ packages:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-    dev: true
 
   /widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
@@ -11766,7 +11716,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
@@ -11776,11 +11725,9 @@ packages:
   /xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
-    dev: true
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: true
 
   /xmlcreate@2.0.4:
     resolution: {integrity: sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==}
@@ -11832,7 +11779,6 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-    dev: true
 
   /zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}


### PR DESCRIPTION
Well, this turned out to be surprisingly annoying.

In short: the idea was to consolidate the display of addresses throughout the UIs and use the `AddressViewComponent`.

However, that didn't work in practice, since that component is designed to render [an `AddressView` object](https://github.com/penumbra-zone/penumbra/blob/main/crates/core/keys/src/address/view.rs) which, once translated into JavaScript, contains properties that need to be [corralled into human-readable values](https://github.com/penumbra-zone/web/blob/jessepinho/web-217-standardize-address-component/packages/ui/components/ui/tx/view/address-view.tsx#L16-L17). The problem is, we render addresses in places where we don't have an `AddressView` object, but rather just an address string. Further complicating matters is the fact that they aren't all designed the same way: in some places, we show "Account #N" and a copy button; in others, we just show the address itself.

So I went through the various places where we render addresses, and extracted out components that they share:
- `<AddressIcon />` renders a consistently styled icon for a given address, so that we don't need to pass the same classes and props to `<Identicon />` everywhere that we render an address.
- `<Address />` renders an address, shortened to the prefix + 24 characters and styled consistently throughout the app.
- `<CopyToClipboardIconButton />` wraps `<CopyToClipboard />` and passes it the copy icon.*

I then used these new components in the various places where there was previously duplicative code. We should use these going forward whenever we need to display these different items. That said, the original goal of #217 was probably not really possible, since the designs of the various places where we render addresses are so different.

\* Weirdly, the linter complained about the `text-muted-foreground` class we were using for that icon — but only when it's inside this component! I don't get why it's only breaking things in this component and not elsewhere that it's used. But it seemed like a minor design thing anyway, so I removed that class to get the linter to pass. If anyone has ideas on how to fix this, I'm all 👂🏻s.

Closes #217 