### PR TITLE
Create UI for when extension is not installed

### DIFF
--- a/apps/extension/src/routes/page/onboarding/success.tsx
+++ b/apps/extension/src/routes/page/onboarding/success.tsx
@@ -1,43 +1,25 @@
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CompressedVideoLogo,
-  FadeTransition,
-} from '@penumbra-zone/ui';
+import { Button, SplashPage } from '@penumbra-zone/ui';
 
 export const OnboardingSuccess = () => {
   return (
-    <FadeTransition>
-      <div className='absolute inset-0 flex w-screen items-center justify-center'>
-        <CompressedVideoLogo noWords className='w-[calc(100%-25vw)]' />
+    <SplashPage title='Account created'>
+      <div className='grid gap-2 text-base font-bold'>
+        <p>You are all set!</p>
+        <p>
+          Use your account to transact, stake, swap or market make. All of it is shielded and
+          private.
+        </p>
+        <Button
+          variant='gradient'
+          onClick={() => {
+            window.open('https://app.testnet.penumbra.zone/', '_blank');
+            window.close();
+          }}
+          className='mt-4'
+        >
+          Visit testnet web app
+        </Button>
       </div>
-      <Card className='w-[608px]' gradient>
-        <CardHeader className='items-start'>
-          <CardTitle className='bg-text-linear bg-clip-text text-[40px] font-bold leading-9 text-transparent opacity-80'>
-            Account created
-          </CardTitle>
-        </CardHeader>
-        <CardContent className='mt-4 grid gap-2 text-base font-bold'>
-          <p>You are all set!</p>
-          <p>
-            Use your account to transact, stake, swap or market make. All of it is shielded and
-            private.
-          </p>
-          <Button
-            variant='gradient'
-            onClick={() => {
-              window.open('https://app.testnet.penumbra.zone/', '_blank');
-              window.close();
-            }}
-            className='mt-4'
-          >
-            Visit testnet web app
-          </Button>
-        </CardContent>
-      </Card>
-    </FadeTransition>
+    </SplashPage>
   );
 };

