### PR TITLE
Update Vite/Vitest

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -57,7 +57,7 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vitest": "^0.34.6",
+    "vitest": "^1.2.1",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
     "webpack-merge": "^5.10.0"

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -44,7 +44,6 @@
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "autoprefixer": "^10.4.16",
-    "buffer": "^6.0.3",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",
     "eslint-config-custom": "workspace:*",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -56,7 +56,7 @@
     "tsconfig": "workspace:*",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.11",
+    "vite": "^5.0.12",
     "vitest": "^1.2.1",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
     "@penumbra-zone/constants": "workspace:*",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -24,6 +24,7 @@
     "@penumbra-zone/ui": "workspace:*",
     "@penumbra-zone/wasm-ts": "workspace:*",
     "@tanstack/react-query": "^5.17.3",
+    "buffer": "^6.0.3",
     "exponential-backoff": "^3.1.1",
     "framer-motion": "^10.17.9",
     "immer": "^10.0.3",

--- a/apps/extension/webpack/webpack.common.js
+++ b/apps/extension/webpack/webpack.common.js
@@ -69,9 +69,6 @@ module.exports = {
     },
   },
   plugins: [
-    new webpack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-    }),
     new CopyPlugin({
       patterns: [{ from: '.', to: '../', context: 'public' }],
       options: {},

--- a/apps/extension/webpack/webpack.common.js
+++ b/apps/extension/webpack/webpack.common.js
@@ -69,6 +69,9 @@ module.exports = {
     },
   },
   plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
     new CopyPlugin({
       patterns: [{ from: '.', to: '../', context: 'public' }],
       options: {},

--- a/apps/extension/webpack/webpack.common.js
+++ b/apps/extension/webpack/webpack.common.js
@@ -70,6 +70,7 @@ module.exports = {
   },
   plugins: [
     new webpack.ProvidePlugin({
+      // Required by the `bip39` library
       Buffer: ['buffer', 'Buffer'],
     }),
     new CopyPlugin({

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -46,6 +46,6 @@
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vitest": "^0.34.6"
+    "vitest": "^1.2.1"
   }
 }

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -45,7 +45,7 @@
     "postcss": "^8.4.33",
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
-    "vite": "^5.0.11",
+    "vite": "^5.0.12",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/crypto/browser.config.ts
+++ b/packages/crypto/browser.config.ts
@@ -3,12 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    include: ['**/sha256.test.ts'],
-    /**
-     * @todo: Get the below tests to pass reliably in CI, then uncomment them.
-     * @see https://github.com/penumbra-zone/web/issues/379
-     */
-    // include: ['**/encryption.test.ts', '**/sha256.test.ts'],
+    include: ['**/encryption.test.ts', '**/sha256.test.ts'],
     browser: {
       name: 'chromium',
       provider: 'playwright',

--- a/packages/crypto/browser.config.ts
+++ b/packages/crypto/browser.config.ts
@@ -2,11 +2,6 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      buffer: 'Buffer',
-    },
-  },
   test: {
     include: ['**/sha256.test.ts'],
     /**

--- a/packages/crypto/browser.config.ts
+++ b/packages/crypto/browser.config.ts
@@ -2,6 +2,11 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      buffer: 'Buffer',
+    },
+  },
   test: {
     include: ['**/sha256.test.ts'],
     /**

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -20,8 +20,8 @@
     "@penumbra-zone/types": "workspace:*",
     "@types/crypto-js": "^4.2.1",
     "@types/lodash": "^4.14.202",
-    "@vitest/browser": "^0.34.6",
+    "@vitest/browser": "^1.2.1",
     "vite": "^5.0.11",
-    "vitest": "^0.34.6"
+    "vitest": "^1.2.1"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,6 +21,7 @@
     "@types/crypto-js": "^4.2.1",
     "@types/lodash": "^4.14.202",
     "@vitest/browser": "^1.2.1",
+    "buffer": "^6.0.3",
     "vite": "^5.0.12",
     "vitest": "^1.2.1"
   }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,7 +21,6 @@
     "@types/crypto-js": "^4.2.1",
     "@types/lodash": "^4.14.202",
     "@vitest/browser": "^1.2.1",
-    "buffer": "^6.0.3",
     "vite": "^5.0.12",
     "vitest": "^1.2.1"
   }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,7 +21,7 @@
     "@types/crypto-js": "^4.2.1",
     "@types/lodash": "^4.14.202",
     "@vitest/browser": "^1.2.1",
-    "vite": "^5.0.11",
+    "vite": "^5.0.12",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint \"**/*.ts*\""
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
     "@penumbra-zone/crypto-web": "workspace:^",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -26,6 +26,6 @@
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vitest": "^0.34.6"
+    "vitest": "^1.2.1"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -25,7 +25,7 @@
     "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
-    "vite": "^5.0.11",
+    "vite": "^5.0.12",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
     "@penumbra-zone/constants": "workspace:*",

--- a/packages/storage/browser.config.ts
+++ b/packages/storage/browser.config.ts
@@ -2,6 +2,11 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      buffer: 'Buffer',
+    },
+  },
   test: {
     include: ['**/indexed-db.test.ts'],
     browser: {

--- a/packages/storage/browser.config.ts
+++ b/packages/storage/browser.config.ts
@@ -2,11 +2,6 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      buffer: 'Buffer',
-    },
-  },
   test: {
     include: ['**/indexed-db.test.ts'],
     browser: {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -17,7 +17,7 @@
     "idb": "^8.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
-    "vite": "^5.0.11"
+    "vite": "^5.0.12"
   },
   "devDependencies": {
     "@types/chrome": "0.0.256",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/chrome": "0.0.256",
-    "vitest": "^0.34.6"
+    "@vitest/browser": "^1.2.1",
+    "vitest": "^1.2.1"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/chrome": "0.0.256",
     "@vitest/browser": "^1.2.1",
+    "buffer": "^6.0.3",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@types/chrome": "0.0.256",
     "@vitest/browser": "^1.2.1",
-    "buffer": "^6.0.3",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,7 +8,7 @@
     "test": "vitest run && npm run run-browser-tests"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@penumbra-zone/constants": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",
     "@penumbra-zone/types": "workspace:*",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint \"**/*.ts*\""
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@connectrpc/connect": "^1.2.1",
     "@connectrpc/connect-web": "^1.2.1",
     "@penumbra-zone/types": "workspace:*"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@types/chrome": "0.0.256",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.1.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,6 @@
     "@types/chrome": "0.0.256",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.1.2",
-    "buffer": "^6.0.3",
     "eslint": "^8.56.0",
     "eslint-config-custom": "workspace:*",
     "idb": "^8.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,6 +20,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "vitest": "^0.34.6"
+    "vitest": "^1.2.1"
   }
 }

--- a/packages/types/src/base64.ts
+++ b/packages/types/src/base64.ts
@@ -19,7 +19,7 @@ export const InnerBase64Schema = z.object({ inner: Base64StringSchema });
 export const base64ToUint8Array = (base64: string): Uint8Array => {
   const validated = validateSchema(Base64StringSchema, base64);
   const binString = atob(validated);
-  return Uint8Array.from(binString, m => m.codePointAt(0)!);
+  return Uint8Array.from(binString, byte => byte.codePointAt(0)!);
 };
 
 export const uint8ArrayToBase64 = (byteArray: Uint8Array): string => {

--- a/packages/types/src/base64.ts
+++ b/packages/types/src/base64.ts
@@ -1,5 +1,4 @@
-// Re: the trailing slash, see https://www.npmjs.com/package/buffer#usage
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer';
 import { z } from 'zod';
 import { validateSchema } from './validation';
 

--- a/packages/types/src/base64.ts
+++ b/packages/types/src/base64.ts
@@ -1,5 +1,6 @@
+// Re: the trailing slash, see https://www.npmjs.com/package/buffer#usage
+import { Buffer } from 'buffer/';
 import { z } from 'zod';
-import { Buffer } from 'buffer';
 import { validateSchema } from './validation';
 
 export const Base64StringSchema = z.string().refine(

--- a/packages/types/src/base64.ts
+++ b/packages/types/src/base64.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 import { z } from 'zod';
 import { validateSchema } from './validation';
 

--- a/packages/types/src/base64.ts
+++ b/packages/types/src/base64.ts
@@ -1,6 +1,5 @@
-import { Buffer } from 'buffer/';
-import { z } from 'zod';
 import { validateSchema } from './validation';
+import { z } from 'zod';
 
 export const Base64StringSchema = z.string().refine(
   str => {
@@ -19,10 +18,11 @@ export const InnerBase64Schema = z.object({ inner: Base64StringSchema });
 
 export const base64ToUint8Array = (base64: string): Uint8Array => {
   const validated = validateSchema(Base64StringSchema, base64);
-  const buffer = Buffer.from(validated, 'base64');
-  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const binString = atob(validated);
+  return Uint8Array.from(binString, m => m.codePointAt(0)!);
 };
 
 export const uint8ArrayToBase64 = (byteArray: Uint8Array): string => {
-  return Buffer.from(byteArray).toString('base64');
+  const binString = String.fromCodePoint(...byteArray);
+  return btoa(binString);
 };

--- a/packages/types/src/hex.test.ts
+++ b/packages/types/src/hex.test.ts
@@ -32,6 +32,13 @@ describe('hexToBase64', () => {
     const expectedBase64 = '';
     expect(hexToBase64(hex)).toBe(expectedBase64);
   });
+
+  it('should throw when passed an invalid hex input', () => {
+    // Hex input must be in pairs of characters, so a single character is
+    // invalid.
+    const hex = 'a';
+    expect(() => hexToBase64(hex)).toThrow('Invalid hexadecimal input');
+  });
 });
 
 describe('uint8ArrayToHex()', () => {

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -1,16 +1,36 @@
-import { Buffer } from 'buffer/';
-import { validateSchema } from './validation';
 import { Base64StringSchema } from './base64';
+import { validateSchema } from './validation';
 
+/**
+ * @see https://stackoverflow.com/a/39460727/974981
+ */
 export const base64ToHex = (base64: string): string => {
   const validated = validateSchema(Base64StringSchema, base64);
-  const buffer = Buffer.from(validated, 'base64');
-  return buffer.toString('hex');
+  const bytes = atob(validated);
+
+  let result = '';
+  for (let i = 0; i < bytes.length; i++) {
+    const hex = bytes.charCodeAt(i).toString(16);
+    result += hex.length === 2 ? hex : '0' + hex;
+  }
+
+  return result;
 };
 
+/**
+ * @see https://stackoverflow.com/a/41797377/974981
+ */
 export const hexToBase64 = (hex: string): string => {
-  const buffer = Buffer.from(hex, 'hex');
-  return buffer.toString('base64');
+  if (!hex) return '';
+
+  return btoa(
+    hex
+      .match(/\w{2}/g)!
+      .map(function (a) {
+        return String.fromCharCode(parseInt(a, 16));
+      })
+      .join(''),
+  );
 };
 
 /**

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -1,5 +1,4 @@
-// Re: the trailing slash, see https://www.npmjs.com/package/buffer#usage
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer';
 import { validateSchema } from './validation';
 import { Base64StringSchema } from './base64';
 

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -1,4 +1,5 @@
-import { Buffer } from 'buffer';
+// Re: the trailing slash, see https://www.npmjs.com/package/buffer#usage
+import { Buffer } from 'buffer/';
 import { validateSchema } from './validation';
 import { Base64StringSchema } from './base64';
 

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -51,5 +51,9 @@ export const hexToUint8Array = (hexString: string): Uint8Array => {
 
   if (!hexString) return new Uint8Array();
 
-  return new Uint8Array(hexString.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)));
+  // Split the string into pairs of characters
+  const hexPairs = hexString.match(/.{1,2}/g)!;
+
+  // Map each hexadecimal pair to the corresponding integer and create a Uint8Array from it
+  return new Uint8Array(hexPairs.map(byte => parseInt(byte, 16)));
 };

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -13,16 +13,23 @@ export const hexToBase64 = (hex: string): string => {
   return buffer.toString('base64');
 };
 
+/**
+ * @see https://stackoverflow.com/a/65851423/974981
+ */
 export const uint8ArrayToHex = (uint8Array: Uint8Array): string => {
-  return Buffer.from(uint8Array).toString('hex');
+  return Array.from(uint8Array, i => i.toString(16).padStart(2, '0')).join('');
 };
 
+/**
+ * @see https://stackoverflow.com/a/65851423/974981
+ */
 export const hexToUint8Array = (hexString: string): Uint8Array => {
   // Check if the input string is a valid hexadecimal string
   if (!/^([0-9A-Fa-f]{2})*$/.test(hexString)) {
     throw new Error(`Invalid hexadecimal string: ${hexString}`);
   }
 
-  const buffer = Buffer.from(hexString, 'hex');
-  return new Uint8Array(buffer);
+  if (!hexString) return new Uint8Array();
+
+  return new Uint8Array(hexString.match(/.{1,2}/g)!.map(byte => parseInt(byte, 16)));
 };

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 import { validateSchema } from './validation';
 import { Base64StringSchema } from './base64';
 

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -23,14 +23,12 @@ export const base64ToHex = (base64: string): string => {
 export const hexToBase64 = (hex: string): string => {
   if (!hex) return '';
 
-  return btoa(
-    hex
-      .match(/\w{2}/g)!
-      .map(function (a) {
-        return String.fromCharCode(parseInt(a, 16));
-      })
-      .join(''),
-  );
+  const hexPairs = hex.match(/[0-9A-Fa-f]{2}/g);
+  if (!hexPairs) throw new Error('Invalid hexadecimal input');
+
+  const binaryString = hexPairs.map(a => String.fromCharCode(parseInt(a, 16))).join('');
+
+  return btoa(binaryString);
 };
 
 /**

--- a/packages/types/src/string.ts
+++ b/packages/types/src/string.ts
@@ -1,14 +1,13 @@
-import { Buffer } from 'buffer/';
 import { BECH32_PREFIX } from './address';
 
+const encoder = new TextEncoder();
 export const stringToUint8Array = (str: string): Uint8Array => {
-  const buffer = Buffer.from(str, 'utf8');
-  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  return encoder.encode(str);
 };
 
+const decoder = new TextDecoder();
 export const uint8ArrayToString = (array: Uint8Array): string => {
-  const buffer = Buffer.from(array.buffer, array.byteOffset, array.byteLength);
-  return buffer.toString('utf8');
+  return decoder.decode(array);
 };
 
 export const shorten = (str: string, endsLength = 4) => {

--- a/packages/types/src/string.ts
+++ b/packages/types/src/string.ts
@@ -1,5 +1,4 @@
-// Re: the trailing slash, see https://www.npmjs.com/package/buffer#usage
-import { Buffer } from 'buffer/';
+import { Buffer } from 'buffer';
 import { BECH32_PREFIX } from './address';
 
 export const stringToUint8Array = (str: string): Uint8Array => {

--- a/packages/types/src/string.ts
+++ b/packages/types/src/string.ts
@@ -1,4 +1,5 @@
-import { Buffer } from 'buffer';
+// Re: the trailing slash, see https://www.npmjs.com/package/buffer#usage
+import { Buffer } from 'buffer/';
 import { BECH32_PREFIX } from './address';
 
 export const stringToUint8Array = (str: string): Uint8Array => {

--- a/packages/types/src/string.ts
+++ b/packages/types/src/string.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'buffer/';
 import { BECH32_PREFIX } from './address';
 
 export const stringToUint8Array = (str: string): Uint8Array => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",
     "@types/tinycolor2": "^1.4.6",
-    "@vitest/browser": "^0.34.6",
+    "@vitest/browser": "^1.2.1",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
     "eslint-config-custom": "workspace:*",
@@ -52,6 +52,6 @@
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vitest": "^0.34.6"
+    "vitest": "^1.2.1"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,7 @@
     "tailwindcss": "^3.4.1",
     "tsconfig": "workspace:*",
     "typescript": "^5.3.3",
-    "vite": "^5.0.11",
+    "vite": "^5.0.12",
     "vitest": "^1.2.1"
   }
 }

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -20,6 +20,6 @@
   "devDependencies": {
     "@penumbra-zone/wasm-nodejs": "0.65.0-pre.0",
     "fake-indexeddb": "^5.0.2",
-    "vitest": "^0.34.6"
+    "vitest": "^1.2.1"
   }
 }

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protobuf": "^1.7.0",
     "@penumbra-zone/types": "workspace:*",
     "@penumbra-zone/wasm-bundler": "0.65.0-pre.0",
     "bech32": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@buf/cosmos_ibc.bufbuild_es':
         specifier: 1.6.0-20231221153343-c805262eb055.1
-        version: 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)
+        version: 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)
       '@buf/cosmos_ibc.connectrpc_es':
         specifier: 1.2.1-20231221153343-c805262eb055.1
-        version: 1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+        version: 1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
       '@buf/penumbra-zone_penumbra.bufbuild_es':
         specifier: 1.6.0-20240108223610-b2df48bf92fa.1
-        version: 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)
+        version: 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)
       '@buf/penumbra-zone_penumbra.connectrpc_es':
         specifier: 1.2.1-20240108223610-b2df48bf92fa.1
-        version: 1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+        version: 1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
       '@penumbra-zone/wasm-bundler':
         specifier: 0.65.0-pre.0
         version: 0.65.0-pre.0
@@ -52,14 +52,14 @@ importers:
   apps/extension:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -93,6 +93,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.17.3
         version: 5.17.3(react@18.2.0)
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       exponential-backoff:
         specifier: ^3.1.1
         version: 3.1.1
@@ -148,9 +151,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
-      buffer:
-        specifier: ^6.0.3
-        version: 6.0.3
       copy-webpack-plugin:
         specifier: ^11.0.0
         version: 11.0.0(webpack@5.89.0)
@@ -185,11 +185,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.10.6)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
       webpack:
         specifier: ^5.89.0
         version: 5.89.0(webpack-cli@5.1.4)
@@ -204,10 +204,10 @@ importers:
     dependencies:
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -271,7 +271,7 @@ importers:
         version: 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.5.0
-        version: 3.5.0(vite@5.0.11)
+        version: 3.5.0(vite@5.0.12)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -300,11 +300,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.10.6)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
 
   packages/constants:
     dependencies:
@@ -358,14 +358,14 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@vitest/browser':
-        specifier: ^0.34.6
-        version: 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
+        specifier: ^1.2.1
+        version: 1.2.1(playwright@1.40.1)(vitest@1.2.1)
       vite:
-        specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.11.5)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1)
 
   packages/eslint-config-custom:
     dependencies:
@@ -412,14 +412,14 @@ importers:
   packages/query:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/crypto-web':
         specifier: workspace:^
         version: link:../crypto
@@ -454,14 +454,14 @@ importers:
   packages/router:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/constants':
         specifier: workspace:*
         version: link:../constants
@@ -503,11 +503,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.11.5)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1)
 
   packages/services:
     dependencies:
@@ -546,8 +546,8 @@ importers:
   packages/storage:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@penumbra-zone/constants':
         specifier: workspace:*
         version: link:../constants
@@ -573,27 +573,30 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.11.5)
     devDependencies:
       '@types/chrome':
         specifier: 0.0.256
         version: 0.0.256
+      '@vitest/browser':
+        specifier: ^1.2.1
+        version: 1.2.1(playwright@1.40.1)(vitest@1.2.1)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1)
 
   packages/transport:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/types':
         specifier: workspace:*
         version: link:../types
@@ -619,8 +622,8 @@ importers:
   packages/types:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@types/chrome':
         specifier: 0.0.256
         version: 0.0.256
@@ -630,9 +633,6 @@ importers:
       bignumber.js:
         specifier: ^9.1.2
         version: 9.1.2
-      buffer:
-        specifier: ^6.0.3
-        version: 6.0.3
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -653,8 +653,8 @@ importers:
         version: 3.22.4
     devDependencies:
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1)
 
   packages/ui:
     dependencies:
@@ -702,7 +702,7 @@ importers:
         version: 1.0.7(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/jest-dom':
         specifier: ^6.2.0
-        version: 6.2.0(vitest@0.34.6)
+        version: 6.2.0(vitest@1.2.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -753,8 +753,8 @@ importers:
         specifier: ^1.4.6
         version: 1.4.6
       '@vitest/browser':
-        specifier: ^0.34.6
-        version: 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
+        specifier: ^1.2.1
+        version: 1.2.1(playwright@1.40.1)(vitest@1.2.1)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -783,17 +783,17 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.10.6)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
 
   packages/wasm:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@penumbra-zone/types':
         specifier: workspace:*
         version: link:../types
@@ -826,8 +826,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1)
 
 packages:
 
@@ -910,280 +910,285 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@buf/cosmos_cosmos-proto.bufbuild_es@1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_cosmos-proto.bufbuild_es@1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.6.0-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_cosmos-proto.connectrpc_es@1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-proto.connectrpc_es@1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.connectrpc_es/-/cosmos_cosmos-proto.connectrpc_es-1.2.1-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.6.0-20230522115704-e7a85cef453e.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.6.0-20230719110346-aa25660f4ff7.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.2.1-20230522115704-e7a85cef453e.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.2.1-20230719110346-aa25660f4ff7.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.6.0-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.6.0-20230509103710-5e5b9fdd0180.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.2.1-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.2.1-20230509103710-5e5b9fdd0180.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.6.0-20230913112312-7ab44ae956a0.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.6.0-20231221153343-c805262eb055.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.2.1-20230913112312-7ab44ae956a0.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.2.1-20231221153343-c805262eb055.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ics23.bufbuild_es@1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_ics23.bufbuild_es@1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.6.0-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_ics23.connectrpc_es@1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ics23.connectrpc_es@1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.connectrpc_es/-/cosmos_ics23.connectrpc_es-1.2.1-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/penumbra-zone_penumbra.bufbuild_es@1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0):
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.6.0-20240108223610-b2df48bf92fa.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/penumbra-zone_penumbra.connectrpc_es@1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/penumbra-zone_penumbra.connectrpc_es@1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.2.1-20240108223610-b2df48bf92fa.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.connectrpc_es': 1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.connectrpc_es': 1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
   /@bufbuild/protobuf@1.6.0:
     resolution: {integrity: sha512-hp19vSFgNw3wBBcVBx5qo5pufCqjaJ0Cfk5H/pfjNOfNWU+4/w0QVOmfAOZNRrNWRrVuaJWxcN8P2vhOkkzbBQ==}
+    dev: true
+
+  /@bufbuild/protobuf@1.7.0:
+    resolution: {integrity: sha512-jIsRadRsyxf6ERBU1auY2c1k3doFdqh15F4HRZs4BELVuBtpN+3ipkXqcsWE+rD+EQNigeR29SfQ+ES6UX/jGg==}
+    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1197,30 +1202,30 @@ packages:
     engines: {node: '>=0.1.90'}
     dev: true
 
-  /@connectrpc/connect-web@1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1):
+  /@connectrpc/connect-web@1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1):
     resolution: {integrity: sha512-fuecLMy024OLFXwycT7uB3WHiPTgaKOIGu6beX4MWxf2K6/NIxUEiS5AzEr0bCS8r3eNyZXuJWalJgmgdrNIGA==}
     peerDependencies:
       '@bufbuild/protobuf': ^1.4.2
       '@connectrpc/connect': 1.2.1
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
-      '@connectrpc/connect': 1.2.1(@bufbuild/protobuf@1.6.0)
+      '@bufbuild/protobuf': 1.7.0
+      '@connectrpc/connect': 1.2.1(@bufbuild/protobuf@1.7.0)
     dev: false
 
-  /@connectrpc/connect@1.2.1(@bufbuild/protobuf@1.6.0):
+  /@connectrpc/connect@1.2.1(@bufbuild/protobuf@1.7.0):
     resolution: {integrity: sha512-CWQNcr0kKLU1LlijdeKhbKOAOsU/t9OKM90l07O82N4nOg1+7JgWjhlcv/QATxatOT8XwJu1DxJiVYyZs+Xixg==}
     peerDependencies:
       '@bufbuild/protobuf': ^1.4.2
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.6.0):
+  /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.7.0):
     resolution: {integrity: sha512-kTeWxJnLLtxKc2ZSDN0rIBgwfP8RwcLknthX4AKlIAmN9ZC4gGnCbwp+3BKcP/WH5c8zGBAWqSY3zeqCM+ah7w==}
     peerDependencies:
       '@bufbuild/protobuf': ^1.4.2
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
   /@cspotcode/source-map-support@0.8.1:
@@ -1277,38 +1282,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64@0.18.20:
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
     optional: true
 
   /@esbuild/android-arm64@0.19.11:
     resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64@0.19.9:
-    resolution: {integrity: sha512-q4cR+6ZD0938R19MyEW3jEsMzbb/1rulLXiNAJQADD/XYp7pT+rOS5JGxvpRW8dFDEfjW4wLgC/3FXIw4zYglQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/android-arm@0.18.20:
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
     requiresBuild: true
     optional: true
@@ -1319,23 +1298,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.19.9:
-    resolution: {integrity: sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/android-x64@0.18.20:
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
     optional: true
 
   /@esbuild/android-x64@0.19.11:
@@ -1344,46 +1306,12 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.19.9:
-    resolution: {integrity: sha512-KOqoPntWAH6ZxDwx1D6mRntIgZh9KodzgNOy5Ebt9ghzffOk9X2c1sPwtM9P+0eXbefnDhqYfkh5PLP5ULtWFA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.18.20:
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-arm64@0.19.11:
     resolution: {integrity: sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.19.9:
-    resolution: {integrity: sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.18.20:
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
@@ -1394,46 +1322,12 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.19.9:
-    resolution: {integrity: sha512-vE0VotmNTQaTdX0Q9dOHmMTao6ObjyPm58CHZr1UK7qpNleQyxlFlNCaHsHx6Uqv86VgPmR4o2wdNq3dP1qyDQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.18.20:
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.11:
     resolution: {integrity: sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.19.9:
-    resolution: {integrity: sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.18.20:
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     optional: true
@@ -1444,46 +1338,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.19.9:
-    resolution: {integrity: sha512-WMLgWAtkdTbTu1AWacY7uoj/YtHthgqrqhf1OaEWnZb7PQgpt8eaA/F3LkV0E6K/Lc0cUr/uaVP/49iE4M4asA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.18.20:
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm64@0.19.11:
     resolution: {integrity: sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.19.9:
-    resolution: {integrity: sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-arm@0.18.20:
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -1494,46 +1354,12 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.19.9:
-    resolution: {integrity: sha512-C/ChPohUYoyUaqn1h17m/6yt6OB14hbXvT8EgM1ZWaiiTYz7nWZR0SYmMnB5BzQA4GXl3BgBO1l8MYqL/He3qw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.18.20:
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ia32@0.19.11:
     resolution: {integrity: sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.19.9:
-    resolution: {integrity: sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.18.20:
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -1544,46 +1370,12 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.19.9:
-    resolution: {integrity: sha512-t6mN147pUIf3t6wUt3FeumoOTPfmv9Cc6DQlsVBpB7eCpLOqQDyWBP1ymXn1lDw4fNUSb/gBcKAmvTP49oIkaA==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.18.20:
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-mips64el@0.19.11:
     resolution: {integrity: sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.19.9:
-    resolution: {integrity: sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.18.20:
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -1594,46 +1386,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.19.9:
-    resolution: {integrity: sha512-tkV0xUX0pUUgY4ha7z5BbDS85uI7ABw3V1d0RNTii7E9lbmV8Z37Pup2tsLV46SQWzjOeyDi1Q7Wx2+QM8WaCQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.18.20:
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-riscv64@0.19.11:
     resolution: {integrity: sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==}
     engines: {node: '>=12'}
     cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.19.9:
-    resolution: {integrity: sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.18.20:
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -1644,23 +1402,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.19.9:
-    resolution: {integrity: sha512-zHbglfEdC88KMgCWpOl/zc6dDYJvWGLiUtmPRsr1OgCViu3z5GncvNVdf+6/56O2Ca8jUU+t1BW261V6kp8qdw==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-x64@0.18.20:
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-x64@0.19.11:
@@ -1668,23 +1409,6 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.19.9:
-    resolution: {integrity: sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.18.20:
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
     requiresBuild: true
     optional: true
 
@@ -1694,23 +1418,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.19.9:
-    resolution: {integrity: sha512-GThgZPAwOBOsheA2RUlW5UeroRfESwMq/guy8uEe3wJlAOjpOXuSevLRd70NZ37ZrpO6RHGHgEHvPg1h3S1Jug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.18.20:
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
     optional: true
 
   /@esbuild/openbsd-x64@0.19.11:
@@ -1718,23 +1425,6 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.19.9:
-    resolution: {integrity: sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.18.20:
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
     requiresBuild: true
     optional: true
 
@@ -1744,46 +1434,12 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.19.9:
-    resolution: {integrity: sha512-MLHj7k9hWh4y1ddkBpvRj2b9NCBhfgBt3VpWbHQnXRedVun/hC7sIyTGDGTfsGuXo4ebik2+3ShjcPbhtFwWDw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.18.20:
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /@esbuild/win32-arm64@0.19.11:
     resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.19.9:
-    resolution: {integrity: sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.18.20:
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
@@ -1794,36 +1450,10 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.19.9:
-    resolution: {integrity: sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@esbuild/win32-x64@0.18.20:
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /@esbuild/win32-x64@0.19.11:
     resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.19.9:
-    resolution: {integrity: sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -2044,9 +1674,6 @@ packages:
     dependencies:
       lodash: 4.17.21
     dev: true
-
-  /@jspm/core@2.0.1:
-    resolution: {integrity: sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==}
 
   /@next/env@14.0.4:
     resolution: {integrity: sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==}
@@ -3069,19 +2696,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@rollup/pluginutils@5.1.0:
-    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-
   /@rollup/rollup-android-arm-eabi@4.8.0:
     resolution: {integrity: sha512-zdTObFRoNENrdPpnTNnhOljYIcOX7aI7+7wyrSpPFFIOf/nRdedE6IYsjaBE7tjukphh1tMTojgJ7p3lKY8x6Q==}
     cpu: [arm]
@@ -3326,7 +2940,7 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom@6.2.0(vitest@0.34.6):
+  /@testing-library/jest-dom@6.2.0(vitest@1.2.1):
     resolution: {integrity: sha512-+BVQlJ9cmEn5RDMUS8c2+TU6giLvzaHZ8sU/x0Jj7fk+6/46wPdwlgOPcpxS17CjcanBi/3VmGMqVr2rmbUmNw==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
     peerDependencies:
@@ -3352,7 +2966,7 @@ packages:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
-      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+      vitest: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
     dev: false
 
   /@testing-library/react@14.1.2(react-dom@18.2.0)(react@18.2.0):
@@ -3433,14 +3047,6 @@ packages:
   /@types/aria-query@5.0.4:
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
-
-  /@types/chai-subset@1.3.5:
-    resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
-    dependencies:
-      '@types/chai': 4.3.11
-
-  /@types/chai@4.3.11:
-    resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
 
   /@types/chrome@0.0.256:
     resolution: {integrity: sha512-NleTQw4DNzhPwObLNuQ3i3nvX1rZ1mgnx5FNHc2KP+Cj1fgd3BrT5yQ6Xvs+7H0kNsYxCY+lxhiCwsqq3JwtEg==}
@@ -3842,61 +3448,69 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitejs/plugin-react-swc@3.5.0(vite@5.0.11):
+  /@vitejs/plugin-react-swc@3.5.0(vite@5.0.12):
     resolution: {integrity: sha512-1PrOvAaDpqlCV+Up8RkAh9qaiUjoDUcjtttyhXDKw53XA6Ve16SOp6cCOpRs8Dj8DqUQs6eTW5YkLcLJjrXAig==}
     peerDependencies:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.3.100
-      vite: 5.0.11(@types/node@20.10.6)
+      vite: 5.0.12(@types/node@20.10.6)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@vitest/browser@0.34.6(esbuild@0.18.20)(vitest@0.34.6):
-    resolution: {integrity: sha512-XCIGROVgw3L+PwYw/T2l+HP/SPrXvh2MfmQNU3aULl5ekE+QVj9A1RYu/1mcYXdac9ES4ahxUz6n4wgcVd9tbA==}
+  /@vitest/browser@1.2.1(playwright@1.40.1)(vitest@1.2.1):
+    resolution: {integrity: sha512-jhaQ15zWYAwz8anXgmLW0yAVLCXdT8RFv7LeW9bg7sMlvGJaTCTIHaHWFvCdADF/i62+22tnrzgiiqSnApjXtA==}
     peerDependencies:
-      vitest: '>=0.34.0'
+      playwright: '*'
+      safaridriver: '*'
+      vitest: ^1.0.0
+      webdriverio: '*'
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
     dependencies:
-      estree-walker: 3.0.3
+      '@vitest/utils': 1.2.1
       magic-string: 0.30.5
-      modern-node-polyfills: 1.0.0(esbuild@0.18.20)
-      sirv: 2.0.3
-      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
+      playwright: 1.40.1
+      sirv: 2.0.4
+      vitest: 1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1)
 
-  /@vitest/expect@0.34.6:
-    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+  /@vitest/expect@1.2.1:
+    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
     dependencies:
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
       chai: 4.3.10
 
-  /@vitest/runner@0.34.6:
-    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+  /@vitest/runner@1.2.1:
+    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
     dependencies:
-      '@vitest/utils': 0.34.6
-      p-limit: 4.0.0
+      '@vitest/utils': 1.2.1
+      p-limit: 5.0.0
       pathe: 1.1.1
 
-  /@vitest/snapshot@0.34.6:
-    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+  /@vitest/snapshot@1.2.1:
+    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
 
-  /@vitest/spy@0.34.6:
-    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+  /@vitest/spy@1.2.1:
+    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
     dependencies:
       tinyspy: 2.2.0
 
-  /@vitest/utils@0.34.6:
-    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+  /@vitest/utils@1.2.1:
+    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
     dependencies:
       diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
 
@@ -4090,6 +3704,11 @@ packages:
 
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
 
   /acorn@8.11.2:
@@ -4642,6 +4261,7 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: false
 
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
@@ -5720,35 +5340,6 @@ packages:
       is-symbol: 1.0.4
     dev: false
 
-  /esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
-
   /esbuild@0.19.11:
     resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
     engines: {node: '>=12'}
@@ -5778,36 +5369,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.11
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
-    dev: true
-
-  /esbuild@0.19.9:
-    resolution: {integrity: sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.19.9
-      '@esbuild/android-arm64': 0.19.9
-      '@esbuild/android-x64': 0.19.9
-      '@esbuild/darwin-arm64': 0.19.9
-      '@esbuild/darwin-x64': 0.19.9
-      '@esbuild/freebsd-arm64': 0.19.9
-      '@esbuild/freebsd-x64': 0.19.9
-      '@esbuild/linux-arm': 0.19.9
-      '@esbuild/linux-arm64': 0.19.9
-      '@esbuild/linux-ia32': 0.19.9
-      '@esbuild/linux-loong64': 0.19.9
-      '@esbuild/linux-mips64el': 0.19.9
-      '@esbuild/linux-ppc64': 0.19.9
-      '@esbuild/linux-riscv64': 0.19.9
-      '@esbuild/linux-s390x': 0.19.9
-      '@esbuild/linux-x64': 0.19.9
-      '@esbuild/netbsd-x64': 0.19.9
-      '@esbuild/openbsd-x64': 0.19.9
-      '@esbuild/sunos-x64': 0.19.9
-      '@esbuild/win32-arm64': 0.19.9
-      '@esbuild/win32-ia32': 0.19.9
-      '@esbuild/win32-x64': 0.19.9
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -6209,9 +5770,6 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
-  /estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
@@ -6254,6 +5812,20 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.2.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   /exegesis-express@4.0.0:
     resolution: {integrity: sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==}
@@ -6806,6 +6378,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -7217,6 +6793,10 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -7581,6 +7161,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
     dev: true
+
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -8021,9 +7605,12 @@ packages:
     engines: {node: '>=6.11.5'}
     dev: true
 
-  /local-pkg@0.4.3:
-    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+  /local-pkg@0.5.0:
+    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.4.2
+      pkg-types: 1.0.3
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -8296,7 +7883,6 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -8340,6 +7926,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
+
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -8471,19 +8061,6 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.3.2
 
-  /modern-node-polyfills@1.0.0(esbuild@0.18.20):
-    resolution: {integrity: sha512-w1yb6ae5qSUJJ2u41krkUAxs+L7i9143Qam8EuXwDMeZHxl1JN8RfTSXG4S2bt0RHIRMeoWm/HCeO0pNIHmIYQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      esbuild: ^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0
-    dependencies:
-      '@jspm/core': 2.0.1
-      '@rollup/pluginutils': 5.1.0
-      esbuild: 0.18.20
-      local-pkg: 0.4.3
-    transitivePeerDependencies:
-      - rollup
-
   /morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
     engines: {node: '>= 0.8.0'}
@@ -8497,8 +8074,8 @@ packages:
       - supports-color
     dev: true
 
-  /mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+  /mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
 
   /ms@2.0.0:
@@ -8704,6 +8281,12 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /npm-run-path@5.2.0:
+    resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+
   /nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
 
@@ -8819,6 +8402,12 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+
   /open@6.4.0:
     resolution: {integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==}
     engines: {node: '>=8'}
@@ -8907,9 +8496,9 @@ packages:
     dependencies:
       yocto-queue: 0.1.0
 
-  /p-limit@4.0.0:
-    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
     dependencies:
       yocto-queue: 1.0.0
 
@@ -9033,6 +8622,10 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -10174,8 +9767,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
-    optional: true
 
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -10183,12 +9774,12 @@ packages:
       is-arrayish: 0.3.2
     dev: true
 
-  /sirv@2.0.3:
-    resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
+  /sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
     dependencies:
       '@polka/url': 1.0.0-next.24
-      mrmime: 1.0.1
+      mrmime: 2.0.0
       totalist: 3.0.1
 
   /slash@3.0.0:
@@ -10407,6 +9998,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
+
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
 
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -10714,8 +10309,8 @@ packages:
       tinycolor2: 1.6.0
     dev: true
 
-  /tinypool@0.7.0:
-    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
     engines: {node: '>=14.0.0'}
 
   /tinyspy@2.2.0:
@@ -11301,17 +10896,16 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-node@0.34.6(@types/node@20.10.6):
-    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
-    engines: {node: '>=v14.18.0'}
+  /vite-node@1.2.1(@types/node@20.10.6):
+    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.11(@types/node@20.10.6)
+      vite: 5.0.12(@types/node@20.10.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -11322,8 +10916,28 @@ packages:
       - supports-color
       - terser
 
-  /vite@5.0.11(@types/node@20.10.6):
-    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
+  /vite-node@1.2.1(@types/node@20.11.5):
+    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.12(@types/node@20.11.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  /vite@5.0.12(@types/node@20.10.6):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -11351,14 +10965,14 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.10.6
-      esbuild: 0.19.9
+      esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@5.0.11(@types/node@20.11.5):
-    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
+  /vite@5.0.12(@types/node@20.11.5):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -11386,27 +11000,27 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.11.5
-      esbuild: 0.19.9
+      esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vitest@0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1):
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
+  /vitest@1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
       happy-dom: '*'
       jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
         optional: true
       '@vitest/browser':
         optional: true
@@ -11416,39 +11030,87 @@ packages:
         optional: true
       jsdom:
         optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
     dependencies:
-      '@types/chai': 4.3.11
-      '@types/chai-subset': 1.3.5
       '@types/node': 20.10.6
-      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.11.2
-      acorn-walk: 8.3.1
+      '@vitest/browser': 1.2.1(playwright@1.40.1)(vitest@1.2.1)
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
+      execa: 8.0.1
       jsdom: 23.0.1
-      local-pkg: 0.4.3
+      local-pkg: 0.5.0
       magic-string: 0.30.5
       pathe: 1.1.1
       picocolors: 1.0.0
-      playwright: 1.40.1
       std-env: 3.6.0
       strip-literal: 1.3.0
       tinybench: 2.5.1
-      tinypool: 0.7.0
-      vite: 5.0.11(@types/node@20.10.6)
-      vite-node: 0.34.6(@types/node@20.10.6)
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.10.6)
+      vite-node: 1.2.1(@types/node@20.10.6)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  /vitest@1.2.1(@types/node@20.11.5)(@vitest/browser@1.2.1):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.11.5
+      '@vitest/browser': 1.2.1(playwright@1.40.1)(vitest@1.2.1)
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.6.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.11.5)
+      vite-node: 1.2.1(@types/node@20.11.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@buf/cosmos_ibc.bufbuild_es':
         specifier: 1.6.0-20231221153343-c805262eb055.1
-        version: 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)
+        version: 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)
       '@buf/cosmos_ibc.connectrpc_es':
         specifier: 1.2.1-20231221153343-c805262eb055.1
-        version: 1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+        version: 1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
       '@buf/penumbra-zone_penumbra.bufbuild_es':
         specifier: 1.6.0-20240108223610-b2df48bf92fa.1
-        version: 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)
+        version: 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)
       '@buf/penumbra-zone_penumbra.connectrpc_es':
         specifier: 1.2.1-20240108223610-b2df48bf92fa.1
-        version: 1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+        version: 1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
       '@penumbra-zone/wasm-bundler':
         specifier: 0.65.0-pre.0
         version: 0.65.0-pre.0
@@ -32,7 +32,7 @@ importers:
         version: 1.11.3(@types/node@20.11.5)(typescript@5.3.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.17.0
-        version: 6.17.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.17.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -144,7 +144,7 @@ importers:
         version: 18.2.18
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.17.0
-        version: 6.17.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.17.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -188,11 +188,11 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@0.34.6)(jsdom@23.0.1)
       webpack:
         specifier: ^5.89.0
-        version: 5.89.0(webpack-cli@5.1.4)
+        version: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.89.0)
@@ -204,10 +204,10 @@ importers:
     dependencies:
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -303,8 +303,8 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@0.34.6)(jsdom@23.0.1)
 
   packages/constants:
     dependencies:
@@ -358,14 +358,14 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@vitest/browser':
-        specifier: ^0.34.6
-        version: 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
+        specifier: ^1.2.1
+        version: 1.2.1(vitest@1.2.1)
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
 
   packages/eslint-config-custom:
     dependencies:
@@ -404,7 +404,7 @@ importers:
         version: 1.11.3(eslint@8.56.0)
       eslint-plugin-vitest:
         specifier: ^0.3.20
-        version: 0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3)
+        version: 0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.1)
       next:
         specifier: ^14.0.4
         version: 14.0.4(react-dom@18.2.0)(react@18.2.0)
@@ -506,8 +506,8 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.11.5)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
 
   packages/services:
     dependencies:
@@ -574,14 +574,17 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.11.5)
+        version: 5.0.11(@types/node@20.10.6)
     devDependencies:
       '@types/chrome':
         specifier: 0.0.256
         version: 0.0.256
+      '@vitest/browser':
+        specifier: ^1.2.1
+        version: 1.2.1(vitest@1.2.1)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
 
   packages/transport:
     dependencies:
@@ -653,8 +656,8 @@ importers:
         version: 3.22.4
     devDependencies:
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
 
   packages/ui:
     dependencies:
@@ -702,7 +705,7 @@ importers:
         version: 1.0.7(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/jest-dom':
         specifier: ^6.2.0
-        version: 6.2.0(vitest@0.34.6)
+        version: 6.2.0(vitest@1.2.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -753,8 +756,8 @@ importers:
         specifier: ^1.4.6
         version: 1.4.6
       '@vitest/browser':
-        specifier: ^0.34.6
-        version: 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
+        specifier: ^1.2.1
+        version: 1.2.1(vitest@1.2.1)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -786,8 +789,8 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
 
   packages/wasm:
     dependencies:
@@ -826,8 +829,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+        specifier: ^1.2.1
+        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
 
 packages:
 
@@ -910,280 +913,284 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@buf/cosmos_cosmos-proto.bufbuild_es@1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_cosmos-proto.bufbuild_es@1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.6.0-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_cosmos-proto.connectrpc_es@1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-proto.connectrpc_es@1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.connectrpc_es/-/cosmos_cosmos-proto.connectrpc_es-1.2.1-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.6.0-20230522115704-e7a85cef453e.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.6.0-20230719110346-aa25660f4ff7.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.2.1-20230522115704-e7a85cef453e.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.2.1-20230719110346-aa25660f4ff7.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.6.0-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.6.0-20230509103710-5e5b9fdd0180.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.2.1-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.2.1-20230509103710-5e5b9fdd0180.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.6.0-20230913112312-7ab44ae956a0.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.6.0-20231221153343-c805262eb055.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.2.1-20230913112312-7ab44ae956a0.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.2.1-20231221153343-c805262eb055.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ics23.bufbuild_es@1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0):
+  /@buf/cosmos_ics23.bufbuild_es@1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.6.0-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/cosmos_ics23.connectrpc_es@1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ics23.connectrpc_es@1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.connectrpc_es/-/cosmos_ics23.connectrpc_es-1.2.1-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/penumbra-zone_penumbra.bufbuild_es@1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0):
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.6.0-20240108223610-b2df48bf92fa.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
-      '@bufbuild/protobuf': 1.6.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
-  /@buf/penumbra-zone_penumbra.connectrpc_es@1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
+  /@buf/penumbra-zone_penumbra.connectrpc_es@1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.2.1-20240108223610-b2df48bf92fa.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.connectrpc_es': 1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
-      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.connectrpc_es': 1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
   /@bufbuild/protobuf@1.6.0:
     resolution: {integrity: sha512-hp19vSFgNw3wBBcVBx5qo5pufCqjaJ0Cfk5H/pfjNOfNWU+4/w0QVOmfAOZNRrNWRrVuaJWxcN8P2vhOkkzbBQ==}
+
+  /@bufbuild/protobuf@1.7.0:
+    resolution: {integrity: sha512-jIsRadRsyxf6ERBU1auY2c1k3doFdqh15F4HRZs4BELVuBtpN+3ipkXqcsWE+rD+EQNigeR29SfQ+ES6UX/jGg==}
+    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1207,6 +1214,16 @@ packages:
       '@connectrpc/connect': 1.2.1(@bufbuild/protobuf@1.6.0)
     dev: false
 
+  /@connectrpc/connect-web@1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1):
+    resolution: {integrity: sha512-fuecLMy024OLFXwycT7uB3WHiPTgaKOIGu6beX4MWxf2K6/NIxUEiS5AzEr0bCS8r3eNyZXuJWalJgmgdrNIGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.4.2
+      '@connectrpc/connect': 1.2.1
+    dependencies:
+      '@bufbuild/protobuf': 1.7.0
+      '@connectrpc/connect': 1.2.1(@bufbuild/protobuf@1.7.0)
+    dev: false
+
   /@connectrpc/connect@1.2.1(@bufbuild/protobuf@1.6.0):
     resolution: {integrity: sha512-CWQNcr0kKLU1LlijdeKhbKOAOsU/t9OKM90l07O82N4nOg1+7JgWjhlcv/QATxatOT8XwJu1DxJiVYyZs+Xixg==}
     peerDependencies:
@@ -1215,12 +1232,20 @@ packages:
       '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.6.0):
+  /@connectrpc/connect@1.2.1(@bufbuild/protobuf@1.7.0):
+    resolution: {integrity: sha512-CWQNcr0kKLU1LlijdeKhbKOAOsU/t9OKM90l07O82N4nOg1+7JgWjhlcv/QATxatOT8XwJu1DxJiVYyZs+Xixg==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.4.2
+    dependencies:
+      '@bufbuild/protobuf': 1.7.0
+    dev: false
+
+  /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.7.0):
     resolution: {integrity: sha512-kTeWxJnLLtxKc2ZSDN0rIBgwfP8RwcLknthX4AKlIAmN9ZC4gGnCbwp+3BKcP/WH5c8zGBAWqSY3zeqCM+ah7w==}
     peerDependencies:
       '@bufbuild/protobuf': ^1.4.2
     dependencies:
-      '@bufbuild/protobuf': 1.6.0
+      '@bufbuild/protobuf': 1.7.0
     dev: false
 
   /@cspotcode/source-map-support@0.8.1:
@@ -1280,6 +1305,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.19.12:
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -1295,6 +1328,14 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.12:
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/android-arm64@0.19.9:
@@ -1322,6 +1363,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.19.12:
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm@0.19.9:
     resolution: {integrity: sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==}
     engines: {node: '>=12'}
@@ -1345,6 +1394,14 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.19.12:
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/android-x64@0.19.9:
@@ -1372,6 +1429,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.19.12:
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.19.9:
     resolution: {integrity: sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==}
     engines: {node: '>=12'}
@@ -1395,6 +1460,14 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.19.12:
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.9:
@@ -1422,6 +1495,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.19.12:
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.19.9:
     resolution: {integrity: sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==}
     engines: {node: '>=12'}
@@ -1445,6 +1526,14 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.19.12:
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.9:
@@ -1472,6 +1561,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.19.12:
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-arm64@0.19.9:
     resolution: {integrity: sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==}
     engines: {node: '>=12'}
@@ -1495,6 +1592,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.19.12:
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm@0.19.9:
@@ -1522,6 +1627,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.19.12:
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-ia32@0.19.9:
     resolution: {integrity: sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==}
     engines: {node: '>=12'}
@@ -1545,6 +1658,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.19.12:
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.9:
@@ -1572,6 +1693,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.19.12:
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.19.9:
     resolution: {integrity: sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==}
     engines: {node: '>=12'}
@@ -1595,6 +1724,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.19.12:
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.9:
@@ -1622,6 +1759,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.19.12:
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.19.9:
     resolution: {integrity: sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==}
     engines: {node: '>=12'}
@@ -1645,6 +1790,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.19.12:
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.9:
@@ -1672,6 +1825,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.19.12:
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-x64@0.19.9:
     resolution: {integrity: sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==}
     engines: {node: '>=12'}
@@ -1695,6 +1856,14 @@ packages:
     os: [netbsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.19.12:
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.9:
@@ -1722,6 +1891,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.19.12:
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.19.9:
     resolution: {integrity: sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==}
     engines: {node: '>=12'}
@@ -1745,6 +1922,14 @@ packages:
     os: [sunos]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.19.12:
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.9:
@@ -1772,6 +1957,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.19.12:
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-arm64@0.19.9:
     resolution: {integrity: sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==}
     engines: {node: '>=12'}
@@ -1797,6 +1990,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.19.12:
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-ia32@0.19.9:
     resolution: {integrity: sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==}
     engines: {node: '>=12'}
@@ -1820,6 +2021,14 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.12:
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@esbuild/win32-x64@0.19.9:
@@ -3089,8 +3298,22 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-android-arm-eabi@4.9.6:
+    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-android-arm64@4.8.0:
     resolution: {integrity: sha512-aiItwP48BiGpMFS9Znjo/xCNQVwTQVcRKkFKsO81m8exrGjHkCBDvm9PHay2kpa8RPnZzzKcD1iQ9KaLY4fPQQ==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.9.6:
+    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -3103,8 +3326,22 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-darwin-arm64@4.9.6:
+    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-darwin-x64@4.8.0:
     resolution: {integrity: sha512-A/FAHFRNQYrELrb/JHncRWzTTXB2ticiRFztP4ggIUAfa9Up1qfW8aG2w/mN9jNiZ+HB0t0u0jpJgFXG6BfRTA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.9.6:
+    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -3117,8 +3354,22 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
+    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-linux-arm64-gnu@4.8.0:
     resolution: {integrity: sha512-hBNCnqw3EVCkaPB0Oqd24bv8SklETptQWcJz06kb9OtiShn9jK1VuTgi7o4zPSt6rNGWQOTDEAccbk0OqJmS+g==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.9.6:
+    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -3131,8 +3382,22 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-arm64-musl@4.9.6:
+    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-linux-riscv64-gnu@4.8.0:
     resolution: {integrity: sha512-BH5xIh7tOzS9yBi8dFrCTG8Z6iNIGWGltd3IpTSKp6+pNWWO6qy8eKoRxOtwFbMrid5NZaidLYN6rHh9aB8bEw==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
+    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
@@ -3145,8 +3410,22 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-x64-gnu@4.9.6:
+    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-linux-x64-musl@4.8.0:
     resolution: {integrity: sha512-mdxnlW2QUzXwY+95TuxZ+CurrhgrPAMveDWI97EQlA9bfhR8tw3Pt7SUlc/eSlCNxlWktpmT//EAA8UfCHOyXg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.9.6:
+    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -3159,6 +3438,13 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-win32-arm64-msvc@4.9.6:
+    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-win32-ia32-msvc@4.8.0:
     resolution: {integrity: sha512-p9E3PZlzurhlsN5h9g7zIP1DnqKXJe8ZUkFwAazqSvHuWfihlIISPxG9hCHCoA+dOOspL/c7ty1eeEVFTE0UTw==}
     cpu: [ia32]
@@ -3166,8 +3452,22 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-win32-ia32-msvc@4.9.6:
+    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@rollup/rollup-win32-x64-msvc@4.8.0:
     resolution: {integrity: sha512-kb4/auKXkYKqlUYTE8s40FcJIj5soOyRLHKd4ugR0dCq0G2EfcF54eYcfQiGkHzjidZ40daB4ulsFdtqNKZtBg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.9.6:
+    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -3326,7 +3626,7 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom@6.2.0(vitest@0.34.6):
+  /@testing-library/jest-dom@6.2.0(vitest@1.2.1):
     resolution: {integrity: sha512-+BVQlJ9cmEn5RDMUS8c2+TU6giLvzaHZ8sU/x0Jj7fk+6/46wPdwlgOPcpxS17CjcanBi/3VmGMqVr2rmbUmNw==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
     peerDependencies:
@@ -3352,7 +3652,7 @@ packages:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
-      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+      vitest: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
     dev: false
 
   /@testing-library/react@14.1.2(react-dom@18.2.0)(react@18.2.0):
@@ -3433,14 +3733,6 @@ packages:
   /@types/aria-query@5.0.4:
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
-
-  /@types/chai-subset@1.3.5:
-    resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
-    dependencies:
-      '@types/chai': 4.3.11
-
-  /@types/chai@4.3.11:
-    resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
 
   /@types/chrome@0.0.256:
     resolution: {integrity: sha512-NleTQw4DNzhPwObLNuQ3i3nvX1rZ1mgnx5FNHc2KP+Cj1fgd3BrT5yQ6Xvs+7H0kNsYxCY+lxhiCwsqq3JwtEg==}
@@ -3635,7 +3927,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-Vih/4xLXmY7V490dGwBQJTpIZxH4ZFH6eCVmQ4RFkB+wmaCTDAx4dtgoWwMNGKLkqRY1L6rPqzEbjorRnDo4rQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3647,7 +3939,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.17.0
       '@typescript-eslint/type-utils': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
@@ -3684,8 +3976,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==}
+  /@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -3694,10 +3986,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.19.0
-      '@typescript-eslint/types': 6.19.0
-      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.19.0
+      '@typescript-eslint/scope-manager': 6.19.1
+      '@typescript-eslint/types': 6.19.1
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.3.4
       eslint: 8.56.0
       typescript: 5.3.3
@@ -3718,6 +4010,15 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.0
       '@typescript-eslint/visitor-keys': 6.19.0
+    dev: false
+
+  /@typescript-eslint/scope-manager@6.19.1:
+    resolution: {integrity: sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.19.1
+      '@typescript-eslint/visitor-keys': 6.19.1
+    dev: true
 
   /@typescript-eslint/type-utils@6.17.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-hDXcWmnbtn4P2B37ka3nil3yi3VCQO2QEB9gBiHJmQp5wmyQWqnjA85+ZcE8c4FqnaB6lBwMrPkgd4aBYz3iNg==}
@@ -3745,6 +4046,12 @@ packages:
   /@typescript-eslint/types@6.19.0:
     resolution: {integrity: sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: false
+
+  /@typescript-eslint/types@6.19.1:
+    resolution: {integrity: sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
 
   /@typescript-eslint/typescript-estree@6.17.0(typescript@5.3.3):
     resolution: {integrity: sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==}
@@ -3787,6 +4094,29 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree@6.19.1(typescript@5.3.3):
+    resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.19.1
+      '@typescript-eslint/visitor-keys': 6.19.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/utils@6.17.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-LofsSPjN/ITNkzV47hxas2JCsNCEnGhVvocfyOcLzT9c/tSZE7SfhS/iWtzP1lKNOEfLhRTZz6xqI8N2RzweSQ==}
@@ -3838,6 +4168,15 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.0
       eslint-visitor-keys: 3.4.3
+    dev: false
+
+  /@typescript-eslint/visitor-keys@6.19.1:
+    resolution: {integrity: sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.19.1
+      eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -3853,7 +4192,7 @@ packages:
       - '@swc/helpers'
     dev: true
 
-  /@vitest/browser@0.34.6(esbuild@0.18.20)(vitest@0.34.6):
+  /@vitest/browser@0.34.6(esbuild@0.18.20)(vitest@1.2.1):
     resolution: {integrity: sha512-XCIGROVgw3L+PwYw/T2l+HP/SPrXvh2MfmQNU3aULl5ekE+QVj9A1RYu/1mcYXdac9ES4ahxUz6n4wgcVd9tbA==}
     peerDependencies:
       vitest: '>=0.34.0'
@@ -3862,41 +4201,62 @@ packages:
       magic-string: 0.30.5
       modern-node-polyfills: 1.0.0(esbuild@0.18.20)
       sirv: 2.0.3
-      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
+      vitest: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
     transitivePeerDependencies:
       - esbuild
       - rollup
 
-  /@vitest/expect@0.34.6:
-    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+  /@vitest/browser@1.2.1(vitest@1.2.1):
+    resolution: {integrity: sha512-jhaQ15zWYAwz8anXgmLW0yAVLCXdT8RFv7LeW9bg7sMlvGJaTCTIHaHWFvCdADF/i62+22tnrzgiiqSnApjXtA==}
+    peerDependencies:
+      playwright: '*'
+      safaridriver: '*'
+      vitest: ^1.0.0
+      webdriverio: '*'
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
     dependencies:
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      chai: 4.3.10
+      '@vitest/utils': 1.2.1
+      magic-string: 0.30.5
+      sirv: 2.0.4
+      vitest: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
 
-  /@vitest/runner@0.34.6:
-    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+  /@vitest/expect@1.2.1:
+    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
     dependencies:
-      '@vitest/utils': 0.34.6
-      p-limit: 4.0.0
-      pathe: 1.1.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      chai: 4.4.1
 
-  /@vitest/snapshot@0.34.6:
-    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+  /@vitest/runner@1.2.1:
+    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
+    dependencies:
+      '@vitest/utils': 1.2.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  /@vitest/snapshot@1.2.1:
+    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
     dependencies:
       magic-string: 0.30.5
-      pathe: 1.1.1
+      pathe: 1.1.2
       pretty-format: 29.7.0
 
-  /@vitest/spy@0.34.6:
-    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+  /@vitest/spy@1.2.1:
+    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
     dependencies:
       tinyspy: 2.2.0
 
-  /@vitest/utils@0.34.6:
-    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+  /@vitest/utils@1.2.1:
+    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
     dependencies:
       diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
 
@@ -4013,7 +4373,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     dev: true
 
@@ -4024,7 +4384,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     dev: true
 
@@ -4039,7 +4399,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     dev: true
 
@@ -4091,9 +4451,19 @@ packages:
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
 
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -4117,6 +4487,7 @@ packages:
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
@@ -4743,8 +5114,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /chai@4.3.10:
-    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
+  /chai@4.4.1:
+    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
@@ -5113,7 +5484,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: true
 
   /core-js-pure@3.34.0:
@@ -5230,7 +5601,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.33)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: true
 
   /css-to-react-native@3.2.0:
@@ -5550,6 +5921,7 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    requiresBuild: true
 
   /enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
@@ -5779,6 +6151,36 @@ packages:
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
     dev: true
+
+  /esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
 
   /esbuild@0.19.9:
     resolution: {integrity: sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==}
@@ -6088,7 +6490,7 @@ packages:
       eslint: 8.56.0
     dev: false
 
-  /eslint-plugin-vitest@0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3):
+  /eslint-plugin-vitest@0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.1):
     resolution: {integrity: sha512-O05k4j9TGMOkkghj9dRgpeLDyOSiVIxQWgNDPfhYPm5ioJsehcYV/zkRLekQs+c8+RBCVXucSED3fYOyy2EoWA==}
     engines: {node: ^18.0.0 || >= 20.0.0}
     peerDependencies:
@@ -6104,6 +6506,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.17.0(@typescript-eslint/parser@6.17.0)(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
+      vitest: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6254,6 +6657,20 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.2.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   /exegesis-express@4.0.0:
     resolution: {integrity: sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==}
@@ -6706,6 +7123,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /fsevents@2.3.3:
@@ -6805,6 +7223,10 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
     dev: true
+
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -7217,6 +7639,10 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -7582,6 +8008,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -7858,8 +8288,8 @@ packages:
       minimist: 1.2.8
     dev: false
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+  /jsonc-parser@3.2.1:
+    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -8024,6 +8454,13 @@ packages:
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
+
+  /local-pkg@0.5.0:
+    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.5.0
+      pkg-types: 1.0.3
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -8296,7 +8733,6 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -8340,6 +8776,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
+
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -8463,11 +8903,11 @@ packages:
     hasBin: true
     dev: true
 
-  /mlly@1.4.2:
-    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
+  /mlly@1.5.0:
+    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
     dependencies:
-      acorn: 8.11.2
-      pathe: 1.1.1
+      acorn: 8.11.3
+      pathe: 1.1.2
       pkg-types: 1.0.3
       ufo: 1.3.2
 
@@ -8499,6 +8939,10 @@ packages:
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+
+  /mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
 
   /ms@2.0.0:
@@ -8704,6 +9148,12 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /npm-run-path@5.2.0:
+    resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+
   /nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
 
@@ -8819,6 +9269,12 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+
   /open@6.4.0:
     resolution: {integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==}
     engines: {node: '>=8'}
@@ -8907,9 +9363,9 @@ packages:
     dependencies:
       yocto-queue: 0.1.0
 
-  /p-limit@4.0.0:
-    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
     dependencies:
       yocto-queue: 1.0.0
 
@@ -9034,6 +9490,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -9061,8 +9521,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /pathe@1.1.1:
-    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
@@ -9092,14 +9552,15 @@ packages:
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
-      jsonc-parser: 3.2.0
-      mlly: 1.4.2
-      pathe: 1.1.1
+      jsonc-parser: 3.2.1
+      mlly: 1.5.0
+      pathe: 1.1.2
 
   /playwright-core@1.40.1:
     resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
     engines: {node: '>=16'}
     hasBin: true
+    dev: true
 
   /playwright@1.40.1:
     resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
@@ -9109,6 +9570,7 @@ packages:
       playwright-core: 1.40.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
@@ -9168,7 +9630,7 @@ packages:
       jiti: 1.21.0
       postcss: 8.4.33
       semver: 7.5.4
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -9924,6 +10386,28 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.8.0
       fsevents: 2.3.3
 
+  /rollup@4.9.6:
+    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.9.6
+      '@rollup/rollup-android-arm64': 4.9.6
+      '@rollup/rollup-darwin-arm64': 4.9.6
+      '@rollup/rollup-darwin-x64': 4.9.6
+      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
+      '@rollup/rollup-linux-arm64-gnu': 4.9.6
+      '@rollup/rollup-linux-arm64-musl': 4.9.6
+      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-musl': 4.9.6
+      '@rollup/rollup-win32-arm64-msvc': 4.9.6
+      '@rollup/rollup-win32-ia32-msvc': 4.9.6
+      '@rollup/rollup-win32-x64-msvc': 4.9.6
+      fsevents: 2.3.3
+
   /router@1.3.8:
     resolution: {integrity: sha512-461UFH44NtSfIlS83PUg2N7OZo86BC/kB3dY77gJdsODsBhhw7+2uE0tzTINxrY9CahCUVk1VhpWCA5i1yoIEg==}
     engines: {node: '>= 0.8'}
@@ -10174,8 +10658,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
-    optional: true
 
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -10189,6 +10671,14 @@ packages:
     dependencies:
       '@polka/url': 1.0.0-next.24
       mrmime: 1.0.1
+      totalist: 3.0.1
+
+  /sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.24
+      mrmime: 2.0.0
       totalist: 3.0.1
 
   /slash@3.0.0:
@@ -10282,8 +10772,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /std-env@3.6.0:
-    resolution: {integrity: sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==}
+  /std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
@@ -10408,6 +10898,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -10427,7 +10921,7 @@ packages:
   /strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
 
   /style-loader@3.3.3(webpack@5.89.0):
     resolution: {integrity: sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==}
@@ -10435,7 +10929,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: true
 
   /styled-components@6.1.8(react-dom@18.2.0)(react@18.2.0):
@@ -10644,7 +11138,7 @@ packages:
       - supports-color
     dev: true
 
-  /terser-webpack-plugin@5.3.9(webpack@5.89.0):
+  /terser-webpack-plugin@5.3.9(esbuild@0.18.20)(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10661,11 +11155,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
+      esbuild: 0.18.20
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.26.0
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: true
 
   /terser@5.26.0:
@@ -10701,8 +11196,8 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
-  /tinybench@2.5.1:
-    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
+  /tinybench@2.6.0:
+    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
 
   /tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
@@ -10714,8 +11209,8 @@ packages:
       tinycolor2: 1.6.0
     dev: true
 
-  /tinypool@0.7.0:
-    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
     engines: {node: '>=14.0.0'}
 
   /tinyspy@2.2.0:
@@ -10816,7 +11311,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.3.3
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: true
 
   /ts-node@10.9.2(@types/node@20.11.5)(typescript@5.3.3):
@@ -11044,6 +11539,7 @@ packages:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /unbox-primitive@1.0.2:
@@ -11301,17 +11797,36 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-node@0.34.6(@types/node@20.10.6):
-    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
-    engines: {node: '>=v14.18.0'}
+  /vite-node@1.2.1(@types/node@20.10.6):
+    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      mlly: 1.4.2
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.11(@types/node@20.10.6)
+      vite: 5.0.12(@types/node@20.10.6)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  /vite-node@1.2.1(@types/node@20.11.5):
+    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.0.12(@types/node@20.11.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -11391,22 +11906,93 @@ packages:
       rollup: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
-  /vitest@0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1):
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
+  /vite@5.0.12(@types/node@20.10.6):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.10.6
+      esbuild: 0.19.12
+      postcss: 8.4.33
+      rollup: 4.9.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  /vite@5.0.12(@types/node@20.11.5):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.11.5
+      esbuild: 0.19.12
+      postcss: 8.4.33
+      rollup: 4.9.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  /vitest@1.2.1(@types/node@20.10.6)(@vitest/browser@0.34.6)(jsdom@23.0.1):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
       happy-dom: '*'
       jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
         optional: true
       '@vitest/browser':
         optional: true
@@ -11416,39 +12002,146 @@ packages:
         optional: true
       jsdom:
         optional: true
-      playwright:
+    dependencies:
+      '@types/node': 20.10.6
+      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@1.2.1)
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      jsdom: 23.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.10.6)
+      vite-node: 1.2.1(@types/node@20.10.6)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
         optional: true
-      safaridriver:
+      '@types/node':
         optional: true
-      webdriverio:
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
     dependencies:
-      '@types/chai': 4.3.11
-      '@types/chai-subset': 1.3.5
       '@types/node': 20.10.6
-      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.11.2
-      acorn-walk: 8.3.1
+      '@vitest/browser': 1.2.1(vitest@1.2.1)
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
       cac: 6.7.14
-      chai: 4.3.10
+      chai: 4.4.1
       debug: 4.3.4
+      execa: 8.0.1
       jsdom: 23.0.1
-      local-pkg: 0.4.3
+      local-pkg: 0.5.0
       magic-string: 0.30.5
-      pathe: 1.1.1
+      pathe: 1.1.2
       picocolors: 1.0.0
-      playwright: 1.40.1
-      std-env: 3.6.0
+      std-env: 3.7.0
       strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.7.0
-      vite: 5.0.11(@types/node@20.10.6)
-      vite-node: 0.34.6(@types/node@20.10.6)
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.10.6)
+      vite-node: 1.2.1(@types/node@20.10.6)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  /vitest@1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.11.5
+      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@1.2.1)
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.11.5)
+      vite-node: 1.2.1(@types/node@20.11.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -11519,7 +12212,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.89.0(webpack-cli@5.1.4)
+      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     dev: true
 
@@ -11537,7 +12230,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack@5.89.0(webpack-cli@5.1.4):
+  /webpack@5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -11568,7 +12261,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(esbuild@0.18.20)(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-cli: 5.1.4(webpack@5.89.0)
       webpack-sources: 3.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@buf/cosmos_ibc.bufbuild_es':
         specifier: 1.6.0-20231221153343-c805262eb055.1
-        version: 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)
+        version: 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)
       '@buf/cosmos_ibc.connectrpc_es':
         specifier: 1.2.1-20231221153343-c805262eb055.1
-        version: 1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+        version: 1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
       '@buf/penumbra-zone_penumbra.bufbuild_es':
         specifier: 1.6.0-20240108223610-b2df48bf92fa.1
-        version: 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)
+        version: 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)
       '@buf/penumbra-zone_penumbra.connectrpc_es':
         specifier: 1.2.1-20240108223610-b2df48bf92fa.1
-        version: 1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
+        version: 1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
       '@penumbra-zone/wasm-bundler':
         specifier: 0.65.0-pre.0
         version: 0.65.0-pre.0
@@ -32,7 +32,7 @@ importers:
         version: 1.11.3(@types/node@20.11.5)(typescript@5.3.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.17.0
-        version: 6.17.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.17.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -144,7 +144,7 @@ importers:
         version: 18.2.18
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.17.0
-        version: 6.17.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.17.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -188,11 +188,11 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@0.34.6)(jsdom@23.0.1)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
       webpack:
         specifier: ^5.89.0
-        version: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+        version: 5.89.0(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.89.0)
@@ -204,10 +204,10 @@ importers:
     dependencies:
       '@connectrpc/connect':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.7.0)
+        version: 1.2.1(@bufbuild/protobuf@1.6.0)
       '@connectrpc/connect-web':
         specifier: ^1.2.1
-        version: 1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1)
+        version: 1.2.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.2.1)
       '@penumbra-zone/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -303,8 +303,8 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@0.34.6)(jsdom@23.0.1)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
   packages/constants:
     dependencies:
@@ -358,14 +358,14 @@ importers:
         specifier: ^4.14.202
         version: 4.14.202
       '@vitest/browser':
-        specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1)
+        specifier: ^0.34.6
+        version: 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.10.6)
+        version: 5.0.11(@types/node@20.11.5)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
   packages/eslint-config-custom:
     dependencies:
@@ -404,7 +404,7 @@ importers:
         version: 1.11.3(eslint@8.56.0)
       eslint-plugin-vitest:
         specifier: ^0.3.20
-        version: 0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.1)
+        version: 0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3)
       next:
         specifier: ^14.0.4
         version: 14.0.4(react-dom@18.2.0)(react@18.2.0)
@@ -506,8 +506,8 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.11.5)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
   packages/services:
     dependencies:
@@ -574,17 +574,14 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.11
-        version: 5.0.11(@types/node@20.10.6)
+        version: 5.0.11(@types/node@20.11.5)
     devDependencies:
       '@types/chrome':
         specifier: 0.0.256
         version: 0.0.256
-      '@vitest/browser':
-        specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
   packages/transport:
     dependencies:
@@ -656,8 +653,8 @@ importers:
         version: 3.22.4
     devDependencies:
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
   packages/ui:
     dependencies:
@@ -705,7 +702,7 @@ importers:
         version: 1.0.7(@types/react-dom@18.2.18)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/jest-dom':
         specifier: ^6.2.0
-        version: 6.2.0(vitest@1.2.1)
+        version: 6.2.0(vitest@0.34.6)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -756,8 +753,8 @@ importers:
         specifier: ^1.4.6
         version: 1.4.6
       '@vitest/browser':
-        specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1)
+        specifier: ^0.34.6
+        version: 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -789,8 +786,8 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/node@20.10.6)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
   packages/wasm:
     dependencies:
@@ -829,8 +826,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
 
 packages:
 
@@ -913,284 +910,280 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@buf/cosmos_cosmos-proto.bufbuild_es@1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_cosmos-proto.bufbuild_es@1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.6.0-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_cosmos-proto.connectrpc_es@1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-proto.connectrpc_es@1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.connectrpc_es/-/cosmos_cosmos-proto.connectrpc_es-1.2.1-20211202220400-1935555c206d.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.6.0-20230522115704-e7a85cef453e.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
-      '@bufbuild/protobuf': 1.7.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_cosmos-sdk.bufbuild_es@1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.6.0-20230719110346-aa25660f4ff7.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)
-      '@bufbuild/protobuf': 1.7.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.2.1-20230522115704-e7a85cef453e.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_cosmos-sdk.connectrpc_es@1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.2.1-20230719110346-aa25660f4ff7.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.6.0-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_gogo-proto.bufbuild_es@1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.6.0-20230509103710-5e5b9fdd0180.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.2.1-20221020125208-34d970b699f8.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_gogo-proto.connectrpc_es@1.2.1-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.2.1-20230509103710-5e5b9fdd0180.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20230509103710-5e5b9fdd0180.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.6.0-20230913112312-7ab44ae956a0.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
-      '@bufbuild/protobuf': 1.7.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_ibc.bufbuild_es@1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.6.0-20231221153343-c805262eb055.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
-      '@bufbuild/protobuf': 1.7.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.2.1-20230913112312-7ab44ae956a0.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ibc.connectrpc_es@1.2.1-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.2.1-20231221153343-c805262eb055.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230719110346-aa25660f4ff7.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20231221153343-c805262eb055.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/cosmos_ics23.bufbuild_es@1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0):
+  /@buf/cosmos_ics23.bufbuild_es@1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.6.0-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/cosmos_ics23.connectrpc_es@1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/cosmos_ics23.connectrpc_es@1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/cosmos_ics23.connectrpc_es/-/cosmos_ics23.connectrpc_es-1.2.1-20221207100654-55085f7c710a.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0):
+  /@buf/googleapis_googleapis.bufbuild_es@1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.6.0-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20220908150232-8d7204855ec1.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20220908150232-8d7204855ec1.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20221214150216-75b4300737fb.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/googleapis_googleapis.connectrpc_es@1.2.1-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.2.1-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/penumbra-zone_penumbra.bufbuild_es@1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0):
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.6.0-20240108223610-b2df48bf92fa.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.6.0
     dependencies:
-      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)
-      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)
-      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)
-      '@bufbuild/protobuf': 1.7.0
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.6.0-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.6.0-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.6.0-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.6.0-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.6.0-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.6.0-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@buf/penumbra-zone_penumbra.connectrpc_es@1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0):
+  /@buf/penumbra-zone_penumbra.connectrpc_es@1.2.1-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0):
     resolution: {registry: https://buf.build/gen/npm/v1/, tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.2.1-20240108223610-b2df48bf92fa.1.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.2.1
     dependencies:
-      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ibc.connectrpc_es': 1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.3.0)
-      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.7.0)
-      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.7.0)
+      '@buf/cosmos_cosmos-proto.connectrpc_es': 1.2.1-20211202220400-1935555c206d.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_cosmos-sdk.connectrpc_es': 1.2.1-20230522115704-e7a85cef453e.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_gogo-proto.connectrpc_es': 1.2.1-20221020125208-34d970b699f8.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ibc.connectrpc_es': 1.2.1-20230913112312-7ab44ae956a0.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/cosmos_ics23.connectrpc_es': 1.2.1-20221207100654-55085f7c710a.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/googleapis_googleapis.connectrpc_es': 1.2.1-20221214150216-75b4300737fb.1(@bufbuild/protobuf@1.6.0)(@connectrpc/connect@1.3.0)
+      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.6.0-20240108223610-b2df48bf92fa.1(@bufbuild/protobuf@1.6.0)
+      '@connectrpc/connect': 1.3.0(@bufbuild/protobuf@1.6.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
     dev: false
 
   /@bufbuild/protobuf@1.6.0:
     resolution: {integrity: sha512-hp19vSFgNw3wBBcVBx5qo5pufCqjaJ0Cfk5H/pfjNOfNWU+4/w0QVOmfAOZNRrNWRrVuaJWxcN8P2vhOkkzbBQ==}
-
-  /@bufbuild/protobuf@1.7.0:
-    resolution: {integrity: sha512-jIsRadRsyxf6ERBU1auY2c1k3doFdqh15F4HRZs4BELVuBtpN+3ipkXqcsWE+rD+EQNigeR29SfQ+ES6UX/jGg==}
-    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1214,16 +1207,6 @@ packages:
       '@connectrpc/connect': 1.2.1(@bufbuild/protobuf@1.6.0)
     dev: false
 
-  /@connectrpc/connect-web@1.2.1(@bufbuild/protobuf@1.7.0)(@connectrpc/connect@1.2.1):
-    resolution: {integrity: sha512-fuecLMy024OLFXwycT7uB3WHiPTgaKOIGu6beX4MWxf2K6/NIxUEiS5AzEr0bCS8r3eNyZXuJWalJgmgdrNIGA==}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.4.2
-      '@connectrpc/connect': 1.2.1
-    dependencies:
-      '@bufbuild/protobuf': 1.7.0
-      '@connectrpc/connect': 1.2.1(@bufbuild/protobuf@1.7.0)
-    dev: false
-
   /@connectrpc/connect@1.2.1(@bufbuild/protobuf@1.6.0):
     resolution: {integrity: sha512-CWQNcr0kKLU1LlijdeKhbKOAOsU/t9OKM90l07O82N4nOg1+7JgWjhlcv/QATxatOT8XwJu1DxJiVYyZs+Xixg==}
     peerDependencies:
@@ -1232,20 +1215,12 @@ packages:
       '@bufbuild/protobuf': 1.6.0
     dev: false
 
-  /@connectrpc/connect@1.2.1(@bufbuild/protobuf@1.7.0):
-    resolution: {integrity: sha512-CWQNcr0kKLU1LlijdeKhbKOAOsU/t9OKM90l07O82N4nOg1+7JgWjhlcv/QATxatOT8XwJu1DxJiVYyZs+Xixg==}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.4.2
-    dependencies:
-      '@bufbuild/protobuf': 1.7.0
-    dev: false
-
-  /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.7.0):
+  /@connectrpc/connect@1.3.0(@bufbuild/protobuf@1.6.0):
     resolution: {integrity: sha512-kTeWxJnLLtxKc2ZSDN0rIBgwfP8RwcLknthX4AKlIAmN9ZC4gGnCbwp+3BKcP/WH5c8zGBAWqSY3zeqCM+ah7w==}
     peerDependencies:
       '@bufbuild/protobuf': ^1.4.2
     dependencies:
-      '@bufbuild/protobuf': 1.7.0
+      '@bufbuild/protobuf': 1.6.0
     dev: false
 
   /@cspotcode/source-map-support@0.8.1:
@@ -1305,14 +1280,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/aix-ppc64@0.19.12:
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -1328,14 +1295,6 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/android-arm64@0.19.12:
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
     optional: true
 
   /@esbuild/android-arm64@0.19.9:
@@ -1363,14 +1322,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.19.12:
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/android-arm@0.19.9:
     resolution: {integrity: sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==}
     engines: {node: '>=12'}
@@ -1394,14 +1345,6 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.19.12:
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
     optional: true
 
   /@esbuild/android-x64@0.19.9:
@@ -1429,14 +1372,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.19.12:
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.19.9:
     resolution: {integrity: sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==}
     engines: {node: '>=12'}
@@ -1460,14 +1395,6 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.19.12:
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.9:
@@ -1495,14 +1422,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.19.12:
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.19.9:
     resolution: {integrity: sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==}
     engines: {node: '>=12'}
@@ -1526,14 +1445,6 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.19.12:
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.9:
@@ -1561,14 +1472,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.19.12:
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-arm64@0.19.9:
     resolution: {integrity: sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==}
     engines: {node: '>=12'}
@@ -1592,14 +1495,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.19.12:
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm@0.19.9:
@@ -1627,14 +1522,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.19.12:
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-ia32@0.19.9:
     resolution: {integrity: sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==}
     engines: {node: '>=12'}
@@ -1658,14 +1545,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.19.12:
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.9:
@@ -1693,14 +1572,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.19.12:
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-mips64el@0.19.9:
     resolution: {integrity: sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==}
     engines: {node: '>=12'}
@@ -1724,14 +1595,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.19.12:
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.9:
@@ -1759,14 +1622,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.19.12:
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-riscv64@0.19.9:
     resolution: {integrity: sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==}
     engines: {node: '>=12'}
@@ -1790,14 +1645,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.19.12:
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.9:
@@ -1825,14 +1672,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.19.12:
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-x64@0.19.9:
     resolution: {integrity: sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==}
     engines: {node: '>=12'}
@@ -1856,14 +1695,6 @@ packages:
     os: [netbsd]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.19.12:
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.9:
@@ -1891,14 +1722,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.19.12:
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.19.9:
     resolution: {integrity: sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==}
     engines: {node: '>=12'}
@@ -1922,14 +1745,6 @@ packages:
     os: [sunos]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.19.12:
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.9:
@@ -1957,14 +1772,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.19.12:
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/win32-arm64@0.19.9:
     resolution: {integrity: sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==}
     engines: {node: '>=12'}
@@ -1990,14 +1797,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.19.12:
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/win32-ia32@0.19.9:
     resolution: {integrity: sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==}
     engines: {node: '>=12'}
@@ -2021,14 +1820,6 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.19.12:
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /@esbuild/win32-x64@0.19.9:
@@ -3298,22 +3089,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-android-arm-eabi@4.9.6:
-    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-android-arm64@4.8.0:
     resolution: {integrity: sha512-aiItwP48BiGpMFS9Znjo/xCNQVwTQVcRKkFKsO81m8exrGjHkCBDvm9PHay2kpa8RPnZzzKcD1iQ9KaLY4fPQQ==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.9.6:
-    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -3326,22 +3103,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.9.6:
-    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-darwin-x64@4.8.0:
     resolution: {integrity: sha512-A/FAHFRNQYrELrb/JHncRWzTTXB2ticiRFztP4ggIUAfa9Up1qfW8aG2w/mN9jNiZ+HB0t0u0jpJgFXG6BfRTA==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.9.6:
-    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -3354,22 +3117,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
-    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-linux-arm64-gnu@4.8.0:
     resolution: {integrity: sha512-hBNCnqw3EVCkaPB0Oqd24bv8SklETptQWcJz06kb9OtiShn9jK1VuTgi7o4zPSt6rNGWQOTDEAccbk0OqJmS+g==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-gnu@4.9.6:
-    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -3382,22 +3131,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.9.6:
-    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-linux-riscv64-gnu@4.8.0:
     resolution: {integrity: sha512-BH5xIh7tOzS9yBi8dFrCTG8Z6iNIGWGltd3IpTSKp6+pNWWO6qy8eKoRxOtwFbMrid5NZaidLYN6rHh9aB8bEw==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
-    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
@@ -3410,22 +3145,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.9.6:
-    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-linux-x64-musl@4.8.0:
     resolution: {integrity: sha512-mdxnlW2QUzXwY+95TuxZ+CurrhgrPAMveDWI97EQlA9bfhR8tw3Pt7SUlc/eSlCNxlWktpmT//EAA8UfCHOyXg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.9.6:
-    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -3438,13 +3159,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.9.6:
-    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-win32-ia32-msvc@4.8.0:
     resolution: {integrity: sha512-p9E3PZlzurhlsN5h9g7zIP1DnqKXJe8ZUkFwAazqSvHuWfihlIISPxG9hCHCoA+dOOspL/c7ty1eeEVFTE0UTw==}
     cpu: [ia32]
@@ -3452,22 +3166,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.9.6:
-    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@rollup/rollup-win32-x64-msvc@4.8.0:
     resolution: {integrity: sha512-kb4/auKXkYKqlUYTE8s40FcJIj5soOyRLHKd4ugR0dCq0G2EfcF54eYcfQiGkHzjidZ40daB4ulsFdtqNKZtBg==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.9.6:
-    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -3626,7 +3326,7 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom@6.2.0(vitest@1.2.1):
+  /@testing-library/jest-dom@6.2.0(vitest@0.34.6):
     resolution: {integrity: sha512-+BVQlJ9cmEn5RDMUS8c2+TU6giLvzaHZ8sU/x0Jj7fk+6/46wPdwlgOPcpxS17CjcanBi/3VmGMqVr2rmbUmNw==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
     peerDependencies:
@@ -3652,7 +3352,7 @@ packages:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
-      vitest: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
+      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
     dev: false
 
   /@testing-library/react@14.1.2(react-dom@18.2.0)(react@18.2.0):
@@ -3733,6 +3433,14 @@ packages:
   /@types/aria-query@5.0.4:
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
+
+  /@types/chai-subset@1.3.5:
+    resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
+    dependencies:
+      '@types/chai': 4.3.11
+
+  /@types/chai@4.3.11:
+    resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
 
   /@types/chrome@0.0.256:
     resolution: {integrity: sha512-NleTQw4DNzhPwObLNuQ3i3nvX1rZ1mgnx5FNHc2KP+Cj1fgd3BrT5yQ6Xvs+7H0kNsYxCY+lxhiCwsqq3JwtEg==}
@@ -3927,7 +3635,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/eslint-plugin@6.17.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-Vih/4xLXmY7V490dGwBQJTpIZxH4ZFH6eCVmQ4RFkB+wmaCTDAx4dtgoWwMNGKLkqRY1L6rPqzEbjorRnDo4rQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3939,7 +3647,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.17.0
       '@typescript-eslint/type-utils': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.17.0(eslint@8.56.0)(typescript@5.3.3)
@@ -3976,8 +3684,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
+  /@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -3986,10 +3694,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.19.1
-      '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.19.1
+      '@typescript-eslint/scope-manager': 6.19.0
+      '@typescript-eslint/types': 6.19.0
+      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.19.0
       debug: 4.3.4
       eslint: 8.56.0
       typescript: 5.3.3
@@ -4010,15 +3718,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.0
       '@typescript-eslint/visitor-keys': 6.19.0
-    dev: false
-
-  /@typescript-eslint/scope-manager@6.19.1:
-    resolution: {integrity: sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    dependencies:
-      '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/visitor-keys': 6.19.1
-    dev: true
 
   /@typescript-eslint/type-utils@6.17.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-hDXcWmnbtn4P2B37ka3nil3yi3VCQO2QEB9gBiHJmQp5wmyQWqnjA85+ZcE8c4FqnaB6lBwMrPkgd4aBYz3iNg==}
@@ -4046,12 +3745,6 @@ packages:
   /@typescript-eslint/types@6.19.0:
     resolution: {integrity: sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: false
-
-  /@typescript-eslint/types@6.19.1:
-    resolution: {integrity: sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    dev: true
 
   /@typescript-eslint/typescript-estree@6.17.0(typescript@5.3.3):
     resolution: {integrity: sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==}
@@ -4094,29 +3787,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/typescript-estree@6.19.1(typescript@5.3.3):
-    resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/visitor-keys': 6.19.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/utils@6.17.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-LofsSPjN/ITNkzV47hxas2JCsNCEnGhVvocfyOcLzT9c/tSZE7SfhS/iWtzP1lKNOEfLhRTZz6xqI8N2RzweSQ==}
@@ -4168,15 +3838,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.19.0
       eslint-visitor-keys: 3.4.3
-    dev: false
-
-  /@typescript-eslint/visitor-keys@6.19.1:
-    resolution: {integrity: sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    dependencies:
-      '@typescript-eslint/types': 6.19.1
-      eslint-visitor-keys: 3.4.3
-    dev: true
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -4192,7 +3853,7 @@ packages:
       - '@swc/helpers'
     dev: true
 
-  /@vitest/browser@0.34.6(esbuild@0.18.20)(vitest@1.2.1):
+  /@vitest/browser@0.34.6(esbuild@0.18.20)(vitest@0.34.6):
     resolution: {integrity: sha512-XCIGROVgw3L+PwYw/T2l+HP/SPrXvh2MfmQNU3aULl5ekE+QVj9A1RYu/1mcYXdac9ES4ahxUz6n4wgcVd9tbA==}
     peerDependencies:
       vitest: '>=0.34.0'
@@ -4201,62 +3862,41 @@ packages:
       magic-string: 0.30.5
       modern-node-polyfills: 1.0.0(esbuild@0.18.20)
       sirv: 2.0.3
-      vitest: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
+      vitest: 0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1)
     transitivePeerDependencies:
       - esbuild
       - rollup
 
-  /@vitest/browser@1.2.1(vitest@1.2.1):
-    resolution: {integrity: sha512-jhaQ15zWYAwz8anXgmLW0yAVLCXdT8RFv7LeW9bg7sMlvGJaTCTIHaHWFvCdADF/i62+22tnrzgiiqSnApjXtA==}
-    peerDependencies:
-      playwright: '*'
-      safaridriver: '*'
-      vitest: ^1.0.0
-      webdriverio: '*'
-    peerDependenciesMeta:
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
+  /@vitest/expect@0.34.6:
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
     dependencies:
-      '@vitest/utils': 1.2.1
-      magic-string: 0.30.5
-      sirv: 2.0.4
-      vitest: 1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1)
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.3.10
 
-  /@vitest/expect@1.2.1:
-    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
+  /@vitest/runner@0.34.6:
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
     dependencies:
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
-      chai: 4.4.1
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.1
 
-  /@vitest/runner@1.2.1:
-    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
-    dependencies:
-      '@vitest/utils': 1.2.1
-      p-limit: 5.0.0
-      pathe: 1.1.2
-
-  /@vitest/snapshot@1.2.1:
-    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
+  /@vitest/snapshot@0.34.6:
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
     dependencies:
       magic-string: 0.30.5
-      pathe: 1.1.2
+      pathe: 1.1.1
       pretty-format: 29.7.0
 
-  /@vitest/spy@1.2.1:
-    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
+  /@vitest/spy@0.34.6:
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
     dependencies:
       tinyspy: 2.2.0
 
-  /@vitest/utils@1.2.1:
-    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
+  /@vitest/utils@0.34.6:
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
     dependencies:
       diff-sequences: 29.6.3
-      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
 
@@ -4373,7 +4013,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     dev: true
 
@@ -4384,7 +4024,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     dev: true
 
@@ -4399,7 +4039,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     dev: true
 
@@ -4451,19 +4091,9 @@ packages:
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /acorn-walk@8.3.2:
-    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
-    engines: {node: '>=0.4.0'}
 
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  /acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -4487,7 +4117,6 @@ packages:
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
-    requiresBuild: true
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
@@ -5114,8 +4743,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /chai@4.4.1:
-    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
+  /chai@4.3.10:
+    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
@@ -5484,7 +5113,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /core-js-pure@3.34.0:
@@ -5601,7 +5230,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.33)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /css-to-react-native@3.2.0:
@@ -5921,7 +5550,6 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    requiresBuild: true
 
   /enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
@@ -6151,36 +5779,6 @@ packages:
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
     dev: true
-
-  /esbuild@0.19.12:
-    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.12
-      '@esbuild/android-arm': 0.19.12
-      '@esbuild/android-arm64': 0.19.12
-      '@esbuild/android-x64': 0.19.12
-      '@esbuild/darwin-arm64': 0.19.12
-      '@esbuild/darwin-x64': 0.19.12
-      '@esbuild/freebsd-arm64': 0.19.12
-      '@esbuild/freebsd-x64': 0.19.12
-      '@esbuild/linux-arm': 0.19.12
-      '@esbuild/linux-arm64': 0.19.12
-      '@esbuild/linux-ia32': 0.19.12
-      '@esbuild/linux-loong64': 0.19.12
-      '@esbuild/linux-mips64el': 0.19.12
-      '@esbuild/linux-ppc64': 0.19.12
-      '@esbuild/linux-riscv64': 0.19.12
-      '@esbuild/linux-s390x': 0.19.12
-      '@esbuild/linux-x64': 0.19.12
-      '@esbuild/netbsd-x64': 0.19.12
-      '@esbuild/openbsd-x64': 0.19.12
-      '@esbuild/sunos-x64': 0.19.12
-      '@esbuild/win32-arm64': 0.19.12
-      '@esbuild/win32-ia32': 0.19.12
-      '@esbuild/win32-x64': 0.19.12
 
   /esbuild@0.19.9:
     resolution: {integrity: sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==}
@@ -6490,7 +6088,7 @@ packages:
       eslint: 8.56.0
     dev: false
 
-  /eslint-plugin-vitest@0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3)(vitest@1.2.1):
+  /eslint-plugin-vitest@0.3.20(@typescript-eslint/eslint-plugin@6.17.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-O05k4j9TGMOkkghj9dRgpeLDyOSiVIxQWgNDPfhYPm5ioJsehcYV/zkRLekQs+c8+RBCVXucSED3fYOyy2EoWA==}
     engines: {node: ^18.0.0 || >= 20.0.0}
     peerDependencies:
@@ -6506,7 +6104,6 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.17.0(@typescript-eslint/parser@6.17.0)(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
-      vitest: 1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6657,20 +6254,6 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
-
-  /execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.2.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
 
   /exegesis-express@4.0.0:
     resolution: {integrity: sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==}
@@ -7123,7 +6706,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /fsevents@2.3.3:
@@ -7223,10 +6805,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
     dev: true
-
-  /get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -7639,10 +7217,6 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
-  /human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -8008,10 +7582,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -8288,8 +7858,8 @@ packages:
       minimist: 1.2.8
     dev: false
 
-  /jsonc-parser@3.2.1:
-    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
+  /jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -8454,13 +8024,6 @@ packages:
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
-
-  /local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
-    dependencies:
-      mlly: 1.5.0
-      pkg-types: 1.0.3
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -8733,6 +8296,7 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -8776,10 +8340,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
     dev: true
-
-  /mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -8903,11 +8463,11 @@ packages:
     hasBin: true
     dev: true
 
-  /mlly@1.5.0:
-    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
+  /mlly@1.4.2:
+    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
     dependencies:
-      acorn: 8.11.3
-      pathe: 1.1.2
+      acorn: 8.11.2
+      pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.3.2
 
@@ -8939,10 +8499,6 @@ packages:
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
-    engines: {node: '>=10'}
-
-  /mrmime@2.0.0:
-    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
 
   /ms@2.0.0:
@@ -9148,12 +8704,6 @@ packages:
       path-key: 3.1.1
     dev: true
 
-  /npm-run-path@5.2.0:
-    resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      path-key: 4.0.0
-
   /nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
 
@@ -9269,12 +8819,6 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      mimic-fn: 4.0.0
-
   /open@6.4.0:
     resolution: {integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==}
     engines: {node: '>=8'}
@@ -9363,9 +8907,9 @@ packages:
     dependencies:
       yocto-queue: 0.1.0
 
-  /p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
+  /p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       yocto-queue: 1.0.0
 
@@ -9490,10 +9034,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  /path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -9521,8 +9061,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
@@ -9552,15 +9092,14 @@ packages:
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
-      jsonc-parser: 3.2.1
-      mlly: 1.5.0
-      pathe: 1.1.2
+      jsonc-parser: 3.2.0
+      mlly: 1.4.2
+      pathe: 1.1.1
 
   /playwright-core@1.40.1:
     resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
     engines: {node: '>=16'}
     hasBin: true
-    dev: true
 
   /playwright@1.40.1:
     resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
@@ -9570,7 +9109,6 @@ packages:
       playwright-core: 1.40.1
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
@@ -9630,7 +9168,7 @@ packages:
       jiti: 1.21.0
       postcss: 8.4.33
       semver: 7.5.4
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -10386,28 +9924,6 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.8.0
       fsevents: 2.3.3
 
-  /rollup@4.9.6:
-    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.6
-      '@rollup/rollup-android-arm64': 4.9.6
-      '@rollup/rollup-darwin-arm64': 4.9.6
-      '@rollup/rollup-darwin-x64': 4.9.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
-      '@rollup/rollup-linux-arm64-gnu': 4.9.6
-      '@rollup/rollup-linux-arm64-musl': 4.9.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-musl': 4.9.6
-      '@rollup/rollup-win32-arm64-msvc': 4.9.6
-      '@rollup/rollup-win32-ia32-msvc': 4.9.6
-      '@rollup/rollup-win32-x64-msvc': 4.9.6
-      fsevents: 2.3.3
-
   /router@1.3.8:
     resolution: {integrity: sha512-461UFH44NtSfIlS83PUg2N7OZo86BC/kB3dY77gJdsODsBhhw7+2uE0tzTINxrY9CahCUVk1VhpWCA5i1yoIEg==}
     engines: {node: '>= 0.8'}
@@ -10658,6 +10174,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -10671,14 +10189,6 @@ packages:
     dependencies:
       '@polka/url': 1.0.0-next.24
       mrmime: 1.0.1
-      totalist: 3.0.1
-
-  /sirv@2.0.4:
-    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@polka/url': 1.0.0-next.24
-      mrmime: 2.0.0
       totalist: 3.0.1
 
   /slash@3.0.0:
@@ -10772,8 +10282,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+  /std-env@3.6.0:
+    resolution: {integrity: sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==}
 
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
@@ -10898,10 +10408,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -10921,7 +10427,7 @@ packages:
   /strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.11.2
 
   /style-loader@3.3.3(webpack@5.89.0):
     resolution: {integrity: sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==}
@@ -10929,7 +10435,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /styled-components@6.1.8(react-dom@18.2.0)(react@18.2.0):
@@ -11138,7 +10644,7 @@ packages:
       - supports-color
     dev: true
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.18.20)(webpack@5.89.0):
+  /terser-webpack-plugin@5.3.9(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -11155,12 +10661,11 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
-      esbuild: 0.18.20
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.26.0
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /terser@5.26.0:
@@ -11196,8 +10701,8 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
-  /tinybench@2.6.0:
-    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
+  /tinybench@2.5.1:
+    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
 
   /tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
@@ -11209,8 +10714,8 @@ packages:
       tinycolor2: 1.6.0
     dev: true
 
-  /tinypool@0.8.2:
-    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
 
   /tinyspy@2.2.0:
@@ -11311,7 +10816,7 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.3.3
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
   /ts-node@10.9.2(@types/node@20.11.5)(typescript@5.3.3):
@@ -11539,7 +11044,6 @@ packages:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-    requiresBuild: true
     dev: true
 
   /unbox-primitive@1.0.2:
@@ -11797,36 +11301,17 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-node@1.2.1(@types/node@20.10.6):
-    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vite-node@0.34.6(@types/node@20.10.6):
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      pathe: 1.1.2
+      mlly: 1.4.2
+      pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.10.6)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  /vite-node@1.2.1(@types/node@20.11.5):
-    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.5)
+      vite: 5.0.11(@types/node@20.10.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -11906,93 +11391,22 @@ packages:
       rollup: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
-  /vite@5.0.12(@types/node@20.10.6):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.10.6
-      esbuild: 0.19.12
-      postcss: 8.4.33
-      rollup: 4.9.6
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  /vite@5.0.12(@types/node@20.11.5):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.5
-      esbuild: 0.19.12
-      postcss: 8.4.33
-      rollup: 4.9.6
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  /vitest@1.2.1(@types/node@20.10.6)(@vitest/browser@0.34.6)(jsdom@23.0.1):
-    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vitest@0.34.6(@vitest/browser@0.34.6)(jsdom@23.0.1)(playwright@1.40.1):
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
       happy-dom: '*'
       jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
-        optional: true
-      '@types/node':
         optional: true
       '@vitest/browser':
         optional: true
@@ -12002,146 +11416,39 @@ packages:
         optional: true
       jsdom:
         optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
     dependencies:
+      '@types/chai': 4.3.11
+      '@types/chai-subset': 1.3.5
       '@types/node': 20.10.6
-      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@1.2.1)
-      '@vitest/expect': 1.2.1
-      '@vitest/runner': 1.2.1
-      '@vitest/snapshot': 1.2.1
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
-      acorn-walk: 8.3.2
+      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@0.34.6)
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.11.2
+      acorn-walk: 8.3.1
       cac: 6.7.14
-      chai: 4.4.1
+      chai: 4.3.10
       debug: 4.3.4
-      execa: 8.0.1
       jsdom: 23.0.1
-      local-pkg: 0.5.0
+      local-pkg: 0.4.3
       magic-string: 0.30.5
-      pathe: 1.1.2
+      pathe: 1.1.1
       picocolors: 1.0.0
-      std-env: 3.7.0
+      playwright: 1.40.1
+      std-env: 3.6.0
       strip-literal: 1.3.0
-      tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.10.6)
-      vite-node: 1.2.1(@types/node@20.10.6)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest@1.2.1(@types/node@20.10.6)(@vitest/browser@1.2.1)(jsdom@23.0.1):
-    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 20.10.6
-      '@vitest/browser': 1.2.1(vitest@1.2.1)
-      '@vitest/expect': 1.2.1
-      '@vitest/runner': 1.2.1
-      '@vitest/snapshot': 1.2.1
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.4.1
-      debug: 4.3.4
-      execa: 8.0.1
-      jsdom: 23.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.10.6)
-      vite-node: 1.2.1(@types/node@20.10.6)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  /vitest@1.2.1(@types/node@20.11.5)(@vitest/browser@0.34.6):
-    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.5
-      '@vitest/browser': 0.34.6(esbuild@0.18.20)(vitest@1.2.1)
-      '@vitest/expect': 1.2.1
-      '@vitest/runner': 1.2.1
-      '@vitest/snapshot': 1.2.1
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.4.1
-      debug: 4.3.4
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.5)
-      vite-node: 1.2.1(@types/node@20.11.5)
+      tinybench: 2.5.1
+      tinypool: 0.7.0
+      vite: 5.0.11(@types/node@20.10.6)
+      vite-node: 0.34.6(@types/node@20.10.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -12212,7 +11519,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4)
+      webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     dev: true
 
@@ -12230,7 +11537,7 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack@5.89.0(esbuild@0.18.20)(webpack-cli@5.1.4):
+  /webpack@5.89.0(webpack-cli@5.1.4):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -12261,7 +11568,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.18.20)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-cli: 5.1.4(webpack@5.89.0)
       webpack-sources: 3.2.3


### PR DESCRIPTION
🚨 Most line changes are due to `pnpm-lock.yaml`

## Background
We wanted to update to the latest version of Vite and especially Vitest, since the version of Vitest we were using was still in beta.

## In this PR
- Update to the latest versions of `vite` and `vitest`.
- Update `@bufbuild/protobuf`, which otherwise broke things when updating to the latest `vite`/`vitest`.
- Update to the latest `@vitest/browser` in `packages/crypto`, and install it in `packages/storage`. This is required by `vitest` v1.0.0+.
- Re-enable the `packages/crypto` test suite that I'd previously disabled due to #379.
- Handle weird issue with the `buffer` library.
  - When Vadim was working on this (#272), he came across the same issue I did: a weird error saying that the `buffer` library `does not provide an export named 'Buffer'`. @grod220 [found](https://github.com/penumbra-zone/web/pull/272#issuecomment-1841412562) that changing the import to add a trailing slash would fix the issue, and indeed [`buffer`'s own docs support this](https://www.npmjs.com/package/buffer#usage). For some reason, though, that only fixed the test failures locally, not in CI.
  
    I couldn't figure out a way to resolve the issue with the `buffer` library, so I took a different approach: uninstalling the library completely and finding native JS ways to accomplish the tasks we were using `buffer` for. We were only using it to encode/decode data between different formats like base64, Uint8 arrays, etc., so I found native JS implementations of those functions and used them instead. Thankfully, the functions were well-tested, so I didn't touch the tests — I only updated the code and saw that the tests still passed, leaving comments for where I got the implementation.

    ~As part of this work, I also removed the `Buffer` global that was provided via Webpack in the extension. We're not using buffers in the extension anywhere anyway, so I'm guessing it's a leftover from when we were. Reviewers, please correct me if I'm wrong.~ Just kidding — looks like that `Buffer` global was being used by `bip39` under the hood.

## Manual testing
I imported the test account wallet locally and sent a transaction. Everything worked fine. If there's other stuff I should do to test that nothing's broken, let me know!

## Punting (until followup PRs)
- We're still getting this warning message during test runs: `The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.` Since it's not blocking anything, I'm going to handle that in a follow-up PR that will close #271, so that this PR doesn't get too big.
- I haven't updated _all_ packages yet via `pnpm up -r --latest` — I was just focusing on Vite/Vitest for this PR.

Relates to #271 
Closes #379 