### PR TITLE
Overwrite metadata on init

### DIFF
--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -189,14 +189,7 @@ export class IndexedDb implements IndexedDbInterface {
 
   // Save all hard-coded assets in config to database
   async saveLocalAssetsMetadata() {
-    const saveLocalMetadata = localAssets.map(async m => {
-      if (m.penumbraAssetId) {
-        const metadata = await this.getAssetsMetadata(m.penumbraAssetId);
-        if (!metadata) {
-          await this.saveAssetsMetadata(m);
-        }
-      }
-    });
+    const saveLocalMetadata = localAssets.map(m => this.saveAssetsMetadata(m));
     await Promise.all(saveLocalMetadata);
   }
 


### PR DESCRIPTION
Discord context: https://discord.com/channels/824484045370818580/1044457038886998137/1208072520784420864

At the moment, we are saving new additions to the local assets registry to the database when the view server starts up. We'll want to overwrite even existing entries though. There are cases where a local asset is edited (say the image icon) and we want our database to pick this up.