### PR TITLE
Use 'vitest' instead of 'vitest run' to allow watching

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rfv dist bin",
     "build": "webpack --config webpack/webpack.prod.js",
     "lint": "eslint \"**/*.ts*\"",
-    "test": "vitest run"
+    "test": "vitest"
   },
   "dependencies": {
     "@penumbra-zone/constants": "workspace:*",

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext ts,tsx",
     "preview": "vite preview",
     "host": "turbo run build && firebase deploy --only hosting",
-    "test": "vitest run"
+    "test": "vitest"
   },
   "dependencies": {
     "@penumbra-zone/constants": "workspace:*",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",
     "test:browser": "vitest run --config browser.config.ts",
-    "test": "vitest run"
+    "test": "vitest"
   },
   "dependencies": {
     "bip39": "^3.1.0",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",
-    "test": "vitest run"
+    "test": "vitest"
   },
   "dependencies": {
     "@penumbra-zone/constants": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",
-    "test": "vitest run"
+    "test": "vitest"
   },
   "dependencies": {
     "@types/chrome": "0.0.260",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",
-    "test": "vitest run",
+    "test": "vitest",
     "ui:add": "pnpm dlx shadcn-ui@latest add",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -9,7 +9,7 @@
     "compile": "cd crate ; wasm-pack build --no-pack --target bundler --out-name index --out-dir ../wasm",
     "build": "tsc",
     "lint": "eslint \"src/*.ts*\"",
-    "test": "vitest run",
+    "test": "vitest",
     "test:rust": "cd crate ; wasm-pack test --headless --firefox -- --test build --target wasm32-unknown-unknown --release --features 'mock-database'"
   },
   "dependencies": {


### PR DESCRIPTION
`vitest` defaults to watch mode when in development, but non-watch mode in CI. `vitest run` always exits after a run.

This PR switches from using `vitest run` to `vitest`, so that we automatically use watch mode in local development when running `pnpm test` inside any package directory.