### PR TITLE
Provide default FmdParams in the transaction planner when not present in the request

### DIFF
--- a/packages/router/src/grpc/view-protocol-server/transaction-planner.test.ts
+++ b/packages/router/src/grpc/view-protocol-server/transaction-planner.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { DEFAULT_FMD_PARAMETERS, transactionPlanner } from './transaction-planner';
+import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
+import { HandlerContext } from '@connectrpc/connect';
+import {
+  ChainParameters,
+  FmdParameters,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/chain/v1alpha1/chain_pb';
+
+const getMockTxPlannerInstance = vi.hoisted(() => () => ({
+  expiryHeight: vi.fn(),
+  memo: vi.fn(),
+  fee: vi.fn(),
+  output: vi.fn(),
+  ics20Withdrawal: vi.fn(),
+  plan: vi.fn(),
+}));
+
+const { MockTxPlanner, mockGetAddressByIndex } = vi.hoisted(() => ({
+  MockTxPlanner: {
+    initialize: vi.fn().mockImplementation(getMockTxPlannerInstance),
+  },
+
+  mockGetAddressByIndex: vi.fn(),
+}));
+
+vi.mock('@penumbra-zone/wasm-ts', () => ({
+  TxPlanner: MockTxPlanner,
+  getAddressByIndex: mockGetAddressByIndex,
+}));
+
+describe('transactionPlanner()', () => {
+  beforeEach(() => {
+    MockTxPlanner.initialize.mockClear();
+  });
+
+  const mockQuerier = {
+    app: {
+      chainParams: vi.fn().mockImplementation(() => new ChainParameters()),
+    },
+  };
+
+  const mockIndexedDb = {
+    getFmdParams: vi.fn(),
+    constants: vi.fn().mockImplementation(() => ({
+      name: 'name',
+      version: 1,
+      tables: {},
+    })),
+  };
+
+  const mockServices = {
+    getWalletServices: () => ({
+      indexedDb: mockIndexedDb,
+      viewServer: { fullViewingKey: 'fvk' },
+    }),
+    querier: mockQuerier,
+  };
+
+  const mockContext = {
+    values: {
+      get: () => mockServices,
+    },
+  } as unknown as HandlerContext;
+
+  describe('when there are no FMD parameters in IndexedDB', () => {
+    beforeEach(() => {
+      mockIndexedDb.getFmdParams.mockImplementation(() => undefined);
+    });
+
+    test('uses defaults of 0 precision bits and a block height of 1n', async () => {
+      const req = new TransactionPlannerRequest();
+      await transactionPlanner(req, mockContext);
+
+      expect(MockTxPlanner.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fmdParams: DEFAULT_FMD_PARAMETERS,
+        }),
+      );
+    });
+  });
+
+  describe('when there are FMD parameters in IndexedDB', () => {
+    const fmdParameters = new FmdParameters({ asOfBlockHeight: 123n, precisionBits: 1234 });
+
+    beforeEach(() => {
+      mockIndexedDb.getFmdParams.mockImplementation(() => fmdParameters);
+    });
+
+    test('uses them', async () => {
+      const req = new TransactionPlannerRequest();
+      await transactionPlanner(req, mockContext);
+
+      expect(MockTxPlanner.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fmdParams: fmdParameters,
+        }),
+      );
+    });
+  });
+});

--- a/packages/router/src/grpc/view-protocol-server/transaction-planner.ts
+++ b/packages/router/src/grpc/view-protocol-server/transaction-planner.ts
@@ -5,7 +5,16 @@ import { TxPlanner, getAddressByIndex } from '@penumbra-zone/wasm-ts';
 
 import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1alpha1/keys_pb';
 
-import { ConnectError, Code } from '@connectrpc/connect';
+import { FmdParameters } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/chain/v1alpha1/chain_pb';
+
+/**
+ * Defaults copied from `Impl Default for Parameters` in
+ * `<core>/crates/core/component/shielded-pool/src/fmd.rs`
+ */
+export const DEFAULT_FMD_PARAMETERS = new FmdParameters({
+  precisionBits: 0,
+  asOfBlockHeight: 1n,
+});
 
 export const transactionPlanner: Impl['transactionPlanner'] = async (req, ctx) => {
   const services = ctx.values.get(servicesCtx);
@@ -14,8 +23,7 @@ export const transactionPlanner: Impl['transactionPlanner'] = async (req, ctx) =
     viewServer: { fullViewingKey },
   } = await services.getWalletServices();
   const chainParams = await services.querier.app.chainParams();
-  const fmdParams = await indexedDb.getFmdParams();
-  if (!fmdParams) throw new ConnectError('Fmd Params not in indexeddb', Code.FailedPrecondition);
+  const fmdParams = (await indexedDb.getFmdParams()) ?? DEFAULT_FMD_PARAMETERS;
   const idbConstants = indexedDb.constants();
 
   const planner = await TxPlanner.initialize({


### PR DESCRIPTION
Temporary workaround for missing FmdParameters from testnet-preview. Should be reverted after core is fixed, although it'd be nice to keep the test setup.