### PR TITLE
Experiment with symbols for delegation tokens

### DIFF
--- a/packages/constants/assets/index.ts
+++ b/packages/constants/assets/index.ts
@@ -3,19 +3,34 @@ import LocalAssetRegistry from './local-asset-registry.json';
 import { JsonValue } from '@bufbuild/protobuf';
 
 export interface AssetPattens {
-  lpNftPattern: RegExp;
-  delegationTokenPattern: RegExp;
-  proposalNftPattern: RegExp;
-  unbondingTokenPattern: RegExp;
-  votingReceiptPattern: RegExp;
+  lpNft: RegExp;
+  delegationToken: RegExp;
+  proposalNft: RegExp;
+  unbondingToken: RegExp;
+  votingReceipt: RegExp;
 }
 
+export interface DelegationCaptureGroups {
+  id: string;
+  bech32IdentityKey: string;
+}
+
+export interface UnbondingCaptureGroups {
+  epoch: string;
+  id: string;
+}
+
+// Source of truth for regex patterns: https://github.com/penumbra-zone/penumbra/blob/main/crates/core/asset/src/asset/registry.rs
 export const assetPatterns: AssetPattens = {
-  lpNftPattern: new RegExp('^lpnft_'),
-  delegationTokenPattern: new RegExp('^delegation_'),
-  proposalNftPattern: new RegExp('^proposal_'),
-  unbondingTokenPattern: new RegExp('^unbonding_'),
-  votingReceiptPattern: new RegExp('^voted_on_'),
+  lpNft: new RegExp(/^lpnft_/),
+  delegationToken: new RegExp(
+    /.*delegation_(?<bech32IdentityKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,
+  ),
+  proposalNft: new RegExp(/^proposal_/),
+  unbondingToken: new RegExp(
+    /.*unbonding_epoch_(?<epoch>[0-9]+)_penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+)$/,
+  ),
+  votingReceipt: new RegExp(/^voted_on_/),
 };
 
 export const localAssets: Metadata[] = LocalAssetRegistry.map(a =>

--- a/packages/constants/assets/local-asset-registry.json
+++ b/packages/constants/assets/local-asset-registry.json
@@ -139,7 +139,7 @@
     "penumbraAssetId": {
       "inner": "CwpUYIdQ9H5Dnf3oQ1l7ISeVMVahWbVNNvMA0dBSdwI="
     },
-    "symbol": "Delegated UM (Penumbra Labs CI 1)",
+    "symbol": "Delegation (Penumbra Labs CI 1)",
     "images": [
       {
         "png": "https://raw.githubusercontent.com/penumbra-zone/web/main/apps/webapp/public/favicon.png"
@@ -165,7 +165,7 @@
     "penumbraAssetId": {
       "inner": "qUn70lKZ3qQlCT5gj5sakux4daiTPKj0AN6ZuuFldQU="
     },
-    "symbol": "Delegated UM (Penumbra Labs CI 2)",
+    "symbol": "Delegation (Penumbra Labs CI 2)",
     "images": [
       {
         "png": "https://raw.githubusercontent.com/penumbra-zone/web/main/apps/webapp/public/favicon.png"

--- a/packages/constants/assets/local-asset-registry.json
+++ b/packages/constants/assets/local-asset-registry.json
@@ -119,5 +119,57 @@
         "svg": "https://raw.githubusercontent.com/giuspen/cherrytree/356649a8f84cd5068d676185937d61fc8e0450d1/icons/ct_pizza.svg"
       }
     ]
+  },
+  {
+    "denomUnits": [
+      {
+        "denom": "delegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
+        "exponent": 6
+      },
+      {
+        "denom": "mdelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
+        "exponent": 3
+      },
+      {
+        "denom": "udelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20"
+      }
+    ],
+    "base": "udelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
+    "display": "delegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
+    "penumbraAssetId": {
+      "inner": "CwpUYIdQ9H5Dnf3oQ1l7ISeVMVahWbVNNvMA0dBSdwI="
+    },
+    "symbol": "Delegated UM (Penumbra Labs CI 1)",
+    "images": [
+      {
+        "png": "https://raw.githubusercontent.com/penumbra-zone/web/main/apps/webapp/public/favicon.png"
+      }
+    ]
+  },
+  {
+    "denomUnits": [
+      {
+        "denom": "delegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+        "exponent": 6
+      },
+      {
+        "denom": "mdelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+        "exponent": 3
+      },
+      {
+        "denom": "udelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050"
+      }
+    ],
+    "base": "udelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+    "display": "delegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+    "penumbraAssetId": {
+      "inner": "qUn70lKZ3qQlCT5gj5sakux4daiTPKj0AN6ZuuFldQU="
+    },
+    "symbol": "Delegated UM (Penumbra Labs CI 2)",
+    "images": [
+      {
+        "png": "https://raw.githubusercontent.com/penumbra-zone/web/main/apps/webapp/public/favicon.png"
+      }
+    ]
   }
 ]

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@penumbra-zone/crypto-web": "workspace:*",
+    "@penumbra-zone/constants": "workspace:*",
     "@penumbra-zone/wasm": "workspace:*",
     "bech32": "^2.0.0",
     "exponential-backoff": "^3.1.1"

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -1,17 +1,12 @@
 import { RootQuerier } from './root-querier';
 
-import { bech32 } from 'bech32';
-
 import { sha256Hash } from '@penumbra-zone/crypto-web';
 import {
   BlockProcessorInterface,
   IndexedDbInterface,
   ViewServerInterface,
 } from '@penumbra-zone/types';
-import { assetPatterns } from '@penumbra-zone/constants';
 import { computePositionId, decodeSctRoot, transactionInfo } from '@penumbra-zone/wasm';
-
-import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import {
   PositionState,
   PositionState_PositionStateEnum,
@@ -29,6 +24,7 @@ import {
   TransactionInfo,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { backOff } from 'exponential-backoff';
+import { customizeSymbol } from './customize-symbol';
 
 interface QueryClientProps {
   fullViewingKey: string;
@@ -247,43 +243,16 @@ export class BlockProcessor implements BlockProcessorInterface {
     for (const n of newNotes) {
       const assetId = n.note?.value?.assetId;
       if (!assetId) continue;
-      if (await this.indexedDb.getAssetsMetadata(assetId)) continue;
 
-      let metadata: Metadata | undefined;
-      metadata = await this.querier.shieldedPool.assetMetadata(assetId);
+      const metadataInDb = await this.indexedDb.getAssetsMetadata(assetId);
+      if (metadataInDb) continue;
 
-      // If the metadata is for a delegation token, customize its symbol.
-      if (metadata && assetPatterns.delegationTokenPattern.test(metadata.display)) {
-        // We can't trust the validator's self-described name, so use their validator ID.
-        // We know it's delegation_penumbravalid1... so use substrings:
+      const metadataFromNode = await this.querier.shieldedPool.assetMetadata(assetId);
 
-        // TODO: what's the best way to handle delegation tokens to unknown validators?
-
-        // Find the index of '1' in the string
-        const index = metadata.display.indexOf('1');
-        // Get the first N characters after the '1'
-        const id = metadata.display.substring(index + 1, index + 1 + 24);
-
-        metadata.symbol = 'Delegated UM (' + id + '...)';
+      if (metadataFromNode) {
+        customizeSymbol(metadataFromNode);
+        await this.indexedDb.saveAssetsMetadata(metadataFromNode);
       }
-
-      // TODO: unbonding tokens?
-
-      // Note: the below code is incorrect, the asset ID is the hash of the denom,
-      // so this is actually generating metadata for a different asset. Not sure
-      // when/if this is used.
-      if (!metadata) {
-        const UNNAMED_ASSET_PREFIX = 'passet';
-        const denom = bech32.encode(UNNAMED_ASSET_PREFIX, bech32.toWords(assetId.inner));
-        metadata = new Metadata({
-          base: denom,
-          denomUnits: [{ aliases: [], denom, exponent: 0 }],
-          display: denom,
-          penumbraAssetId: assetId,
-        });
-      }
-
-      await this.indexedDb.saveAssetsMetadata(metadata);
     }
   }
 

--- a/packages/query/src/customize-symbol.test.ts
+++ b/packages/query/src/customize-symbol.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { customizeSymbol } from './customize-symbol';
+
+describe('Customizing metadata', () => {
+  test('should work for delegation token', () => {
+    const metadata = new Metadata({
+      display:
+        'delegation_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
+    });
+    customizeSymbol(metadata);
+    expect(metadata.symbol).toBe('Delegated UM (fjuj67ayaqueqxg03d65ps5aa...)');
+  });
+
+  test('should work for unbonding token', () => {
+    const metadata = new Metadata({
+      display:
+        'uunbonding_epoch_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
+    });
+    customizeSymbol(metadata);
+    expect(metadata.symbol).toBe('Unbonding UM, epoch 29 (fjuj67ayaqueqxg03d65ps5aa...)');
+  });
+
+  test('should do nothing if no matches', () => {
+    const metadata = new Metadata({
+      display: 'test_usd',
+      symbol: 'usdc',
+    });
+    customizeSymbol(metadata);
+    expect(metadata.symbol).toBe('usdc');
+  });
+});

--- a/packages/query/src/customize-symbol.ts
+++ b/packages/query/src/customize-symbol.ts
@@ -1,0 +1,27 @@
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import {
+  assetPatterns,
+  DelegationCaptureGroups,
+  UnbondingCaptureGroups,
+} from '@penumbra-zone/constants';
+
+const DELEGATION_SYMBOL_LENGTH = 50 - 'delegation_penumbravalid1'.length;
+const UNBONDING_SYMBOL_LENGTH = 41 - 'unbonding_epoch_'.length;
+
+// If the metadata is for a delegation or unbonding tokens, customize its symbol.
+// We can't trust the validator's self-described name, so use their validator ID (in metadata.display).
+export const customizeSymbol = (metadata: Metadata) => {
+  const delegationMatch = assetPatterns.delegationToken.exec(metadata.display);
+  if (delegationMatch) {
+    const { id } = delegationMatch.groups as unknown as DelegationCaptureGroups;
+    const shortenedId = id.slice(0, DELEGATION_SYMBOL_LENGTH);
+    metadata.symbol = `Delegated UM (${shortenedId}...)`;
+  }
+
+  const unbondingMatch = assetPatterns.unbondingToken.exec(metadata.display);
+  if (unbondingMatch) {
+    const { id, epoch } = unbondingMatch.groups as unknown as UnbondingCaptureGroups;
+    const shortenedId = id.slice(0, UNBONDING_SYMBOL_LENGTH);
+    metadata.symbol = `Unbonding UM, epoch ${epoch} (${shortenedId}...)`;
+  }
+};

--- a/packages/router/src/grpc/view-protocol-server/assets.ts
+++ b/packages/router/src/grpc/view-protocol-server/assets.ts
@@ -22,23 +22,23 @@ export const assets: Impl['assets'] = async function* (req, ctx) {
   }[] = [
     {
       includeReq: includeLpNfts,
-      pattern: assetPatterns.lpNftPattern,
+      pattern: assetPatterns.lpNft,
     },
     {
       includeReq: includeDelegationTokens,
-      pattern: assetPatterns.delegationTokenPattern,
+      pattern: assetPatterns.delegationToken,
     },
     {
       includeReq: includeProposalNfts,
-      pattern: assetPatterns.proposalNftPattern,
+      pattern: assetPatterns.proposalNft,
     },
     {
       includeReq: includeUnbondingTokens,
-      pattern: assetPatterns.unbondingTokenPattern,
+      pattern: assetPatterns.unbondingToken,
     },
     {
       includeReq: includeVotingReceiptTokens,
-      pattern: assetPatterns.votingReceiptPattern,
+      pattern: assetPatterns.votingReceipt,
     },
     ...includeSpecificDenominations.map(d => ({
       includeReq: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,9 @@ importers:
 
   packages/query:
     dependencies:
+      '@penumbra-zone/constants':
+        specifier: workspace:*
+        version: link:../constants
       '@penumbra-zone/crypto-web':
         specifier: workspace:*
         version: link:../crypto


### PR DESCRIPTION
This PR experiments with symbols for delegation tokens. Two possible approaches are illustrated:

1. The extension's asset registry can be augmented with the validator-specific token info, as I did for the two main testnet validators.
2. The extension could auto-create a symbol for the delegation token, but we must be very very careful about this, because the `symbol` field is shown to users and it is potentially attacker-controlled. For instance, if we just read the label off the chain, someone could spoof another validator's identity without consequence.

However, this seems like a good place to start.