### PR TITLE
declare Map.groupBy type

### DIFF
--- a/packages/polyfills/Map.groupBy.ts
+++ b/packages/polyfills/Map.groupBy.ts
@@ -1,0 +1,11 @@
+/** @see https://tc39.es/proposal-array-grouping/#sec-map.groupby */
+// already shipped in chrome, no type definition yet
+
+type MapGroupBy = <T, G>(
+  items: Iterable<T>,
+  callbackfn: (value: T, index: number) => G,
+) => Map<G, T[]>;
+
+type MapWithGroupBy = typeof Map & { groupBy: MapGroupBy };
+
+export default Map as MapWithGroupBy;


### PR DESCRIPTION
another standard api already shipped to our target platform with no ts definition

once again can't just declare, but must declare and re-export, because typescript does not support declaration merging for vars