### PR TITLE
Simplify the Card component to no longer need z-indexes

### DIFF
--- a/apps/webapp/src/components/send/layout.tsx
+++ b/apps/webapp/src/components/send/layout.tsx
@@ -13,7 +13,7 @@ export const SendLayout = () => {
     <div className='relative mx-auto grid gap-6 md:grid-cols-2 md:gap-4 xl:max-w-[1276px] xl:grid-cols-3 xl:gap-5'>
       <div className='hidden xl:order-1 xl:block' />
       <Card gradient className='order-2 row-span-2 flex-1 p-5 md:order-1 md:p-4 xl:p-5'>
-        <Tabs tabs={sendTabs} activeTab={pathname} className='mx-auto w-[75%] lg:w-[372px]' />
+        <Tabs tabs={sendTabs} activeTab={pathname} className='mx-auto flex w-[75%] lg:w-[372px]' />
         <Outlet />
       </Card>
       <EduInfoCard

--- a/packages/tailwind-config/index.js
+++ b/packages/tailwind-config/index.js
@@ -131,8 +131,16 @@ export default {
         },
       },
       backgroundImage: {
-        'card-radial':
-          'radial-gradient(33% 50% at 15% 44%, var(--rust), transparent),radial-gradient(33% 40% at 105% 42%, var(--teal), transparent),radial-gradient(33% 80% at 85% 124%, var(--teal), transparent)',
+        // The final `linear-gradient` is just to make a solid charcoal
+        // background color for the radial gradients to sit on top of. If
+        // there's a way to make a solid background color without
+        // `linear-gradient`, feel free to update this.
+        'card-radial': `
+          radial-gradient(33% 50% at 15% 44%, color-mix(in srgb, var(--rust) 20%, transparent), transparent),
+          radial-gradient(33% 40% at 105% 42%, color-mix(in srgb, var(--teal) 20%, transparent), transparent),
+          radial-gradient(33% 80% at 85% 124%, color-mix(in srgb, var(--teal) 20%, transparent), transparent),
+          linear-gradient(to right, var(--charcoal), var(--charcoal))
+        `,
         'button-gradient':
           'linear-gradient(90deg, var(--teal-700) 0%, var(--sand-700) 25%, var(--rust-600) 50%, var(--rust-600) 50%, var(--sand-700) 75%, var(--teal-700) 100%)',
         'text-linear': 'linear-gradient(90deg, var(--teal-700), var(--sand-700), var(--rust-600))',

--- a/packages/ui/components/ui/card.tsx
+++ b/packages/ui/components/ui/card.tsx
@@ -11,7 +11,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
     return (
       <div
         ref={ref}
-        className={cn(baseClasses, gradient && 'bg-card-radial', className)}
+        className={cn(baseClasses, !!gradient && 'bg-card-radial', className)}
         {...props}
       >
         {children}

--- a/packages/ui/components/ui/card.tsx
+++ b/packages/ui/components/ui/card.tsx
@@ -8,13 +8,12 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, gradient, children, ...props }, ref) => {
     const baseClasses = 'bg-charcoal rounded-lg shadow-sm p-[30px]';
-    return gradient ? (
-      <div ref={ref} className={cn(baseClasses, 'relative', className)} {...props}>
-        <div className='relative z-10 flex flex-col'>{children}</div>
-        <div className='absolute inset-0 z-0 rounded-lg bg-card-radial p-[30px] opacity-20 ' />
-      </div>
-    ) : (
-      <div ref={ref} className={cn(baseClasses, className)} {...props}>
+    return (
+      <div
+        ref={ref}
+        className={cn(baseClasses, gradient && 'bg-card-radial', className)}
+        {...props}
+      >
         {children}
       </div>
     );


### PR DESCRIPTION
I noticed that the dropdown menu on tablets was hiding behind the form on the Send page. This was due to some weird use of absolute positioning just to create a gradient background on our `Card` component. To fix this, I removed all the absolute positioning, and modified the gradient to include the semi-transparency and background color that was previously being achieved via markup.

## Before
<img width="1064" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/6e7c4596-620f-4f4a-9ba0-c93158476a57">


## After
<img width="1012" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/7734013a-64bf-45d9-bb6d-b81bdbfa6e71">