### PR TITLE
don't attempt to type message json with Jsonified

### DIFF
--- a/apps/extension/src/offscreen.ts
+++ b/apps/extension/src/offscreen.ts
@@ -66,12 +66,12 @@ const spawnWorker = ({
       else reject(new Error(`No Action data from worker ${actionPlanIndex}`));
     };
 
-    const onWorkerError = ({ filename, lineno, colno, message, error }: ErrorEvent) => {
+    const onWorkerError = (ev: ErrorEvent) => {
+      const { filename, lineno, colno, message } = ev;
       worker.removeEventListener('message', onWorkerMessage);
       worker.terminate();
-      const location = `Worker ${filename}:${lineno}:${colno}`;
-      console.error(location, message, error);
-      reject(error ?? new Error(`${location} ${message}`));
+      console.error('Worker ErrorEvent', ev);
+      reject(ev.error ?? new Error(`Worker ErrorEvent ${filename}:${lineno}:${colno} ${message}`));
     };
 
     worker.addEventListener('message', onWorkerMessage, { once: true });

--- a/apps/extension/src/offscreen.ts
+++ b/apps/extension/src/offscreen.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from '@bufbuild/protobuf';
+import { isJsonObject } from '@penumbra-zone/types';
 import {
   OffscreenRequest,
   OffscreenResponse,
@@ -7,7 +8,6 @@ import {
   WasmBuildActionInput,
   WasmBuildActionOutput,
   isActionBuildRequest,
-  isWasmBuildActionOutput,
 } from '@penumbra-zone/types/src/internal-msg/offscreen';
 
 export const isOffscreenRequest = (req: unknown): req is OffscreenRequest =>
@@ -62,7 +62,7 @@ const spawnWorker = ({
     const onWorkerMessage = (e: MessageEvent<unknown>) => {
       worker.removeEventListener('error', onWorkerError);
       worker.terminate();
-      if (isWasmBuildActionOutput(e.data)) resolve(e.data);
+      if (isJsonObject(e.data)) resolve(e.data);
       else reject(new Error(`No Action data from worker ${actionPlanIndex}`));
     };
 

--- a/apps/extension/src/offscreen.ts
+++ b/apps/extension/src/offscreen.ts
@@ -66,10 +66,12 @@ const spawnWorker = ({
       else reject(new Error(`No Action data from worker ${actionPlanIndex}`));
     };
 
-    const onWorkerError = (error: ErrorEvent) => {
+    const onWorkerError = ({ filename, lineno, colno, message, error }: ErrorEvent) => {
       worker.removeEventListener('message', onWorkerMessage);
       worker.terminate();
-      reject(new Error(`${error.filename}:${error.lineno} ${error.message}`));
+      const location = `Worker ${filename}:${lineno}:${colno}`;
+      console.error(location, message, error);
+      reject(error ?? new Error(`${location} ${message}`));
     };
 
     worker.addEventListener('message', onWorkerMessage, { once: true });

--- a/apps/extension/src/routes/popup/approval/transaction.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction.tsx
@@ -7,7 +7,8 @@ import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbr
 export const TransactionApproval = () => {
   const { authorizeRequest, transactionViewFromPlan, responder } = useStore(txApprovalSelector);
 
-  if (!authorizeRequest?.plan || !responder || !transactionViewFromPlan) return null;
+  if (!authorizeRequest || !authorizeRequest['plan'] || !responder || !transactionViewFromPlan)
+    return null;
 
   return (
     <div className='flex h-screen flex-col justify-between p-[30px] pt-10 '>

--- a/apps/extension/src/routes/popup/approval/transaction.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction.tsx
@@ -4,11 +4,20 @@ import { txApprovalSelector } from '../../../state/tx-approval';
 import { JsonViewer } from '@penumbra-zone/ui/components/ui/json-viewer';
 import { Jsonified } from '@penumbra-zone/types';
 import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
+import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 
 export const TransactionApproval = () => {
-  const { authorizeRequest, transactionViewFromPlan, responder } = useStore(txApprovalSelector);
+  const {
+    authorizeRequest: authReqString,
+    transactionViewFromPlan: txPlanString,
+    responder,
+  } = useStore(txApprovalSelector);
+  if (!authReqString || !txPlanString || !responder) return null;
 
-  if (!authorizeRequest?.plan || !responder || !transactionViewFromPlan) return null;
+  const authorizeRequest = AuthorizeRequest.fromJsonString(authReqString);
+  const transactionViewFromPlan = TransactionView.fromJsonString(txPlanString);
+
+  if (!authorizeRequest.plan) return null;
 
   return (
     <div className='flex h-screen flex-col justify-between p-[30px] pt-10 '>

--- a/apps/extension/src/routes/popup/approval/transaction.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction.tsx
@@ -2,13 +2,11 @@ import { Button, TransactionViewComponent } from '@penumbra-zone/ui';
 import { useStore } from '../../../state';
 import { txApprovalSelector } from '../../../state/tx-approval';
 import { JsonViewer } from '@penumbra-zone/ui/components/ui/json-viewer';
-import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 
 export const TransactionApproval = () => {
   const { authorizeRequest, transactionViewFromPlan, responder } = useStore(txApprovalSelector);
 
-  if (!authorizeRequest || !authorizeRequest['plan'] || !responder || !transactionViewFromPlan)
-    return null;
+  if (!authorizeRequest?.plan || !responder || !transactionViewFromPlan) return null;
 
   return (
     <div className='flex h-screen flex-col justify-between p-[30px] pt-10 '>
@@ -17,7 +15,7 @@ export const TransactionApproval = () => {
           Confirm transaction
         </p>
 
-        <TransactionViewComponent txv={TransactionView.fromJson(transactionViewFromPlan)} />
+        <TransactionViewComponent txv={transactionViewFromPlan} />
 
         <div className='mt-8'>
           <JsonViewer jsonObj={authorizeRequest} />

--- a/apps/extension/src/routes/popup/approval/transaction.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction.tsx
@@ -2,6 +2,8 @@ import { Button, TransactionViewComponent } from '@penumbra-zone/ui';
 import { useStore } from '../../../state';
 import { txApprovalSelector } from '../../../state/tx-approval';
 import { JsonViewer } from '@penumbra-zone/ui/components/ui/json-viewer';
+import { Jsonified } from '@penumbra-zone/types';
+import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
 
 export const TransactionApproval = () => {
   const { authorizeRequest, transactionViewFromPlan, responder } = useStore(txApprovalSelector);
@@ -18,7 +20,7 @@ export const TransactionApproval = () => {
         <TransactionViewComponent txv={transactionViewFromPlan} />
 
         <div className='mt-8'>
-          <JsonViewer jsonObj={authorizeRequest} />
+          <JsonViewer jsonObj={authorizeRequest.toJson() as Jsonified<AuthorizeRequest>} />
         </div>
       </div>
       <div className='fixed inset-x-0 bottom-0 flex flex-col gap-4 bg-black px-6 py-4 shadow-lg'>

--- a/apps/extension/src/routes/popup/approval/tx-msg-handler.ts
+++ b/apps/extension/src/routes/popup/approval/tx-msg-handler.ts
@@ -11,10 +11,12 @@ export const isTxApprovalReq = (req: PopupRequest): req is TxApproval => {
 
 export const handleTxApproval: InternalMessageHandler<TxApproval> = (jsonReq, responder) => {
   useStore.setState(state => {
-    state.txApproval.authorizeRequest = AuthorizeRequest.fromJson(jsonReq.authorizeRequest);
+    state.txApproval.authorizeRequest = AuthorizeRequest.fromJson(
+      jsonReq.authorizeRequest,
+    ).toJsonString();
     state.txApproval.transactionViewFromPlan = TransactionView.fromJson(
       jsonReq.transactionViewFromPlan,
-    );
+    ).toJsonString();
     state.txApproval.responder = responder;
   });
 };

--- a/apps/extension/src/routes/popup/approval/tx-msg-handler.ts
+++ b/apps/extension/src/routes/popup/approval/tx-msg-handler.ts
@@ -2,6 +2,8 @@ import { TxApproval } from '@penumbra-zone/types/src/internal-msg/tx-approval';
 import { InternalMessageHandler } from '@penumbra-zone/types/src/internal-msg/shared';
 import { PopupRequest } from '@penumbra-zone/types/src/internal-msg/popup';
 import { useStore } from '../../../state';
+import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
+import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 
 export const isTxApprovalReq = (req: PopupRequest): req is TxApproval => {
   return req.type === 'TX-APPROVAL';
@@ -9,8 +11,10 @@ export const isTxApprovalReq = (req: PopupRequest): req is TxApproval => {
 
 export const handleTxApproval: InternalMessageHandler<TxApproval> = (jsonReq, responder) => {
   useStore.setState(state => {
-    state.txApproval.authorizeRequest = jsonReq.authorizeRequest;
-    state.txApproval.transactionViewFromPlan = jsonReq.transactionViewFromPlan;
+    state.txApproval.authorizeRequest = AuthorizeRequest.fromJson(jsonReq.authorizeRequest);
+    state.txApproval.transactionViewFromPlan = TransactionView.fromJson(
+      jsonReq.transactionViewFromPlan,
+    );
     state.txApproval.responder = responder;
   });
 };

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -1,13 +1,13 @@
 import type { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 import type { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
-import type { Jsonified, Stringified } from '@penumbra-zone/types';
+import type { Stringified } from '@penumbra-zone/types';
 import { AllSlices, SliceCreator } from './index';
 import { MessageResponder } from '@penumbra-zone/types/src/internal-msg/shared';
 import { TxApproval } from '@penumbra-zone/types/src/internal-msg/tx-approval';
 
 export interface TxApprovalSlice {
-  authorizeRequest?: Stringified<Jsonified<AuthorizeRequest>>;
-  transactionViewFromPlan?: Stringified<Jsonified<TransactionView>>;
+  authorizeRequest?: Stringified<AuthorizeRequest>;
+  transactionViewFromPlan?: Stringified<TransactionView>;
   // Holding the message responder function. Service worker will be "awaiting" the call of this.
   responder?: MessageResponder<TxApproval>;
 }

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -6,6 +6,7 @@ import { MessageResponder } from '@penumbra-zone/types/src/internal-msg/shared';
 import { TxApproval } from '@penumbra-zone/types/src/internal-msg/tx-approval';
 
 export interface TxApprovalSlice {
+  // zustand doesn't like JsonValue, because the type is infinitely deep. so store json strings
   authorizeRequest?: Stringified<AuthorizeRequest>;
   transactionViewFromPlan?: Stringified<TransactionView>;
   // Holding the message responder function. Service worker will be "awaiting" the call of this.

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -1,13 +1,12 @@
 import { AllSlices, SliceCreator } from './index';
 import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
-import { Jsonified } from '@penumbra-zone/types';
 import { MessageResponder } from '@penumbra-zone/types/src/internal-msg/shared';
 import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 import { TxApproval } from '@penumbra-zone/types/src/internal-msg/tx-approval';
 
 export interface TxApprovalSlice {
-  authorizeRequest?: Jsonified<AuthorizeRequest>;
-  transactionViewFromPlan?: Jsonified<TransactionView>;
+  authorizeRequest?: AuthorizeRequest;
+  transactionViewFromPlan?: TransactionView;
   // Holding the message responder function. Service worker will be "awaiting" the call of this.
   responder?: MessageResponder<TxApproval>;
 }

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -1,12 +1,10 @@
 import { AllSlices, SliceCreator } from './index';
-import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
 import { MessageResponder } from '@penumbra-zone/types/src/internal-msg/shared';
-import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 import { TxApproval } from '@penumbra-zone/types/src/internal-msg/tx-approval';
 
 export interface TxApprovalSlice {
-  authorizeRequest?: AuthorizeRequest;
-  transactionViewFromPlan?: TransactionView;
+  authorizeRequest?: string;
+  transactionViewFromPlan?: string;
   // Holding the message responder function. Service worker will be "awaiting" the call of this.
   responder?: MessageResponder<TxApproval>;
 }

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -1,10 +1,13 @@
+import type { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
+import type { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
+import type { Jsonified, Stringified } from '@penumbra-zone/types';
 import { AllSlices, SliceCreator } from './index';
 import { MessageResponder } from '@penumbra-zone/types/src/internal-msg/shared';
 import { TxApproval } from '@penumbra-zone/types/src/internal-msg/tx-approval';
 
 export interface TxApprovalSlice {
-  authorizeRequest?: string;
-  transactionViewFromPlan?: string;
+  authorizeRequest?: Stringified<Jsonified<AuthorizeRequest>>;
+  transactionViewFromPlan?: Stringified<Jsonified<TransactionView>>;
   // Holding the message responder function. Service worker will be "awaiting" the call of this.
   responder?: MessageResponder<TxApproval>;
 }

--- a/apps/extension/src/wasm-build-action.ts
+++ b/apps/extension/src/wasm-build-action.ts
@@ -1,9 +1,9 @@
+import type { Action } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
 import {
   TransactionPlan,
   WitnessData,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
-import type { WasmBuildActionInput } from '@penumbra-zone/types/src/internal-msg/offscreen';
-import type { JsonValue } from '@bufbuild/protobuf';
+import { isWasmBuildActionInput } from '@penumbra-zone/types/src/internal-msg/offscreen';
 
 // necessary to propagate errors that occur in promises
 // see: https://stackoverflow.com/questions/39992417/how-to-bubble-a-web-worker-error-in-a-promise-via-worker-onerror
@@ -18,31 +18,27 @@ self.addEventListener(
   { once: true },
 );
 
-const workerListener = ({ data }: { data: WasmBuildActionInput }) => {
-  const {
-    transactionPlan: transactionPlanJson,
-    witness: witnessJson,
-    fullViewingKey,
-    actionPlanIndex,
-  } = data;
-
-  // Deserialize payload
-  const transactionPlan = TransactionPlan.fromJson(transactionPlanJson);
-  const witness = WitnessData.fromJson(witnessJson);
-
-  void executeWorker(transactionPlan, witness, fullViewingKey, actionPlanIndex).then(
-    self.postMessage,
-  );
+const workerInputListener = (ev: MessageEvent<unknown>) => {
+  if (ev.data && isWasmBuildActionInput(ev.data)) {
+    const { transactionPlan, witness, fullViewingKey, actionPlanIndex } = ev.data;
+    void executeWasmBuildAction(
+      TransactionPlan.fromJson(transactionPlan),
+      WitnessData.fromJson(witness),
+      fullViewingKey,
+      actionPlanIndex,
+    ).then((builtAction: Action) => {
+      self.postMessage(builtAction.toJson());
+    });
+  } else throw new Error('Unknown worker input');
 };
+self.addEventListener('message', workerInputListener, { once: true });
 
-self.addEventListener('message', workerListener, { once: true });
-
-async function executeWorker(
+async function executeWasmBuildAction(
   transactionPlan: TransactionPlan,
   witness: WitnessData,
   fullViewingKey: string,
   actionPlanIndex: number,
-): Promise<JsonValue> {
+): Promise<Action> {
   // Dynamically load wasm module
   const penumbraWasmModule = await import('@penumbra-zone/wasm-ts');
 
@@ -53,7 +49,10 @@ async function executeWorker(
   await penumbraWasmModule.loadProvingKey(actionPlanType);
 
   // Build action according to specification in `TransactionPlan`
-  return penumbraWasmModule
-    .buildActionParallel(transactionPlan, witness, fullViewingKey, actionPlanIndex)
-    .toJson();
+  return penumbraWasmModule.buildActionParallel(
+    transactionPlan,
+    witness,
+    fullViewingKey,
+    actionPlanIndex,
+  );
 }

--- a/apps/webapp/src/components/tx-details/hash-parser.tsx
+++ b/apps/webapp/src/components/tx-details/hash-parser.tsx
@@ -5,9 +5,10 @@ import {
   TabsTrigger,
   TransactionViewComponent,
 } from '@penumbra-zone/ui';
-import { viewFromEmptyPerspective } from '@penumbra-zone/types';
+import { Jsonified, viewFromEmptyPerspective } from '@penumbra-zone/types';
 import { TxDetailsLoaderResult } from './index.tsx';
 import { JsonViewer } from '@penumbra-zone/ui/components/ui/json-viewer';
+import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
 
 export enum TxDetailsTab {
   PUBLIC = 'public',
@@ -28,7 +29,7 @@ export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
           <TransactionViewComponent txv={txInfo.view!} />
           <div className='mt-8'>
             <div className='text-xl font-bold'>Raw JSON</div>
-            <JsonViewer jsonObj={txInfo.toJson() as object} />
+            <JsonViewer jsonObj={txInfo.toJson() as Jsonified<TransactionInfo>} />
           </div>
         </TabsContent>
         <TabsContent value={TxDetailsTab.PUBLIC} className='mt-10'>

--- a/packages/router/src/grpc/custody/view-transaction-plan/index.ts
+++ b/packages/router/src/grpc/custody/view-transaction-plan/index.ts
@@ -1,6 +1,6 @@
 import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
 import { getAddressView } from './get-address-view';
-import { Jsonified } from '@penumbra-zone/types/src/jsonified';
+import { Jsonified } from '@penumbra-zone/types';
 import {
   TransactionPlan,
   TransactionView,

--- a/packages/router/src/grpc/custody/view-transaction-plan/view-action-plan.test.ts
+++ b/packages/router/src/grpc/custody/view-transaction-plan/view-action-plan.test.ts
@@ -16,7 +16,7 @@ import {
   ValueView_KnownDenom,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1alpha1/keys_pb';
-import { Jsonified } from '@penumbra-zone/types/src/jsonified';
+import { Jsonified } from '@penumbra-zone/types';
 import { bech32AssetId } from '@penumbra-zone/types/src/asset';
 import { bech32ToUint8Array } from '@penumbra-zone/types/src/address';
 

--- a/packages/router/src/grpc/custody/view-transaction-plan/view-action-plan.ts
+++ b/packages/router/src/grpc/custody/view-transaction-plan/view-action-plan.ts
@@ -17,7 +17,7 @@ import {
   SpendPlan,
   SpendView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1alpha1/shielded_pool_pb';
-import { Jsonified } from '@penumbra-zone/types/src/jsonified';
+import { Jsonified } from '@penumbra-zone/types';
 
 const getValueView = (
   value: Value | undefined,

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -5,6 +5,7 @@ import {
   IdbConstants,
   IdbUpdate,
   IndexedDbInterface,
+  Jsonified,
   PenumbraDb,
   ScanBlockResult,
   StateCommitmentTree,
@@ -144,7 +145,10 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async saveSpendableNote(note: SpendableNoteRecord) {
-    await this.u.update({ table: 'SPENDABLE_NOTES', value: note.toJson() });
+    await this.u.update({
+      table: 'SPENDABLE_NOTES',
+      value: note.toJson() as Jsonified<SpendableNoteRecord>,
+    });
   }
 
   async getAssetsMetadata(assetId: AssetId): Promise<DenomMetadata | undefined> {
@@ -160,7 +164,7 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async saveAssetsMetadata(metadata: DenomMetadata) {
-    await this.u.update({ table: 'ASSETS', value: metadata.toJson() });
+    await this.u.update({ table: 'ASSETS', value: metadata.toJson() as Jsonified<DenomMetadata> });
   }
 
   async getAllSpendableNotes() {
@@ -174,8 +178,10 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async saveTransactionInfo(tx: TransactionInfo): Promise<void> {
-    const value = tx.toJson();
-    await this.u.update({ table: 'TRANSACTION_INFO', value });
+    await this.u.update({
+      table: 'TRANSACTION_INFO',
+      value: tx.toJson() as Jsonified<TransactionInfo>,
+    });
   }
 
   async getTransactionInfo(txId: TransactionId): Promise<TransactionInfo | undefined> {
@@ -192,8 +198,11 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async saveFmdParams(fmd: FmdParameters): Promise<void> {
-    const value = fmd.toJson();
-    await this.u.update({ table: 'FMD_PARAMETERS', value, key: 'params' });
+    await this.u.update({
+      table: 'FMD_PARAMETERS',
+      value: fmd.toJson() as Jsonified<FmdParameters>,
+      key: 'params',
+    });
   }
 
   async getAllSwaps(): Promise<SwapRecord[]> {
@@ -237,13 +246,13 @@ export class IndexedDb implements IndexedDbInterface {
 
   private addNewNotes(txs: IbdUpdates, notes: SpendableNoteRecord[]): void {
     for (const n of notes) {
-      txs.add({ table: 'SPENDABLE_NOTES', value: n.toJson() });
+      txs.add({ table: 'SPENDABLE_NOTES', value: n.toJson() as Jsonified<SpendableNoteRecord> });
     }
   }
 
   private addNewSwaps(txs: IbdUpdates, swaps: SwapRecord[]): void {
     for (const n of swaps) {
-      txs.add({ table: 'SWAPS', value: n.toJson() });
+      txs.add({ table: 'SWAPS', value: n.toJson() as Jsonified<SwapRecord> });
     }
   }
 
@@ -255,7 +264,7 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async saveSwap(swap: SwapRecord) {
-    await this.u.update({ table: 'SWAPS', value: swap.toJson() });
+    await this.u.update({ table: 'SWAPS', value: swap.toJson() as Jsonified<SwapRecord> });
   }
 
   async getSwapByCommitment(commitment: StateCommitment): Promise<SwapRecord | undefined> {

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -8,8 +8,6 @@ import {
   StoreHash,
 } from './state-commitment-tree';
 
-import { JsonValue } from '@bufbuild/protobuf';
-
 import {
   NotesForVotingResponse,
   SpendableNoteRecord,
@@ -26,6 +24,8 @@ import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1alpha1/tct_pb';
 import { GasPrices } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1alpha1/fee_pb';
 import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1alpha1/keys_pb';
+import { Jsonified } from './jsonified';
+import { Note } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1alpha1/shielded_pool_pb';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
   table: StoreName;
@@ -86,29 +86,28 @@ export interface PenumbraDb extends DBSchema {
     value: StoreHash;
   };
   TREE_COMMITMENTS: {
-    key: string; // string base64 StoreCommitment['commitment']['inner']
+    key: string; // base64 StoreCommitment['commitment']['inner']
     value: StoreCommitment;
   };
   FMD_PARAMETERS: {
     key: 'params';
-    value: JsonValue; // FmdParameters
+    value: Jsonified<FmdParameters>;
   };
   TRANSACTION_INFO: {
-    key: string; // string base64 TransactionInfo['id']['inner']
-    value: JsonValue; // TransactionInfo
-    //indexes: { nullifier: string; }; // string base64 TransactionInfo['nullifier']['inner']
+    key: Jsonified<Required<TransactionInfo>['id']['inner']>; // base64 Jsonified<TransactionInfo>['id']['inner']
+    value: Jsonified<TransactionInfo>;
   };
   // ======= Json serialized values =======
   // Allows wasm crate to directly deserialize
   ASSETS: {
-    key: string; // string base64 DenomMetadata['penumbraAssetId']['inner']
-    value: JsonValue; // DenomMetadata
+    key: string; // base64 Jsonified<DenomMetadata>['penumbraAssetId']['inner']
+    value: Jsonified<DenomMetadata>;
   };
   SPENDABLE_NOTES: {
-    key: string; // string base64 SpendableNoteRecord['noteCommitment']['inner']
-    value: JsonValue; // SpendableNoteRecord
+    key: string; // base64 Jsonified<SpendableNoteRecord>['noteCommitment']['inner']
+    value: Jsonified<SpendableNoteRecord>;
     indexes: {
-      nullifier: string; // string base64 SpendableNoteRecord['nullifier']['inner']
+      nullifier: string; // base64 Jsonified<SpendableNoteRecord>['nullifier']['inner']
     };
   };
   // Store for Notes that have been detected but cannot yet be spent
@@ -116,11 +115,11 @@ export interface PenumbraDb extends DBSchema {
   // This table is never written or queried by typescript
   NOTES: {
     key: string; // string base64 StateCommitment['inner']  key is not part of the stored object
-    value: JsonValue; // Note;
+    value: Jsonified<Note>;
   };
   SWAPS: {
     key: string; // string base64 SwapRecord['swapCommitment']['inner']
-    value: JsonValue; // SwapRecord
+    value: Jsonified<SwapRecord>;
     indexes: {
       nullifier: string; // base64 SwapRecord['nullifier']['inner']
     };

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -86,7 +86,7 @@ export interface PenumbraDb extends DBSchema {
     value: StoreHash;
   };
   TREE_COMMITMENTS: {
-    key: string; // base64 StoreCommitment['commitment']['inner']
+    key: StoreCommitment['commitment']['inner']; // base64
     value: StoreCommitment;
   };
   FMD_PARAMETERS: {
@@ -94,34 +94,35 @@ export interface PenumbraDb extends DBSchema {
     value: Jsonified<FmdParameters>;
   };
   TRANSACTION_INFO: {
-    key: Jsonified<Required<TransactionInfo>['id']['inner']>; // base64 Jsonified<TransactionInfo>['id']['inner']
+    key: Jsonified<Required<TransactionInfo>['id']['inner']>; // base64
     value: Jsonified<TransactionInfo>;
   };
   // ======= Json serialized values =======
   // Allows wasm crate to directly deserialize
   ASSETS: {
-    key: string; // base64 Jsonified<DenomMetadata>['penumbraAssetId']['inner']
+    key: Jsonified<Required<DenomMetadata>['penumbraAssetId']['inner']>; // base64
     value: Jsonified<DenomMetadata>;
   };
   SPENDABLE_NOTES: {
-    key: string; // base64 Jsonified<SpendableNoteRecord>['noteCommitment']['inner']
+    key: Jsonified<Required<SpendableNoteRecord>['noteCommitment']['inner']>; // base64
     value: Jsonified<SpendableNoteRecord>;
     indexes: {
-      nullifier: string; // base64 Jsonified<SpendableNoteRecord>['nullifier']['inner']
+      nullifier: Jsonified<Required<SpendableNoteRecord>['nullifier']['inner']>; // base64
     };
   };
   // Store for Notes that have been detected but cannot yet be spent
   // Used in wasm crate to process swap and swap claim
   // This table is never written or queried by typescript
   NOTES: {
-    key: string; // string base64 StateCommitment['inner']  key is not part of the stored object
+    // key is not part of the stored object
+    key: Jsonified<StateCommitment['inner']>; // base64
     value: Jsonified<Note>;
   };
   SWAPS: {
-    key: string; // string base64 SwapRecord['swapCommitment']['inner']
+    key: Jsonified<Required<SwapRecord>['swapCommitment']['inner']>; // base64
     value: Jsonified<SwapRecord>;
     indexes: {
-      nullifier: string; // base64 SwapRecord['nullifier']['inner']
+      nullifier: Jsonified<Required<SwapRecord>['nullifier']['inner']>; // base64
     };
   };
   GAS_PRICES: {

--- a/packages/types/src/internal-msg/offscreen.ts
+++ b/packages/types/src/internal-msg/offscreen.ts
@@ -44,6 +44,3 @@ export const isActionBuildRequest = (req: unknown): req is ActionBuildRequest =>
 
 export const isWasmBuildActionInput = (req: unknown): req is WasmBuildActionInput =>
   isActionBuildRequest(req) && 'actionPlanIndex' in req && typeof req.actionPlanIndex === 'number';
-
-export const isWasmBuildActionOutput = (res: unknown): res is WasmBuildActionOutput =>
-  res != null && typeof res === 'object';

--- a/packages/types/src/internal-msg/offscreen.ts
+++ b/packages/types/src/internal-msg/offscreen.ts
@@ -1,6 +1,10 @@
-import { Action } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
-import { InternalMessage, InternalRequest } from './shared';
-import { JsonObject, JsonValue } from '@bufbuild/protobuf';
+import type {
+  Action,
+  TransactionPlan,
+  WitnessData,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb';
+import type { Jsonified } from '../jsonified';
+import type { InternalMessage, InternalRequest, InternalResponse } from './shared';
 
 export type ActionBuildMessage = InternalMessage<
   'BUILD_ACTION',
@@ -10,29 +14,36 @@ export type ActionBuildMessage = InternalMessage<
 
 export type OffscreenMessage = ActionBuildMessage;
 export type OffscreenRequest = InternalRequest<OffscreenMessage>;
+export type OffscreenResponse = InternalResponse<OffscreenMessage>;
 
 export interface ActionBuildRequest {
-  transactionPlan: JsonObject & { actions: JsonValue[] };
-  witness: JsonObject;
+  transactionPlan: Jsonified<TransactionPlan> & {
+    actions: Jsonified<TransactionPlan['actions']>;
+  };
+  witness: Jsonified<WitnessData>;
   fullViewingKey: string;
 }
-export type ActionBuildResponse = ActionJsonValue<ActionCase>[];
+export type ActionBuildResponse = Jsonified<Action>[];
 
 export type WasmBuildActionInput = ActionBuildRequest & { actionPlanIndex: number };
-
-type ActionCase = NonNullable<Action['action']['case']>;
-type ActionJsonValue<C extends ActionCase> = Record<C, JsonValue>;
-
-const hasActionPlanJsonArray = (x: JsonValue): x is JsonObject & { actions: JsonValue[] } =>
-  x != null && typeof x === 'object' && 'actions' in x && Array.isArray(x['actions']);
+export type WasmBuildActionOutput = Jsonified<Action>;
 
 export const isActionBuildRequest = (req: unknown): req is ActionBuildRequest =>
   req != null &&
   typeof req === 'object' &&
   'transactionPlan' in req &&
-  hasActionPlanJsonArray(req.transactionPlan as JsonObject) &&
+  req.transactionPlan != null &&
+  typeof req.transactionPlan === 'object' &&
+  'actions' in req.transactionPlan &&
+  Array.isArray(req.transactionPlan.actions) &&
   'witness' in req &&
-  typeof req.witness === 'object' &&
   req.witness != null &&
+  typeof req.witness === 'object' &&
   'fullViewingKey' in req &&
   typeof req.fullViewingKey === 'string';
+
+export const isWasmBuildActionInput = (req: unknown): req is WasmBuildActionInput =>
+  isActionBuildRequest(req) && 'actionPlanIndex' in req && typeof req.actionPlanIndex === 'number';
+
+export const isWasmBuildActionOutput = (res: unknown): res is WasmBuildActionOutput =>
+  res != null && typeof res === 'object';

--- a/packages/types/src/jsonified.ts
+++ b/packages/types/src/jsonified.ts
@@ -4,7 +4,6 @@ import type { JsonValue, JsonObject, AnyMessage } from '@bufbuild/protobuf';
 export type Jsonified<T> = T extends JsonValue ? T
                          : T extends (Date | Uint8Array | bigint) ? string
                          : T extends (infer U)[] ? Jsonified<U>[]
-                         // eslint-disable-next-line @typescript-eslint/no-unused-vars
                          : T extends AnyMessage ? JsonObject
                          : T extends object ? {
                             [P in keyof T as

--- a/packages/types/src/jsonified.ts
+++ b/packages/types/src/jsonified.ts
@@ -1,5 +1,23 @@
 import type { JsonValue, JsonObject, AnyMessage } from '@bufbuild/protobuf';
 
+export const isJsonObject = (res: unknown): res is JsonObject =>
+  res != null &&
+  typeof res === 'object' &&
+  !Array.isArray(res) &&
+  Object.keys(res).every(k => typeof k === 'string') &&
+  Object.values(res).every(isJsonValue);
+
+export const isJsonArray = (res: unknown): res is JsonValue[] =>
+  res != null && Array.isArray(res) && res.every(isJsonValue);
+
+export const isJsonValue = (res: unknown): res is JsonValue =>
+  res === null ||
+  typeof res === 'string' ||
+  typeof res === 'number' ||
+  typeof res === 'boolean' ||
+  isJsonObject(res) ||
+  isJsonArray(res);
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Stringified<J> = J extends Jsonified<infer _T> ? string : never;
 

--- a/packages/types/src/jsonified.ts
+++ b/packages/types/src/jsonified.ts
@@ -1,10 +1,11 @@
-import type { JsonValue, Message, PlainMessage } from '@bufbuild/protobuf';
+import type { JsonValue, JsonObject, AnyMessage } from '@bufbuild/protobuf';
 
 // prettier-ignore
 export type Jsonified<T> = T extends JsonValue ? T
                          : T extends (Date | Uint8Array | bigint) ? string
                          : T extends (infer U)[] ? Jsonified<U>[]
-                         : T extends Message<infer U> ? Jsonified<PlainMessage<U>>
+                         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                         : T extends AnyMessage ? JsonObject
                          : T extends object ? {
                             [P in keyof T as
                               // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/types/src/jsonified.ts
+++ b/packages/types/src/jsonified.ts
@@ -22,7 +22,6 @@ export const isJsonValue = (res: unknown): res is JsonValue =>
  * This is used to suggest the purpose of a string to a human. It provides no
  * actual type assistance.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Stringified<J> = Jsonified<J> extends JsonValue ? string : never;
 
 /**

--- a/packages/types/src/jsonified.ts
+++ b/packages/types/src/jsonified.ts
@@ -1,5 +1,8 @@
 import type { JsonValue, JsonObject, AnyMessage } from '@bufbuild/protobuf';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Stringified<J> = J extends Jsonified<infer _T> ? string : never;
+
 // prettier-ignore
 export type Jsonified<T> = T extends JsonValue ? T
                          : T extends (Date | Uint8Array | bigint) ? string

--- a/packages/types/src/jsonified.ts
+++ b/packages/types/src/jsonified.ts
@@ -18,21 +18,44 @@ export const isJsonValue = (res: unknown): res is JsonValue =>
   isJsonObject(res) ||
   isJsonArray(res);
 
+/**
+ * This is used to suggest the purpose of a string to a human. It provides no
+ * actual type assistance.
+ */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type Stringified<J> = J extends Jsonified<infer _T> ? string : never;
+export type Stringified<J> = Jsonified<J> extends JsonValue ? string : never;
 
+/**
+ * This is used to approximate a json-compatible version of a type. Mostly, it
+ * is for *suggesting* what a parameter or return *should* represent, *to a
+ * human*. It performs no actual data conversion, and makes assumptions about
+ * how some json-incompatible types will be converted.
+ *
+ * Our idb schema uses it for identifying key/index types generated from stored
+ * object fields.
+ *
+ * It's based on PlainMessage from `@bufbuild/protobuf`, but notably we treat
+ * any `Message<T>` as a black-box `JsonObject`, to avoid the complex and
+ * configurable details of protojson.
+ *
+ * - members of `JsonValue` are directly equivalent
+ * - `Date`, `Uint8Array`, and `bigint` are assumed to stringify
+ * - Arrays are recursively Jsonified.
+ * - `AnyMessage` becomes generic `JsonObject`
+ * - other objects maintain structure, and filter out functions
+ */
 // prettier-ignore
-export type Jsonified<T> = T extends JsonValue ? T
-                         : T extends (Date | Uint8Array | bigint) ? string
-                         : T extends (infer U)[] ? Jsonified<U>[]
-                         : T extends AnyMessage ? JsonObject
-                         : T extends object ? {
-                            [P in keyof T as
+export type Jsonified<T> = T extends JsonValue ? T                          // JsonValue members equivalent
+                         : T extends (Date | Uint8Array | bigint) ? string  // these types stringify
+                         : T extends (infer U)[] ? Jsonified<U>[]           // recurse into array members
+                         : T extends AnyMessage ? JsonObject                // AnyMessage is a black box
+                         : T extends object ? {                             // any object...
+                            [P in keyof T as                                // ...index into...
                               // eslint-disable-next-line @typescript-eslint/ban-types
-                              T[P] extends (Function) ? never
-                            : P extends string ? P
-                            : P extends number ? `${P}`
-                            : never
-                            ]: Jsonified<T[P]>;
+                              T[P] extends (Function) ? never               // ...strip function members
+                            : P extends string ? P                          // ...keep string keys
+                            : P extends number ? `${P}`                     // ...stringify number keys
+                            : never                                         // ...strip symbol keys
+                            ]: Jsonified<T[P]>;                             // ...recurse object members
                           } 
-                         : T extends undefined ? never : T;
+                         : T extends undefined ? never : T; // undefined not allowed

--- a/packages/ui/components/ui/json-viewer/index.tsx
+++ b/packages/ui/components/ui/json-viewer/index.tsx
@@ -1,8 +1,9 @@
 import ReactJson from 'react-json-view';
+import type { JsonObject } from '@bufbuild/protobuf';
 
 import './overrides.css';
 
-export const JsonViewer = ({ jsonObj }: { jsonObj: object }) => {
+export const JsonViewer = ({ jsonObj }: { jsonObj: JsonObject }) => {
   return (
     <div className='mt-5 rounded bg-black p-5'>
       <ReactJson

--- a/packages/ui/components/ui/json-viewer/index.tsx
+++ b/packages/ui/components/ui/json-viewer/index.tsx
@@ -1,9 +1,9 @@
 import ReactJson from 'react-json-view';
-import type { JsonObject } from '@bufbuild/protobuf';
+import type { JsonObject, JsonValue } from '@bufbuild/protobuf';
 
 import './overrides.css';
 
-export const JsonViewer = ({ jsonObj }: { jsonObj: JsonObject }) => {
+export const JsonViewer = ({ jsonObj }: { jsonObj: JsonObject | JsonValue[] }) => {
   return (
     <div className='mt-5 rounded bg-black p-5'>
       <ReactJson

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "tinycolor2": "^1.6.0"
   },
   "devDependencies": {
+    "@bufbuild/protobuf": "^1.6.0",
     "@testing-library/react": "^14.1.2",
     "@types/node": "^20.10.6",
     "@types/react": "^18.2.46",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
     devDependencies:
+      '@bufbuild/protobuf':
+        specifier: ^1.6.0
+        version: 1.6.0
       '@testing-library/react':
         specifier: ^14.1.2
         version: 14.1.2(react-dom@18.2.0)(react@18.2.0)
@@ -1181,7 +1184,6 @@ packages:
 
   /@bufbuild/protobuf@1.6.0:
     resolution: {integrity: sha512-hp19vSFgNw3wBBcVBx5qo5pufCqjaJ0Cfk5H/pfjNOfNWU+4/w0QVOmfAOZNRrNWRrVuaJWxcN8P2vhOkkzbBQ==}
-    dev: false
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}


### PR DESCRIPTION
`Jsonified<AnyMessage>` becomes a black-box `JsonObject` to avoid any kind of structural inaccuracy, because protojson has rules that were not satisfied.

other types are converted more informatively.

jsonified is used in idb schema to identify contents and key types, which resolve to either `JsonObject` or primitives.

also, added type guards (and fixed some bugs) in offscreen.ts because it was a major internal user of jsonified.

use `Jsonified<T>` in your schemas/parameter/return types to convey the presence of unparsed json, and suggest what the json should deserialize to.