### PR TITLE
Account for delegate/undelegate actions in the public/private views of a transaction

### DIFF
--- a/packages/router/src/grpc/custody/view-transaction-plan/view-action-plan.ts
+++ b/packages/router/src/grpc/custody/view-transaction-plan/view-action-plan.ts
@@ -34,14 +34,13 @@ const getValueView = (
   if (!value.amount) throw new Error('No amount in value');
 
   const denomMetadata = denomMetadataByAssetId[bech32AssetId(value.assetId)];
-  if (!denomMetadata) throw new Error('Asset ID refers to an unknown asset type');
 
   return new ValueView({
     valueView: {
       case: 'knownAssetId',
       value: {
         amount: value.amount,
-        metadata: Metadata.fromJson(denomMetadata),
+        metadata: denomMetadata ? Metadata.fromJson(denomMetadata) : undefined,
       },
     },
   });
@@ -217,6 +216,10 @@ export const viewActionPlan =
             value: {},
           },
         });
+      case 'delegate':
+      case 'undelegate':
+        return new ActionView({ actionView: actionPlan.action });
+
       case undefined:
         throw new Error('No action case in action plan');
       default:

--- a/packages/types/src/transaction/perspective.ts
+++ b/packages/types/src/transaction/perspective.ts
@@ -77,6 +77,11 @@ export const viewActionFromEmptyPerspective = (action: Action): ActionView | und
           }),
         },
       });
+    case 'delegate':
+    case 'undelegate':
+      return new ActionView({
+        actionView: action.action,
+      });
     default:
       // TODO: fill in other actions. most actions don't have views (they are their own view) so they can be passed through.
       return undefined;

--- a/packages/types/src/translators/action-view.test.ts
+++ b/packages/types/src/translators/action-view.test.ts
@@ -168,6 +168,38 @@ describe('asPublicActionView()', () => {
       expect(asPublicActionView(actionView).equals(expected)).toBe(true);
     });
   });
+
+  describe('when passed a delegate action view', () => {
+    const actionView = new ActionView({
+      actionView: {
+        case: 'delegate',
+        value: {
+          epochIndex: 0n,
+          delegationAmount: { hi: 0n, lo: 1n },
+        },
+      },
+    });
+
+    test('returns the action view as-is', () => {
+      expect(asPublicActionView(actionView).equals(actionView)).toBe(true);
+    });
+  });
+
+  describe('when passed an undelegate action view', () => {
+    const actionView = new ActionView({
+      actionView: {
+        case: 'undelegate',
+        value: {
+          startEpochIndex: 0n,
+          delegationAmount: { hi: 0n, lo: 1n },
+        },
+      },
+    });
+
+    test('returns the action view as-is', () => {
+      expect(asPublicActionView(actionView).equals(actionView)).toBe(true);
+    });
+  });
 });
 
 describe('asReceiverActionView()', () => {
@@ -321,6 +353,44 @@ describe('asReceiverActionView()', () => {
     });
 
     test('returns an action view with a receiver output view', async () => {
+      const isControlledAddress = () => Promise.resolve(false);
+      const result = await asReceiverActionView(actionView, { isControlledAddress });
+
+      expect(result.equals(actionView)).toBe(true);
+    });
+  });
+
+  describe('when passed a delegate action view', () => {
+    const actionView = new ActionView({
+      actionView: {
+        case: 'delegate',
+        value: {
+          epochIndex: 0n,
+          delegationAmount: { hi: 0n, lo: 1n },
+        },
+      },
+    });
+
+    test('returns the action view as-is', async () => {
+      const isControlledAddress = () => Promise.resolve(false);
+      const result = await asReceiverActionView(actionView, { isControlledAddress });
+
+      expect(result.equals(actionView)).toBe(true);
+    });
+  });
+
+  describe('when passed an undelegate action view', () => {
+    const actionView = new ActionView({
+      actionView: {
+        case: 'undelegate',
+        value: {
+          startEpochIndex: 0n,
+          delegationAmount: { hi: 0n, lo: 1n },
+        },
+      },
+    });
+
+    test('returns the action view as-is', async () => {
       const isControlledAddress = () => Promise.resolve(false);
       const result = await asReceiverActionView(actionView, { isControlledAddress });
 

--- a/packages/types/src/translators/action-view.ts
+++ b/packages/types/src/translators/action-view.ts
@@ -22,6 +22,10 @@ export const asPublicActionView: Translator<ActionView> = actionView => {
         },
       });
 
+    case 'delegate':
+    case 'undelegate':
+      return actionView;
+
     default:
       return new ActionView({
         actionView: actionView?.actionView.case


### PR DESCRIPTION
As part of my work on the staking page, this makes sure that the public/private views of a transaction account for delegate and undelegate actions. Without this change, those actions would be displayed in correctly when, e.g., clicking the "Public" view in the approval popup.