### PR TITLE
Store `Epoch`s in IndexedDB and serve from extension

### DIFF
--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -1,6 +1,6 @@
 
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe
-IDB_VERSION=25
+IDB_VERSION=26
 USDC_ASSET_ID="reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
 MINIFRONT_URL=https://app.testnet.penumbra.zone/
 PENUMBRA_NODE_PD_URL=https://grpc.testnet.penumbra.zone/

--- a/apps/extension/src/impls.ts
+++ b/apps/extension/src/impls.ts
@@ -17,6 +17,7 @@ import { TendermintProxyService } from '@buf/penumbra-zone_penumbra.connectrpc_e
 import { CustodyService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/custody/v1/custody_connect';
 import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
 import { custodyImpl } from '@penumbra-zone/router/src/grpc/custody';
+import { sctImpl } from '@penumbra-zone/router/src/grpc/sct';
 import { viewImpl } from '@penumbra-zone/router/src/grpc/view-protocol-server';
 
 import { localExtStorage } from '@penumbra-zone/storage';
@@ -30,7 +31,6 @@ const penumbraProxies = [
   DexService,
   DexSimulationService,
   GovernanceService,
-  SctService,
   ShieldedPoolService,
   StakeService,
   TendermintProxyService,
@@ -49,6 +49,7 @@ export const rpcImpls = [
   // rpc local implementations
   // @ts-expect-error TODO: accept partial impl
   [CustodyService, rethrowImplErrors(CustodyService, custodyImpl)],
+  [SctService, rethrowImplErrors(SctService, sctImpl)],
   [ViewService, rethrowImplErrors(ViewService, viewImpl)],
   // rpc remote proxies
   ...penumbraProxies,

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -236,7 +236,8 @@ export class BlockProcessor implements BlockProcessorInterface {
         await this.saveTransactionInfos(compactBlock.height, relevantTx);
       }
 
-      if (compactBlock.epochRoot) nextEpochStartHeight = compactBlock.height + 1n;
+      const isLastBlockOfEpoch = !!compactBlock.epochRoot;
+      if (isLastBlockOfEpoch) nextEpochStartHeight = compactBlock.height + 1n;
     }
   }
 

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -142,9 +142,8 @@ export class BlockProcessor implements BlockProcessorInterface {
       keepAlive: true,
       abortSignal: this.abortController.signal,
     })) {
-      const isNewEpoch = nextEpochStartHeight === compactBlock.height;
-      if (isNewEpoch) {
-        await this.indexedDb.addEpoch(nextEpochStartHeight!);
+      if (nextEpochStartHeight === compactBlock.height) {
+        await this.indexedDb.addEpoch(nextEpochStartHeight);
         nextEpochStartHeight = undefined;
       }
 

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -133,6 +133,8 @@ export class BlockProcessor implements BlockProcessorInterface {
     const startHeight = fullSyncHeight ? fullSyncHeight + 1n : 0n;
     const latestBlockHeight = await this.querier.tendermint.latestBlockHeight();
 
+    let nextEpochStartHeight: bigint | undefined = startHeight === 0n ? 0n : undefined;
+
     // this is an indefinite stream of the (compact) chain from the network
     // intended to run continuously
     for await (const compactBlock of this.querier.compactBlock.compactBlockRange({
@@ -140,15 +142,17 @@ export class BlockProcessor implements BlockProcessorInterface {
       keepAlive: true,
       abortSignal: this.abortController.signal,
     })) {
-      if (compactBlock.appParametersUpdated) {
+      const isNewEpoch = nextEpochStartHeight === compactBlock.height;
+      if (isNewEpoch) {
+        await this.indexedDb.addEpoch(nextEpochStartHeight!);
+        nextEpochStartHeight = undefined;
+      }
+
+      if (compactBlock.appParametersUpdated)
         await this.indexedDb.saveAppParams(await this.querier.app.appParams());
-      }
-      if (compactBlock.fmdParameters) {
+      if (compactBlock.fmdParameters)
         await this.indexedDb.saveFmdParams(compactBlock.fmdParameters);
-      }
-      if (compactBlock.gasPrices) {
-        await this.indexedDb.saveGasPrices(compactBlock.gasPrices);
-      }
+      if (compactBlock.gasPrices) await this.indexedDb.saveGasPrices(compactBlock.gasPrices);
 
       // wasm view server scan
       // - decrypts new notes
@@ -229,6 +233,8 @@ export class BlockProcessor implements BlockProcessorInterface {
         // - saves to idb
         await this.saveTransactionInfos(compactBlock.height, relevantTx);
       }
+
+      if (compactBlock.epochRoot) nextEpochStartHeight = compactBlock.height + 1n;
     }
   }
 

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -146,12 +146,15 @@ export class BlockProcessor implements BlockProcessorInterface {
         await this.indexedDb.addEpoch(nextEpochStartHeight);
         nextEpochStartHeight = undefined;
       }
-
-      if (compactBlock.appParametersUpdated)
+      if (compactBlock.appParametersUpdated) {
         await this.indexedDb.saveAppParams(await this.querier.app.appParams());
-      if (compactBlock.fmdParameters)
+      }
+      if (compactBlock.fmdParameters) {
         await this.indexedDb.saveFmdParams(compactBlock.fmdParameters);
-      if (compactBlock.gasPrices) await this.indexedDb.saveGasPrices(compactBlock.gasPrices);
+      }
+      if (compactBlock.gasPrices) {
+        await this.indexedDb.saveGasPrices(compactBlock.gasPrices);
+      }
 
       // wasm view server scan
       // - decrypts new notes

--- a/packages/router/src/grpc/sct/epoch-by-height.test.ts
+++ b/packages/router/src/grpc/sct/epoch-by-height.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { epochByHeight } from './epoch-by-height';
+import { IndexedDbMock, MockServices } from '../test-utils';
+import { HandlerContext, createContextValues, createHandlerContext } from '@connectrpc/connect';
+import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
+import { ServicesInterface } from '@penumbra-zone/types';
+import { servicesCtx } from '../../ctx';
+import {
+  Epoch,
+  EpochByHeightRequest,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb';
+
+describe('EpochByHeight request handler', () => {
+  let mockServices: MockServices;
+  let mockIndexedDb: IndexedDbMock;
+  let mockCtx: HandlerContext;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockIndexedDb = {
+      getEpochByHeight: vi.fn(),
+    };
+    mockServices = {
+      getWalletServices: vi.fn(() =>
+        Promise.resolve({ indexedDb: mockIndexedDb }),
+      ) as MockServices['getWalletServices'],
+    };
+    mockCtx = createHandlerContext({
+      service: ViewService,
+      method: ViewService.methods.appParameters,
+      protocolName: 'mock',
+      requestMethod: 'MOCK',
+      url: '/mock',
+      contextValues: createContextValues().set(
+        servicesCtx,
+        mockServices as unknown as ServicesInterface,
+      ),
+    });
+  });
+
+  it('returns an `EpochByHeightResponse` with the result of the database query', async () => {
+    const expected = new Epoch({ startHeight: 0n, index: 0n });
+
+    mockIndexedDb.getEpochByHeight?.mockResolvedValue(expected);
+    const req = new EpochByHeightRequest({ height: 0n });
+
+    const result = await epochByHeight(req, mockCtx);
+
+    expect(result.epoch).toBeInstanceOf(Epoch);
+    expect((result.epoch as Epoch).toJson()).toEqual(expected.toJson());
+  });
+});

--- a/packages/router/src/grpc/sct/epoch-by-height.test.ts
+++ b/packages/router/src/grpc/sct/epoch-by-height.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { epochByHeight } from './epoch-by-height';
 import { IndexedDbMock, MockServices } from '../test-utils';
 import { HandlerContext, createContextValues, createHandlerContext } from '@connectrpc/connect';
-import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
+import { QueryService as SctService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/sct/v1/sct_connect';
 import { ServicesInterface } from '@penumbra-zone/types';
 import { servicesCtx } from '../../ctx';
 import {
@@ -27,8 +27,8 @@ describe('EpochByHeight request handler', () => {
       ) as MockServices['getWalletServices'],
     };
     mockCtx = createHandlerContext({
-      service: ViewService,
-      method: ViewService.methods.appParameters,
+      service: SctService,
+      method: SctService.methods.epochByHeight,
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',

--- a/packages/router/src/grpc/sct/epoch-by-height.ts
+++ b/packages/router/src/grpc/sct/epoch-by-height.ts
@@ -1,0 +1,14 @@
+import { EpochByHeightResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb';
+import { Impl } from '.';
+import { servicesCtx } from '../../ctx';
+
+export const epochByHeight: Impl['epochByHeight'] = async (req, ctx) => {
+  const { height } = req;
+
+  const services = ctx.values.get(servicesCtx);
+  const { indexedDb } = await services.getWalletServices();
+
+  const epoch = await indexedDb.getEpochByHeight(height);
+
+  return new EpochByHeightResponse({ epoch });
+};

--- a/packages/router/src/grpc/sct/index.ts
+++ b/packages/router/src/grpc/sct/index.ts
@@ -1,0 +1,9 @@
+import { QueryService as SctService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/sct/v1/sct_connect';
+import { ServiceImpl } from '@connectrpc/connect';
+import { epochByHeight } from './epoch-by-height';
+
+export type Impl = ServiceImpl<typeof SctService>;
+
+export const sctImpl: Impl = {
+  epochByHeight,
+};

--- a/packages/router/src/grpc/test-utils.ts
+++ b/packages/router/src/grpc/test-utils.ts
@@ -20,6 +20,7 @@ export interface IndexedDbMock {
   iterateTransactionInfo?: () => Partial<AsyncIterable<Mock>>;
   subscribe?: (table: string) => Partial<AsyncIterable<Mock>>;
   getSwapByCommitment?: Mock;
+  getEpochByHeight?: Mock;
 }
 export interface TendermintMock {
   broadcastTx?: Mock;

--- a/packages/storage/src/indexed-db/indexed-db.test-data.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test-data.ts
@@ -10,6 +10,7 @@ import {
   PositionId,
   TradingPair,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
+import { Epoch } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb';
 
 export const emptyScanResult: ScanBlockResult = {
   height: 1092n,
@@ -1462,4 +1463,19 @@ export const positionIdGmGnSell = PositionId.fromJson({
 export const tradingPairGmGn = TradingPair.fromJson({
   asset1: { inner: 'HW2Eq3UZVSBttoUwUi/MUtE7rr2UU7/UH500byp7OAc=' },
   asset2: { inner: 'nwPDkQq3OvLnBwGTD+nmv1Ifb2GEmFCgNHrU++9BsRE=' },
+});
+
+export const epoch1 = new Epoch({
+  index: 0n,
+  startHeight: 0n,
+});
+
+export const epoch2 = new Epoch({
+  index: 1n,
+  startHeight: 100n,
+});
+
+export const epoch3 = new Epoch({
+  index: 2n,
+  startHeight: 200n,
 });

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -527,7 +527,7 @@ describe('IndexedDb', () => {
     });
 
     describe('addEpoch', () => {
-      it('auto-incrememnts the epoch index if one is not provided', async () => {
+      it('auto-increments the epoch index if one is not provided', async () => {
         const [result1, result2, result3] = await Promise.all([
           db.getEpochByHeight(50n),
           db.getEpochByHeight(150n),

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -22,7 +22,10 @@ import {
   FmdParameters,
   Note,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
-import { Nullifier } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb';
+import {
+  Epoch,
+  Nullifier,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb';
 import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
 import { GasPrices } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1/fee_pb';
@@ -83,6 +86,8 @@ export interface IndexedDbInterface {
   ): AsyncGenerator<PositionId, void>;
   addPosition(positionId: PositionId, position: Position): Promise<void>;
   updatePosition(positionId: PositionId, newState: PositionState): Promise<void>;
+  addEpoch(startHeight: bigint, index?: bigint): Promise<void>;
+  getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
 }
 
 export interface PenumbraDb extends DBSchema {
@@ -154,6 +159,12 @@ export interface PenumbraDb extends DBSchema {
     key: string; // base64 PositionRecord['id']['inner'];
     value: PositionRecord;
   };
+  EPOCHS: {
+    // The stringified epoch start height -- NOT the epoch index -- so that
+    // querying epoch by height is more performant.
+    key: string;
+    value: Jsonified<Epoch>;
+  };
 }
 
 // need to store PositionId and Position in the same table
@@ -180,4 +191,5 @@ export const IDB_TABLES: Tables = {
   fmd_parameters: 'FMD_PARAMETERS',
   app_parameters: 'APP_PARAMETERS',
   gas_prices: 'GAS_PRICES',
+  epochs: 'EPOCHS',
 };

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -160,9 +160,7 @@ export interface PenumbraDb extends DBSchema {
     value: PositionRecord;
   };
   EPOCHS: {
-    // The stringified epoch start height -- NOT the epoch index -- so that
-    // querying epoch by height is more performant.
-    key: string;
+    key: number; // auto-increment
     value: Jsonified<Epoch>;
   };
 }


### PR DESCRIPTION
This started as a PR to address #601 (serving validator info from the extension), but I quickly realized I'd need to store epochs in IndexedDB first. So this PR takes care of that.

## In this PR
- Create a new `EPOCHS` table in IndexedDB.
- Since we're storing epochs locally anyway, I also created an `SctService` impl in the extension. (It only has one method, `GetEpochByHeight`.)