### PR TITLE
Create scripts for creating and delegating to validators

### DIFF
--- a/scripts/create-validators.sh
+++ b/scripts/create-validators.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Creates wallets and validators for testing with.
+#
+# Usage:
+# sh scripts/create-validators -n 100 -b /tmp/pcli-validators
+#
+# Options:
+# -n Number of wallets/validators to create. (default: 2)
+# -b The base directory to put the wallets/validators in. Subdirectories named
+#    `validator-N` will be created in this directory, containing config for pcli
+#    and the validator. If a subdirectory by that name already exists, it will
+#    skip that name. (default: /tmp/pcli-validators)
+# -D Delete all subdirectories of the base directory specified in `-b`.
+#    DANGEROUS!  Only use this if you are sure that all subdirectories can be
+#    deleted.
+
+NUMBER=2
+BASE_DIRECTORY="/tmp/pcli-validators"
+
+while getopts "n:b:D" opt; do
+  case $opt in
+    n) NUMBER="$OPTARG"
+    ;;
+    b) BASE_DIRECTORY="$OPTARG"
+    ;;
+    D)
+      echo "-D flag not yet implemented"
+      exit -1
+    ;;
+  esac
+done
+
+
+for ((i=1; i <= NUMBER; i++)); do
+  DIRECTORY="$BASE_DIRECTORY/validator-$i"
+
+  if test -d $DIRECTORY; then
+    echo "$DIRECTORY already exists. Skipping."
+  else
+    mkdir -p $DIRECTORY
+
+    # Initialize a wallet and validator template
+    pcli --home $DIRECTORY init --grpc-url http://localhost:8080 soft-kms generate
+    pcli --home $DIRECTORY validator definition template --file $DIRECTORY/validator.toml
+
+    # Enable the validator, and give it a name/description/website
+    sed -i '' \
+      -e 's/enabled = false/enabled = true/' \
+      -e "s/name = \"\"/name = \"Test validator $i\"/" \
+      -e "s/description = \"\"/description = \"Description for test validator $i\"/" \
+      -e "s/website = \"\"/website = \"https:\/\/test-validator-$i.example.com\"/" \
+      $DIRECTORY/validator.toml
+
+    # Upload the validator definition
+    pcli --home $DIRECTORY validator definition upload --file $DIRECTORY/validator.toml &
+  fi
+done

--- a/scripts/delegate-to-validators.sh
+++ b/scripts/delegate-to-validators.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Delegates to test validators created via ./create-validators.sh.
+#
+# Usage:
+# sh scripts/delegate-to-validators -d 100 -b /tmp/pcli-validators
+#
+# Options:
+# -n Number of validators to delegate to. (default: 2)
+# -b The base directory that the validators were generated in. (default:
+#    /tmp/pcli-validators)
+# -d Amount (in penumbra) to delegate to each validator *from your default pcli
+#    wallet*. If left empty, no delegations will be created.
+# -s Start index of validators to delegate to. Only validators at this index and
+#    higher will receive a delegation, until the number of validators
+#    represented by the `-n` option is reached. (default: 1)
+# -e End index of validators to delegate to. Validators starting at the start
+#    index and up to the end index will receive a delegation, until the number
+#    of validators represented by the `-n` option is reached. (Note: this means
+#    that you may not actually reach the end index, if the distance between the
+#    start and end indexes is greater than the value of the -n flag.) (default:
+#    value of -n flag)
+
+NUMBER=2
+BASE_DIRECTORY="/tmp/pcli-validators"
+DELEGATION_AMOUNT="test"
+START_INDEX=1
+
+while getopts "n:b:d:s:e:" opt; do
+  case $opt in
+    n) NUMBER=$OPTARG
+    ;;
+    b) BASE_DIRECTORY="$OPTARG"
+    ;;
+    d) DELEGATION_AMOUNT="$OPTARG"
+    ;;
+    s) START_INDEX="$OPTARG"
+    ;;
+    e) END_INDEX="$OPTARG"
+    ;;
+  esac
+done
+
+if [ -z "$DELEGATION_AMOUNT" ]; then
+  echo "Please provide a delegation amount via the -d flag."
+  exit -1
+fi
+
+if [ -z "$END_INDEX" ]; then
+  END_INDEX=$(($START_INDEX + $NUMBER - 1))
+fi
+
+for ((i=$START_INDEX; i<=$END_INDEX; i++)); do
+  if  [ $(($i - $START_INDEX)) -gt $NUMBER ]; then continue; fi
+  echo $i;
+
+  DIRECTORY="$BASE_DIRECTORY/validator-$i"
+
+  VALIDATOR_IDENTITY_KEY=$(sed -n -E 's/(.*^identity_key = "([^"]+)"$.*)/\2/p' $DIRECTORY/validator.toml)
+  echo "Delegating $DELEGATION_AMOUNT""penumbra to $VALIDATOR_IDENTITY_KEY"
+  pcli tx delegate --to $VALIDATOR_IDENTITY_KEY $DELEGATION_AMOUNT"penumbra" &
+done


### PR DESCRIPTION
I create these to make it easier for myself to test staking-related functionality on my local devnet, by spinning up hundreds of validators and delegating to them in bulk.

Not sure these should actually exist in the web repo, or anywhere at all other than for my personal use. The delegation script specifically doesn't even work super well. But I didn't want to lose track of these. Thoughts? Should these be in core?