### PR TITLE
Hotfix: only open the form dialog for the selected validator info

### DIFF
--- a/apps/webapp/src/components/staking/account/delegation-value-view/staking-actions/form-dialog.tsx
+++ b/apps/webapp/src/components/staking/account/delegation-value-view/staking-actions/form-dialog.tsx
@@ -26,6 +26,7 @@ export const FormDialog = ({
   amount,
   delegationTokens,
   unstakedTokens,
+  open,
   onChangeAmount,
   onClose,
   onSubmit,
@@ -45,6 +46,10 @@ export const FormDialog = ({
    * Used to show the user how many tokens they have available to delegate.
    */
   unstakedTokens?: ValueView;
+  /**
+   * Whether the form is open.
+   */
+  open: boolean;
   onChangeAmount: (amount: string) => void;
   onClose: () => void;
   onSubmit: () => void;
@@ -59,9 +64,9 @@ export const FormDialog = ({
   };
 
   return (
-    <Dialog open={!!action} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent size='sm'>
-        {!!action && (
+        {!!open && !!action && (
           <>
             <DialogHeader>{getCapitalizedAction(action)}</DialogHeader>
             <form className='flex flex-col gap-4 overflow-hidden px-4 pb-4' onSubmit={handleSubmit}>

--- a/apps/webapp/src/components/staking/account/delegation-value-view/staking-actions/index.tsx
+++ b/apps/webapp/src/components/staking/account/delegation-value-view/staking-actions/index.tsx
@@ -30,8 +30,16 @@ export const StakingActions = ({
    */
   unstakedTokens?: ValueView;
 }) => {
-  const { action, amount, onClickActionButton, delegate, undelegate, onClose, setAmount } =
-    useStore(stakingSelector);
+  const {
+    action,
+    amount,
+    onClickActionButton,
+    delegate,
+    undelegate,
+    onClose,
+    setAmount,
+    validatorInfo: selectedValidatorInfo,
+  } = useStore(stakingSelector);
 
   const validator = getValidator(validatorInfo);
 
@@ -73,6 +81,7 @@ export const StakingActions = ({
 
       <FormDialog
         action={action}
+        open={!!action && validator.equals(getValidator(selectedValidatorInfo))}
         validator={validator}
         amount={amount}
         delegationTokens={delegationTokens}


### PR DESCRIPTION
Previously, _all_ form dialogs were opening when _any_ validator was clicked on, so the incorrect validator info would show up in the dialog. This fixes that by making sure that the validator in state (i.e., the one the user clicked on ) matches the validator for the given `<FormDialog />`.