### PR TITLE
refactor(web): v0.68.0 32-bit crypto backend

### DIFF
--- a/apps/extension/src/offscreen.ts
+++ b/apps/extension/src/offscreen.ts
@@ -28,6 +28,7 @@ export const offscreenMessageHandler = (
           type,
           error: `Offscreen: ${e.message}`,
         }));
+
       sendResponse(res);
     })();
   }

--- a/packages/router/src/grpc/offscreen-client.ts
+++ b/packages/router/src/grpc/offscreen-client.ts
@@ -75,6 +75,13 @@ const buildActions = (
       }),
     ]);
     if ('error' in buildRes) throw new Error(String(buildRes.error));
+
+    console.log('buildRes.data performance', buildRes.data['performance']);
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete buildRes.data['performance'];
+
+    console.log('buildRes.data action', buildRes.data);
+
     return Action.fromJson(buildRes.data);
   });
   void Promise.all(buildTasks).finally(() => void releaseOffscreen());

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,15 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -99,6 +111,7 @@ dependencies = [
  "blake2",
  "derivative",
  "digest 0.10.7",
+ "rayon",
  "sha2 0.10.8",
 ]
 
@@ -116,6 +129,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "itertools 0.10.5",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -128,7 +142,6 @@ dependencies = [
  "ark-bls12-377",
  "ark-ec",
  "ark-ff",
- "ark-r1cs-std",
  "ark-std",
 ]
 
@@ -148,6 +161,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
+ "rayon",
  "rustc_version",
  "zeroize",
 ]
@@ -188,6 +202,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
+ "rayon",
 ]
 
 [[package]]
@@ -201,6 +216,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
+ "rayon",
 ]
 
 [[package]]
@@ -229,7 +245,7 @@ dependencies = [
  "ark-ff",
  "ark-std",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -275,6 +291,7 @@ checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand",
+ "rayon",
 ]
 
 [[package]]
@@ -333,6 +350,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base16ct"
@@ -614,6 +646,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +669,31 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -706,9 +773,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75bb0f9fde498b60e4563c9346bbd4527d4ff4930a43c404ceb4cf63166c9ea4"
+version = "0.8.0"
+source = "git+https://github.com/penumbra-zone/decaf377?branch=87-missing-methods-temporary#d20b7ab9e2f1b03d493900c6501e1bf23ac0c4ff"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -721,51 +787,28 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
+ "cfg-if",
+ "hashbrown 0.14.3",
  "hex",
  "num-bigint",
  "once_cell",
- "thiserror",
+ "rand_core",
+ "subtle",
  "tracing",
- "tracing-subscriber",
- "zeroize",
-]
-
-[[package]]
-name = "decaf377"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80011d442d81fccfbefb5bd0d20bf70f111ca544ffed943d335dacf6a85713"
-dependencies = [
- "anyhow",
- "ark-bls12-377",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ff",
- "ark-groth16",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
- "ark-std",
- "hex",
- "num-bigint",
- "once_cell",
- "thiserror",
- "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
  "zeroize",
 ]
 
 [[package]]
 name = "decaf377-fmd"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
  "blake2b_simd 1.0.2",
- "decaf377 0.5.0",
+ "decaf377",
  "rand_core",
  "thiserror",
 ]
