### PR TITLE
Remove password strength requirements

### DIFF
--- a/apps/extension/src/routes/page/onboarding/import.tsx
+++ b/apps/extension/src/routes/page/onboarding/import.tsx
@@ -14,10 +14,16 @@ import { importSelector } from '../../../state/seed-phrase/import';
 import { usePageNav } from '../../../utils/navigate';
 import { PagePath } from '../paths';
 import { ImportForm } from '../../../shared';
+import { FormEvent, MouseEvent } from 'react';
 
 export const ImportSeedPhrase = () => {
   const navigate = usePageNav();
   const { phrase, phraseIsValid } = useStore(importSelector);
+
+  const handleSubmit = (event: MouseEvent | FormEvent) => {
+    event.preventDefault();
+    navigate(PagePath.SET_PASSWORD);
+  };
 
   return (
     <FadeTransition>
@@ -29,20 +35,22 @@ export const ImportSeedPhrase = () => {
             Feel free to paste it into the first box and the rest will fill
           </CardDescription>
         </CardHeader>
-        <CardContent className='mt-6 grid gap-4'>
-          <ImportForm />
-          <Button
-            className='mt-4'
-            variant='gradient'
-            disabled={!phrase.every(w => w.length > 0) || !phraseIsValid()}
-            onClick={() => navigate(PagePath.SET_PASSWORD)}
-          >
-            {!phrase.length || !phrase.every(w => w.length > 0)
-              ? 'Fill in passphrase'
-              : !phraseIsValid()
-                ? 'Phrase is invalid'
-                : 'Import'}
-          </Button>
+        <CardContent>
+          <form className='mt-6 grid gap-4' onSubmit={handleSubmit}>
+            <ImportForm />
+            <Button
+              className='mt-4'
+              variant='gradient'
+              disabled={!phrase.every(w => w.length > 0) || !phraseIsValid()}
+              onClick={handleSubmit}
+            >
+              {!phrase.length || !phrase.every(w => w.length > 0)
+                ? 'Fill in passphrase'
+                : !phraseIsValid()
+                  ? 'Phrase is invalid'
+                  : 'Import'}
+            </Button>
+          </form>
         </CardContent>
       </Card>
     </FadeTransition>

--- a/apps/extension/src/routes/page/onboarding/set-password.tsx
+++ b/apps/extension/src/routes/page/onboarding/set-password.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { FormEvent, MouseEvent, useState } from 'react';
 import {
   BackIcon,
   Button,
@@ -20,6 +20,15 @@ export const SetPassword = () => {
   const [password, setPassword] = useState('');
   const [confirmation, setConfirmation] = useState('');
 
+  const handleSubmit = (event: FormEvent | MouseEvent) => {
+    event.preventDefault();
+
+    void (async () => {
+      await finalOnboardingSave(password);
+      navigate(PagePath.ONBOARDING_SUCCESS);
+    })();
+  };
+
   return (
     <FadeTransition>
       <BackIcon className='float-left mb-4' onClick={() => navigate(-1)} />
@@ -31,44 +40,38 @@ export const SetPassword = () => {
             wallet.
           </CardDescription>
         </CardHeader>
-        <CardContent className='mt-6 grid gap-4'>
-          <PasswordInput
-            passwordValue={password}
-            label='New password'
-            onChange={({ target: { value } }) => setPassword(value)}
-            validations={[
-              {
-                type: 'warn',
-                issue: 'password too short',
-                checkFn: (txt: string) => Boolean(txt.length) && txt.length < 8,
-              },
-            ]}
-          />
-          <PasswordInput
-            passwordValue={confirmation}
-            label='Confirm password'
-            onChange={({ target: { value } }) => setConfirmation(value)}
-            validations={[
-              {
-                type: 'warn',
-                issue: "passwords don't match",
-                checkFn: (txt: string) => Boolean(txt.length) && password !== txt,
-              },
-            ]}
-          />
-          <Button
-            variant='gradient'
-            className='mt-2'
-            disabled={password.length < 8 || password !== confirmation}
-            onClick={() => {
-              void (async function () {
-                await finalOnboardingSave(password);
-                navigate(PagePath.ONBOARDING_SUCCESS);
-              })();
-            }}
-          >
-            Next
-          </Button>
+        <CardContent>
+          <form className='mt-6 grid gap-4' onSubmit={handleSubmit}>
+            <PasswordInput
+              passwordValue={password}
+              label='New password'
+              onChange={({ target: { value } }) => setPassword(value)}
+            />
+            <PasswordInput
+              passwordValue={confirmation}
+              label='Confirm password'
+              onChange={({ target: { value } }) => setConfirmation(value)}
+              validations={[
+                {
+                  type: 'warn',
+                  issue: "passwords don't match",
+                  checkFn: (txt: string) => password !== txt,
+                },
+              ]}
+            />
+            <Button
+              variant='gradient'
+              className='mt-2'
+              disabled={password !== confirmation}
+              onClick={handleSubmit}
+            >
+              Next
+            </Button>
+
+            <Button variant='secondary' onClick={handleSubmit}>
+              Skip
+            </Button>
+          </form>
         </CardContent>
       </Card>
     </FadeTransition>

--- a/apps/extension/src/routes/page/onboarding/set-password.tsx
+++ b/apps/extension/src/routes/page/onboarding/set-password.tsx
@@ -67,10 +67,6 @@ export const SetPassword = () => {
             >
               Next
             </Button>
-
-            <Button variant='secondary' onClick={handleSubmit}>
-              Skip
-            </Button>
           </form>
         </CardContent>
       </Card>

--- a/apps/extension/src/routes/page/restore-password/set-password.tsx
+++ b/apps/extension/src/routes/page/restore-password/set-password.tsx
@@ -36,13 +36,6 @@ export const SetPassword = () => {
             passwordValue={password}
             label='New password'
             onChange={({ target: { value } }) => setPassword(value)}
-            validations={[
-              {
-                type: 'warn',
-                issue: 'password too short',
-                checkFn: (txt: string) => Boolean(txt.length) && txt.length < 8,
-              },
-            ]}
           />
           <PasswordInput
             passwordValue={confirmation}
@@ -52,14 +45,14 @@ export const SetPassword = () => {
               {
                 type: 'warn',
                 issue: "passwords don't match",
-                checkFn: (txt: string) => Boolean(txt.length) && password !== txt,
+                checkFn: (txt: string) => password !== txt,
               },
             ]}
           />
           <Button
             variant='gradient'
             className='mt-2'
-            disabled={password.length < 8 || password !== confirmation}
+            disabled={password !== confirmation}
             onClick={() => {
               void (async function () {
                 await finalOnboardingSave(password);

--- a/apps/extension/src/routes/popup/login.tsx
+++ b/apps/extension/src/routes/popup/login.tsx
@@ -51,7 +51,7 @@ export const Login = () => {
               {
                 type: 'error',
                 issue: 'wrong password',
-                checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
+                checkFn: () => enteredIncorrect,
               },
             ]}
           />

--- a/apps/extension/src/routes/popup/login.tsx
+++ b/apps/extension/src/routes/popup/login.tsx
@@ -55,7 +55,7 @@ export const Login = () => {
               },
             ]}
           />
-          <Button size='lg' variant='gradient' disabled={!input || enteredIncorrect} type='submit'>
+          <Button size='lg' variant='gradient' disabled={enteredIncorrect} type='submit'>
             Unlock
           </Button>
         </form>

--- a/apps/extension/src/shared/components/password-input.tsx
+++ b/apps/extension/src/shared/components/password-input.tsx
@@ -8,7 +8,7 @@ import { useValidationResult } from '../../hooks/validation-result';
 interface PasswordInputProps {
   passwordValue: string;
   label: string | ReactElement;
-  validations: Validation[];
+  validations?: Validation[];
   onChange: InputProps['onChange'];
 }
 

--- a/apps/extension/src/state/wallets.ts
+++ b/apps/extension/src/state/wallets.ts
@@ -30,7 +30,7 @@ export const createWalletsSlice =
         const fullViewingKey = getFullViewingKey(spendKey);
 
         const passwordKey = get().password.key;
-        if (!passwordKey) throw new Error('Password Key not in storage');
+        if (passwordKey === undefined) throw new Error('Password Key not in storage');
 
         const key = await Key.fromJson(passwordKey);
         const encryptedSeedPhrase = await key.seal(seedPhraseStr);


### PR DESCRIPTION
🚨 When reviewing this PR, you'll prob want to use "Hide whitespace" for the indentation changes:
![image](https://github.com/penumbra-zone/web/assets/1121544/bafbe30a-542e-49f0-a1b3-0ac5ca6cdc6e)

Per #442:
> The extension forces users to use a "strong enough" password, but it's not clear this improves security, because the key material ends up in the extension memory anyways, and something that's compromised the user's machine can probably get access to that. It also makes operating on the testnet less convenient. If there were no strength requirements, users who were comfortable with lower security could set an empty password.

This PR takes the naive approach and allows users to set an empty password, but doesn't actually change any of the underlying wiring that uses the (now-possibly-empty) password to encrypt the seed phrase. It also doesn't advertise that an empty password is allowed — it just leaves the "Next" button enabled even if the user leaves the password empty.


https://github.com/penumbra-zone/web/assets/1121544/73209ca5-11af-4a80-b4e1-456c7243c463



## In this PR
- Remove password length validation from the password form, effectively allowing an empty password.
- Also remove it from the restore password form (not sure if this is being used...?).
- Remove a password requirement from the login form.
- Wrap the password fields in a `<form>` with an `onSubmit` handler. (I also did this in the Import step, since that makes it easier to submit the form via the keyboard, and is semantically correct.)

Closes #442.