### PR TITLE
Support swap claims when doing a swap

### DIFF
--- a/apps/extension/src/wasm-build-action.ts
+++ b/apps/extension/src/wasm-build-action.ts
@@ -4,6 +4,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import type { WasmBuildActionInput } from '@penumbra-zone/types/src/internal-msg/offscreen';
 import type { JsonValue } from '@bufbuild/protobuf';
+import { camelToSnakeCase } from '@penumbra-zone/types';
 
 // necessary to propagate errors that occur in promises
 // see: https://stackoverflow.com/questions/39992417/how-to-bubble-a-web-worker-error-in-a-promise-via-worker-onerror
@@ -50,7 +51,7 @@ async function executeWorker(
   const actionPlanType = transactionPlan.actions[actionPlanIndex]?.action.case;
   if (!actionPlanType) throw new Error('No action key provided');
 
-  await penumbraWasmModule.loadProvingKey(actionPlanType);
+  await penumbraWasmModule.loadProvingKey(camelToSnakeCase(actionPlanType));
 
   // Build action according to specification in `TransactionPlan`
   return penumbraWasmModule

--- a/apps/webapp/src/components/swap/asset-out-box.tsx
+++ b/apps/webapp/src/components/swap/asset-out-box.tsx
@@ -15,8 +15,6 @@ const findMatchingBalance = (
   balances: AssetBalance[],
 ): ValueView | undefined => {
   if (!denom?.penumbraAssetId) return undefined;
-  const grouped = balances.reduce(groupByAsset, []);
-  console.log(grouped);
 
   return balances.reduce(groupByAsset, []).find(v => {
     if (v.valueView.case !== 'knownAssetId') return false;

--- a/apps/webapp/src/state/helpers.ts
+++ b/apps/webapp/src/state/helpers.ts
@@ -12,14 +12,18 @@ export const getTransactionPlan = async (req: TransactionPlannerRequest) => {
 
 export const planWitnessBuildBroadcast = async (
   req: TransactionPlannerRequest,
-  awaitDetection = true,
+  options: {
+    awaitDetection?: boolean;
+    rpcMethod?: 'authorizeAndBuild' | 'witnessAndBuild';
+  } = {},
 ) => {
+  const { awaitDetection = true, rpcMethod = 'authorizeAndBuild' } = options;
   const transactionPlan = await getTransactionPlan(req);
 
   if (!transactionPlan) throw new Error('no plan in response');
 
   let transaction: Transaction | undefined;
-  for await (const { status } of viewClient.authorizeAndBuild({ transactionPlan }))
+  for await (const { status } of viewClient[rpcMethod]({ transactionPlan }))
     switch (status.case) {
       case 'buildProgress':
         break;

--- a/apps/webapp/src/state/helpers.ts
+++ b/apps/webapp/src/state/helpers.ts
@@ -48,5 +48,8 @@ export const planWitnessBuildBroadcast = async (
     }
   if (!detectionHeight) throw new Error('did not detect transaction');
 
-  return uint8ArrayToHex(expectId.inner);
+  return transaction;
 };
+
+export const getTransactionHash = async (transaction: Transaction): Promise<string> =>
+  uint8ArrayToHex(await sha256Hash(transaction.toBinary()));

--- a/apps/webapp/src/state/ibc.ts
+++ b/apps/webapp/src/state/ibc.ts
@@ -8,7 +8,7 @@ import { typeRegistry } from '@penumbra-zone/types/src/registry';
 import { ClientState } from '@buf/cosmos_ibc.bufbuild_es/ibc/lightclients/tendermint/v1/tendermint_pb';
 import { Height } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/client/v1/client_pb';
 import { ibcClient, viewClient } from '../clients/grpc';
-import { planWitnessBuildBroadcast } from './helpers';
+import { getTransactionHash, planWitnessBuildBroadcast } from './helpers';
 import { AssetBalance } from '../fetchers/balances';
 
 export interface IbcSendSlice {
@@ -60,7 +60,8 @@ export const createIbcSendSlice = (): SliceCreator<IbcSendSlice> => (set, get) =
 
       try {
         const plannerReq = await getPlanRequest(get().ibc);
-        const txHash = await planWitnessBuildBroadcast(plannerReq);
+        const transaction = await planWitnessBuildBroadcast(plannerReq);
+        const txHash = await getTransactionHash(transaction);
         dismiss();
         toastFn(successTxToast(txHash));
 

--- a/apps/webapp/src/state/send.ts
+++ b/apps/webapp/src/state/send.ts
@@ -15,7 +15,7 @@ import BigNumber from 'bignumber.js';
 import { errorTxToast, loadingTxToast, successTxToast } from '../components/shared/toast-content';
 import { AssetBalance } from '../fetchers/balances';
 import { MemoPlaintext } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
-import { getTransactionPlan, planWitnessBuildBroadcast } from './helpers';
+import { getTransactionHash, getTransactionPlan, planWitnessBuildBroadcast } from './helpers';
 
 import {
   Fee,
@@ -103,7 +103,8 @@ export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
 
       try {
         const req = assembleRequest(get().send);
-        const txHash = await planWitnessBuildBroadcast(req);
+        const transaction = await planWitnessBuildBroadcast(req);
+        const txHash = await getTransactionHash(transaction);
         dismiss();
         toastFn(successTxToast(txHash));
 

--- a/apps/webapp/src/state/swap.ts
+++ b/apps/webapp/src/state/swap.ts
@@ -58,9 +58,10 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
 
         const swapClaimReq = assembleSwapClaimRequest(swapCommitment);
         const swapClaimTx = await planWitnessBuildBroadcast(swapClaimReq);
+        const swapClaimTxHash = await getTransactionHash(swapClaimTx);
 
         dismiss();
-        toastFn(successTxToast(await getTransactionHash(swapClaimTx)));
+        toastFn(successTxToast(swapClaimTxHash));
 
         // Reset form
         set(state => {

--- a/apps/webapp/src/state/swap.ts
+++ b/apps/webapp/src/state/swap.ts
@@ -57,7 +57,9 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
         const swapCommitment = getSwapCommitment(swapTx);
 
         const swapClaimReq = assembleSwapClaimRequest(swapCommitment);
-        const swapClaimTx = await planWitnessBuildBroadcast(swapClaimReq);
+        const swapClaimTx = await planWitnessBuildBroadcast(swapClaimReq, {
+          rpcMethod: 'witnessAndBuild',
+        });
         const swapClaimTxHash = await getTransactionHash(swapClaimTx);
 
         dismiss();

--- a/apps/webapp/src/state/swap.ts
+++ b/apps/webapp/src/state/swap.ts
@@ -58,6 +58,13 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
 
         const swapClaimReq = assembleSwapClaimRequest(swapCommitment);
         const swapClaimTx = await planWitnessBuildBroadcast(swapClaimReq, {
+          /**
+           * Swap claims are self-authenticating, so we'll use `witnessAndBuild`
+           * rather than `authorizeAndBuild` for the swap claim. That way, we
+           * won't trigger a second, unnecessary approval popup.
+           *
+           * @see https://protocol.penumbra.zone/main/zswap/swap.html#claiming-swap-outputs
+           */
           rpcMethod: 'witnessAndBuild',
         });
         const swapClaimTxHash = await getTransactionHash(swapClaimTx);

--- a/apps/webapp/src/state/swap.ts
+++ b/apps/webapp/src/state/swap.ts
@@ -2,12 +2,15 @@ import { AllSlices, SliceCreator } from './index';
 import { errorTxToast, loadingTxToast, successTxToast } from '../components/shared/toast-content';
 import { toast } from '@penumbra-zone/ui/components/ui/use-toast';
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import { planWitnessBuildBroadcast } from './helpers';
+import { getTransactionHash, planWitnessBuildBroadcast } from './helpers';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { AssetBalance } from '../fetchers/balances';
 import { getDisplayDenomExponent, toBaseUnit } from '@penumbra-zone/types';
 import BigNumber from 'bignumber.js';
 import { getAddressByIndex } from '../fetchers/address';
+import { Swap } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
+import { Transaction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
+import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
 
 export interface SwapSlice {
   assetIn: AssetBalance | undefined;
@@ -49,10 +52,15 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
       const { dismiss } = toastFn(loadingTxToast);
 
       try {
-        const req = await assembleRequest(get().swap);
-        const txHash = await planWitnessBuildBroadcast(req);
+        const swapReq = await assembleSwapRequest(get().swap);
+        const swapTx = await planWitnessBuildBroadcast(swapReq);
+        const swapCommitment = getSwapCommitment(swapTx);
+
+        const swapClaimReq = assembleSwapClaimRequest(swapCommitment);
+        const swapClaimTx = await planWitnessBuildBroadcast(swapClaimReq);
+
         dismiss();
-        toastFn(successTxToast(txHash));
+        toastFn(successTxToast(await getTransactionHash(swapClaimTx)));
 
         // Reset form
         set(state => {
@@ -71,7 +79,7 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
   };
 };
 
-const assembleRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => {
+const assembleSwapRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => {
   if (assetIn?.value.valueView.case !== 'knownAssetId') throw new Error('unknown denom selected');
   if (!assetIn.value.valueView.value.metadata?.penumbraAssetId)
     throw new Error('missing metadata for assetIn');
@@ -104,6 +112,26 @@ const assembleRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => {
       },
     ],
     source: assetIn.address.addressView.value.index,
+  });
+};
+
+const getSwapCommitment = (transaction: Transaction): StateCommitment => {
+  const swap = transaction.body?.actions.find(action => action.action.case === 'swap')?.action
+    .value as Swap | undefined;
+  if (!swap) throw new Error('Swap action could not be found in transaction for swap claim');
+  if (!swap.body?.payload?.commitment)
+    throw new Error('Swap commitment could not be found in swap action');
+
+  return swap.body.payload.commitment;
+};
+
+const assembleSwapClaimRequest = (swapCommitment: StateCommitment) => {
+  return new TransactionPlannerRequest({
+    swapClaims: [
+      {
+        swapCommitment,
+      },
+    ],
   });
 };
 

--- a/packages/router/src/grpc/custody/view-transaction-plan/index.test.ts
+++ b/packages/router/src/grpc/custody/view-transaction-plan/index.test.ts
@@ -33,7 +33,7 @@ describe('viewTransactionPlan()', () => {
     },
   });
 
-  test('includes the return address', () => {
+  test('includes the return address if it exists', () => {
     const txnView = viewTransactionPlan(validTxnPlan, {}, mockFvk);
     const memoViewValue = txnView.bodyView!.memoView!.memoView.value! as MemoView_Visible;
 
@@ -42,10 +42,21 @@ describe('viewTransactionPlan()', () => {
     ).toBe(true);
   });
 
-  test('throws when there is no return address', () => {
-    expect(() => viewTransactionPlan(new TransactionPlan(), {}, mockFvk)).toThrow(
-      'No return address found in transaction plan',
-    );
+  test('leaves out the return address when it does not exist', () => {
+    const txnPlan = new TransactionPlan({
+      transactionParameters: {
+        fee: {
+          amount: {
+            hi: 1n,
+            lo: 0n,
+          },
+        },
+      },
+    });
+    const txnView = viewTransactionPlan(txnPlan, {}, mockFvk);
+    const memoViewValue = txnView.bodyView!.memoView!.memoView.value! as MemoView_Visible;
+
+    expect(memoViewValue.plaintext?.returnAddress).toBeUndefined();
   });
 
   test('includes the fee', () => {

--- a/packages/router/src/grpc/custody/view-transaction-plan/index.ts
+++ b/packages/router/src/grpc/custody/view-transaction-plan/index.ts
@@ -23,7 +23,6 @@ export const viewTransactionPlan = (
   fullViewingKey: string,
 ): TransactionView => {
   const returnAddress = txPlan.memo?.plaintext?.returnAddress;
-  if (!returnAddress) throw new Error('No return address found in transaction plan');
   const transactionParameters = txPlan.transactionParameters;
   if (!transactionParameters?.fee) throw new Error('No fee found in transaction plan');
 
@@ -35,7 +34,9 @@ export const viewTransactionPlan = (
           case: 'visible',
           value: {
             plaintext: {
-              returnAddress: getAddressView(returnAddress, fullViewingKey),
+              returnAddress: returnAddress
+                ? getAddressView(returnAddress, fullViewingKey)
+                : undefined,
               text: txPlan.memo?.plaintext?.text ?? '',
             },
           },

--- a/packages/router/src/grpc/view-protocol-server/witness-and-build.ts
+++ b/packages/router/src/grpc/view-protocol-server/witness-and-build.ts
@@ -6,11 +6,10 @@ import { offscreenClient } from '../offscreen-client';
 import { buildParallel, getWitness } from '@penumbra-zone/wasm-ts';
 
 import { ConnectError, Code } from '@connectrpc/connect';
+import { AuthorizationData } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 
 export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (req, ctx) {
   const services = ctx.values.get(servicesCtx);
-  if (!req.authorizationData)
-    throw new ConnectError('No authorization data in request', Code.InvalidArgument);
   if (!req.transactionPlan) throw new ConnectError('No tx plan in request', Code.InvalidArgument);
 
   const {
@@ -31,7 +30,7 @@ export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (req, ct
     batchActions,
     req.transactionPlan,
     witnessData,
-    req.authorizationData,
+    req.authorizationData ?? new AuthorizationData(),
   );
 
   yield {

--- a/packages/types/src/transaction/classification.ts
+++ b/packages/types/src/transaction/classification.ts
@@ -8,4 +8,8 @@ export type TransactionClassification =
   /** The transaction is a send to an external account. */
   | 'send'
   /** The transaction is a receive from an external account. */
-  | 'receive';
+  | 'receive'
+  /** The transaction contains a `swap` action. */
+  | 'swap'
+  /** The transaction contains a `swapClaim` action. */
+  | 'swapClaim';

--- a/packages/types/src/transaction/classify.test.ts
+++ b/packages/types/src/transaction/classify.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+import { classifyTransaction } from './classify';
+import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
+
+describe('classifyTransaction()', () => {
+  it('returns `receive` for transactions with an opaque spend and a visible output + address', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'spend',
+              value: {
+                spendView: {
+                  case: 'opaque',
+                  value: {},
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {
+                outputView: {
+                  case: 'visible',
+                  value: {
+                    note: {
+                      address: {
+                        addressView: {
+                          case: 'decoded',
+                          value: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('receive');
+  });
+
+  it('returns `send` for transactions with visible spends but at least one opaque output', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'spend',
+              value: {
+                spendView: {
+                  case: 'visible',
+                  value: {
+                    note: {
+                      address: {
+                        addressView: {
+                          case: 'decoded',
+                          value: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {
+                outputView: {
+                  case: 'visible',
+                  value: {
+                    note: {
+                      address: {
+                        addressView: {
+                          case: 'decoded',
+                          value: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {
+                outputView: {
+                  case: 'visible',
+                  value: {
+                    note: {
+                      address: {
+                        addressView: {
+                          case: 'opaque',
+                          value: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('send');
+  });
+
+  it('returns `internalTransfer` for transactions with fully visible spends, outputs, and addresses', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'spend',
+              value: {
+                spendView: {
+                  case: 'visible',
+                  value: {},
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {
+                outputView: {
+                  case: 'visible',
+                  value: {
+                    note: {
+                      address: {
+                        addressView: {
+                          case: 'decoded',
+                          value: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {
+                outputView: {
+                  case: 'visible',
+                  value: {
+                    note: {
+                      address: {
+                        addressView: {
+                          case: 'decoded',
+                          value: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('internalTransfer');
+  });
+
+  it('returns `swap` for transactions with a `swap` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'swap',
+              value: {},
+            },
+          },
+          {
+            actionView: {
+              case: 'spend',
+              value: {},
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('swap');
+  });
+
+  it('returns `swapClaim` for transactions with a `swapClaim` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'swapClaim',
+              value: {},
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('swapClaim');
+  });
+
+  it("returns `unknown` for transactions that don't fit the above categories", () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'spend',
+              value: {
+                spendView: {
+                  case: 'visible',
+                  value: {},
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {
+                outputView: {
+                  case: 'opaque',
+                  value: {},
+                },
+              },
+            },
+          },
+          {
+            actionView: {
+              case: 'delegate',
+              value: {},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('unknown');
+  });
+});

--- a/packages/types/src/transaction/classify.ts
+++ b/packages/types/src/transaction/classify.ts
@@ -7,6 +7,9 @@ export const classifyTransaction = (txv?: TransactionView): TransactionClassific
     return 'unknown';
   }
 
+  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'swap')) return 'swap';
+  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'swapClaim')) return 'swapClaim';
+
   const hasOpaqueSpend = txv.bodyView?.actionViews.some(
     a => a.actionView.case === 'spend' && a.actionView.value.spendView.case === 'opaque',
   );
@@ -73,6 +76,8 @@ const TRANSACTION_LABEL_BY_CLASSIFICATION: Record<TransactionClassification, str
   receive: 'Receive',
   send: 'Send',
   internalTransfer: 'Internal Transfer',
+  swap: 'Swap',
+  swapClaim: 'Swap Claim',
 };
 
 export const getTransactionClassificationLabel = (txv?: TransactionView): string =>

--- a/packages/types/src/utility.test.ts
+++ b/packages/types/src/utility.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { camelToSnakeCase } from './utility';
+
+describe('camelToSnakeCase()', () => {
+  it('converts camelCase to snake_case', () => {
+    expect(camelToSnakeCase('needsToBeConverted')).toBe('needs_to_be_converted');
+  });
+});

--- a/packages/types/src/utility.ts
+++ b/packages/types/src/utility.ts
@@ -6,3 +6,6 @@ export const isEmptyObj = <T>(input: T): input is T & EmptyObject => {
   }
   return false;
 };
+
+export const camelToSnakeCase = (str: string) =>
+  str.replace(/[A-Z]/g, letter => `_${letter}`).toLowerCase();

--- a/packages/ui/components/ui/tx/view/action-view.tsx
+++ b/packages/ui/components/ui/tx/view/action-view.tsx
@@ -3,6 +3,7 @@ import { SpendViewComponent } from './spend';
 import { OutputViewComponent } from './output';
 import { ActionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { SwapViewComponent } from './swap';
+import { SwapClaimViewComponent } from './swap-claim';
 
 const CASE_TO_LABEL: Record<string, string> = {
   daoDeposit: 'DAO Deposit',
@@ -48,7 +49,7 @@ export const ActionViewComponent = ({ av: { actionView } }: { av: ActionView }) 
       return <SwapViewComponent value={actionView.value} />;
 
     case 'swapClaim':
-      return <ViewBox label='Swap Claim' />;
+      return <SwapClaimViewComponent value={actionView.value} />;
 
     case 'ics20Withdrawal':
       return <ViewBox label='ICS20 Withdrawal' />;

--- a/packages/ui/components/ui/tx/view/output.tsx
+++ b/packages/ui/components/ui/tx/view/output.tsx
@@ -26,5 +26,5 @@ export const OutputViewComponent = ({ value }: { value: OutputView }) => {
     return <ViewBox label='Output' />;
   }
 
-  return <div>Invalid SpendView</div>;
+  return <div>Invalid OutputView</div>;
 };

--- a/packages/ui/components/ui/tx/view/swap-claim.tsx
+++ b/packages/ui/components/ui/tx/view/swap-claim.tsx
@@ -1,0 +1,24 @@
+import { ViewBox } from './viewbox';
+import { SwapClaimView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
+import { JsonViewer } from '../../json-viewer';
+import { JsonObject } from '@bufbuild/protobuf';
+
+export const SwapClaimViewComponent = ({ value }: { value: SwapClaimView }) => {
+  if (value.swapClaimView.case === 'visible') {
+    return (
+      <ViewBox
+        label='Swap Claim'
+        visibleContent={
+          /** @todo: Make a real UI for swap claims -- web#424 */
+          <JsonViewer jsonObj={value.swapClaimView.value.toJson() as JsonObject} />
+        }
+      />
+    );
+  }
+
+  if (value.swapClaimView.case === 'opaque') {
+    return <ViewBox label='Swap Claim' />;
+  }
+
+  return <div>Invalid SpendView</div>;
+};

--- a/packages/ui/components/ui/tx/view/swap.tsx
+++ b/packages/ui/components/ui/tx/view/swap.tsx
@@ -64,5 +64,5 @@ export const SwapViewComponent = ({ value }: { value: SwapView }) => {
     return <ViewBox label='Swap' />;
   }
 
-  return <div>Invalid SpendView</div>;
+  return <div>Invalid SwapView</div>;
 };

--- a/packages/wasm/src/utils.ts
+++ b/packages/wasm/src/utils.ts
@@ -10,7 +10,10 @@ export const loadLocalBinary = async (filename: string) => {
   return await response.arrayBuffer();
 };
 
-export const loadProvingKey = async (keyType: string) => {
+export const loadProvingKey = async (
+  /** The `snake_case`d name of the proving key to load. */
+  keyType: string,
+) => {
   const keyEntry = provingKeys.find(entry => entry.keyType === keyType);
 
   if (keyEntry) {


### PR DESCRIPTION
🚨 471 line additions are just test files
🚨 Note that the "Swap into" field is not yet used. This PR is just for adding the swap claim step after a swap.

https://github.com/penumbra-zone/web/assets/1121544/22da28c4-328d-4a03-927b-e5d3d2c63d5d

## In this PR
- Build and submit a swap claim transaction automatically after building and submitting the swap transaction.
- Fix bug where we were trying to load proving keys in `camelCase` when we should have been loading them in `snake_case`
- Update `planWitnessBuildBroadcast` to now return the entire built transaction; extract a `getTransactionHash` helper so we can use that where needed.
- Update `classifyTransaction` to also handle `swap`/`swapClaim` transactions.

## Manual testing
If reviewers want to manually test, here's how I tested:
1. Check out penumbra core on the v0.65.0 tag
2. `rm -rf ~/.penumbra/testnet_data`
3. `cargo run --release --bin pd -- testnet generate`
4. Start Penumbra + CometBFT
5. Configure pcli to run against the local devnet, not testnet/testnet-preview
6. `cargo run --bin pcli tx position order buy 1000penumbra@5test_usd` (This sets the exchange rate at 1penumbra = 5test_usd)
7. On the swap page, swap 1 penumbra for test_usd:
    ![image](https://github.com/penumbra-zone/web/assets/1121544/8a77a22d-c317-40bc-89c0-f01e8cdf0bd1)
8. When it's finished, go back to the homepage to see that you have 1 less penumbra, and 5 more test_usd.


Closes #420, #467