### PR TITLE
Move web app deploy from continuous to manual

### DIFF
--- a/.github/workflows/deploy-firebase-dapp.yml
+++ b/.github/workflows/deploy-firebase-dapp.yml
@@ -6,9 +6,7 @@ on:
   # Support ad-hoc runs via dispatch, so we can deploy from
   # unmerged feature branches if necessary.
   workflow_dispatch:
-  push:
-    branches:
-      - main
+
 jobs:
   build:
     name: Deploy


### PR DESCRIPTION
Follow up from web weekly. Given the _unstable_ times we are in, moving the web app deployment to manual (syncing with extension publishes) in order to not break user experiences between testnet launches.

After this, will manually run this action on an old commit that works with our current extension. This should revive the current experience for users.