@@ -773,10 +816,10 @@ dependencies = [
 [[package]]
 name = "decaf377-ka"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "ark-ff",
- "decaf377 0.5.0",
+ "decaf377",
  "hex",
  "rand_core",
  "thiserror",
@@ -787,14 +830,13 @@ dependencies = [
 [[package]]
 name = "decaf377-rdsa"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2356bb010273c2b6e4e928b2bb442ddaa255ec242c16ff46cf9c3811fefa5ace"
+source = "git+https://github.com/penumbra-zone/decaf377-rdsa?branch=update-deps#64a93b8177514ea2a2c9b6753d6f7df4ce676496"
 dependencies = [
  "ark-ff",
  "ark-serialize",
  "blake2b_simd 0.5.11",
  "byteorder",
- "decaf377 0.5.0",
+ "decaf377",
  "digest 0.9.0",
  "hex",
  "rand_core",
@@ -943,6 +985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,7 +1015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1040,6 +1091,30 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "funty"
@@ -1161,6 +1236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1250,25 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.2.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1197,12 +1297,22 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1225,7 +1335,78 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1552,6 +1733,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,15 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,10 +1970,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "num"
@@ -1880,6 +2112,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2141,50 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -1996,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "penumbra-asset"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2008,7 +2303,7 @@ dependencies = [
  "bech32",
  "blake2b_simd 1.0.2",
  "bytes",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-rdsa",
  "derivative",
@@ -2033,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "penumbra-community-pool"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2063,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "penumbra-compact-block"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2095,7 +2390,7 @@ dependencies = [
 [[package]]
 name = "penumbra-dex"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2109,7 +2404,7 @@ dependencies = [
  "base64",
  "bincode",
  "blake2b_simd 1.0.2",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -2147,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "penumbra-distributions"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2163,14 +2458,14 @@ dependencies = [
 [[package]]
 name = "penumbra-fee"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-rdsa",
  "metrics",
  "penumbra-asset",
@@ -2186,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "penumbra-funding"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "penumbra-governance"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2219,7 +2514,7 @@ dependencies = [
  "base64",
  "blake2b_simd 1.0.2",
  "bytes",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-rdsa",
  "futures",
  "ibc-types",
@@ -2256,7 +2551,7 @@ dependencies = [
 [[package]]
 name = "penumbra-ibc"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2289,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "penumbra-keys"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "aes",
  "anyhow",
@@ -2304,7 +2599,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -2333,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "penumbra-num"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2347,7 +2642,7 @@ dependencies = [
  "bech32",
  "blake2b_simd 1.0.2",
  "bytes",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-rdsa",
  "derivative",
@@ -2369,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "penumbra-proof-params"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2381,13 +2676,17 @@ dependencies = [
  "ark-snark",
  "ark-std",
  "bech32",
- "decaf377 0.5.0",
+ "decaf377",
+ "hex",
  "lazy_static",
  "num-bigint",
  "once_cell",
  "rand",
  "rand_core",
+ "regex",
+ "reqwest",
  "serde",
+ "serde_json",
  "sha2 0.10.8",
  "tracing",
 ]
@@ -2395,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "penumbra-proto"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "penumbra-sct"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2433,7 +2732,7 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.2",
  "bytes",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-rdsa",
  "hex",
  "im",
@@ -2453,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "penumbra-shielded-pool"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2467,7 +2766,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -2500,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "penumbra-stake"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2512,7 +2811,7 @@ dependencies = [
  "base64",
  "bech32",
  "bitvec",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-rdsa",
  "hex",
  "once_cell",
@@ -2541,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "penumbra-tct"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2550,7 +2849,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "blake2b_simd 1.0.2",
- "decaf377 0.5.0",
+ "decaf377",
  "derivative",
  "futures",
  "hash_hasher",
@@ -2569,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "penumbra-transaction"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2579,7 +2878,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.5.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -2619,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "penumbra-txhash"
 version = "0.68.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.0#1c99e24ad5cf1ecc2855849d66221ecec25f9235"
+source = "git+https://github.com/penumbra-zone/penumbra.git?branch=upgrade-decaf377#fdf0427534171577a0646531ae3c93ebaa42e002"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -2637,7 +2936,7 @@ dependencies = [
  "ark-ff",
  "base64",
  "console_error_panic_hook",
- "decaf377 0.5.0",
+ "decaf377",
  "hex",
  "indexed_db_futures",
  "penumbra-asset",
@@ -2665,6 +2964,12 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -2719,6 +3024,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "poly1305"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,8 +3049,7 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 [[package]]
 name = "poseidon-parameters"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58236ff8bf455c13046c92f041e887c4fd0e64819387a81177d6c70ebeb41711"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-deps#57eba310a5b377ac90fb813bec4d955c6a29e0c1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2749,8 +3059,7 @@ dependencies = [
 [[package]]
 name = "poseidon-paramgen"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69506f91189a68bff6c0e4f8c2beaf6b053430be7743059a0110477e9c28fda"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-deps#57eba310a5b377ac90fb813bec4d955c6a29e0c1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2766,8 +3075,7 @@ dependencies = [
 [[package]]
 name = "poseidon-permutation"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a022268b53cec1e99c4bd8c81be249709e971b78a433d9f5556e31f3cd7730b0"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-deps#57eba310a5b377ac90fb813bec4d955c6a29e0c1"
 dependencies = [
  "ark-ff",
  "ark-r1cs-std",
@@ -2779,8 +3087,7 @@ dependencies = [
 [[package]]
 name = "poseidon377"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11dbcae1c9e4624576dd7631a1f2419a18afeaeef104263d70b6f20256ea5b72"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-deps#57eba310a5b377ac90fb813bec4d955c6a29e0c1"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-377",
@@ -2791,7 +3098,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "decaf377 0.4.0",
+ "decaf377",
  "num-bigint",
  "once_cell",
  "poseidon-parameters",
@@ -2971,6 +3278,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,17 +3314,8 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3008,20 +3326,54 @@ checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rfc6979"
@@ -3041,6 +3393,12 @@ checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hex"
@@ -3067,7 +3425,16 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -3124,6 +3491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3522,29 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3236,6 +3635,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,15 +3711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,6 +3744,16 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "socket2"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "spki"
@@ -3409,6 +3821,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,7 +3862,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3507,16 +3946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "time"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,6 +3974,61 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3621,47 +4105,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
  "tracing-core",
- "tracing-log",
- "tracing-serde",
 ]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3682,10 +4147,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -3701,6 +4181,17 @@ checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3720,10 +4211,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -3845,34 +4351,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4005,6 +4498,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -34,7 +34,7 @@ anyhow                   = "1.0.75"
 ark-ff                   = { version = "0.4.2", features = ["std"] }
 base64                   = "0.21.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
-decaf377                 = { default-features = false, git = "https://github.com/penumbra-zone/decaf377", branch = "visibility" }
+decaf377                 = { default-features = false, git = "https://github.com/penumbra-zone/decaf377", branch = "visibility", features = ["r1cs", "u32_backend"] }
 hex                      = "0.4.3"
 indexed_db_futures       = "0.3.0"
 rand_core                = { version = "0.6.4", features = ["getrandom"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -34,7 +34,7 @@ anyhow                   = "1.0.75"
 ark-ff                   = { version = "0.4.2", features = ["std"] }
 base64                   = "0.21.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
-decaf377                 = { default-features = false, git = "https://github.com/penumbra-zone/decaf377", branch = "visibility", features = ["r1cs", "u32_backend"] }
+decaf377                 = { default-features = false, git = "https://github.com/penumbra-zone/decaf377", branch = "87-missing-methods-temporary", features = ["r1cs", "u32_backend"] }
 hex                      = "0.4.3"
 indexed_db_futures       = "0.3.0"
 rand_core                = { version = "0.6.4", features = ["getrandom"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "penumbra-wasm"
 version = "0.1.0"
@@ -15,27 +14,27 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-fee", default-features = false }
-penumbra-governance    = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-governance", default-features = false }
-penumbra-ibc           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-ibc", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.0", package = "penumbra-transaction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-fee", default-features = false }
+penumbra-governance    = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-governance", default-features = false }
+penumbra-ibc           = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-ibc", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", branch = "upgrade-decaf377", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.75"
 ark-ff                   = { version = "0.4.2", features = ["std"] }
 base64                   = "0.21.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
-decaf377                 = { version = "0.5", features = ["r1cs"] }
+decaf377                 = { default-features = false, git = "https://github.com/penumbra-zone/decaf377", branch = "visibility" }
 hex                      = "0.4.3"
 indexed_db_futures       = "0.3.0"
 rand_core                = { version = "0.6.4", features = ["getrandom"] }

--- a/packages/wasm/src/build.ts
+++ b/packages/wasm/src/build.ts
@@ -39,12 +39,14 @@ export const buildActionParallel = (
   fullViewingKey: string,
   actionId: number,
 ): Action => {
+  performance.mark('buildActionParallel-start');
   const result = build_action(
     txPlan.toJson(),
     txPlan.actions[actionId]?.toJson(),
     fullViewingKey,
     witnessData.toJson(),
   ) as unknown;
+  performance.mark('buildActionParallel-end');
 
   return Action.fromJson(result as JsonValue);
 };

--- a/packages/wasm/src/utils.ts
+++ b/packages/wasm/src/utils.ts
@@ -14,6 +14,7 @@ export const loadProvingKey = async (
   /** The `snake_case`d name of the proving key to load. */
   keyType: string,
 ) => {
+  performance.mark('loadProvingKey-start');
   const keyEntry = provingKeys.find(entry => entry.keyType === keyType);
 
   if (keyEntry) {
@@ -22,4 +23,5 @@ export const loadProvingKey = async (
   } else {
     throw new Error(`Proving key not found for key type: ${keyType}`);
   }
+  performance.mark('loadProvingKey-end');
 };

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
       "outputs": ["bin/**"]
     },
     "compile": {
-      "inputs": ["crate/src/**"],
+      "inputs": ["crate/src/**", "crate/Cargo.*"],
       "outputs": ["wasm/**"]
     },
     "host": {


### PR DESCRIPTION
Swapping our internal cryptography used in the circuits to use our new [decaf377](https://github.com/penumbra-zone/penumbra) backend in the web. There's still a performance disparity with the old decaf377 backend that needs to be investigated. 

This is currently blocked by https://github.com/penumbra-zone/penumbra/pull/3806. 