### PR TITLE
Fix imports from tests to use core v1

### DIFF
--- a/packages/router/src/grpc/view-protocol-server/status.test.ts
+++ b/packages/router/src/grpc/view-protocol-server/status.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   StatusRequest,
   StatusResponse,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1alpha1/view_pb';
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { ServicesInterface } from '@penumbra-zone/types';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
-import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1alpha1/view_connect';
+import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
 import { servicesCtx } from '../../ctx';
 import { IndexedDbMock, MockServices, TendermintMock } from './test-utils';
 import { status } from './status';


### PR DESCRIPTION
Looks like a couple imports were missing in the recent upgrade to v1