### PR TITLE
Include token metadata for zero-balance ValueViews of delegation tokens

### DIFF
--- a/apps/webapp/src/fetchers/staking.ts
+++ b/apps/webapp/src/fetchers/staking.ts
@@ -6,6 +6,7 @@ import { stakingClient, viewClient } from '../clients/grpc';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import {
   bech32IdentityKey,
+  customizeSymbol,
   getDisplayDenomFromView,
   getIdentityKeyFromValidatorInfo,
   getValidatorInfo,
@@ -70,7 +71,7 @@ export const getDelegationsForAccount = async function* (addressIndex: AddressIn
 
       yield withValidatorInfo;
     } else {
-      const assetMetadataByIdResponse = await viewClient.assetMetadataById({
+      const { denomMetadata } = await viewClient.assetMetadataById({
         assetId: { altBaseDenom: getDelegationTokenBaseDenom(validatorInfo) },
       });
 
@@ -82,7 +83,7 @@ export const getDelegationsForAccount = async function* (addressIndex: AddressIn
               hi: 0n,
               lo: 0n,
             },
-            metadata: assetMetadataByIdResponse.denomMetadata,
+            metadata: denomMetadata ? customizeSymbol(denomMetadata) : undefined,
             extendedMetadata,
           },
         },

--- a/apps/webapp/src/fetchers/staking.ts
+++ b/apps/webapp/src/fetchers/staking.ts
@@ -2,7 +2,7 @@ import {
   AddressIndex,
   IdentityKey,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
-import { stakingClient } from '../clients/grpc';
+import { stakingClient, viewClient } from '../clients/grpc';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import {
   bech32IdentityKey,
@@ -25,6 +25,9 @@ const isDelegationBalance = (balance: BalancesResponse, identityKey: IdentityKey
   return bech32IdentityKey(identityKey) === matchGroups.bech32IdentityKey;
 };
 
+const getDelegationTokenBaseDenom = (validatorInfo: ValidatorInfo) =>
+  `udelegation_${bech32IdentityKey(getIdentityKeyFromValidatorInfo(validatorInfo))}`;
+
 /**
  * Given an `AddressIndex`, yields `ValueView`s of the given address's balance
  * of delegation tokens. Each `ValueView` has an `extendedMetadata` property
@@ -46,9 +49,10 @@ export const getDelegationsForAccount = async function* (addressIndex: AddressIn
   const validatorInfoResponses = stakingClient.validatorInfo({ showInactive: false });
 
   for await (const validatorInfoResponse of validatorInfoResponses) {
+    const validatorInfo = getValidatorInfo(validatorInfoResponse);
     const extendedMetadata = new Any({
       typeUrl: ValidatorInfo.typeName,
-      value: validatorInfoResponse.validatorInfo?.toBinary(),
+      value: validatorInfo.toBinary(),
     });
 
     const identityKey = getValidatorInfo.pipe(getIdentityKeyFromValidatorInfo)(
@@ -66,6 +70,10 @@ export const getDelegationsForAccount = async function* (addressIndex: AddressIn
 
       yield withValidatorInfo;
     } else {
+      const assetMetadataByIdResponse = await viewClient.assetMetadataById({
+        assetId: { altBaseDenom: getDelegationTokenBaseDenom(validatorInfo) },
+      });
+
       yield new ValueView({
         valueView: {
           case: 'knownAssetId',
@@ -74,6 +82,7 @@ export const getDelegationsForAccount = async function* (addressIndex: AddressIn
               hi: 0n,
               lo: 0n,
             },
+            metadata: assetMetadataByIdResponse.denomMetadata,
             extendedMetadata,
           },
         },

--- a/apps/webapp/src/state/staking.test.ts
+++ b/apps/webapp/src/state/staking.test.ts
@@ -5,7 +5,10 @@ import {
   ValidatorInfo,
   ValidatorInfoResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
-import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import {
+  Metadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { bech32IdentityKey, getValidatorInfoFromValueView } from '@penumbra-zone/types';
 import {
   AddressView,
@@ -159,8 +162,13 @@ vi.mock('../fetchers/balances', () => ({
   ),
 }));
 
+const mockViewClient = vi.hoisted(() => ({
+  assetMetadataById: vi.fn(() => new Metadata()),
+}));
+
 vi.mock('../clients/grpc', () => ({
   stakingClient: mockStakingClient,
+  viewClient: mockViewClient,
 }));
 
 describe('Staking Slice', () => {

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -3,6 +3,7 @@ import { RootQuerier } from './root-querier';
 import { sha256Hash } from '@penumbra-zone/crypto-web';
 import {
   BlockProcessorInterface,
+  customizeSymbol,
   IndexedDbInterface,
   ViewServerInterface,
 } from '@penumbra-zone/types';
@@ -249,7 +250,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       const metadataFromNode = await this.querier.shieldedPool.assetMetadata(assetId);
 
       if (metadataFromNode) {
-        await this.indexedDb.saveAssetsMetadata(metadataFromNode);
+        await this.indexedDb.saveAssetsMetadata(customizeSymbol(metadataFromNode));
       }
     }
   }

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -24,7 +24,6 @@ import {
   TransactionInfo,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { backOff } from 'exponential-backoff';
-import { customizeSymbol } from './customize-symbol';
 
 interface QueryClientProps {
   fullViewingKey: string;
@@ -250,7 +249,6 @@ export class BlockProcessor implements BlockProcessorInterface {
       const metadataFromNode = await this.querier.shieldedPool.assetMetadata(assetId);
 
       if (metadataFromNode) {
-        customizeSymbol(metadataFromNode);
         await this.indexedDb.saveAssetsMetadata(metadataFromNode);
       }
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,6 +8,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@penumbra-zone/constants": "workspace:*",
+    "@types/chrome": "0.0.260",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.1.2",
     "idb": "^8.0.0",

--- a/packages/types/src/customize-symbol.test.ts
+++ b/packages/types/src/customize-symbol.test.ts
@@ -8,8 +8,8 @@ describe('Customizing metadata', () => {
       display:
         'delegation_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
     });
-    customizeSymbol(metadata);
-    expect(metadata.symbol).toBe('Delegated UM (fjuj67ayaqueqxg03d65ps5aa...)');
+
+    expect(customizeSymbol(metadata).symbol).toBe('Delegated UM (fjuj67ayaqueqxg03d65ps5aa...)');
   });
 
   test('should work for unbonding token', () => {
@@ -17,8 +17,10 @@ describe('Customizing metadata', () => {
       display:
         'uunbonding_epoch_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
     });
-    customizeSymbol(metadata);
-    expect(metadata.symbol).toBe('Unbonding UM, epoch 29 (fjuj67ayaqueqxg03d65ps5aa...)');
+
+    expect(customizeSymbol(metadata).symbol).toBe(
+      'Unbonding UM, epoch 29 (fjuj67ayaqueqxg03d65ps5aa...)',
+    );
   });
 
   test('should do nothing if no matches', () => {
@@ -26,7 +28,7 @@ describe('Customizing metadata', () => {
       display: 'test_usd',
       symbol: 'usdc',
     });
-    customizeSymbol(metadata);
-    expect(metadata.symbol).toBe('usdc');
+
+    expect(customizeSymbol(metadata).symbol).toBe('usdc');
   });
 });

--- a/packages/types/src/customize-symbol.ts
+++ b/packages/types/src/customize-symbol.ts
@@ -15,13 +15,19 @@ export const customizeSymbol = (metadata: Metadata) => {
   if (delegationMatch) {
     const { id } = delegationMatch.groups as unknown as DelegationCaptureGroups;
     const shortenedId = id.slice(0, DELEGATION_SYMBOL_LENGTH);
-    metadata.symbol = `Delegated UM (${shortenedId}...)`;
+    const customized = metadata.clone();
+    customized.symbol = `Delegated UM (${shortenedId}...)`;
+    return customized;
   }
 
   const unbondingMatch = assetPatterns.unbondingToken.exec(metadata.display);
   if (unbondingMatch) {
     const { id, epoch } = unbondingMatch.groups as unknown as UnbondingCaptureGroups;
     const shortenedId = id.slice(0, UNBONDING_SYMBOL_LENGTH);
-    metadata.symbol = `Unbonding UM, epoch ${epoch} (${shortenedId}...)`;
+    const customized = metadata.clone();
+    customized.symbol = `Unbonding UM, epoch ${epoch} (${shortenedId}...)`;
+    return customized;
   }
+
+  return metadata;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -26,3 +26,4 @@ export * from './type-predicates';
 export * from './getters';
 export * from './staking';
 export * from './identity-key';
+export * from './customize-symbol';

--- a/packages/ui/components/ui/tx/view/value.tsx
+++ b/packages/ui/components/ui/tx/view/value.tsx
@@ -1,5 +1,6 @@
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import {
+  customizeSymbol,
   fromBaseUnitAmount,
   getDisplayDenomExponent,
   getDisplayDenomFromView,
@@ -29,7 +30,7 @@ export const ValueViewComponent = ({
 
   if (view.valueView.case === 'knownAssetId' && view.valueView.value.metadata) {
     const value = view.valueView.value;
-    const metadata = view.valueView.value.metadata;
+    const metadata = customizeSymbol(view.valueView.value.metadata);
     const amount = value.amount ?? new Amount();
     const exponent = getDisplayDenomExponent(metadata);
     // The regex trims trailing zeros which toFormat adds in

--- a/packages/ui/components/ui/tx/view/value.tsx
+++ b/packages/ui/components/ui/tx/view/value.tsx
@@ -1,6 +1,5 @@
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import {
-  customizeSymbol,
   fromBaseUnitAmount,
   getDisplayDenomExponent,
   getDisplayDenomFromView,
@@ -30,7 +29,7 @@ export const ValueViewComponent = ({
 
   if (view.valueView.case === 'knownAssetId' && view.valueView.value.metadata) {
     const value = view.valueView.value;
-    const metadata = customizeSymbol(view.valueView.value.metadata);
+    const metadata = view.valueView.value.metadata;
     const amount = value.amount ?? new Amount();
     const exponent = getDisplayDenomExponent(metadata);
     // The regex trims trailing zeros which toFormat adds in

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,12 @@ importers:
 
   packages/types:
     dependencies:
+      '@penumbra-zone/constants':
+        specifier: workspace:*
+        version: link:../constants
+      '@types/chrome':
+        specifier: 0.0.260
+        version: 0.0.260
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -5747,6 +5753,13 @@ packages:
       '@types/node': 20.11.22
     dev: true
 
+  /@types/chrome@0.0.260:
+    resolution: {integrity: sha512-lX6QpgfsZRTDpNcCJ+3vzfFnFXq9bScFRTlfhbK5oecSAjamsno+ejFTCbNtc5O/TPnVK9Tja/PyecvWQe0F2w==}
+    dependencies:
+      '@types/filesystem': 0.0.35
+      '@types/har-format': 1.2.15
+    dev: false
+
   /@types/chrome@0.0.262:
     resolution: {integrity: sha512-TOoj3dqSYE13PD2fRuMQ6X6pggEvL9rRk/yOYOyWE6sfqRWxsJm4VoVm+wr9pkr4Sht/M5t7FFL4vXato8d1gA==}
     dependencies:
@@ -5843,11 +5856,9 @@ packages:
     resolution: {integrity: sha512-1eKvCaIBdrD2mmMgy5dwh564rVvfEhZTWVQQGRNn0Nt4ZEnJ0C8oSUCzvMKRA4lGde5oEVo+q2MrTTbV/GHDCQ==}
     dependencies:
       '@types/filewriter': 0.0.33
-    dev: true
 
   /@types/filewriter@0.0.33:
     resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
-    dev: true
 
   /@types/find-cache-dir@3.2.1:
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
@@ -5879,7 +5890,6 @@ packages:
 
   /@types/har-format@1.2.15:
     resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
-    dev: true
 
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}


### PR DESCRIPTION
Previously we weren't rendering any balance for delegation tokens that the user doesn't hold any of. That's because there wasn't any metadata for those tokens, so `ValueViewComponent` rendered nothing for them.

## Before
<img width="1015" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/2d4ac396-5290-464c-b4bd-d84b62623d6f">


## After
<img width="1034" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/46f7f480-e788-4ff0-b071-1ab2dc0cd55e">


## In this PR
- Fetch asset metadata based on the validator's delegation token name, and use it to render the zero balances.
- Remove `customizeSymbol` from the block processor
  - Would especially like @grod220's thoughts on this. I made two changes to `customizeSymbol`: 1) I made it a pure function, returning a new copy of the `Metadata` with the symbol customized, rather than mutating the existing one; and 2) I moved it to `ValueViewComponent`, so that the customizing happens at the render stage rather than the block processing stage. This means that:
    - The webapp, rather than the extension, is now responsible for accurately displaying the type of token. This could be a downside if we are worried that other web apps won't realize that validator names could be spoofed. However, I think the benefits outweigh the downsides.
    - If/when we want to change the rendering of the symbol, we don't have to blow away all the IndexedDB data and rebuild. Rather, we can just change the `ValueViewComponent`'s rendering logic. Another way of saying this: _The concern of how to render a symbol rests within the rendering layer (where it belongs, I'd argue), rather than the processing layer._

## Punting for now
- I'd love to build out the `ValueViewComponent` a bit in the future so that it has a tooltip that shows much more information. Then, we could make the symbol much shorter, and show which validator the token is for on hover.

Closes #617