### PR TITLE
Fix when we reset the delegate form

### DIFF
--- a/apps/webapp/src/state/staking.ts
+++ b/apps/webapp/src/state/staking.ts
@@ -204,10 +204,9 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
     try {
       const transactionPlan = await plan(assembleDelegateRequest(get().staking));
 
-      // Reset form _after_ building the transaction form, since it depends on
+      // Reset form _after_ building the transaction planner request, since it depends on
       // the state.
       set(state => {
-        state.staking.amount = '';
         state.staking.action = undefined;
         state.staking.validatorInfo = undefined;
       });
@@ -232,6 +231,10 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
       } else {
         toast.onFailure(e);
       }
+    } finally {
+      set(state => {
+        state.staking.amount = '';
+      });
     }
   },
   undelegate: async () => {


### PR DESCRIPTION
Per @grod220 's [comment](https://github.com/penumbra-zone/web/pull/651#discussion_r1511036516), I had fixed this for the `undelegate` action, but missed that it was needed for the `delegate` action too. (This points to how duplicated some of this code is; I'm going to attempt to DRY all this up shortly, but this PR fixes this specific issue in the meantime.)