### PR TITLE
fix: do not render no memo as 'Invalid MemoView'

### DIFF
--- a/packages/ui/components/ui/tx/view/memo-view.tsx
+++ b/packages/ui/components/ui/tx/view/memo-view.tsx
@@ -2,33 +2,32 @@ import { MemoView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { AddressViewComponent } from './address-view';
 import { ViewBox, ViewSection } from './viewbox';
 
-export const MemoViewComponent = ({ memo }: { memo: MemoView | undefined }) => {
-  if (!memo?.memoView.case) return null;
-  if (memo.memoView.case === 'visible') {
-    const mv = memo.memoView.value;
-    const text = mv.plaintext?.text;
-
-    return (
-      <ViewSection heading='Memo'>
-        <ViewBox
-          label='Memo Text'
-          visibleContent={
-            /* Ensure that an empty memo string is rendered as a blank space, highlighting absence */
-            text ? <div>{text}</div> : <div>&nbsp;</div>
-          }
-        />
-        <ViewBox
-          label='Sender Return Address'
-          visibleContent={<AddressViewComponent view={mv.plaintext!.returnAddress} />}
-        />
-      </ViewSection>
-    );
+export const MemoViewComponent = ({ memo: { memoView } }: { memo: MemoView }) => {
+  switch (memoView.case) {
+    case 'visible':
+      return (
+        <ViewSection heading='Memo'>
+          <ViewBox
+            label='Memo Text'
+            visibleContent={
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+              <div>{memoView.value.plaintext?.text || '&nbsp;'}</div>
+            }
+          />
+          <ViewBox
+            label='Sender Return Address'
+            visibleContent={<AddressViewComponent view={memoView.value.plaintext!.returnAddress} />}
+          />
+        </ViewSection>
+      );
+    case 'opaque':
+      return (
+        <ViewSection heading='Memo'>
+          <ViewBox label='Memo Text' />
+          <ViewBox label='Sender Return Address' />
+        </ViewSection>
+      );
+    default:
+      return <span>Invalid MemoView</span>;
   }
-
-  return (
-    <ViewSection heading='Memo'>
-      <ViewBox label='Memo Text' />
-      <ViewBox label='Sender Return Address' />
-    </ViewSection>
-  );
 };

--- a/packages/ui/components/ui/tx/view/memo-view.tsx
+++ b/packages/ui/components/ui/tx/view/memo-view.tsx
@@ -3,7 +3,7 @@ import { AddressViewComponent } from './address-view';
 import { ViewBox, ViewSection } from './viewbox';
 
 export const MemoViewComponent = ({ memo }: { memo: MemoView | undefined }) => {
-  if (!memo?.memoView) return null;
+  if (!memo?.memoView.case) return null;
   if (memo.memoView.case === 'visible') {
     const mv = memo.memoView.value;
     const text = mv.plaintext?.text;
@@ -25,14 +25,10 @@ export const MemoViewComponent = ({ memo }: { memo: MemoView | undefined }) => {
     );
   }
 
-  if (memo.memoView.case === 'opaque') {
-    return (
-      <ViewSection heading='Memo'>
-        <ViewBox label='Memo Text' />
-        <ViewBox label='Sender Return Address' />
-      </ViewSection>
-    );
-  }
-
-  return <span>Invalid MemoView</span>;
+  return (
+    <ViewSection heading='Memo'>
+      <ViewBox label='Memo Text' />
+      <ViewBox label='Sender Return Address' />
+    </ViewSection>
+  );
 };

--- a/packages/ui/components/ui/tx/view/transaction.tsx
+++ b/packages/ui/components/ui/tx/view/transaction.tsx
@@ -12,7 +12,7 @@ export const TransactionViewComponent = ({ txv }: { txv: TransactionView }) => {
 
   return (
     <div className='flex flex-col gap-8'>
-      <MemoViewComponent memo={txv.bodyView.memoView} />
+      {txv.bodyView.memoView?.memoView ? <MemoViewComponent memo={txv.bodyView.memoView} /> : null}
       <ViewSection heading='Actions'>
         {txv.bodyView.actionViews.map((av, i) => (
           <ActionViewComponent av={av} key={i} />


### PR DESCRIPTION
from #631

> `swap` and `swapClaim` transactions have no memo.
