### PR TITLE
more turbo suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ lerna-debug.log*
 
 # Editor directories and files
 .vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -4,10 +4,10 @@
   "description": "chrome-extension",
   "type": "module",
   "scripts": {
-    "pull-keys": "tsx src/utils/download-proving-keys.ts",
-    "dev": "pnpm pull-keys && webpack --config webpack/webpack.dev.js --watch",
-    "clean": "rm -rf dist",
-    "build": "pnpm pull-keys && webpack --config webpack/webpack.prod.js",
+    "download-keys": "tsx src/utils/download-proving-keys.ts",
+    "dev": "webpack --config webpack/webpack.dev.js --watch",
+    "clean": "rm -rfv dist bin",
+    "build": "webpack --config webpack/webpack.prod.js",
     "lint": "eslint \"**/*.ts*\"",
     "test": "vitest run"
   },

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "clean": "rm -rf dist",
+    "clean": "rm -rfv dist",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx",
     "preview": "vite preview",

--- a/packages/wasm/.gitignore
+++ b/packages/wasm/.gitignore
@@ -1,0 +1,4 @@
+crate/target
+crate/**/*.rs.bk
+crate/Cargo.lock
+crate/wasm-pack.log

--- a/packages/wasm/crate/.gitignore
+++ b/packages/wasm/crate/.gitignore
@@ -1,7 +1,0 @@
-/target
-**/*.rs.bk
-Cargo.lock
-bin/
-pkg/
-wasm-pack.log
-dist

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -4,6 +4,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "clean": "rm -rfv dist wasm ; cargo clean --manifest-path ./crate/Cargo.toml",
+    "dev": "cargo watch -C ./crate --postpone -- pnpm turbo run compile",
     "compile": "wasm-pack build --no-pack ./crate --release --target bundler --out-name index --out-dir ../wasm",
     "build": "tsc",
     "lint": "eslint \"web/*.ts*\"",

--- a/turbo.json
+++ b/turbo.json
@@ -4,15 +4,11 @@
   "globalEnv": ["NODE_ENV"],
   "pipeline": {
     "build": {
-      "dependsOn": ["^build", "@penumbra-zone/wasm#build"]
+      "dependsOn": ["download-keys", "compile", "^build"]
     },
-    "@penumbra-zone/wasm#build": {
-      "dependsOn": ["^build", "compile"],
-      "inputs": ["web/**"]
-    },
-    "@penumbra-zone/wasm#compile": {
-      "dependsOn": ["^compile"],
-      "inputs": ["crate/**"],
+    "download-keys": {},
+    "compile": {
+      "inputs": ["crate/src/**"],
       "outputs": ["wasm/**"]
     },
     "host": {
@@ -20,12 +16,12 @@
       "cache": false,
       "persistent": true
     },
-    "lint": { "dependsOn": ["@penumbra-zone/wasm#compile"] },
+    "lint": { "dependsOn": ["compile"] },
     "dev": {
-      "cache": false,
+      "dependsOn": ["download-keys", "compile"],
       "persistent": true
     },
-    "test": { "dependsOn": ["@penumbra-zone/wasm#compile"] },
+    "test": { "dependsOn": ["compile"] },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
uses `cargo watch` for wasm dev (users must install with `cargo install cargo-watch`)

sets up turbo dependency tree to use cacheing properly