### PR TITLE
Hardcode an estimated fee of 0 for swap claims

### DIFF
--- a/apps/webapp/src/state/swap.ts
+++ b/apps/webapp/src/state/swap.ts
@@ -96,11 +96,10 @@ const assembleRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => {
         //       Asset Id should almost certainly be upenumbra,
         //       may need to indicate native denom in registry
         fee: {
-          amount: toBaseUnit(
-            BigNumber(amount),
-            getDisplayDenomExponent(assetIn.value.valueView.value.metadata),
-          ),
-          assetId: assetIn.value.valueView.value.metadata.penumbraAssetId,
+          amount: {
+            hi: 0n,
+            lo: 0n,
+          },
         },
       },
     ],


### PR DESCRIPTION
Per @hdevalence 's comment in Discord, we'll just set the fee for swap claims to 0 for now, since gas prices are 0 in testnet anyway. Once we have nonzero gas prices in testnet, we'll revisit this.