### PR TITLE
Keep IDB queries awake

### DIFF
--- a/packages/router/src/grpc/view-protocol-server/assets.ts
+++ b/packages/router/src/grpc/view-protocol-server/assets.ts
@@ -1,7 +1,6 @@
 import type { Impl } from '.';
 import { servicesCtx } from '../../ctx';
 import { assetPatterns } from '@penumbra-zone/constants';
-import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 
 export const assets: Impl['assets'] = async function* (req, ctx) {
   const services = ctx.values.get(servicesCtx);
@@ -47,15 +46,8 @@ export const assets: Impl['assets'] = async function* (req, ctx) {
     })),
   ].filter(i => i.includeReq);
 
-  // NOTE: https://github.com/penumbra-zone/web/issues/495
-  //      Results collected a temp workaround until issue is resolved.
-  const assets: { denomMetadata: Metadata }[] = [];
   for await (const metadata of indexedDb.iterateAssetsMetadata()) {
     if (filtered && !patterns.find(p => p.pattern.test(metadata.display))) continue;
-    assets.push({ denomMetadata: metadata });
-  }
-
-  for (const asset of assets) {
-    yield asset;
+    yield { denomMetadata: metadata };
   }
 };

--- a/packages/router/src/grpc/view-protocol-server/transaction-info.ts
+++ b/packages/router/src/grpc/view-protocol-server/transaction-info.ts
@@ -1,22 +1,15 @@
 import type { Impl } from '.';
 import { servicesCtx } from '../../ctx';
-import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 
 export const transactionInfo: Impl['transactionInfo'] = async function* (req, ctx) {
   const services = ctx.values.get(servicesCtx);
   const { indexedDb } = await services.getWalletServices();
 
-  // NOTE: https://github.com/penumbra-zone/web/issues/495
-  //      Results collected a temp workaround until issue is resolved.
-  const txs: { txInfo: TransactionInfo }[] = [];
   for await (const txInfo of indexedDb.iterateTransactionInfo()) {
     // filter transactions between startHeight and endHeight, inclusive
     if (txInfo.height < req.startHeight || (req.endHeight && txInfo.height > req.endHeight))
       continue;
-    txs.push({ txInfo });
-  }
 
-  for (const tx of txs) {
-    yield tx;
+    yield { txInfo };
   }
 };

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -41,6 +41,10 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { AppParameters } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/app/v1/app_pb';
 
+import { IdbCursorSource } from './stream';
+
+import { streamToGenerator } from '@penumbra-zone/types/src/stream';
+
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
   chainId: string;
