### PR TITLE
refactor settings rpc page

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -35,6 +35,7 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
+    "@penumbra-zone/polyfills": "workspace:*",
     "@radix-ui/react-icons": "^1.3.0",
     "@types/chrome": "0.0.260",
     "@types/firefox-webext-browser": "^120.0.0",

--- a/apps/extension/src/hooks/chain-id.ts
+++ b/apps/extension/src/hooks/chain-id.ts
@@ -8,12 +8,12 @@ export const getChainId = async (): Promise<string> => {
   return parameters.chainId;
 };
 
-export const useChainId = () => {
+export const useChainIdQuery = () => {
   const { data, refetch } = useQuery({
     queryKey: ['chain-id'],
     queryFn: getChainId,
     refetchInterval: false,
   });
 
-  return { chainId: data, refetch };
+  return { chainId: data, refetchChainId: refetch };
 };

--- a/apps/extension/src/routes/popup/home/index-header.tsx
+++ b/apps/extension/src/routes/popup/home/index-header.tsx
@@ -2,12 +2,12 @@ import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
 import { NetworksPopover } from '@penumbra-zone/ui';
-import { useChainId } from '../../../hooks/chain-id';
+import { useChainIdQuery } from '../../../hooks/chain-id';
 import { motion } from 'framer-motion';
 
 export const IndexHeader = () => {
   const navigate = usePopupNav();
-  const { chainId } = useChainId();
+  const { chainId } = useChainIdQuery();
 
   return (
     <header className='top-0 z-40 w-full'>

--- a/apps/extension/src/routes/popup/settings/settings-rpc.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-rpc.tsx
@@ -10,6 +10,7 @@ import { useStore } from '../../../state';
 import { networkSelector } from '../../../state/network';
 import { internalSwClient } from '@penumbra-zone/router';
 import '@penumbra-zone/polyfills/Promise.withResolvers';
+import { TrashIcon } from '@radix-ui/react-icons';
 
 export const SettingsRPC = () => {
   const { chainId: currentChainId } = useChainIdQuery();
@@ -74,15 +75,28 @@ export const SettingsRPC = () => {
                 <div className='text-base font-bold'>RPC URL</div>
                 {rpcError ? <div className='italic text-red-400'>{rpcError}</div> : null}
               </div>
-              <Input
-                variant={rpcError ? 'error' : 'default'}
-                value={rpcInput}
-                onChange={evt => {
-                  setRpcError(undefined);
-                  setRpcInput(evt.target.value);
-                }}
-                className='text-muted-foreground'
-              />
+              <div className='relative w-full'>
+                <div className='absolute inset-y-0 right-4 flex cursor-pointer items-center'>
+                  {rpcInput != grpcEndpoint ? (
+                    <Button
+                      type='reset'
+                      variant='outline'
+                      onClick={() => setRpcInput(grpcEndpoint ?? DEFAULT_GRPC_URL)}
+                    >
+                      <TrashIcon />
+                    </Button>
+                  ) : null}
+                </div>
+                <Input
+                  variant={rpcError ? 'error' : rpcInput != grpcEndpoint ? 'warn' : 'default'}
+                  value={rpcInput}
+                  onChange={evt => {
+                    setRpcError(undefined);
+                    setRpcInput(evt.target.value);
+                  }}
+                  className='text-muted-foreground'
+                />
+              </div>
             </div>
             <div className='flex flex-col gap-2'>
               <p className='font-headline text-base font-semibold'>Chain id</p>
@@ -96,7 +110,12 @@ export const SettingsRPC = () => {
               Saved! Restarting in {countdownTime}...
             </Button>
           ) : (
-            <Button variant='gradient' size='lg' className='w-full' type='submit'>
+            <Button
+              variant={rpcInput != grpcEndpoint ? 'gradient' : 'outline'}
+              size='lg'
+              className='w-full'
+              type='submit'
+            >
               Save
             </Button>
           )}

--- a/packages/polyfills/Promise.withResolvers.ts
+++ b/packages/polyfills/Promise.withResolvers.ts
@@ -10,6 +10,6 @@ export interface PromiseWithResolvers<T> {
 
 declare global {
   interface PromiseConstructor {
-    withResolvers<T>(): PromiseWithResolvers<T>;
+    withResolvers<T = void>(): PromiseWithResolvers<T>;
   }
 }

--- a/packages/router/src/grpc/view-protocol-server/util/build-tx.ts
+++ b/packages/router/src/grpc/view-protocol-server/util/build-tx.ts
@@ -55,10 +55,10 @@ export const optimisticBuild = async function* (
 
 const progressStream = async function* <T>(tasks: PromiseLike<T>[], cancel: PromiseLike<never>) {
   // deliberately not a 'map' - tasks and promises have no direct relationship.
-  const tasksRemaining = Array.from(tasks, () => Promise.withResolvers<T>());
+  const tasksRemaining = Array.from(tasks, () => Promise.withResolvers());
 
   // tasksRemaining will be consumed in order, as tasks complete in any order.
-  tasks.forEach(task => void task.then(() => tasksRemaining.shift()?.resolve(task)));
+  tasks.forEach(task => void task.then(() => tasksRemaining.shift()?.resolve()));
 
   // yield status when any task resolves the next 'remaining' promise
   while (tasksRemaining.length) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0(@types/react@18.2.57)(immer@10.0.3)(react@18.2.0)
     devDependencies:
+      '@penumbra-zone/polyfills':
+        specifier: workspace:*
+        version: link:../../packages/polyfills
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.0(react@18.2.0)


### PR DESCRIPTION
this now avoids clearing cache if the chainid at the new rpc endpoint remains the same

i refactored this when i expected to need to request permissions on a new endpoint after config change. that turned out to be unnecessary but i think this is better, provides some visual feedback, and prevents a long reset in some cases