### PR TITLE
Shorten symbols for delegation/unbonding tokens

### DIFF
--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -1,6 +1,6 @@
 
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe
-IDB_VERSION=24
+IDB_VERSION=25
 USDC_ASSET_ID="reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
 MINIFRONT_URL=https://app.testnet.penumbra.zone/
 PENUMBRA_NODE_PD_URL=https://grpc.testnet.penumbra.zone/

--- a/packages/types/src/customize-symbol.test.ts
+++ b/packages/types/src/customize-symbol.test.ts
@@ -9,7 +9,7 @@ describe('Customizing metadata', () => {
         'delegation_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
     });
 
-    expect(customizeSymbol(metadata).symbol).toBe('Delegated UM (fjuj67ayaqueqxg03d65ps5aa...)');
+    expect(customizeSymbol(metadata).symbol).toBe('delUM(fjuj67ay…)');
   });
 
   test('should work for unbonding token', () => {
@@ -18,9 +18,7 @@ describe('Customizing metadata', () => {
         'uunbonding_epoch_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
     });
 
-    expect(customizeSymbol(metadata).symbol).toBe(
-      'Unbonding UM, epoch 29 (fjuj67ayaqueqxg03d65ps5aa...)',
-    );
+    expect(customizeSymbol(metadata).symbol).toBe('unbondUMe29(fjuj67ay…)');
   });
 
   test('should do nothing if no matches', () => {

--- a/packages/types/src/customize-symbol.ts
+++ b/packages/types/src/customize-symbol.ts
@@ -5,8 +5,7 @@ import {
   UnbondingCaptureGroups,
 } from '@penumbra-zone/constants';
 
-const DELEGATION_SYMBOL_LENGTH = 50 - 'delegation_penumbravalid1'.length;
-const UNBONDING_SYMBOL_LENGTH = 41 - 'unbonding_epoch_'.length;
+const SHORTENED_ID_LENGTH = 8;
 
 // If the metadata is for a delegation or unbonding tokens, customize its symbol.
 // We can't trust the validator's self-described name, so use their validator ID (in metadata.display).
@@ -14,18 +13,18 @@ export const customizeSymbol = (metadata: Metadata) => {
   const delegationMatch = assetPatterns.delegationToken.exec(metadata.display);
   if (delegationMatch) {
     const { id } = delegationMatch.groups as unknown as DelegationCaptureGroups;
-    const shortenedId = id.slice(0, DELEGATION_SYMBOL_LENGTH);
+    const shortenedId = id.slice(0, SHORTENED_ID_LENGTH);
     const customized = metadata.clone();
-    customized.symbol = `Delegated UM (${shortenedId}...)`;
+    customized.symbol = `delUM(${shortenedId}…)`;
     return customized;
   }
 
   const unbondingMatch = assetPatterns.unbondingToken.exec(metadata.display);
   if (unbondingMatch) {
     const { id, epoch } = unbondingMatch.groups as unknown as UnbondingCaptureGroups;
-    const shortenedId = id.slice(0, UNBONDING_SYMBOL_LENGTH);
+    const shortenedId = id.slice(0, SHORTENED_ID_LENGTH);
     const customized = metadata.clone();
-    customized.symbol = `Unbonding UM, epoch ${epoch} (${shortenedId}...)`;
+    customized.symbol = `unbondUMe${epoch}(${shortenedId}…)`;
     return customized;
   }
 


### PR DESCRIPTION
Previous symbols were a bit large and cumbersome in the UI. Per @hdevalence , we're OK to just use the first 8 characters of a validator identity key.

<img width="1203" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/cb6b0fba-9f48-43ba-b40b-3764f834f213">

<img width="502" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/50c4b02d-c42c-4765-a7f8-ef74b44181c2">

Closes #653