@@ -172,9 +176,11 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async *iterateAssetsMetadata() {
-    for await (const { value } of this.db.transaction('ASSETS').store) {
-      yield Metadata.fromJson(value);
-    }
+    yield* streamToGenerator(
+      new ReadableStream(
+        new IdbCursorSource(this.db.transaction('ASSETS').store.openCursor(), Metadata),
+      ),
+    );
   }
 
   async saveAssetsMetadata(metadata: Metadata) {
@@ -195,15 +201,25 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async *iterateSpendableNotes() {
-    for await (const { value } of this.db.transaction('SPENDABLE_NOTES').store) {
-      yield SpendableNoteRecord.fromJson(value);
-    }
+    yield* streamToGenerator(
+      new ReadableStream(
+        new IdbCursorSource(
+          this.db.transaction('SPENDABLE_NOTES').store.openCursor(),
+          SpendableNoteRecord,
+        ),
+      ),
+    );
   }
 
   async *iterateTransactionInfo() {
-    for await (const { value } of this.db.transaction('TRANSACTION_INFO').store) {
-      yield TransactionInfo.fromJson(value);
-    }
+    yield* streamToGenerator(
+      new ReadableStream(
+        new IdbCursorSource(
+          this.db.transaction('TRANSACTION_INFO').store.openCursor(),
+          TransactionInfo,
+        ),
+      ),
+    );
   }
 
   async saveTransactionInfo(tx: TransactionInfo): Promise<void> {
@@ -254,9 +270,11 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async *iterateSwaps() {
-    for await (const { value } of this.db.transaction('SWAPS').store) {
-      yield SwapRecord.fromJson(value);
-    }
+    yield* streamToGenerator(
+      new ReadableStream(
+        new IdbCursorSource(this.db.transaction('SWAPS').store.openCursor(), SwapRecord),
+      ),
+    );
   }
 
   async clear() {

--- a/packages/storage/src/indexed-db/stream.ts
+++ b/packages/storage/src/indexed-db/stream.ts
@@ -1,0 +1,24 @@
+import { AnyMessage, JsonValue, Message, MessageType } from '@bufbuild/protobuf';
+import { PenumbraDb, PenumbraStoreNames } from '@penumbra-zone/types';
+import { IDBPCursorWithValue } from 'idb';
+
+export class IdbCursorSource<N extends PenumbraStoreNames, T extends Message<T> = AnyMessage>
+  implements UnderlyingDefaultSource<T>
+{
+  constructor(
+    private cursor: Promise<IDBPCursorWithValue<PenumbraDb, [N], N> | null>,
+    private messageType: MessageType<T>,
+  ) {}
+
+  start(cont: ReadableStreamDefaultController<T>) {
+    // immediately stream as fast as possible, to prevent idb from closing the tx
+    void (async () => {
+      let cursor = await this.cursor;
+      while (cursor) {
+        cont.enqueue(this.messageType.fromJson(cursor.value as JsonValue));
+        cursor = await cursor.continue();
+      }
+      cont.close();
+    })();
+  }
+}

--- a/packages/transport/src/chrome-runtime/adapter.ts
+++ b/packages/transport/src/chrome-runtime/adapter.ts
@@ -27,7 +27,8 @@ import {
 } from '@connectrpc/connect/protocol';
 import { createTransport } from '@connectrpc/connect/protocol-connect';
 
-import { iterableToStream, MessageToJson } from '../stream';
+import { MessageToJson } from '../stream';
+import { iterableToStream } from '@penumbra-zone/types/src/stream';
 
 // see https://github.com/connectrpc/connect-es/pull/925
 // hopefully also simplifies transport call soon

--- a/packages/transport/src/create.ts
+++ b/packages/transport/src/create.ts
@@ -17,7 +17,8 @@ import {
 } from '@connectrpc/connect';
 import { errorFromJson } from '@connectrpc/connect/protocol-connect';
 import { CreateAnyMethodImpl, makeAnyServiceImpl } from './any-impl';
-import { JsonToMessage, streamToGenerator } from './stream';
+import { JsonToMessage } from './stream';
+import { streamToGenerator } from '@penumbra-zone/types/src/stream';
 import {
   TransportEvent,
   TransportMessage,

--- a/packages/transport/src/stream.ts
+++ b/packages/transport/src/stream.ts
@@ -10,7 +10,6 @@
  */
 
 import { Any, AnyMessage, JsonValue, JsonReadOptions, JsonWriteOptions } from '@bufbuild/protobuf';
-import { ConnectError } from '@connectrpc/connect';
 
 /**
  * Packs any registered message to json with "@type" annotation.
@@ -41,45 +40,3 @@ export class JsonToMessage extends TransformStream<JsonValue, AnyMessage> {
     });
   }
 }
-
-/**
- * These functions are used to transform between streams and iterables.
- *
- * This shouldn't be necessary for very long, as the Streams API specifies
- * readable streams should provide Symbol.asyncIterator
- */
-
-export const streamToGenerator = async function* <T>(s: ReadableStream<T>) {
-  const r = s.getReader();
-  try {
-    for (;;) {
-      const result = await r.read();
-      if (result.done) break;
-      else yield result.value;
-    }
-  } catch (e) {
-    throw ConnectError.from(e);
-  } finally {
-    r.releaseLock();
-  }
-};
-
-// local iterable type guards for iterableToStream
-const isAsyncIterable = <T>(i: unknown): i is AsyncIterable<T> =>
-  i != null && typeof i === 'object' && Symbol.asyncIterator in i;
-const isIterable = <T>(i: unknown): i is Iterable<T> =>
-  i != null && typeof i === 'object' && Symbol.iterator in i;
-
-export const iterableToStream = <T>(iterable: Iterable<T> | AsyncIterable<T>) => {
-  let iterator: AsyncIterator<T> | Iterator<T>;
-  if (isAsyncIterable(iterable)) iterator = iterable[Symbol.asyncIterator]();
-  else if (isIterable(iterable)) iterator = iterable[Symbol.iterator]();
-  else throw TypeError('Not iterable');
-  return new ReadableStream({
-    async pull(cont: ReadableStreamDefaultController<T>) {
-      const result = await Promise.resolve(iterator.next());
-      if (result.done) cont.close();
-      else cont.enqueue(result.value);
-    },
-  });
-};

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -163,6 +163,7 @@ export interface PositionRecord {
 }
 
 export type Tables = Record<string, StoreNames<PenumbraDb>>;
+export type PenumbraStoreNames = StoreNames<PenumbraDb>;
 
 // Must be kept in sync with: https://github.com/penumbra-zone/penumbra/blob/02462635d6c825019822cbeeb44d422cf900f25d/crates/wasm/src/storage.rs#L15C1-L30
 export interface IdbConstants {

--- a/packages/types/src/stream.ts
+++ b/packages/types/src/stream.ts
@@ -1,0 +1,43 @@
+/**
+ * These functions are used to transform between streams and iterables.
+ *
+ * This shouldn't be necessary for very long, as the Streams API specifies
+ * readable streams should provide Symbol.asyncIterator
+ */
+
+import { ConnectError } from '@connectrpc/connect';
+
+export const streamToGenerator = async function* <T>(s: ReadableStream<T>) {
+  const r = s.getReader();
+  try {
+    for (;;) {
+      const result = await r.read();
+      if (result.done) break;
+      else yield result.value;
+    }
+  } catch (e) {
+    throw ConnectError.from(e);
+  } finally {
+    r.releaseLock();
+  }
+};
+
+// local iterable type guards for iterableToStream
+const isAsyncIterable = <T>(i: unknown): i is AsyncIterable<T> =>
+  i != null && typeof i === 'object' && Symbol.asyncIterator in i;
+const isIterable = <T>(i: unknown): i is Iterable<T> =>
+  i != null && typeof i === 'object' && Symbol.iterator in i;
+
+export const iterableToStream = <T>(iterable: Iterable<T> | AsyncIterable<T>) => {
+  let iterator: AsyncIterator<T> | Iterator<T>;
+  if (isAsyncIterable(iterable)) iterator = iterable[Symbol.asyncIterator]();
+  else if (isIterable(iterable)) iterator = iterable[Symbol.iterator]();
+  else throw TypeError('Not iterable');
+  return new ReadableStream({
+    async pull(cont: ReadableStreamDefaultController<T>) {
+      const result = await Promise.resolve(iterator.next());
+      if (result.done) cont.close();
+      else cont.enqueue(result.value);
+    },
+  });
+};


### PR DESCRIPTION
~~This didn't actually solve the problem, because it turns out ConnectRPC will use await internally, and break the IDB transaction.~~

~~But, it involves more robust rethrow logic to bypass ConnectRPC's obscuring rethrow.~~

~~Removed the rethrow wrapper in service-worker.ts and just wrapped every impl with a try/catch.~~

~~May be able to address the IDB issue more fundamentally by rewriting IDB queries as streams.~~

# edit

This is is now a complete solution

rebased onto #500 which provides a better rethrow wrapper

now using a ReadableStream to iterate idb, which provides buffering and async iteration while allowing IDB to perceive its caller as remaining active, while still allowing free async behavior outside the stream


https://github.com/penumbra-zone/web/assets/134443988/2955a70a-5db6-4c84-8bf1-ae8db268ad81

