### PR TITLE
Refactor selections/balances to use `DenomMetadata`, and to render a ValueViewComponent when possible

### DIFF
--- a/apps/webapp/src/components/dashboard/assets-table.tsx
+++ b/apps/webapp/src/components/dashboard/assets-table.tsx
@@ -1,5 +1,5 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@penumbra-zone/ui';
-import { displayUsd, fromBaseUnitAmount } from '@penumbra-zone/types';
+import { displayUsd, fromBaseUnitAmountAndDenomMetadata } from '@penumbra-zone/types';
 import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { throwIfExtNotInstalled } from '../../fetchers/is-connected.ts';
 import { AccountBalance, getBalancesByAccount } from '../../fetchers/balances.ts';
@@ -52,9 +52,9 @@ export default function AssetsTable() {
                     <p className='font-mono text-base font-bold'>{asset.denomMetadata.display}</p>
                   </div>
                   <p className='font-mono text-base font-bold'>
-                    {fromBaseUnitAmount(
+                    {fromBaseUnitAmountAndDenomMetadata(
                       asset.amount,
-                      asset.denomMetadata.denomUnits[0]?.exponent,
+                      asset.denomMetadata,
                     ).toFormat()}
                   </p>
                   <p className='font-mono text-base font-bold'>
@@ -85,9 +85,9 @@ export default function AssetsTable() {
                     <TableCell className='w-1/3 text-center font-mono'>
                       <div className='flex flex-col'>
                         <p className='text-base font-bold'>
-                          {fromBaseUnitAmount(
+                          {fromBaseUnitAmountAndDenomMetadata(
                             asset.amount,
-                            asset.denomMetadata.denomUnits[0]?.exponent,
+                            asset.denomMetadata,
                           ).toFormat()}
                         </p>
                       </div>

--- a/apps/webapp/src/components/dashboard/assets-table.tsx
+++ b/apps/webapp/src/components/dashboard/assets-table.tsx
@@ -48,11 +48,14 @@ export default function AssetsTable() {
               {a.balances.map((asset, i) => (
                 <div key={i} className='flex items-center justify-between border-b pb-3'>
                   <div className='flex items-center gap-2'>
-                    <AssetIcon name={asset.denom.display} />
-                    <p className='font-mono text-base font-bold'>{asset.denom.display}</p>
+                    <AssetIcon name={asset.denomMetadata.display} />
+                    <p className='font-mono text-base font-bold'>{asset.denomMetadata.display}</p>
                   </div>
                   <p className='font-mono text-base font-bold'>
-                    {fromBaseUnitAmount(asset.amount, asset.denom.exponent).toFormat()}
+                    {fromBaseUnitAmount(
+                      asset.amount,
+                      asset.denomMetadata.denomUnits[0]?.exponent,
+                    ).toFormat()}
                   </p>
                   <p className='font-mono text-base font-bold'>
                     {asset.usdcValue == 0 ? '$–' : `$${displayUsd(asset.usdcValue)}`}
@@ -73,14 +76,19 @@ export default function AssetsTable() {
                   <TableRow key={i}>
                     <TableCell className='w-1/3'>
                       <div className='flex items-center gap-2'>
-                        <AssetIcon name={asset.denom.display} />
-                        <p className='font-mono text-base font-bold'>{asset.denom.display}</p>
+                        <AssetIcon name={asset.denomMetadata.display} />
+                        <p className='font-mono text-base font-bold'>
+                          {asset.denomMetadata.display}
+                        </p>
                       </div>
                     </TableCell>
                     <TableCell className='w-1/3 text-center font-mono'>
                       <div className='flex flex-col'>
                         <p className='text-base font-bold'>
-                          {fromBaseUnitAmount(asset.amount, asset.denom.exponent).toFormat()}
+                          {fromBaseUnitAmount(
+                            asset.amount,
+                            asset.denomMetadata.denomUnits[0]?.exponent,
+                          ).toFormat()}
                         </p>
                       </div>
                     </TableCell>

--- a/apps/webapp/src/components/shared/select-token-modal.tsx
+++ b/apps/webapp/src/components/shared/select-token-modal.tsx
@@ -8,7 +8,7 @@ import {
   DialogTrigger,
   Input,
 } from '@penumbra-zone/ui';
-import { fromBaseUnitAmount } from '@penumbra-zone/types';
+import { fromBaseUnitAmountAndDenomMetadata } from '@penumbra-zone/types';
 import { cn } from '@penumbra-zone/ui/lib/utils';
 import { AccountBalance } from '../../fetchers/balances';
 import { AssetIcon } from './asset-icon';
@@ -81,10 +81,7 @@ export default function SelectTokenModal({
                           <p>{k.denomMetadata.display}</p>
                         </div>
                         <p className='flex justify-end'>
-                          {fromBaseUnitAmount(
-                            k.amount,
-                            k.denomMetadata.denomUnits[0]?.exponent,
-                          ).toFormat()}
+                          {fromBaseUnitAmountAndDenomMetadata(k.amount, k.denomMetadata).toFormat()}
                         </p>
                       </div>
                     </DialogClose>

--- a/apps/webapp/src/components/shared/select-token-modal.tsx
+++ b/apps/webapp/src/components/shared/select-token-modal.tsx
@@ -31,9 +31,11 @@ export default function SelectTokenModal({
     <Dialog>
       <DialogTrigger disabled={!balances.length}>
         <div className='flex h-9 min-w-[100px] items-center justify-center gap-2 rounded-lg bg-light-brown px-2'>
-          {selection?.asset?.denom.display && <AssetIcon name={selection.asset.denom.display} />}
+          {selection?.asset?.denomMetadata.display && (
+            <AssetIcon name={selection.asset.denomMetadata.display} />
+          )}
           <p className='font-bold text-light-grey md:text-sm xl:text-base'>
-            {selection?.asset?.denom.display}
+            {selection?.asset?.denomMetadata.display}
           </p>
         </div>
       </DialogTrigger>
@@ -75,11 +77,14 @@ export default function SelectTokenModal({
                       >
                         <p className='flex justify-start'>{b.index}</p>
                         <div className='flex justify-start gap-[6px]'>
-                          <AssetIcon name={k.denom.display} />
-                          <p>{k.denom.display}</p>
+                          <AssetIcon name={k.denomMetadata.display} />
+                          <p>{k.denomMetadata.display}</p>
                         </div>
                         <p className='flex justify-end'>
-                          {fromBaseUnitAmount(k.amount, k.denom.exponent).toFormat()}
+                          {fromBaseUnitAmount(
+                            k.amount,
+                            k.denomMetadata.denomUnits[0]?.exponent,
+                          ).toFormat()}
                         </p>
                       </div>
                     </DialogClose>

--- a/apps/webapp/src/components/swap/asset-out-box.tsx
+++ b/apps/webapp/src/components/swap/asset-out-box.tsx
@@ -29,8 +29,8 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
           value: {
             amount: balanceOfDenom.amount,
             denom: new DenomMetadata({
-              display: balanceOfDenom.denom.display,
-              denomUnits: [balanceOfDenom.denom],
+              display: balanceOfDenom.denomMetadata.display,
+              denomUnits: balanceOfDenom.denomMetadata.denomUnits,
             }),
           },
         },

--- a/apps/webapp/src/state/ibc.test.ts
+++ b/apps/webapp/src/state/ibc.test.ts
@@ -2,9 +2,13 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import { create, StoreApi, UseBoundStore } from 'zustand';
 import { AllSlices, initializeStore } from './index.ts';
 import { Chain } from '@penumbra-zone/types';
-import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import {
+  AssetId,
+  DenomMetadata,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
 import { sendValidationErrors } from './send.ts';
+import { Selection } from './types.ts';
 
 // TODO: Revisit tests when re-implementing ibc form
 
@@ -15,14 +19,14 @@ describe.skip('IBC Slice', () => {
         lo: 0n,
         hi: 0n,
       }),
-      denom: { display: 'test_usd', exponent: 18 },
+      denomMetadata: new DenomMetadata({ display: 'test_usd', denomUnits: [{ exponent: 18 }] }),
       usdcValue: 0,
       assetId: new AssetId().fromJson({ inner: 'reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg=' }),
     },
     address:
       'penumbra1e8k5c3ds484dxvapeamwveh5khqv4jsvyvaf5wwxaaccgfghm229qw03pcar3ryy8smptevstycch0qk3uurrgkvtjpny3cu3rjd0agawqtlz6erev28a6sg69u7cxy0t02nd1',
     accountIndex: 0,
-  };
+  } satisfies Selection;
   let useStore: UseBoundStore<StoreApi<AllSlices>>;
 
   beforeEach(() => {

--- a/apps/webapp/src/state/ibc.ts
+++ b/apps/webapp/src/state/ibc.ts
@@ -11,6 +11,7 @@ import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/c
 import { Selection } from './types';
 import { ibcClient, viewClient } from '../clients/grpc';
 import { planWitnessBuildBroadcast } from './helpers';
+import { getDisplayDenomExponent } from '@penumbra-zone/types/src/denom-metadata';
 
 export interface IbcSendSlice {
   selection: Selection | undefined;
@@ -132,7 +133,7 @@ const getPlanRequest = async ({
       {
         amount: toBaseUnit(
           BigNumber(amount),
-          selection.asset.denomMetadata.denomUnits[0]?.exponent,
+          getDisplayDenomExponent(selection.asset.denomMetadata),
         ),
         denom: { denom: selection.asset.denomMetadata.display },
         destinationChainAddress,

--- a/apps/webapp/src/state/ibc.ts
+++ b/apps/webapp/src/state/ibc.ts
@@ -130,8 +130,11 @@ const getPlanRequest = async ({
   return new TransactionPlannerRequest({
     ics20Withdrawals: [
       {
-        amount: toBaseUnit(BigNumber(amount), selection.asset.denom.exponent),
-        denom: { denom: selection.asset.denom.display },
+        amount: toBaseUnit(
+          BigNumber(amount),
+          selection.asset.denomMetadata.denomUnits[0]?.exponent,
+        ),
+        denom: { denom: selection.asset.denomMetadata.display },
         destinationChainAddress,
         returnAddress,
         timeoutHeight,

--- a/apps/webapp/src/state/send.test.ts
+++ b/apps/webapp/src/state/send.test.ts
@@ -3,13 +3,17 @@ import { create, StoreApi, UseBoundStore } from 'zustand';
 import { AllSlices, initializeStore } from './index.ts';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
 import { sendValidationErrors } from './send.ts';
-import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import {
+  AssetId,
+  DenomMetadata,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
 import { Fee } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1alpha1/fee_pb';
 import { viewClient } from '../clients/grpc.ts';
 import {
   AddressByIndexResponse,
   TransactionPlannerResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
+import { Selection } from './types.ts';
 
 vi.mock('../fetchers/address', () => ({
   getAddressByIndex: vi.fn(),
@@ -22,14 +26,14 @@ describe('Send Slice', () => {
         lo: 0n,
         hi: 0n,
       }),
-      denom: { display: 'test_usd', exponent: 18 },
+      denomMetadata: new DenomMetadata({ display: 'test_usd', denomUnits: [{ exponent: 18 }] }),
       usdcValue: 0,
       assetId: new AssetId().fromJson({ inner: 'reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg=' }),
     },
     address:
       'penumbra1e8k5c3ds484dxvapeamwveh5khqv4jsvyvaf5wwxaaccgfghm229qw03pcar3ryy8smptevstycch0qk3uurrgkvtjpny3cu3rjd0agawqtlz6erev28a6sg69u7cxy0t02nd1',
     accountIndex: 0,
-  };
+  } satisfies Selection;
 
   let useStore: UseBoundStore<StoreApi<AllSlices>>;
 

--- a/apps/webapp/src/state/send.ts
+++ b/apps/webapp/src/state/send.ts
@@ -113,7 +113,10 @@ const assembleRequest = async ({ amount, recipient, selection, memo }: SendSlice
       {
         address: { altBech32m: recipient },
         value: {
-          amount: toBaseUnit(BigNumber(amount), selection.asset.denom.exponent),
+          amount: toBaseUnit(
+            BigNumber(amount),
+            selection.asset.denomMetadata.denomUnits[0]?.exponent,
+          ),
           assetId: { inner: selection.asset.assetId.inner },
         },
       },
@@ -127,7 +130,7 @@ const assembleRequest = async ({ amount, recipient, selection, memo }: SendSlice
 };
 
 export const validateAmount = (asset: AssetBalance, amount: string): boolean => {
-  const balanceAmt = fromBaseUnitAmount(asset.amount, asset.denom.exponent);
+  const balanceAmt = fromBaseUnitAmount(asset.amount, asset.denomMetadata.denomUnits[0]?.exponent);
   return Boolean(amount) && BigNumber(amount).gt(balanceAmt);
 };
 

--- a/apps/webapp/src/state/swap.test.ts
+++ b/apps/webapp/src/state/swap.test.ts
@@ -2,7 +2,10 @@ import { create, StoreApi, UseBoundStore } from 'zustand';
 import { AllSlices, initializeStore } from './index';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { AssetBalance } from '../fetchers/balances';
-import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import {
+  AssetId,
+  DenomMetadata,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
 import { stringToUint8Array } from '@penumbra-zone/types';
 import { Selection } from './types';
@@ -10,10 +13,10 @@ import { localAssets } from '@penumbra-zone/constants';
 
 describe('Swap Slice', () => {
   const assetBalance: AssetBalance = {
-    denom: {
+    denomMetadata: new DenomMetadata({
       display: 'xyz',
-      exponent: 3,
-    },
+      denomUnits: [{ denom: 'xyz', exponent: 3 }],
+    }),
     assetId: new AssetId({ inner: stringToUint8Array('abcdefg') }),
     amount: new Amount(),
     usdcValue: 1234,

--- a/apps/webapp/src/state/swap.ts
+++ b/apps/webapp/src/state/swap.ts
@@ -9,6 +9,7 @@ import { getAddressByIndex } from '../fetchers/address';
 import BigNumber from 'bignumber.js';
 import { planWitnessBuildBroadcast } from './helpers';
 import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import { getDisplayDenomExponent } from '@penumbra-zone/types/src/denom-metadata';
 
 export interface SwapSlice {
   assetIn: Selection | undefined;
@@ -81,7 +82,10 @@ const assembleRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => {
       {
         targetAsset: assetOut.penumbraAssetId,
         value: {
-          amount: toBaseUnit(BigNumber(amount), assetIn.asset.denom.exponent),
+          amount: toBaseUnit(
+            BigNumber(amount),
+            getDisplayDenomExponent(assetIn.asset.denomMetadata),
+          ),
           assetId: assetIn.asset.assetId,
         },
         claimAddress: await getAddressByIndex(assetIn.accountIndex),
@@ -89,7 +93,10 @@ const assembleRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => {
         //       Asset Id should almost certainly be upenumbra,
         //       may need to indicate native denom in registry
         fee: {
-          amount: toBaseUnit(BigNumber(amount), assetIn.asset.denom.exponent),
+          amount: toBaseUnit(
+            BigNumber(amount),
+            getDisplayDenomExponent(assetIn.asset.denomMetadata),
+          ),
           assetId: assetIn.asset.assetId,
         },
       },

--- a/packages/types/src/amount.test.ts
+++ b/packages/types/src/amount.test.ts
@@ -4,12 +4,14 @@ import {
   displayAmount,
   displayUsd,
   fromBaseUnitAmount,
+  fromBaseUnitAmountAndDenomMetadata,
   joinLoHiAmount,
 } from './amount';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
+import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
 
 describe('lohi helpers', () => {
-  it('convertFromBaseUnitAmount works', () => {
+  it('fromBaseUnitAmount works', () => {
     const result = fromBaseUnitAmount(new Amount({ lo: 1000n, hi: 5n }), 6);
     expect(result.toString()).toBe('92233720368547.75908');
   });
@@ -18,6 +20,33 @@ describe('lohi helpers', () => {
     const lo = 18446744073709551615n;
     const hi = 18446744073709551615n;
     expect(joinLoHiAmount(new Amount({ lo, hi }))).toBe(340282366920938463463374607431768211455n);
+  });
+
+  it('fromBaseUnitAmountAndDenomMetadata works', () => {
+    const penumbraDenomMetadata = new DenomMetadata({
+      display: 'penumbra',
+      denomUnits: [
+        {
+          denom: 'penumbra',
+          exponent: 6,
+        },
+        {
+          denom: 'mpenumbra',
+          exponent: 3,
+        },
+        {
+          denom: 'upenumbra',
+          exponent: 0,
+        },
+      ],
+    });
+
+    const result = fromBaseUnitAmountAndDenomMetadata(
+      new Amount({ lo: 123456789n, hi: 0n }),
+      penumbraDenomMetadata,
+    );
+
+    expect(result.toString()).toBe('123.456789');
   });
 });
 

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -6,7 +6,7 @@ export const joinLoHiAmount = (amount: Amount): bigint => {
   return joinLoHi(amount.lo, amount.hi);
 };
 
-export const fromBaseUnitAmount = (amount: Amount, exponent: number): BigNumber => {
+export const fromBaseUnitAmount = (amount: Amount, exponent = 0): BigNumber => {
   return fromBaseUnit(amount.lo, amount.hi, exponent);
 };
 

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -1,6 +1,8 @@
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
 import { fromBaseUnit, joinLoHi, splitLoHi } from './lo-hi';
 import BigNumber from 'bignumber.js';
+import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import { getDisplayDenomExponent } from './denom-metadata';
 
 export const joinLoHiAmount = (amount: Amount): bigint => {
   return joinLoHi(amount.lo, amount.hi);
@@ -8,6 +10,13 @@ export const joinLoHiAmount = (amount: Amount): bigint => {
 
 export const fromBaseUnitAmount = (amount: Amount, exponent = 0): BigNumber => {
   return fromBaseUnit(amount.lo, amount.hi, exponent);
+};
+
+export const fromBaseUnitAmountAndDenomMetadata = (
+  amount: Amount,
+  denomMetadata: DenomMetadata,
+): BigNumber => {
+  return fromBaseUnitAmount(amount, getDisplayDenomExponent(denomMetadata));
 };
 
 export const addAmounts = (a: Amount, b: Amount): Amount => {

--- a/packages/types/src/denom-metadata.test.ts
+++ b/packages/types/src/denom-metadata.test.ts
@@ -1,0 +1,27 @@
+import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import { describe, expect, test } from 'vitest';
+import { getDisplayDenomExponent } from './denom-metadata';
+
+describe('getDisplayDenomExponent()', () => {
+  test("gets the exponent from the denom unit whose `denom` is equal to the metadata's `display` property", () => {
+    const penumbraDenomMetadata = new DenomMetadata({
+      display: 'penumbra',
+      denomUnits: [
+        {
+          denom: 'penumbra',
+          exponent: 6,
+        },
+        {
+          denom: 'mpenumbra',
+          exponent: 3,
+        },
+        {
+          denom: 'upenumbra',
+          exponent: 0,
+        },
+      ],
+    });
+
+    expect(getDisplayDenomExponent(penumbraDenomMetadata)).toBe(6);
+  });
+});

--- a/packages/types/src/denom-metadata.ts
+++ b/packages/types/src/denom-metadata.ts
@@ -1,0 +1,17 @@
+import { DenomMetadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+
+/**
+ * Returns the exponent for a given asset type's display denom unit, given that
+ * denom's metadata.
+ *
+ * `DenomMetadata`s have an array of `DenomUnit`s, describing the exponent of
+ * each denomination in relation to the base unit. For example, upenumbra is
+ * penumbra's base unit -- the unit which can not be further divided into
+ * decimals. 1 penumbra is equal to 1,000,000 (AKA, 10 to the 6th) upenumbra, so
+ * penumbra's display exponent -- the exponent used to multiply the base unit
+ * when displaying a penumbra value to a user -- is 6. (For a non-crypto
+ * example, think of US dollars. The dollar is the display unit; the cent is the
+ * base unit; the display exponent is 2 (10 to the 2nd).)
+ */
+export const getDisplayDenomExponent = (denomMetadata: DenomMetadata): number | undefined =>
+  denomMetadata.denomUnits.find(denomUnit => denomUnit.denom === denomMetadata.display)?.exponent;

--- a/packages/types/src/lo-hi.ts
+++ b/packages/types/src/lo-hi.ts
@@ -76,7 +76,7 @@ export const fromBaseUnit = (lo = 0n, hi = 0n, exponent: number): BigNumber => {
  * @param {number} exponent - The exponent to be applied.
  * @returns {LoHi} An object with properties `lo` and `hi`, representing the low and high 64 bits of the multiplied value.
  */
-export const toBaseUnit = (value: BigNumber, exponent: number): LoHi => {
+export const toBaseUnit = (value: BigNumber, exponent = 0): LoHi => {
   const multipliedValue = value.multipliedBy(new BigNumber(10).pow(exponent));
   const bigInt = BigInt(multipliedValue.toFixed());
 

--- a/packages/ui/components/ui/tx/view/value.test.tsx
+++ b/packages/ui/components/ui/tx/view/value.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest';
+import { ValueViewComponent } from './value';
+import { render } from '@testing-library/react';
+import {
+  DenomMetadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1alpha1/asset_pb';
+import { base64ToUint8Array, bech32AssetId } from '@penumbra-zone/types';
+
+describe('<ValueViewComponent />', () => {
+  const penumbraDenomMetadata = new DenomMetadata({
+    base: 'upenumbra',
+    display: 'penumbra',
+    penumbraAssetId: {
+      inner: base64ToUint8Array('KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA='),
+    },
+    images: [
+      {
+        png: 'https://raw.githubusercontent.com/penumbra-zone/web/main/apps/webapp/public/favicon.png',
+      },
+    ],
+    denomUnits: [
+      {
+        denom: 'penumbra',
+        exponent: 6,
+      },
+      {
+        denom: 'mpenumbra',
+        exponent: 3,
+      },
+      {
+        denom: 'upenumbra',
+        exponent: 0,
+      },
+    ],
+  });
+
+  describe('when rendering a known denomination', () => {
+    const valueView = new ValueView({
+      valueView: {
+        case: 'knownDenom',
+        value: {
+          amount: {
+            hi: 0n,
+            lo: 123_456_789n,
+          },
+          denom: penumbraDenomMetadata,
+        },
+      },
+    });
+
+    test('renders the amount in the display denom unit', () => {
+      const { container } = render(<ValueViewComponent view={valueView} />);
+
+      expect(container).toHaveTextContent('123.456789 penumbra');
+    });
+  });
+
+  describe('when rendering an unknown denomination', () => {
+    const valueView = new ValueView({
+      valueView: {
+        case: 'unknownDenom',
+        value: {
+          amount: {
+            hi: 0n,
+            lo: 123_456_789n,
+          },
+          assetId: {
+            inner: penumbraDenomMetadata.penumbraAssetId!.inner,
+          },
+        },
+      },
+    });
+
+    test('renders the amount in the base unit, along with an asset ID', () => {
+      const { container } = render(<ValueViewComponent view={valueView} />);
+      const assetIdAsString = bech32AssetId(penumbraDenomMetadata.penumbraAssetId!);
+
+      expect(container).toHaveTextContent(`123,456,789${assetIdAsString}`);
+    });
+  });
+});

--- a/packages/ui/components/ui/tx/view/value.tsx
+++ b/packages/ui/components/ui/tx/view/value.tsx
@@ -4,11 +4,11 @@ import { CopyToClipboard } from '../../copy-to-clipboard';
 import { CopyIcon } from '@radix-ui/react-icons';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
 
-interface ValueViewPrpos {
+interface ValueViewProps {
   view: ValueView | undefined;
 }
 
-export const ValueViewComponent = ({ view }: ValueViewPrpos) => {
+export const ValueViewComponent = ({ view }: ValueViewProps) => {
   if (!view) return <></>;
 
   if (view.valueView.case === 'unknownDenom') {

--- a/packages/ui/components/ui/tx/view/value.tsx
+++ b/packages/ui/components/ui/tx/view/value.tsx
@@ -3,6 +3,7 @@ import { bech32AssetId, fromBaseUnitAmount } from '@penumbra-zone/types';
 import { CopyToClipboard } from '../../copy-to-clipboard';
 import { CopyIcon } from '@radix-ui/react-icons';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1alpha1/num_pb';
+import { getDisplayDenomExponent } from '@penumbra-zone/types/src/denom-metadata';
 
 interface ValueViewProps {
   view: ValueView | undefined;
@@ -17,7 +18,7 @@ export const ValueViewComponent = ({ view }: ValueViewProps) => {
     const encodedAssetId = bech32AssetId(value.assetId!);
     return (
       <div className='flex font-mono'>
-        <p className='text-[15px] leading-[22px]'>{fromBaseUnitAmount(amount, 1).toFormat()}</p>
+        <p className='text-[15px] leading-[22px]'>{fromBaseUnitAmount(amount, 0).toFormat()}</p>
         <span className='font-mono text-sm italic text-foreground'>{encodedAssetId}</span>
         <CopyToClipboard
           text={encodedAssetId}
@@ -36,8 +37,8 @@ export const ValueViewComponent = ({ view }: ValueViewProps) => {
     const value = view.valueView.value;
     const amount = value.amount ?? new Amount();
     const display_denom = value.denom?.display ?? '';
-    // The first denom unit in the list is the display denom, according to cosmos practice
-    const exponent = value.denom?.denomUnits[0]?.exponent ?? 1;
+    const exponent = value.denom ? getDisplayDenomExponent(value.denom) : 0;
+
     return (
       <div className='flex font-mono'>
         {fromBaseUnitAmount(amount, exponent).toFormat()} {display_denom}


### PR DESCRIPTION
This started as a change to how we render a user's balance on the Send form. @grod220 [pointed out](https://github.com/penumbra-zone/web/pull/362#discussion_r1472411058) that we should be using a `ValueViewComponent`, as that is the standard for how we render `ValueView`s throughout the app.

As I worked on this, though, I realized this change wasn't possible without also changing the form of data that we pass around in `apps/webapp/src/fetchers/balances.ts`. So I refactored the helpers in that file so that we could work with full `DenomMetadata` objects, rather than just a few properties pulled off of those objects. 

When I did this, I also realized there were a few places where we were making incorrect assumptions and calculations about how to render financial values! I'll comment on those in the code so you can check my work, but I believe I corrected them.

## In this PR
- Modify the `AssetBalance` type to convert the `denom` property to a full `denomMetadata` property containing all metadata about the asset.
- Create a couple new helpers for converting between amounts and display values (based on the denom metadata).
- Fix a couple bugs in `ValueViewComponent` where the default exponent was assumed to be `1`, when it should be `0`. (Reviewers, please double-check this logic — I'll leave a comment where I'm referring to).
- Write tests for `ValueViewComponent` to ensure we're rendering financial figures correctly.