### PR TITLE
Don't swallow errors thrown in streaming RPC methods

### DIFF
--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -84,8 +84,9 @@ const rpcImpls = [
   [
     CustodyService,
     /**
-     * @todo Remove `as` below once `custodyImpl` implemented the entire custody
-     * service. It's just there temporarily to make `rethrowImplErrors` happy.
+     * @todo Remove `as` below once `custodyImpl` has implemented the entire
+     * custody service. It's just there temporarily to make `rethrowImplErrors`
+     * happy.
      */
     rethrowImplErrors(CustodyService, custodyImpl as ServiceImpl<typeof CustodyService>),
   ],

--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -23,11 +23,11 @@ import { createProxyImpl } from '@penumbra-zone/transport/src/proxy';
 import { connectChromeRuntimeAdapter } from '@penumbra-zone/transport/src/chrome-runtime/adapter';
 
 import {
-  ConnectError,
   ConnectRouter,
   createContextValues,
   createPromiseClient,
   PromiseClient,
+  ServiceImpl,
 } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 
@@ -44,6 +44,7 @@ import { viewImpl } from '@penumbra-zone/router/src/grpc/view-protocol-server';
 import { stdRouter } from '@penumbra-zone/router/src/std/router';
 import { isStdRequest } from '@penumbra-zone/types';
 import { createSameScriptClient } from './clients/extension-service';
+import { rethrowImplErrors } from './utils/rethrow-impl-errors';
 
 // configure and initialize extension services. services are passed directly to stdRouter, and to rpc handlers as context
 const grpcEndpoint = await localExtStorage.get('grpcEndpoint');
@@ -78,40 +79,17 @@ const ibcImpl = createProxyImpl(
   createPromiseClient(IbcClientService, createGrpcWebTransport({ baseUrl: grpcEndpoint })),
 );
 
-/**
- * unfortunately, the handler factory in connectrpc suppresses internal errors,
- * unless they are thrown as `ConnectError`.  this is a workaround that wraps
- * impls to rethrow everything as ConnectError before return to the router.
- *
- * would prefer to use `SI extends Partial<ServiceImpl<ServiceType>>` here, but
- * typescript `exactOptionalPropertTypes` and `Partial` interaction is buggy.
- * see: https://github.com/microsoft/TypeScript/issues/46969
- */
-const rethrowImplErrors = <SI extends object>(sImpl: SI) =>
-  Object.fromEntries(
-    Object.entries(sImpl).map(([k, v]) => [
-      k,
-      (...args: unknown[]) => {
-        try {
-          const x = (v as (...args: unknown[]) => unknown)(...args);
-          if (x instanceof Promise)
-            return (x as Promise<unknown>).catch(e => {
-              console.error('Error in impl:', e);
-              throw ConnectError.from(e);
-            });
-          return x;
-        } catch (e) {
-          console.error('Error in impl:', e);
-          throw ConnectError.from(e);
-        }
-      },
-    ]),
-  ) as typeof sImpl;
-
 const rpcImpls = [
   // rpc we provide
-  [CustodyService, rethrowImplErrors(custodyImpl)],
-  [ViewService, rethrowImplErrors(viewImpl)],
+  [
+    CustodyService,
+    /**
+     * @todo Remove `as` below once `custodyImpl` implemented the entire custody
+     * service. It's just there temporarily to make `rethrowImplErrors` happy.
+     */
+    rethrowImplErrors(CustodyService, custodyImpl as ServiceImpl<typeof CustodyService>),
+  ],
+  [ViewService, rethrowImplErrors(ViewService, viewImpl)],
   // rpc proxy
   [IbcClientService, ibcImpl],
 ] as const;

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -104,7 +104,7 @@ describe('rethrowImplErrors()', () => {
     possiblyThrowError.mockReset();
   });
 
-  describe('for a unary method', () => {
+  describe('for a MethodKind.Unary method', () => {
     describe('when the request succeeds', () => {
       it('returns the response', async () => {
         await expect(
@@ -140,7 +140,7 @@ describe('rethrowImplErrors()', () => {
     });
   });
 
-  describe('for a streaming method', () => {
+  describe('for a MethodKind.ServerStreaming method', () => {
     describe('when the request succeeds', () => {
       it('yields the response', async () => {
         expect.assertions(3);

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -105,6 +105,14 @@ describe('rethrowImplErrors()', () => {
   });
 
   describe('for a unary method', () => {
+    describe('when the request succeeds', () => {
+      it('returns the response', async () => {
+        await expect(
+          wrappedServiceImplementation.getFoos(new FooRequest(), mockHandlerContext),
+        ).resolves.toEqual(['foo1', 'foo2']);
+      });
+    });
+
     describe('when the impl throws a `ConnectError`', () => {
       it('throws the error as-is', async () => {
         const error = new ConnectError('oh no!');
@@ -133,6 +141,21 @@ describe('rethrowImplErrors()', () => {
   });
 
   describe('for a streaming method', () => {
+    describe('when the request succeeds', () => {
+      it('yields the response', async () => {
+        expect.assertions(3);
+
+        let whichBar = 1;
+        for await (const item of wrappedServiceImplementation.getBars(
+          new BarRequest(),
+          mockHandlerContext,
+        )) {
+          expect(item).toBe(`bar${whichBar}`);
+          whichBar++;
+        }
+      });
+    });
+
     describe('when the impl throws a `ConnectError`', () => {
       it('throws the error as-is', async () => {
         const error = new ConnectError('oh no!');

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -50,9 +50,6 @@ const MockService = {
 
     getBars: {
       name: 'getBars',
-      // Just supplying `I`/`O` to make TypeScript happy. The specific
-      // `TransactionPlanner*` classes I've passed here aren't relevant to the
-      // tests.
       I: BarRequest,
       O: BarResponse,
       kind: MethodKind.ServerStreaming,

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -57,7 +57,7 @@ const MockService = {
   },
 } satisfies ServiceType;
 
-const possiblyThrowError = vi.fn().mockImplementation(() => undefined);
+const possiblyThrowError = vi.fn();
 
 const mockServiceImplementation = {
   getFoos: async () => {

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -80,11 +80,15 @@ const possiblyThrowError = vi.fn().mockImplementation(() => undefined);
 const mockServiceImplementation = {
   getFoos: async () => {
     possiblyThrowError();
+
     return Promise.resolve(['foo1', 'foo2']);
   },
+
   getBars: async function* () {
     possiblyThrowError();
-    const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+
+    const promises = [Promise.resolve('bar1'), Promise.resolve('bar2'), Promise.resolve('bar3')];
+
     for await (const i of promises) {
       yield i;
     }
@@ -92,6 +96,8 @@ const mockServiceImplementation = {
 } satisfies ServiceImpl<typeof MockService>;
 
 const mockHandlerContext = {} as HandlerContext;
+
+const wrappedServiceImplementation = rethrowImplErrors(MockService, mockServiceImplementation);
 
 describe('rethrowImplErrors()', () => {
   beforeEach(() => {
@@ -101,10 +107,6 @@ describe('rethrowImplErrors()', () => {
   describe('for a unary method', () => {
     describe('when the impl throws a `ConnectError`', () => {
       it('throws the error as-is', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(
-          MockService,
-          mockServiceImplementation,
-        );
         const error = new ConnectError('oh no!');
         possiblyThrowError.mockImplementation(() => {
           throw error;
@@ -118,10 +120,6 @@ describe('rethrowImplErrors()', () => {
 
     describe('when the impl throws an error that is not a `ConnectError`', () => {
       it('throws the error as a `ConnectError`', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(
-          MockService,
-          mockServiceImplementation,
-        );
         const error = new Error('oh no!');
         possiblyThrowError.mockImplementation(() => {
           throw error;
@@ -137,10 +135,6 @@ describe('rethrowImplErrors()', () => {
   describe('for a streaming method', () => {
     describe('when the impl throws a `ConnectError`', () => {
       it('throws the error as-is', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(
-          MockService,
-          mockServiceImplementation,
-        );
         const error = new ConnectError('oh no!');
         possiblyThrowError.mockImplementation(() => {
           throw error;
@@ -160,10 +154,6 @@ describe('rethrowImplErrors()', () => {
 
     describe('when the impl throws an error that is not a `ConnectError`', () => {
       it('throws the error as a `ConnectError`', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(
-          MockService,
-          mockServiceImplementation,
-        );
         const error = new Error('oh no!');
         possiblyThrowError.mockImplementation(() => {
           throw error;

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { rethrowImplErrors } from './rethrow-impl-errors';
+import { ConnectError } from '@connectrpc/connect';
+
+const mockServiceImplementation = {
+  getFoos: async (errorToThrow?: Error) => {
+    if (errorToThrow) throw errorToThrow;
+    return Promise.resolve(['foo1', 'foo2']);
+  },
+  getBars: async function* (errorToThrow?: Error) {
+    if (errorToThrow) throw errorToThrow;
+    const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+    for await (const i of promises) {
+      yield i;
+    }
+  },
+} satisfies Record<string, (error?: Error) => unknown>;
+
+describe('rethrowImplErrors()', () => {
+  describe('for a unary method', () => {
+    describe('when the impl throws a `ConnectError`', () => {
+      it('throws the error as-is', async () => {
+        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const error = new ConnectError('oh no!');
+
+        await expect(() => wrappedServiceImplementation.getFoos(error)).rejects.toThrow(error);
+      });
+    });
+
+    describe('when the impl throws an error that is not a `ConnectError`', () => {
+      it('throws the error as a `ConnectError`', async () => {
+        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const error = new Error('oh no!');
+
+        await expect(() => wrappedServiceImplementation.getFoos(error)).rejects.toThrow(
+          new ConnectError('oh no!'),
+        );
+      });
+    });
+  });
+
+  describe('for a streaming method', () => {
+    describe('when the impl throws a `ConnectError`', () => {
+      it('throws the error as-is', async () => {
+        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const error = new ConnectError('oh no!');
+
+        await expect(async () => {
+          for await (const item of wrappedServiceImplementation.getBars(error)) {
+            // no-op
+            item;
+          }
+        }).rejects.toThrow(error);
+      });
+    });
+
+    describe('when the impl throws an error that is not a `ConnectError`', () => {
+      it('throws the error as a `ConnectError`', async () => {
+        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const error = new Error('oh no!');
+
+        await expect(async () => {
+          for await (const item of wrappedServiceImplementation.getBars(error)) {
+            // no-op
+            item;
+          }
+        }).rejects.toThrow(new ConnectError('oh no!'));
+      });
+    });
+  });
+});

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -1,40 +1,135 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { rethrowImplErrors } from './rethrow-impl-errors';
-import { ConnectError } from '@connectrpc/connect';
+import { ConnectError, HandlerContext, ServiceImpl } from '@connectrpc/connect';
+import {
+  AnyMessage,
+  BinaryReadOptions,
+  FieldList,
+  JsonReadOptions,
+  JsonValue,
+  Message,
+  MethodKind,
+  PlainMessage,
+  ServiceType,
+  proto3,
+} from '@bufbuild/protobuf';
+
+class MockMessage<T extends Message<T> = AnyMessage> extends Message<T> {
+  static readonly runtime: typeof proto3;
+  static readonly typeName = 'penumbra.view.v1.MockMessage';
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): MockMessage {
+    bytes;
+    options;
+    return new MockMessage();
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): MockMessage {
+    jsonValue;
+    options;
+    return new MockMessage();
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): MockMessage {
+    jsonString;
+    options;
+    return new MockMessage();
+  }
+
+  static equals(
+    a: MockMessage | PlainMessage<MockMessage> | undefined,
+    b: MockMessage | PlainMessage<MockMessage> | undefined,
+  ): boolean {
+    a;
+    b;
+    return true;
+  }
+}
+
+class FooRequest extends MockMessage<FooRequest> {}
+class FooResponse extends MockMessage<FooResponse> {}
+class BarRequest extends MockMessage<BarRequest> {}
+class BarResponse extends MockMessage<BarResponse> {}
+
+const MockService = {
+  typeName: 'MockService',
+
+  methods: {
+    getFoos: {
+      name: 'getFoos',
+      I: FooRequest,
+      O: FooResponse,
+      kind: MethodKind.Unary,
+    },
+
+    getBars: {
+      name: 'getBars',
+      // Just supplying `I`/`O` to make TypeScript happy. The specific
+      // `TransactionPlanner*` classes I've passed here aren't relevant to the
+      // tests.
+      I: BarRequest,
+      O: BarResponse,
+      kind: MethodKind.ServerStreaming,
+    },
+  },
+} satisfies ServiceType;
+
+const possiblyThrowError = vi.fn().mockImplementation(() => undefined);
 
 const mockServiceImplementation = {
-  getFoos: async (errorToThrow?: Error) => {
-    if (errorToThrow) throw errorToThrow;
+  getFoos: async () => {
+    possiblyThrowError();
     return Promise.resolve(['foo1', 'foo2']);
   },
-  getBars: async function* (errorToThrow?: Error) {
-    if (errorToThrow) throw errorToThrow;
+  getBars: async function* () {
+    possiblyThrowError();
     const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
     for await (const i of promises) {
       yield i;
     }
   },
-} satisfies Record<string, (error?: Error) => unknown>;
+} satisfies ServiceImpl<typeof MockService>;
+
+const mockHandlerContext = {} as HandlerContext;
 
 describe('rethrowImplErrors()', () => {
+  beforeEach(() => {
+    possiblyThrowError.mockReset();
+  });
+
   describe('for a unary method', () => {
     describe('when the impl throws a `ConnectError`', () => {
       it('throws the error as-is', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const wrappedServiceImplementation = rethrowImplErrors(
+          MockService,
+          mockServiceImplementation,
+        );
         const error = new ConnectError('oh no!');
+        possiblyThrowError.mockImplementation(() => {
+          throw error;
+        });
 
-        await expect(() => wrappedServiceImplementation.getFoos(error)).rejects.toThrow(error);
+        await expect(() =>
+          wrappedServiceImplementation.getFoos(new FooRequest(), mockHandlerContext),
+        ).rejects.toThrow(error);
       });
     });
 
     describe('when the impl throws an error that is not a `ConnectError`', () => {
       it('throws the error as a `ConnectError`', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
-        const error = new Error('oh no!');
-
-        await expect(() => wrappedServiceImplementation.getFoos(error)).rejects.toThrow(
-          new ConnectError('oh no!'),
+        const wrappedServiceImplementation = rethrowImplErrors(
+          MockService,
+          mockServiceImplementation,
         );
+        const error = new Error('oh no!');
+        possiblyThrowError.mockImplementation(() => {
+          throw error;
+        });
+
+        await expect(() =>
+          wrappedServiceImplementation.getFoos(new FooRequest(), mockHandlerContext),
+        ).rejects.toThrow(new ConnectError('oh no!'));
       });
     });
   });
@@ -42,11 +137,20 @@ describe('rethrowImplErrors()', () => {
   describe('for a streaming method', () => {
     describe('when the impl throws a `ConnectError`', () => {
       it('throws the error as-is', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const wrappedServiceImplementation = rethrowImplErrors(
+          MockService,
+          mockServiceImplementation,
+        );
         const error = new ConnectError('oh no!');
+        possiblyThrowError.mockImplementation(() => {
+          throw error;
+        });
 
         await expect(async () => {
-          for await (const item of wrappedServiceImplementation.getBars(error)) {
+          for await (const item of wrappedServiceImplementation.getBars(
+            new BarRequest(),
+            mockHandlerContext,
+          )) {
             // no-op
             item;
           }
@@ -56,11 +160,20 @@ describe('rethrowImplErrors()', () => {
 
     describe('when the impl throws an error that is not a `ConnectError`', () => {
       it('throws the error as a `ConnectError`', async () => {
-        const wrappedServiceImplementation = rethrowImplErrors(mockServiceImplementation);
+        const wrappedServiceImplementation = rethrowImplErrors(
+          MockService,
+          mockServiceImplementation,
+        );
         const error = new Error('oh no!');
+        possiblyThrowError.mockImplementation(() => {
+          throw error;
+        });
 
         await expect(async () => {
-          for await (const item of wrappedServiceImplementation.getBars(error)) {
+          for await (const item of wrappedServiceImplementation.getBars(
+            new BarRequest(),
+            mockHandlerContext,
+          )) {
             // no-op
             item;
           }

--- a/apps/extension/src/utils/rethrow-impl-errors.test.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.test.ts
@@ -3,13 +3,9 @@ import { rethrowImplErrors } from './rethrow-impl-errors';
 import { ConnectError, HandlerContext, ServiceImpl } from '@connectrpc/connect';
 import {
   AnyMessage,
-  BinaryReadOptions,
   FieldList,
-  JsonReadOptions,
-  JsonValue,
   Message,
   MethodKind,
-  PlainMessage,
   ServiceType,
   proto3,
 } from '@bufbuild/protobuf';
@@ -19,30 +15,19 @@ class MockMessage<T extends Message<T> = AnyMessage> extends Message<T> {
   static readonly typeName = 'penumbra.view.v1.MockMessage';
   static readonly fields: FieldList;
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): MockMessage {
-    bytes;
-    options;
+  static fromBinary(): MockMessage {
     return new MockMessage();
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): MockMessage {
-    jsonValue;
-    options;
+  static fromJson(): MockMessage {
     return new MockMessage();
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): MockMessage {
-    jsonString;
-    options;
+  static fromJsonString(): MockMessage {
     return new MockMessage();
   }
 
-  static equals(
-    a: MockMessage | PlainMessage<MockMessage> | undefined,
-    b: MockMessage | PlainMessage<MockMessage> | undefined,
-  ): boolean {
-    a;
-    b;
+  static equals(): boolean {
     return true;
   }
 }

--- a/apps/extension/src/utils/rethrow-impl-errors.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.ts
@@ -1,0 +1,42 @@
+import { ConnectError } from '@connectrpc/connect';
+
+const wrapUnaryImpl =
+  (methodImplementation: (...args: unknown[]) => unknown) =>
+  (...args: unknown[]) => {
+    try {
+      const result = methodImplementation(...args);
+      if (result instanceof Promise)
+        return (result as Promise<unknown>).catch(e => {
+          throw ConnectError.from(e);
+        });
+      return result;
+    } catch (e) {
+      throw ConnectError.from(e);
+    }
+  };
+
+const wrapStreamingImpl = (methodImplementation: (...args: unknown[]) => AsyncIterable<unknown>) =>
+  async function* (...args: unknown[]) {
+    try {
+      for await (const result of methodImplementation(...args)) {
+        yield result;
+      }
+    } catch (e) {
+      throw ConnectError.from(e);
+    }
+  };
+
+export const rethrowImplErrors = <
+  ServiceImplementation extends Record<string, (...args: unknown[]) => unknown>,
+>(
+  serviceImpl: ServiceImplementation,
+) =>
+  Object.fromEntries(
+    Object.entries(serviceImpl).map(([methodName, methodImplementation]) => [
+      methodName,
+      methodImplementation.constructor.name === 'GeneratorFunction' ||
+      methodImplementation.constructor.name === 'AsyncGeneratorFunction'
+        ? wrapStreamingImpl(methodImplementation)
+        : wrapUnaryImpl(methodImplementation),
+    ]),
+  ) as ServiceImplementation;

--- a/apps/extension/src/utils/rethrow-impl-errors.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.ts
@@ -24,7 +24,9 @@ const wrapUnaryImpl =
     }
   };
 
-const wrapStreamingImpl = (methodImplementation: ServerStreamingImpl<AnyMessage, AnyMessage>) =>
+const wrapServerStreamingImpl = (
+  methodImplementation: ServerStreamingImpl<AnyMessage, AnyMessage>,
+) =>
   async function* (req: AnyMessage, ctx: HandlerContext) {
     try {
       for await (const result of methodImplementation(req, ctx)) {
@@ -81,7 +83,7 @@ export const rethrowImplErrors = <T extends ServiceType>(
       ]) => [
         methodName,
         isServerStreamingMethodKind(serviceType.methods[methodName]!.kind, methodImplementation)
-          ? wrapStreamingImpl(methodImplementation)
+          ? wrapServerStreamingImpl(methodImplementation)
           : isUnaryMethodKind(serviceType.methods[methodName]!.kind, methodImplementation)
             ? wrapUnaryImpl(methodImplementation)
             : wrapUnhandledImpl(methodImplementation, serviceType.methods[methodName]!.kind),

--- a/apps/extension/src/utils/rethrow-impl-errors.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.ts
@@ -54,15 +54,20 @@ const isUnaryMethodKind = (
   methodImplementation:
     | ((req: AsyncIterable<AnyMessage>, ctx: HandlerContext) => unknown)
     | ((req: AnyMessage, ctx: HandlerContext) => unknown),
-): methodImplementation is UnaryImpl<AnyMessage, AnyMessage> => methodKind === MethodKind.Unary;
+): methodImplementation is UnaryImpl<AnyMessage, AnyMessage> => {
+  methodImplementation;
+  return methodKind === MethodKind.Unary;
+};
 
 const isServerStreamingMethodKind = (
   methodKind: MethodKind,
   methodImplementation:
     | ((req: AsyncIterable<AnyMessage>, ctx: HandlerContext) => unknown)
     | ((req: AnyMessage, ctx: HandlerContext) => unknown),
-): methodImplementation is ServerStreamingImpl<AnyMessage, AnyMessage> =>
-  methodKind === MethodKind.ServerStreaming;
+): methodImplementation is ServerStreamingImpl<AnyMessage, AnyMessage> => {
+  methodImplementation;
+  return methodKind === MethodKind.ServerStreaming;
+};
 
 export const rethrowImplErrors = <T extends ServiceType>(
   serviceType: T,

--- a/apps/extension/src/utils/rethrow-impl-errors.ts
+++ b/apps/extension/src/utils/rethrow-impl-errors.ts
@@ -15,7 +15,7 @@ const wrapUnaryImpl =
     try {
       const result = methodImplementation(req, ctx);
       if (result instanceof Promise)
-        return (result as Promise<unknown>).catch(e => {
+        return result.catch(e => {
           throw ConnectError.from(e);
         });
       return result;


### PR DESCRIPTION
Previously, `rethrowImplErrors` was only catching errors thrown by view service methods with a `kind` of `MethodKind.Unary`. This meant that, for `MethodKind.ServerStreaming` methods, any errors thrown would get swallowed by the ConnectRPC method, and turned into a generic, unhelpful "internal error". (See [this ticket](https://github.com/penumbra-zone/web/issues/437).)

This PR fixes that by extending `rethrowImplErrors` to handle server streaming methods.

## Manual testing
1. Update the `balances` impl to throw on its first line:
    <img width="513" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/0880fa0b-e6cf-4c9e-846c-fe58fcce77dd">
2. Reload the extension.
3. Visit the web app.

### Before
<img width="873" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/0328f4af-27b5-4684-83aa-f0011d671e57">

### After
<img width="877" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/761f4a09-3a89-4b30-94af-6d344399010a">



Closes #437.