### PR TITLE
Truncate overly long balances

### DIFF
--- a/packages/ui/components/ui/tx/view/value.tsx
+++ b/packages/ui/components/ui/tx/view/value.tsx
@@ -40,7 +40,7 @@ export const ValueViewComponent = ({
     return (
       <div className='flex items-center text-base font-bold'>
         {showIcon && <AssetIcon metadata={metadata} />}
-        {showValue && <span className='ml-1'>{formattedAmount}</span>}
+        {showValue && <span className='ml-1 truncate'>{formattedAmount}</span>}
         {showDenom && <span className='ml-1'>{symbol}</span>}
         {
           // TODO: this will need refinement once we actually hand out


### PR DESCRIPTION
Found while investigating #524 

## Before (note the overflowing penumbra balance)
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/baa3c58e-1365-467b-a76e-e0242003ab28">


## After
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/c4d70b8b-a6d7-4eec-859f-362a729e173d">