--- a/apps/webapp/src/components/dashboard/assets-table.tsx
+++ b/apps/webapp/src/components/dashboard/assets-table.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunction, useLoaderData } from 'react-router-dom';
-import { throwIfExtNotInstalled } from '../../fetchers/is-connected.ts';
+import { throwIfExtNotInstalled } from '../../utils/is-connected.ts';
 import { AddressIcon } from '@penumbra-zone/ui/components/ui/address-icon';
 import { AddressComponent } from '@penumbra-zone/ui/components/ui/address-component';
 import {

--- a/apps/webapp/src/components/dashboard/constants.ts
+++ b/apps/webapp/src/components/dashboard/constants.ts
@@ -1,6 +1,6 @@
 import { DashboardTabMap } from './types';
 import { PagePath } from '../metadata/paths.ts';
-import { EduPanel } from '../shared/edu-panels/content.ts';
+import { EduPanel } from '../shared/edu-panels/content';
 
 export const dashboardTabs = [
   { title: 'Assets', href: PagePath.DASHBOARD, active: true },

--- a/apps/webapp/src/components/dashboard/transaction-table.tsx
+++ b/apps/webapp/src/components/dashboard/transaction-table.tsx
@@ -1,7 +1,7 @@
 import { shorten } from '@penumbra-zone/types';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@penumbra-zone/ui';
 import { Link, LoaderFunction, useLoaderData } from 'react-router-dom';
-import { throwIfExtNotInstalled } from '../../fetchers/is-connected.ts';
+import { throwIfExtNotInstalled } from '../../utils/is-connected.ts';
 import { getAllTransactions, TransactionSummary } from '../../fetchers/transactions.ts';
 
 export const TxsLoader: LoaderFunction = async (): Promise<TransactionSummary[]> => {

--- a/apps/webapp/src/components/extension-not-installed.tsx
+++ b/apps/webapp/src/components/extension-not-installed.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@penumbra-zone/ui';
+import { Button, SplashPage } from '@penumbra-zone/ui';
 import { HeadTag } from './metadata/head-tag';
-import { EduInfoCard } from './shared/edu-panels/edu-info-card';
 
 const CHROME_EXTENSION_ID = 'lkpmkhpnhknhmibgnmmhdhgdilepfghe';
 
@@ -8,26 +7,20 @@ export const ExtensionNotInstalled = () => {
   return (
     <>
       <HeadTag />
-      <main className='flex h-screen items-center justify-center'>
-        <EduInfoCard
-          className='order-1 md:order-2'
-          src='./receive-gradient.svg'
-          label='Install our extension'
-        >
-          <div className='flex items-center gap-4'>
-            You need to install the Penumbra Chrome extension to use this app.
-            <Button asChild className='px-4 text-white'>
-              <a
-                href={`https://chrome.google.com/webstore/detail/penumbra-wallet/${CHROME_EXTENSION_ID}`}
-                target='_blank'
-                rel='noreferrer'
-              >
-                Install
-              </a>
-            </Button>
-          </div>
-        </EduInfoCard>
-      </main>
+      <SplashPage title='Install our extension'>
+        <div className='flex items-center justify-between gap-4'>
+          To get started, install the Penumbra Chrome extension.
+          <Button asChild className='px-4 text-white'>
+            <a
+              href={`https://chrome.google.com/webstore/detail/penumbra-wallet/${CHROME_EXTENSION_ID}`}
+              target='_blank'
+              rel='noreferrer'
+            >
+              Install
+            </a>
+          </Button>
+        </div>
+      </SplashPage>
     </>
   );
 };

--- a/apps/webapp/src/components/extension-not-installed.tsx
+++ b/apps/webapp/src/components/extension-not-installed.tsx
@@ -1,16 +1,19 @@
+import { HeadTag } from './metadata/head-tag';
 import { EduPanel } from './shared/edu-panels/content';
 import { EduInfoCard } from './shared/edu-panels/edu-info-card';
 
 export const ExtensionNotInstalled = () => {
   return (
-    <div className='relative mx-auto grid gap-6 md:grid-cols-2 md:gap-4 xl:max-w-[1276px] xl:grid-cols-3 xl:gap-5'>
-      <div className='xl:order-1 xl:block' />
-      <EduInfoCard
-        className='order-1 md:order-2'
-        src='./receive-gradient.svg'
-        label='Install our extension'
-        content={EduPanel.EXTENSION_NOT_INSTALLED}
-      />
-    </div>
+    <>
+      <HeadTag />
+      <main className='flex h-screen items-center justify-center'>
+        <EduInfoCard
+          className='order-1 md:order-2'
+          src='./receive-gradient.svg'
+          label='Install our extension'
+          content={EduPanel.EXTENSION_NOT_INSTALLED}
+        />
+      </main>
+    </>
   );
 };

--- a/apps/webapp/src/components/extension-not-installed.tsx
+++ b/apps/webapp/src/components/extension-not-installed.tsx
@@ -1,6 +1,8 @@
+import { Button } from '@penumbra-zone/ui';
 import { HeadTag } from './metadata/head-tag';
-import { EduPanel } from './shared/edu-panels/content';
 import { EduInfoCard } from './shared/edu-panels/edu-info-card';
+
+const CHROME_EXTENSION_ID = 'lkpmkhpnhknhmibgnmmhdhgdilepfghe';
 
 export const ExtensionNotInstalled = () => {
   return (
@@ -11,8 +13,20 @@ export const ExtensionNotInstalled = () => {
           className='order-1 md:order-2'
           src='./receive-gradient.svg'
           label='Install our extension'
-          content={EduPanel.EXTENSION_NOT_INSTALLED}
-        />
+        >
+          <div className='flex items-center gap-4'>
+            You need to install the Penumbra Chrome extension to use this app.
+            <Button asChild className='px-4 text-white'>
+              <a
+                href={`https://chrome.google.com/webstore/detail/penumbra-wallet/${CHROME_EXTENSION_ID}`}
+                target='_blank'
+                rel='noreferrer'
+              >
+                Install
+              </a>
+            </Button>
+          </div>
+        </EduInfoCard>
       </main>
     </>
   );

--- a/apps/webapp/src/components/extension-not-installed.tsx
+++ b/apps/webapp/src/components/extension-not-installed.tsx
@@ -1,0 +1,16 @@
+import { EduPanel } from './shared/edu-panels/content';
+import { EduInfoCard } from './shared/edu-panels/edu-info-card';
+
+export const ExtensionNotInstalled = () => {
+  return (
+    <div className='relative mx-auto grid gap-6 md:grid-cols-2 md:gap-4 xl:max-w-[1276px] xl:grid-cols-3 xl:gap-5'>
+      <div className='xl:order-1 xl:block' />
+      <EduInfoCard
+        className='order-1 md:order-2'
+        src='./receive-gradient.svg'
+        label='Install our extension'
+        content={EduPanel.EXTENSION_NOT_INSTALLED}
+      />
+    </div>
+  );
+};

--- a/apps/webapp/src/components/extension-not-installed.tsx
+++ b/apps/webapp/src/components/extension-not-installed.tsx
@@ -7,7 +7,7 @@ export const ExtensionNotInstalled = () => {
   return (
     <>
       <HeadTag />
-      <SplashPage title='Install our extension'>
+      <SplashPage title='Welcome to Penumbra'>
         <div className='flex items-center justify-between gap-4'>
           To get started, install the Penumbra Chrome extension.
           <Button asChild className='px-4 text-white'>

--- a/apps/webapp/src/components/layout.tsx
+++ b/apps/webapp/src/components/layout.tsx
@@ -3,7 +3,7 @@ import { HeadTag } from './metadata/head-tag.tsx';
 import { Header } from './header/header.tsx';
 import { Toaster } from '@penumbra-zone/ui';
 import '@penumbra-zone/ui/styles/globals.css';
-import { isExtensionInstalled } from '../fetchers/is-connected.ts';
+import { isExtensionInstalled } from '../utils/is-connected.ts';
 import { getChainId } from '../fetchers/chain-id.ts';
 import { ExtensionNotInstalled } from './extension-not-installed.tsx';
 
@@ -24,13 +24,15 @@ export const LayoutLoader: LoaderFunction = async (): Promise<LayoutLoaderResult
 export const Layout = () => {
   const { isInstalled } = useLoaderData() as LayoutLoaderResult;
 
+  if (!isInstalled) return <ExtensionNotInstalled />;
+
   return (
     <>
       <HeadTag />
       <div className='relative flex min-h-screen flex-col bg-background text-muted'>
         <Header />
         <main className='flex-1 px-6 pb-4 pt-10 md:px-[88px] md:pb-0 xl:px-12'>
-          {isInstalled ? <Outlet /> : <ExtensionNotInstalled />}
+          <Outlet />
         </main>
       </div>
       <Toaster />

--- a/apps/webapp/src/components/layout.tsx
+++ b/apps/webapp/src/components/layout.tsx
@@ -1,10 +1,11 @@
-import { LoaderFunction, Outlet } from 'react-router-dom';
+import { LoaderFunction, Outlet, useLoaderData } from 'react-router-dom';
 import { HeadTag } from './metadata/head-tag.tsx';
 import { Header } from './header/header.tsx';
 import { Toaster } from '@penumbra-zone/ui';
 import '@penumbra-zone/ui/styles/globals.css';
 import { isExtensionInstalled } from '../fetchers/is-connected.ts';
 import { getChainId } from '../fetchers/chain-id.ts';
+import { ExtensionNotInstalled } from './extension-not-installed.tsx';
 
 export type LayoutLoaderResult =
   | { isInstalled: false }
@@ -21,13 +22,15 @@ export const LayoutLoader: LoaderFunction = async (): Promise<LayoutLoaderResult
 };
 
 export const Layout = () => {
+  const { isInstalled } = useLoaderData() as LayoutLoaderResult;
+
   return (
     <>
       <HeadTag />
       <div className='relative flex min-h-screen flex-col bg-background text-muted'>
         <Header />
         <main className='flex-1 px-6 pb-4 pt-10 md:px-[88px] md:pb-0 xl:px-12'>
-          <Outlet />
+          {isInstalled ? <Outlet /> : <ExtensionNotInstalled />}
         </main>
       </div>
       <Toaster />

--- a/apps/webapp/src/components/metadata/content.ts
+++ b/apps/webapp/src/components/metadata/content.ts
@@ -1,10 +1,9 @@
 import { PagePath } from './paths.ts';
 import { EduPanel, eduPanelContent } from '../shared/edu-panels/content';
-import { ReactNode } from 'react';
 
 export interface PageMetadata {
   title: string;
-  description: ReactNode;
+  description: string;
 }
 
 export const metadata: Record<PagePath, PageMetadata> = {

--- a/apps/webapp/src/components/metadata/content.ts
+++ b/apps/webapp/src/components/metadata/content.ts
@@ -1,9 +1,10 @@
 import { PagePath } from './paths.ts';
-import { EduPanel, eduPanelContent } from '../shared/edu-panels/content.ts';
+import { EduPanel, eduPanelContent } from '../shared/edu-panels/content';
+import { ReactNode } from 'react';
 
 export interface PageMetadata {
   title: string;
-  description: string;
+  description: ReactNode;
 }
 
 export const metadata: Record<PagePath, PageMetadata> = {

--- a/apps/webapp/src/components/send/constants.ts
+++ b/apps/webapp/src/components/send/constants.ts
@@ -1,6 +1,6 @@
 import { SendTabMap } from './types';
 import { PagePath } from '../metadata/paths.ts';
-import { EduPanel } from '../shared/edu-panels/content.ts';
+import { EduPanel } from '../shared/edu-panels/content';
 
 export const sendTabsHelper: SendTabMap = {
   [PagePath.SEND]: {

--- a/apps/webapp/src/components/send/send-form/index.tsx
+++ b/apps/webapp/src/components/send/send-form/index.tsx
@@ -6,7 +6,7 @@ import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { AssetBalance, getAssetBalances } from '../../../fetchers/balances';
 import { useMemo } from 'react';
 import { penumbraAddrValidation } from '../helpers';
-import { throwIfExtNotInstalled } from '../../../fetchers/is-connected';
+import { throwIfExtNotInstalled } from '../../../utils/is-connected.ts';
 import InputToken from '../../shared/input-token.tsx';
 import { useRefreshFee } from './use-refresh-fee.ts';
 import { GasFee } from '../../shared/gas-fee.tsx';

--- a/apps/webapp/src/components/shared/edu-panels/content.tsx
+++ b/apps/webapp/src/components/shared/edu-panels/content.tsx
@@ -1,8 +1,3 @@
-import { Button } from '@penumbra-zone/ui';
-import { ReactNode } from 'react';
-
-const CHROME_EXTENSION_ID = 'lkpmkhpnhknhmibgnmmhdhgdilepfghe';
-
 export enum EduPanel {
   ASSETS,
   TRANSACTIONS_LIST,
@@ -11,10 +6,9 @@ export enum EduPanel {
   RECEIVING_FUNDS,
   IBC_WITHDRAW,
   TEMP_FILLER,
-  EXTENSION_NOT_INSTALLED,
 }
 
-export const eduPanelContent: Record<EduPanel, ReactNode> = {
+export const eduPanelContent: Record<EduPanel, string> = {
   [EduPanel.ASSETS]:
     'Your balances are shielded, and are known only to you. They are not visible on chain. Each Penumbra wallet controls many numbered accounts, each with its own balance. Account information is never revealed on-chain.',
   [EduPanel.TRANSACTIONS_LIST]:
@@ -29,18 +23,4 @@ export const eduPanelContent: Record<EduPanel, ReactNode> = {
     'IBC to a connected chain. Note that if the chain is a transparent chain, the transaction will be visible to others.',
   [EduPanel.TEMP_FILLER]:
     "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
-  [EduPanel.EXTENSION_NOT_INSTALLED]: (
-    <div className='flex items-center gap-4'>
-      You need to install the Penumbra Chrome extension to use this app.
-      <Button asChild className='px-4 text-white'>
-        <a
-          href={`https://chrome.google.com/webstore/detail/penumbra-wallet/${CHROME_EXTENSION_ID}`}
-          target='_blank'
-          rel='noreferrer'
-        >
-          Install
-        </a>
-      </Button>
-    </div>
-  ),
 };

--- a/apps/webapp/src/components/shared/edu-panels/content.tsx
+++ b/apps/webapp/src/components/shared/edu-panels/content.tsx
@@ -1,3 +1,8 @@
+import { Button } from '@penumbra-zone/ui';
+import { ReactNode } from 'react';
+
+const CHROME_EXTENSION_ID = 'lkpmkhpnhknhmibgnmmhdhgdilepfghe';
+
 export enum EduPanel {
   ASSETS,
   TRANSACTIONS_LIST,
@@ -6,9 +11,10 @@ export enum EduPanel {
   RECEIVING_FUNDS,
   IBC_WITHDRAW,
   TEMP_FILLER,
+  EXTENSION_NOT_INSTALLED,
 }
 
-export const eduPanelContent: Record<EduPanel, string> = {
+export const eduPanelContent: Record<EduPanel, ReactNode> = {
   [EduPanel.ASSETS]:
     'Your balances are shielded, and are known only to you. They are not visible on chain. Each Penumbra wallet controls many numbered accounts, each with its own balance. Account information is never revealed on-chain.',
   [EduPanel.TRANSACTIONS_LIST]:
@@ -23,4 +29,18 @@ export const eduPanelContent: Record<EduPanel, string> = {
     'IBC to a connected chain. Note that if the chain is a transparent chain, the transaction will be visible to others.',
   [EduPanel.TEMP_FILLER]:
     "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+  [EduPanel.EXTENSION_NOT_INSTALLED]: (
+    <div className='flex gap-2'>
+      You need to install the Penumbra Chrome extension to use this app.
+      <Button asChild className='px-4 text-white'>
+        <a
+          href={`https://chrome.google.com/webstore/detail/penumbra-wallet/${CHROME_EXTENSION_ID}`}
+          target='_blank'
+          rel='noreferrer'
+        >
+          Install
+        </a>
+      </Button>
+    </div>
+  ),
 };

--- a/apps/webapp/src/components/shared/edu-panels/content.tsx
+++ b/apps/webapp/src/components/shared/edu-panels/content.tsx
@@ -30,7 +30,7 @@ export const eduPanelContent: Record<EduPanel, ReactNode> = {
   [EduPanel.TEMP_FILLER]:
     "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
   [EduPanel.EXTENSION_NOT_INSTALLED]: (
-    <div className='flex gap-2'>
+    <div className='flex items-center gap-4'>
       You need to install the Penumbra Chrome extension to use this app.
       <Button asChild className='px-4 text-white'>
         <a

--- a/apps/webapp/src/components/shared/edu-panels/edu-info-card.tsx
+++ b/apps/webapp/src/components/shared/edu-panels/edu-info-card.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@penumbra-zone/ui';
 import { cn } from '@penumbra-zone/ui/lib/utils.ts';
-import { EduPanel, eduPanelContent } from './content.ts';
+import { EduPanel, eduPanelContent } from './content';
 
 interface HelperCardProps {
   src: string;

--- a/apps/webapp/src/components/shared/edu-panels/edu-info-card.tsx
+++ b/apps/webapp/src/components/shared/edu-panels/edu-info-card.tsx
@@ -1,17 +1,15 @@
 import { Card } from '@penumbra-zone/ui';
 import { cn } from '@penumbra-zone/ui/lib/utils.ts';
 import { EduPanel, eduPanelContent } from './content';
-import { ReactNode } from 'react';
 
 interface HelperCardProps {
   src: string;
   label: string;
   className?: string;
-  content?: EduPanel;
-  children?: ReactNode;
+  content: EduPanel;
 }
 
-export const EduInfoCard = ({ src, label, className, content, children }: HelperCardProps) => {
+export const EduInfoCard = ({ src, label, className, content }: HelperCardProps) => {
   return (
     <Card gradient className={cn('p-5 row-span-1', className)}>
       <div className='flex gap-2'>
@@ -20,9 +18,7 @@ export const EduInfoCard = ({ src, label, className, content, children }: Helper
           {label}
         </p>
       </div>
-      <p className='mt-4 text-muted-foreground md:mt-2'>
-        {content ? eduPanelContent[content] : children}
-      </p>
+      <p className='mt-4 text-muted-foreground md:mt-2'>{eduPanelContent[content]}</p>
     </Card>
   );
 };

--- a/apps/webapp/src/components/shared/edu-panels/edu-info-card.tsx
+++ b/apps/webapp/src/components/shared/edu-panels/edu-info-card.tsx
@@ -1,15 +1,17 @@
 import { Card } from '@penumbra-zone/ui';
 import { cn } from '@penumbra-zone/ui/lib/utils.ts';
 import { EduPanel, eduPanelContent } from './content';
+import { ReactNode } from 'react';
 
 interface HelperCardProps {
   src: string;
   label: string;
   className?: string;
-  content: EduPanel;
+  content?: EduPanel;
+  children?: ReactNode;
 }
 
-export const EduInfoCard = ({ src, label, className, content }: HelperCardProps) => {
+export const EduInfoCard = ({ src, label, className, content, children }: HelperCardProps) => {
   return (
     <Card gradient className={cn('p-5 row-span-1', className)}>
       <div className='flex gap-2'>
@@ -18,7 +20,9 @@ export const EduInfoCard = ({ src, label, className, content }: HelperCardProps)
           {label}
         </p>
       </div>
-      <p className='mt-4 text-muted-foreground md:mt-2'>{eduPanelContent[content]}</p>
+      <p className='mt-4 text-muted-foreground md:mt-2'>
+        {content ? eduPanelContent[content] : children}
+      </p>
     </Card>
   );
 };

--- a/apps/webapp/src/components/shared/error-boundary.tsx
+++ b/apps/webapp/src/components/shared/error-boundary.tsx
@@ -1,7 +1,12 @@
 import { useRouteError } from 'react-router-dom';
+import { ExtensionNotInstalledError } from '../../utils/extension-not-installed-error';
+import { ExtensionNotInstalled } from '../extension-not-installed';
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
+
+  if (error instanceof ExtensionNotInstalledError) return <ExtensionNotInstalled />;
+
   console.error(error);
 
   return (

--- a/apps/webapp/src/components/swap/swap-loader.tsx
+++ b/apps/webapp/src/components/swap/swap-loader.tsx
@@ -1,7 +1,7 @@
 import { LoaderFunction } from 'react-router-dom';
 import { AssetBalance, getAssetBalances } from '../../fetchers/balances';
 import { useStore } from '../../state';
-import { throwIfExtNotInstalled } from '../../fetchers/is-connected';
+import { throwIfExtNotInstalled } from '../../utils/is-connected.ts';
 import { SwapRecord } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { fetchUnclaimedSwaps } from '../../fetchers/unclaimed-swaps.ts';

--- a/apps/webapp/src/components/tx-details/index.tsx
+++ b/apps/webapp/src/components/tx-details/index.tsx
@@ -1,7 +1,7 @@
 import { Card, FadeTransition } from '@penumbra-zone/ui';
 import { TxViewer } from './hash-parser.tsx';
 import { EduInfoCard } from '../shared/edu-panels/edu-info-card.tsx';
-import { EduPanel } from '../shared/edu-panels/content.ts';
+import { EduPanel } from '../shared/edu-panels/content';
 import { LoaderFunction, useLoaderData, useRouteError } from 'react-router-dom';
 import { getTxInfoByHash } from '../../fetchers/tx-info-by-hash.ts';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';

--- a/apps/webapp/src/components/tx-details/index.tsx
+++ b/apps/webapp/src/components/tx-details/index.tsx
@@ -5,7 +5,7 @@ import { EduPanel } from '../shared/edu-panels/content';
 import { LoaderFunction, useLoaderData, useRouteError } from 'react-router-dom';
 import { getTxInfoByHash } from '../../fetchers/tx-info-by-hash.ts';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import { throwIfExtNotInstalled } from '../../fetchers/is-connected.ts';
+import { throwIfExtNotInstalled } from '../../utils/is-connected.ts';
 
 export interface TxDetailsLoaderResult {
   hash: string;

--- a/apps/webapp/src/fetchers/is-connected.ts
+++ b/apps/webapp/src/fetchers/is-connected.ts
@@ -1,8 +1,0 @@
-const CHROME_EXTENSION_ID = 'lkpmkhpnhknhmibgnmmhdhgdilepfghe';
-const INSTALLATION_ERROR = `Penumbra extension is not installed. Please visit: https://chrome.google.com/webstore/detail/penumbra-wallet/${CHROME_EXTENSION_ID}`;
-
-export const isExtensionInstalled = (): boolean => Symbol.for('penumbra') in window;
-
-export const throwIfExtNotInstalled = () => {
-  if (!isExtensionInstalled()) throw Error(INSTALLATION_ERROR);
-};

--- a/apps/webapp/src/utils/extension-not-installed-error.ts
+++ b/apps/webapp/src/utils/extension-not-installed-error.ts
@@ -1,0 +1,1 @@
+export class ExtensionNotInstalledError extends Error {}

--- a/apps/webapp/src/utils/is-connected.ts
+++ b/apps/webapp/src/utils/is-connected.ts
@@ -1,0 +1,7 @@
+import { ExtensionNotInstalledError } from './extension-not-installed-error';
+
+export const isExtensionInstalled = (): boolean => Symbol.for('penumbra') in window;
+
+export const throwIfExtNotInstalled = () => {
+  if (!isExtensionInstalled()) throw new ExtensionNotInstalledError();
+};

--- a/packages/ui/components/ui/logo/compressed-video.tsx
+++ b/packages/ui/components/ui/logo/compressed-video.tsx
@@ -28,7 +28,7 @@ const VideoLogo = React.forwardRef<HTMLDivElement, InnerVidProps>(
     return (
       <div className={cn(logoVariants({ size, className }), 'relative')} ref={ref} {...props}>
         {noWords ? null : <Logo onlyWords={!noWords} className='absolute z-10' />}
-        <video autoPlay loop playsInline className='absolute z-0 w-[70%]'>
+        <video autoPlay loop playsInline muted className='absolute z-0 w-[70%]'>
           <source src={videoSrc} type='video/mp4' />
         </video>
       </div>

--- a/packages/ui/components/ui/splash-page.tsx
+++ b/packages/ui/components/ui/splash-page.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from './card';
+import { CompressedVideoLogo } from './logo/compressed-video';
+import { FadeTransition } from './fade-transition';
+
+export const SplashPage = ({ title, children }: { title: string; children: ReactNode }) => {
+  return (
+    <FadeTransition>
+      <div className='absolute inset-0 flex w-screen items-center justify-center'>
+        <CompressedVideoLogo noWords className='w-[calc(100%-25vw)]' />
+      </div>
+      <Card className='w-[608px]' gradient>
+        <CardHeader className='items-start'>
+          <CardTitle className='bg-text-linear bg-clip-text text-[40px] font-bold leading-9 text-transparent opacity-80'>
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className='mt-4'>{children}</CardContent>
+      </Card>
+    </FadeTransition>
+  );
+};

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -17,6 +17,7 @@ export * from './components/ui/segmented-picker';
 export * from './components/ui/select';
 export * from './components/ui/select-account';
 export * from './components/ui/sheet';
+export * from './components/ui/splash-page';
 export * from './components/ui/switch';
 export * from './components/ui/table';
 export * from './components/ui/tabs';


### PR DESCRIPTION
Tests seem to be failing due to an issue in `main`.

## Before
### Dashboard
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/509fb5d1-8d93-4905-81b7-1de2ac72097f">

### Swap page
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/8817b742-f106-4af8-b96b-881e2190df4c">


## After (any page when the extension is not installed)
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/f321f9bc-b154-4ab2-bc62-108080d5799a">

Closes #520