### PR TITLE
add tests for notes-for-voting

### DIFF
--- a/packages/router/src/grpc/view-protocol-server/notes-for-voting.test.ts
+++ b/packages/router/src/grpc/view-protocol-server/notes-for-voting.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  NotesForVotingRequest,
+  NotesForVotingResponse,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { ServicesInterface } from '@penumbra-zone/types';
+import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
+import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
+import { servicesCtx } from '../../ctx';
+import { IndexedDbMock, MockServices } from './test-utils';
+import { notesForVoting } from './notes-for-voting';
+
+describe('NotesForVoting request handler', () => {
+  let mockServices: MockServices;
+  let mockIndexedDb: IndexedDbMock;
+  let mockCtx: HandlerContext;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockIndexedDb = {
+      getNotesForVoting: vi.fn(),
+    };
+    mockServices = {
+      getWalletServices: vi.fn(() => Promise.resolve({ indexedDb: mockIndexedDb })),
+    };
+    mockCtx = createHandlerContext({
+      service: ViewService,
+      method: ViewService.methods.notesForVoting,
+      protocolName: 'mock',
+      requestMethod: 'MOCK',
+      contextValues: createContextValues().set(
+        servicesCtx,
+        mockServices as unknown as ServicesInterface,
+      ),
+    });
+  });
+
+  test('should successfully get notes for voting', async () => {
+    mockIndexedDb.getNotesForVoting?.mockResolvedValueOnce(testData);
+    const responses: NotesForVotingResponse[] = [];
+    const req = new NotesForVotingRequest({});
+    for await (const res of notesForVoting(req, mockCtx)) {
+      responses.push(new NotesForVotingResponse(res));
+    }
+    expect(responses.length).toBe(2);
+  });
+});
+
+const testData: NotesForVotingResponse[] = [
+  NotesForVotingResponse.fromJson({
+    noteRecord: {
+      noteCommitment: {
+        inner: 'pXS1k2kvlph+vuk9uhqeoP1mZRc+f526a06/bg3EBwQ=',
+      },
+    },
+    identityKey: {
+      ik: 'VAv+z5ieJk7AcAIJoVIqB6boOj0AhZB2FKWsEidfvAE=',
+    },
+  }),
+  NotesForVotingResponse.fromJson({
+    noteRecord: {
+      noteCommitment: {
+        inner: '2XS1k2kvlph+vuk9uhqeoP1mZRc+f526a06/bg3EBwQ=',
+      },
+    },
+    identityKey: {
+      ik: 'pkxdxOn9EMqdjoCJdEGBKA8XY9P9RK9XmurIly/9yBA=',
+    },
+  }),
+];

--- a/packages/router/src/grpc/view-protocol-server/test-utils.ts
+++ b/packages/router/src/grpc/view-protocol-server/test-utils.ts
@@ -7,6 +7,7 @@ export interface IndexedDbMock {
   getGasPrices?: Mock;
   getFmdParams?: Mock;
   getLastBlockSynced?: Mock;
+  getNotesForVoting?: Mock;
   getSpendableNoteByCommitment?: Mock;
   getSpendableNoteByNullifier?: Mock;
   getStateCommitmentTree?: Mock;


### PR DESCRIPTION
This test does not really test anything, because all the filtering logic takes place in the storage package and is covered by the tests there. 

Should we refactor to move the filtering logic to the rpc layer?