### PR TITLE
Prevent popup spam

### DIFF
--- a/packages/router/src/grpc/offscreen-client.ts
+++ b/packages/router/src/grpc/offscreen-client.ts
@@ -12,26 +12,18 @@ import {
 
 const OFFSCREEN_DOCUMENT_PATH = '/offscreen.html';
 
-interface ContextsRequest {
-  contextTypes: string[];
-  documentUrls: string[];
-}
-
 let active = 0;
 
 const activateOffscreen = async () => {
-  const getContexts = chrome.runtime.getContexts as (
-    request: ContextsRequest,
-  ) => Promise<unknown[]>;
-
-  const offscreenExists = await getContexts({
-    contextTypes: ['OFFSCREEN_DOCUMENT'],
-    documentUrls: [OFFSCREEN_DOCUMENT_PATH],
-  }).then(contexts => contexts.length > 0);
+  const offscreenExists = await chrome.runtime
+    .getContexts({
+      contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
+    })
+    .then(contexts => contexts.length > 0);
 
   if (!active || !offscreenExists) {
     await chrome.offscreen.createDocument({
-      url: OFFSCREEN_DOCUMENT_PATH,
+      url: chrome.runtime.getURL(OFFSCREEN_DOCUMENT_PATH),
       reasons: [chrome.offscreen.Reason.WORKERS],
       justification: 'Manages Penumbra transaction WASM workers',
     });

--- a/packages/types/src/internal-msg/popup.ts
+++ b/packages/types/src/internal-msg/popup.ts
@@ -27,11 +27,16 @@ export const sendPopupRequest = async <M extends PopupSupportedMsg>(
   }
 };
 
-export const spawnDetachedPopup = async (url: string) => {
+export const spawnDetachedPopup = async (path: string) => {
+  const alreadyPopup = await chrome.runtime.getContexts({
+    documentUrls: [chrome.runtime.getURL(path)],
+  });
+  if (alreadyPopup.length) throw new Error('Popup already open');
+
   const { top, left, width } = await chrome.windows.getLastFocused();
 
   await chrome.windows.create({
-    url,
+    url: chrome.runtime.getURL(path),
     type: 'popup',
     width: 400,
     height: 628,


### PR DESCRIPTION
Refuse to open multiple popups of the same path.

This is important for any externally-triggerable popup, such as connection request, or transaction request.

If we later do want to provide multiple simultaneous popups, we might want to add some kind of id hash.