### PR TITLE
Fix asset paths

### DIFF
--- a/apps/webapp/index.html
+++ b/apps/webapp/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link href="/favicon.png" rel="icon" sizes="80x80" type="image/png" />
+    <link href="./favicon.png" rel="icon" sizes="80x80" type="image/png" />
   </head>
   <body>
     <div id="root"></div>
-    <script src="/src/main.tsx" type="module"></script>
+    <script src="./src/main.tsx" type="module"></script>
   </body>
 </html>

--- a/apps/webapp/src/components/dashboard/constants.ts
+++ b/apps/webapp/src/components/dashboard/constants.ts
@@ -10,17 +10,17 @@ export const dashboardTabs = [
 
 export const dashboardTabsHelper: DashboardTabMap = {
   [PagePath.DASHBOARD]: {
-    src: '/funds-gradient.svg',
+    src: './funds-gradient.svg',
     label: 'Asset Balances',
     content: EduPanel.ASSETS,
   },
   [PagePath.TRANSACTIONS]: {
-    src: '/receive-gradient.svg',
+    src: './receive-gradient.svg',
     label: 'Transaction history',
     content: EduPanel.TRANSACTIONS_LIST,
   },
   [PagePath.NFTS]: {
-    src: '/ibc-gradient.svg',
+    src: './ibc-gradient.svg',
     label: 'NFTs history',
     content: EduPanel.TEMP_FILLER,
   },

--- a/apps/webapp/src/components/dashboard/transaction-table.tsx
+++ b/apps/webapp/src/components/dashboard/transaction-table.tsx
@@ -50,7 +50,7 @@ export default function TransactionTable() {
               <TableCell>
                 <Link to={`/tx/${tx.hash}`}>
                   <img
-                    src='/more.svg'
+                    src='./more.svg'
                     className='h-4 w-4 cursor-pointer hover:opacity-50'
                     alt='More'
                   />

--- a/apps/webapp/src/components/header/block-sync.tsx
+++ b/apps/webapp/src/components/header/block-sync.tsx
@@ -20,7 +20,7 @@ export const BlockSync = ({ data }: BlockSyncProps) => {
             <>
               <div className='flex items-center justify-between text-base text-sand'>
                 <div className='flex items-center gap-2'>
-                  <img src='/sync-bold.svg' alt='Syncing blocks...' className='h-6 w-6' />
+                  <img src='./sync-bold.svg' alt='Syncing blocks...' className='h-6 w-6' />
                   <p className='font-headline font-semibold'>Syncing blocks...</p>
                 </div>
                 <p className='font-mono'>

--- a/apps/webapp/src/components/header/header.tsx
+++ b/apps/webapp/src/components/header/header.tsx
@@ -26,13 +26,13 @@ export const Header = () => {
     <header className='z-10 flex w-full flex-col items-center justify-between px-6 md:h-[82px] md:flex-row md:gap-12 md:px-12'>
       <div className='mb-[30px] md:mb-0'>
         <img
-          src='/penumbra-logo.svg'
+          src='./penumbra-logo.svg'
           alt='Penumbra logo'
           className='absolute inset-x-0 top-[-75px] mx-auto h-[141px] w-[136px] rotate-[320deg] md:left-[-100px] md:top-[-140px] md:mx-0 md:h-[234px] md:w-[234px]'
         />
         <Link to={PagePath.INDEX}>
           <img
-            src='/logo.svg'
+            src='./logo.svg'
             alt='Penumbra logo'
             className='relative z-10 mt-[20px] h-4 w-[171px] md:mt-0'
           />

--- a/apps/webapp/src/components/header/notifications.tsx
+++ b/apps/webapp/src/components/header/notifications.tsx
@@ -33,7 +33,7 @@ export default function Notifications() {
               <div className='absolute right-[2px] top-[5px] z-10 h-[11px] w-[11px] rounded-full bg-red'></div>
             ) : (
               <img
-                src='/sync-bold.svg'
+                src='./sync-bold.svg'
                 alt='Syncing blocks...'
                 className='absolute right-[2px] top-[5px] z-10 h-[15px] w-[15px]'
               />

--- a/apps/webapp/src/components/send/constants.ts
+++ b/apps/webapp/src/components/send/constants.ts
@@ -4,17 +4,17 @@ import { EduPanel } from '../shared/edu-panels/content.ts';
 
 export const sendTabsHelper: SendTabMap = {
   [PagePath.SEND]: {
-    src: '/funds-gradient.svg',
+    src: './funds-gradient.svg',
     label: 'Sending Funds',
     content: EduPanel.SENDING_FUNDS,
   },
   [PagePath.RECEIVE]: {
-    src: '/receive-gradient.svg',
+    src: './receive-gradient.svg',
     label: 'Receiving Funds',
     content: EduPanel.RECEIVING_FUNDS,
   },
   [PagePath.IBC]: {
-    src: '/ibc-gradient.svg',
+    src: './ibc-gradient.svg',
     label: 'IBC withdraw',
     content: EduPanel.IBC_WITHDRAW,
   },

--- a/apps/webapp/src/components/shared/input-token.tsx
+++ b/apps/webapp/src/components/shared/input-token.tsx
@@ -76,7 +76,7 @@ export default function InputToken({
           ${displayAmount(Number(value) * tempPrice)}
         </p>
         <div className='flex items-start gap-1'>
-          <img src='/wallet.svg' alt='Wallet' className='h-5 w-5' />
+          <img src='./wallet.svg' alt='Wallet' className='h-5 w-5' />
           <p className='font-bold text-muted-foreground'>
             {selection?.asset
               ? fromBaseUnitAmount(

--- a/apps/webapp/src/components/tx-details/index.tsx
+++ b/apps/webapp/src/components/tx-details/index.tsx
@@ -48,7 +48,7 @@ export const TxDetails = () => {
         </Card>
         <EduInfoCard
           className='row-span-1'
-          src='/incognito.svg'
+          src='./incognito.svg'
           label='Shielded Transactions'
           content={EduPanel.SHIELDED_TRANSACTION}
         />

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 });

--- a/packages/constants/assets.ts
+++ b/packages/constants/assets.ts
@@ -41,7 +41,8 @@ export const assets: Asset[] = [
     symbol: '',
     uri: '',
     uriHash: '',
-    icon: '/favicon.png',
+    /** @todo: Figure out a better long-term URL for this. */
+    icon: 'https://raw.githubusercontent.com/penumbra-zone/web/main/apps/webapp/public/favicon.png',
     penumbraAssetId: {
       inner: 'KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=',
       altBaseDenom: '',


### PR DESCRIPTION
Pairing with @turbocrime on fixing references to various assets. This allows us to serve the Penumbra web app from a subdirectory.

To test:

1. `cd apps/webapp`
2. `pnpm build`
3. `python3 -m http.server`
4. Navigate to http://127.0.0.1:8000/dist
5. Verify that all CSS, images, etc. load as expected, even though we're serving under a `/dist` subdirectory
6. Quit the python server
7. `cd dist`
8. `python3 -m http.server`
9. Navigate to http://127.0.0.1:8000/
10. Verify that all CSS, images, etc. load as expected, now that we're serving from the root directory