### PR TITLE
Use a countdown before enabling the Approve button

### DIFF
--- a/apps/extension/src/routes/popup/approval/transaction/index.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction/index.tsx
@@ -6,12 +6,17 @@ import { Jsonified } from '@penumbra-zone/types';
 import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1alpha1/custody_pb';
 import { useTransactionViewSwitcher } from './use-transaction-view-switcher';
 import { ViewTabs } from './view-tabs';
+import { useCountdown } from 'usehooks-ts';
+import { useEffect } from 'react';
 
 export const TransactionApproval = () => {
   const { authorizeRequest: authReqString, responder } = useStore(txApprovalSelector);
 
   const { selectedTransactionView, selectedTransactionViewName, setSelectedTransactionViewName } =
     useTransactionViewSwitcher();
+
+  const [count, { startCountdown }] = useCountdown({ countStart: 3 });
+  useEffect(startCountdown, [startCountdown]);
 
   if (!authReqString) return null;
   const authorizeRequest = AuthorizeRequest.fromJsonString(authReqString);
@@ -43,8 +48,9 @@ export const TransactionApproval = () => {
             responder({ type: 'TX-APPROVAL', data: true });
             window.close();
           }}
+          disabled={!!count}
         >
-          Approve
+          Approve {count !== 0 && `(${count})`}
         </Button>
         <Button
           size='lg'


### PR DESCRIPTION
We want to put a little speed bump in place so that users don't approve transactions without reviewing them. This PR adds a countdown so that the Approve button is disabled for a few seconds.

Fixes #457