### PR TITLE
Disable flaky tests

### DIFF
--- a/packages/crypto/browser.config.ts
+++ b/packages/crypto/browser.config.ts
@@ -3,7 +3,12 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    include: ['**/encryption.test.ts', '**/sha256.test.ts'],
+    include: ['**/sha256.test.ts'],
+    /**
+     * @todo: Get the below tests to pass reliably in CI, then uncomment them.
+     * @see https://github.com/penumbra-zone/web/issues/379
+     */
+    // include: ['**/encryption.test.ts', '**/sha256.test.ts'],
     browser: {
       name: 'chromium',
       provider: 'playwright',


### PR DESCRIPTION
In #379, I've documented that we're getting flaky build failures due to something about the `packages/crypto/src/encryption.test.ts` test suite. 

I've tried fixing it to no avail (so far); per @hdevalence, we should just temporarily disable that test suite so that other development efforts aren't blocked. So this PR disables that test suite for now.