### PR TITLE
minor tweaks to tx views

### DIFF
--- a/packages/ui/components/ui/address.tsx
+++ b/packages/ui/components/ui/address.tsx
@@ -11,9 +11,7 @@ export const Address = ({
   address: string;
   ephemeral?: boolean;
 }) => (
-  <span
-    className={'font-mono' + (ephemeral ? ' text-[#8D5728]' : ' text-muted-foreground')}
-  >
+  <span className={'font-mono' + (ephemeral ? ' text-[#8D5728]' : ' text-muted-foreground')}>
     {shortenAddress(address)}
   </span>
 );

--- a/packages/ui/components/ui/address.tsx
+++ b/packages/ui/components/ui/address.tsx
@@ -12,7 +12,7 @@ export const Address = ({
   ephemeral?: boolean;
 }) => (
   <span
-    className={'font-mono text-[12px]' + (ephemeral ? ' text-[#8D5728]' : ' text-muted-foreground')}
+    className={'font-mono' + (ephemeral ? ' text-[#8D5728]' : ' text-muted-foreground')}
   >
     {shortenAddress(address)}
   </span>

--- a/packages/ui/components/ui/select-account.tsx
+++ b/packages/ui/components/ui/select-account.tsx
@@ -103,7 +103,7 @@ export const SelectAccount = ({ getAccount }: SelectAccountProps) => {
             <div className='flex items-center gap-[6px]'>
               <AddressIcon address={account.address} size={24} />
 
-              <p>
+              <p className='text-sm'>
                 <Address address={account.address} ephemeral={ephemeral} />
               </p>
             </div>

--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -23,7 +23,7 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
       ? !view.addressView.value.index?.randomizer.every(v => v === 0) // Randomized (and thus, a one-time address) if the randomizer is not all zeros.
       : undefined;
 
-  const addressIndexLabel = isOneTimeAddress ? 'One-time Address for Account #' : 'Account #';
+  const addressIndexLabel = isOneTimeAddress ? 'IBC Deposit Address for Account #' : 'Account #';
 
   copyable = isOneTimeAddress ? false : copyable;
 

--- a/packages/ui/components/ui/tx/view/output.tsx
+++ b/packages/ui/components/ui/tx/view/output.tsx
@@ -12,8 +12,8 @@ export const OutputViewComponent = ({ value }: { value: OutputView }) => {
         visibleContent={
           <div className='flex flex-col justify-between gap-2 sm:flex-row sm:gap-0'>
             <ValueViewComponent view={note.value} />
-            <div className='flex gap-2'>
-              <span className='font-mono text-sm italic text-foreground'>to</span>
+            <div className='flex gap-2 font-mono text-sm italic text-foreground'>
+              <span className='font-mono'>to</span>
               <AddressViewComponent view={note.address} />
             </div>
           </div>


### PR DESCRIPTION
Previously, the addresses in tx views were an inconsistent size with the surrounding text. This makes the address component not specify a text size, so it can fit with its surroundings.

Before:
<img width="564" alt="Screenshot 2024-01-31 at 3 08 17 PM" src="https://github.com/penumbra-zone/web/assets/44879/e1eb2ac2-f9f1-4d22-88da-a99d90fe1c73">
After
<img width="599" alt="Screenshot 2024-01-31 at 3 34 35 PM" src="https://github.com/penumbra-zone/web/assets/44879/8cdfce06-f0b6-4c83-9bce-b32c4d77551b">

Note however that there's a bug where the "to" and "from" labels are offset 2px upwards, it's quite unfortunate.