### PR TITLE
Show an account switcher on the Staking page

### DIFF
--- a/apps/webapp/src/components/staking/account/index.tsx
+++ b/apps/webapp/src/components/staking/account/index.tsx
@@ -9,6 +9,7 @@ import { DelegationValueView } from './delegation-value-view';
 import { Card, CardContent, CardHeader, CardTitle } from '@penumbra-zone/ui';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
+import { AccountSwitcher } from '@penumbra-zone/ui/components/ui/account-switcher';
 
 const getVotingPowerAsIntegerPercentage = (
   votingPowerByValidatorInfo: Record<string, VotingPowerAsIntegerPercentage>,
@@ -16,23 +17,29 @@ const getVotingPowerAsIntegerPercentage = (
 ) => votingPowerByValidatorInfo[bech32IdentityKey(getIdentityKeyFromValueView(delegation))];
 
 export const Account = () => {
-  const { account, delegationsByAccount, unstakedTokensByAccount, votingPowerByValidatorInfo } =
-    useStore(stakingSelector);
+  const {
+    account,
+    setAccount,
+    delegationsByAccount,
+    unstakedTokensByAccount,
+    votingPowerByValidatorInfo,
+  } = useStore(stakingSelector);
   const unstakedTokens = unstakedTokensByAccount.get(account);
   const delegations = delegationsByAccount.get(account) ?? [];
 
   return (
     <div className='flex flex-col gap-4'>
-      {!!unstakedTokens && (
-        <Card gradient>
-          <CardContent>
-            <div className='flex gap-1'>
+      <Card gradient>
+        <CardContent>
+          <AccountSwitcher account={account} onChange={setAccount} />
+          {!!unstakedTokens && (
+            <div className='flex justify-center gap-1'>
               <ValueViewComponent view={unstakedTokens} />
               <span>available to delegate</span>
             </div>
-          </CardContent>
-        </Card>
-      )}
+          )}
+        </CardContent>
+      </Card>
 
       {!!delegations.length && (
         <Card>

--- a/apps/webapp/src/components/staking/layout.tsx
+++ b/apps/webapp/src/components/staking/layout.tsx
@@ -22,6 +22,5 @@ export const StakingLayout = () => {
     [account, loadDelegationsForCurrentAccount],
   );
 
-  /** @todo: Render an account switcher. */
   return <Account />;
 };

--- a/apps/webapp/src/state/staking.test.ts
+++ b/apps/webapp/src/state/staking.test.ts
@@ -175,6 +175,7 @@ describe('Staking Slice', () => {
       account: 0,
       delegationsByAccount: new Map(),
       unstakedTokensByAccount: new Map(),
+      setAccount: expect.any(Function) as unknown,
       loadDelegationsForCurrentAccount: expect.any(Function) as unknown,
       loadUnstakedTokensByAccount: expect.any(Function) as unknown,
       error: undefined,

--- a/apps/webapp/src/state/staking.ts
+++ b/apps/webapp/src/state/staking.ts
@@ -18,6 +18,8 @@ import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/c
 export interface StakingSlice {
   /** The account for which we're viewing delegations. */
   account: number;
+  /** Switch to view a different account. */
+  setAccount: (account: number) => void;
   /** A map of numeric account indexes to delegations for that account. */
   delegationsByAccount: Map<number, ValueView[]>;
   /**
@@ -63,6 +65,10 @@ const byBalanceAndVotingPower = (valueViewA: ValueView, valueViewB: ValueView): 
 
 export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) => ({
   account: 0,
+  setAccount: (account: number) =>
+    set(state => {
+      state.staking.account = account;
+    }),
   delegationsByAccount: new Map(),
   unstakedTokensByAccount: new Map(),
   loadDelegationsForCurrentAccount: async () => {

--- a/packages/ui/components/ui/account-switcher.tsx
+++ b/packages/ui/components/ui/account-switcher.tsx
@@ -1,0 +1,80 @@
+import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import { Button } from './button';
+import { Input } from './input';
+import { useState } from 'react';
+
+const MAX_INDEX = 2 ** 32;
+
+/**
+ * Renders arrows with which to switch between accounts by index, from 0 to
+ * 2^32.
+ */
+export const AccountSwitcher = ({
+  account,
+  onChange,
+}: {
+  account: number;
+  onChange: (account: number) => void;
+}) => {
+  const [inputCharWidth, setInputCharWidth] = useState(1);
+
+  const handleChange = (value: number) => {
+    onChange(value);
+    setInputCharWidth(String(value).length);
+  };
+
+  return (
+    <div className='flex items-center justify-between'>
+      <Button variant='ghost' className={cn('hover:bg-inherit', account === 0 && 'cursor-default')}>
+        {account !== 0 ? (
+          <ArrowLeftIcon
+            onClick={() => {
+              if (account > 0) handleChange(account - 1);
+            }}
+            className='size-6 hover:cursor-pointer'
+          />
+        ) : (
+          <span className='size-6' />
+        )}
+      </Button>
+      <div className='select-none text-center font-headline text-xl font-semibold leading-[30px]'>
+        <div className='flex flex-row flex-wrap items-end gap-[6px]'>
+          <span>Account</span>
+          <div className='flex items-end gap-0'>
+            <p>#</p>
+            <div className='relative w-min min-w-[24px]'>
+              <Input
+                variant='transparent'
+                type='number'
+                className='mb-[3px] h-6 py-[2px] font-headline text-xl font-semibold leading-[30px]'
+                onChange={e => {
+                  const value = Number(e.target.value);
+                  const valueLength = e.target.value.replace(/^0+/, '').length;
+
+                  if (value > MAX_INDEX || valueLength > MAX_INDEX.toString().length) return;
+                  handleChange(value);
+                }}
+                style={{ width: `${inputCharWidth}ch` }}
+                value={account ? account.toString().replace(/^0+/, '') : '0'}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <Button
+        variant='ghost'
+        className={cn('hover:bg-inherit', account === MAX_INDEX && 'cursor-default')}
+      >
+        {account < MAX_INDEX ? (
+          <ArrowRightIcon
+            onClick={() => handleChange(account + 1)}
+            className='size-6 hover:cursor-pointer'
+          />
+        ) : (
+          <span className='size-6' />
+        )}
+      </Button>
+    </div>
+  );
+};

--- a/packages/ui/components/ui/select-account.tsx
+++ b/packages/ui/components/ui/select-account.tsx
@@ -1,28 +1,26 @@
 import { AddressIcon } from './address-icon';
-import { ArrowLeftIcon, ArrowRightIcon, InfoIcon } from 'lucide-react';
-import { cn } from '../../lib/utils';
+import { InfoIcon } from 'lucide-react';
 import { CopyToClipboardIconButton } from './copy-to-clipboard-icon-button';
-import { Button } from './button';
 import { IncognitoIcon } from './icons/incognito';
-import { Input } from './input';
 import { Switch } from './switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 import { useEffect, useState } from 'react';
 import { AddressComponent } from './address-component';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import { bech32Address } from '@penumbra-zone/types';
+import { AccountSwitcher } from './account-switcher';
 
 interface SelectAccountProps {
   getAddrByIndex: (index: number, ephemeral: boolean) => Promise<Address> | Address;
 }
 
-const MAX_INDEX = 2 ** 32;
-
+/**
+ * Renders an account address, along with a switcher to choose a different
+ * account index. Also allows the user to view a one-time IBC deposit address.
+ */
 export const SelectAccount = ({ getAddrByIndex }: SelectAccountProps) => {
   const [index, setIndex] = useState<number>(0);
   const [ephemeral, setEphemeral] = useState<boolean>(false);
-
-  const [width, setWidth] = useState(index.toString().length);
   const [address, setAddress] = useState<Address>();
 
   useEffect(() => {
@@ -40,67 +38,8 @@ export const SelectAccount = ({ getAddrByIndex }: SelectAccountProps) => {
         <></>
       ) : (
         <div className='flex w-full flex-col'>
-          <div className='flex items-center justify-between'>
-            <Button
-              variant='ghost'
-              className={cn('hover:bg-inherit', index === 0 && 'cursor-default')}
-            >
-              {index !== 0 ? (
-                <ArrowLeftIcon
-                  onClick={() => {
-                    if (index > 0) {
-                      setIndex(state => state - 1);
-                      setWidth(Number(String(index - 1).length));
-                    }
-                  }}
-                  className='size-6 hover:cursor-pointer'
-                />
-              ) : (
-                <span className='size-6' />
-              )}
-            </Button>
-            <div className='select-none text-center font-headline text-xl font-semibold leading-[30px]'>
-              <div className='flex flex-row flex-wrap items-end gap-[6px]'>
-                <span>Account</span>
-                <div className='flex items-end gap-0'>
-                  <p>#</p>
-                  <div className='relative w-min min-w-[24px]'>
-                    <Input
-                      variant='transparent'
-                      type='number'
-                      className='mb-[3px] h-6 py-[2px] font-headline text-xl font-semibold leading-[30px]'
-                      onChange={e => {
-                        const value = Number(e.target.value);
-                        const valueLength = e.target.value.replace(/^0+/, '').length;
+          <AccountSwitcher account={index} onChange={setIndex} />
 
-                        if (value > MAX_INDEX || valueLength > MAX_INDEX.toString().length) return;
-                        setWidth(valueLength ? valueLength : 1);
-                        setIndex(value);
-                      }}
-                      style={{ width: width + 'ch' }}
-                      value={index ? index.toString().replace(/^0+/, '') : '0'}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <Button
-              variant='ghost'
-              className={cn('hover:bg-inherit', index === MAX_INDEX && 'cursor-default')}
-            >
-              {index < MAX_INDEX ? (
-                <ArrowRightIcon
-                  onClick={() => {
-                    setIndex(state => state + 1);
-                    setWidth(Number(String(index + 1).length));
-                  }}
-                  className='size-6 hover:cursor-pointer'
-                />
-              ) : (
-                <span className='size-6' />
-              )}
-            </Button>
-          </div>
           <div className='mt-4 flex items-center justify-between gap-1 break-all rounded-lg border bg-background px-3 py-4'>
             <div className='flex items-center gap-[6px]'>
               <AddressIcon address={address} size={24} />


### PR DESCRIPTION
Previously, you could only delegate, view validators, etc. from account #0. Now you can switch accounts.

Note that at the moment, it makes a request to the RPC node every time you switch accounts. This will no longer be the case once #601 and #612 are done.


https://github.com/penumbra-zone/web/assets/1121544/eeac65ab-2727-4f96-b584-1102b4088d4b


## In this PR
- Extract a new `<AccountSwitcher />` component from the `<SelectAccount />` component.
- Use it at the top of the account view.

## Future PRs
- Put `account` state in the query string? But that could require a bit of refactoring, so I'll leave that for a future improvement.