### PR TITLE
Extract common transaction tasks to a planBuildBroadcast helper

### DIFF
--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -5,6 +5,7 @@ import type {
   InternalRequest,
   InternalResponse,
 } from '@penumbra-zone/types/src/internal-msg/shared';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 export const popup = async <M extends PopupMessage>(
   req: PopupRequest<M>,
@@ -58,7 +59,7 @@ const spawnPopup = async (pop: PopupType) => {
   if (!loggedIn) {
     popUrl.hash = PopupPath.LOGIN;
     void spawnExtensionPopup(popUrl.href);
-    throw Error('User must login to extension');
+    throw new ConnectError('User must login to extension', Code.Unauthenticated);
   }
 
   switch (pop) {

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -42,6 +42,7 @@ export interface TxApprovalSlice {
     req: InternalRequest<TxApproval>,
     responder: (m: InternalResponse<TxApproval>) => void,
   ) => Promise<void>;
+  handleCloseWindow: () => void;
 
   setChoice: (choice: UserChoice) => void;
 
@@ -83,6 +84,15 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
 
       state.txApproval.choice = undefined;
     });
+
+    window.onbeforeunload = get().txApproval.handleCloseWindow;
+  },
+
+  handleCloseWindow: () => {
+    set(state => {
+      state.txApproval.choice = UserChoice.Ignored;
+    });
+    get().txApproval.sendResponse();
   },
 
   setChoice: choice => {
@@ -97,6 +107,7 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
       choice,
       transactionView: transactionViewString,
       authorizeRequest: authorizeRequestString,
+      handleCloseWindow,
     } = get().txApproval;
 
     if (!responder) throw new Error('No responder');
@@ -138,6 +149,8 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
         state.txApproval.asPublic = undefined;
         state.txApproval.transactionClassification = undefined;
       });
+
+      if (window.onbeforeunload === handleCloseWindow) window.onbeforeunload = null;
     }
   },
 });

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -8,7 +8,6 @@ import {
   WitnessAndBuildResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { viewClient } from '../clients';
-import { TransactionClassification, uint8ArrayToHex } from '@penumbra-zone/types';
 import { sha256Hash } from '@penumbra-zone/crypto-web';
 import {
   Transaction,
@@ -17,6 +16,8 @@ import {
 import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
 import { PartialMessage } from '@bufbuild/protobuf';
 import { TransactionToast } from '@penumbra-zone/ui';
+import { TransactionClassification } from '@penumbra-zone/types/src/transaction';
+import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
 
 /**
  * Handles the common use case of planning, building, and broadcasting a

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -8,6 +8,7 @@ import {
   WitnessAndBuildResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { viewClient } from '../clients';
+import { TransactionClassification, uint8ArrayToHex } from '@penumbra-zone/types';
 import { sha256Hash } from '@penumbra-zone/crypto-web';
 import {
   Transaction,
@@ -16,7 +17,59 @@ import {
 import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
 import { PartialMessage } from '@bufbuild/protobuf';
 import { ConnectError } from '@connectrpc/connect';
-import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
+import { TransactionToast } from '@penumbra-zone/ui';
+
+/**
+ * Handles the common use case of planning, building, and broadcasting a
+ * transaction, along with the appropriate toasts. Throws if there is an
+ * unhandled error (i.e., any error other than the user denying authorization
+ * for the transaction) so that consuming code can take different actions based
+ * on whether the transaction succeeded or failed.
+ */
+export const planBuildBroadcast = async (
+  transactionClassification: TransactionClassification,
+  req: PartialMessage<TransactionPlannerRequest>,
+  options?: {
+    /**
+     * If set to `true`, the `ViewService#witnessAndBuild` method will be used,
+     * which does not prompt the user to authorize the transaction. If `false`,
+     * the `ViewService#authorizeAndBuild` method will be used, which _does_
+     * prompt the user to authorize the transaction. (This is required in the
+     * case of most transactions.) Default: `false`
+     */
+    skipAuth?: boolean;
+  },
+): Promise<Transaction | undefined> => {
+  const toast = new TransactionToast(transactionClassification);
+  toast.onStart();
+
+  try {
+    const transactionPlan = await plan(req);
+
+    const transaction = await build({ transactionPlan }, !!options?.skipAuth, status =>
+      toast.onBuildStatus(status),
+    );
+
+    const txHash = await getTxHash(transaction);
+    toast.txHash(txHash);
+
+    const { detectionHeight } = await broadcast({ transaction, awaitDetection: true }, status =>
+      toast.onBroadcastStatus(status),
+    );
+    toast.onSuccess(detectionHeight);
+
+    return transaction;
+  } catch (e) {
+    if (userDeniedTransaction(e)) {
+      toast.onDenied();
+    } else {
+      toast.onFailure(e);
+      throw e;
+    }
+  }
+
+  return undefined;
+};
 
 export const plan = async (
   req: PartialMessage<TransactionPlannerRequest>,
@@ -26,35 +79,18 @@ export const plan = async (
   return plan;
 };
 
-export const authWitnessBuild = async (
-  req: PartialMessage<AuthorizeAndBuildRequest>,
-  onStatusUpdate?: (
-    status?: (AuthorizeAndBuildResponse | WitnessAndBuildResponse)['status'],
-  ) => void,
-) => {
-  for await (const { status } of viewClient.authorizeAndBuild(req)) {
-    if (onStatusUpdate) onStatusUpdate(status);
-    switch (status.case) {
-      case undefined:
-      case 'buildProgress':
-        break;
-      case 'complete':
-        return status.value.transaction!;
-      default:
-        console.warn('unknown authorizeAndBuild status', status);
-    }
-  }
-  throw new Error('did not build transaction');
-};
-
-export const witnessBuild = async (
-  req: PartialMessage<WitnessAndBuildRequest>,
+const build = async (
+  req: PartialMessage<AuthorizeAndBuildRequest> | PartialMessage<WitnessAndBuildRequest>,
+  skipAuth: boolean,
   onStatusUpdate: (
     status?: (AuthorizeAndBuildResponse | WitnessAndBuildResponse)['status'],
   ) => void,
 ) => {
-  for await (const { status } of viewClient.witnessAndBuild(req)) {
+  const buildFn = skipAuth ? 'witnessAndBuild' : 'authorizeAndBuild';
+
+  for await (const { status } of viewClient[buildFn](req)) {
     onStatusUpdate(status);
+
     switch (status.case) {
       case undefined:
       case 'buildProgress':
@@ -62,13 +98,13 @@ export const witnessBuild = async (
       case 'complete':
         return status.value.transaction!;
       default:
-        console.warn('unknown witnessAndBuild status', status);
+        console.warn(`unknown ${buildFn} status`, status);
     }
   }
   throw new Error('did not build transaction');
 };
 
-export const broadcast = async (
+const broadcast = async (
   req: PartialMessage<BroadcastTransactionRequest>,
   onStatusUpdate: (status?: BroadcastTransactionResponse['status']) => void,
 ): Promise<{ txHash: string; detectionHeight?: bigint }> => {
@@ -94,9 +130,7 @@ export const broadcast = async (
   throw new Error('did not broadcast transaction');
 };
 
-export const getTxHash = <
-  T extends Required<PartialMessage<TransactionId>> | PartialMessage<Transaction>,
->(
+const getTxHash = <T extends Required<PartialMessage<TransactionId>> | PartialMessage<Transaction>>(
   t: T,
 ): T extends Required<PartialMessage<TransactionId>> ? string : Promise<string> =>
   'inner' in t && t.inner instanceof Uint8Array
@@ -107,7 +141,7 @@ export const getTxHash = <
         uint8ArrayToHex(inner),
       ) as T extends Required<PartialMessage<TransactionId>> ? never : Promise<string>);
 
-export const getTxId = (tx: Transaction | PartialMessage<Transaction>) =>
+const getTxId = (tx: Transaction | PartialMessage<Transaction>) =>
   sha256Hash(tx instanceof Transaction ? tx.toBinary() : new Transaction(tx).toBinary()).then(
     inner => new TransactionId({ inner }),
   );

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -10,7 +10,6 @@ import {
   STAKING_TOKEN_METADATA,
 } from '@penumbra-zone/constants/src/assets';
 import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
-import { TransactionToast } from '@penumbra-zone/ui';
 import { planBuildBroadcast } from '../helpers';
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { BigNumber } from 'bignumber.js';

--- a/apps/minifront/src/state/swap.ts
+++ b/apps/minifront/src/state/swap.ts
@@ -3,14 +3,7 @@ import {
   BalancesResponse,
   TransactionPlannerRequest,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import {
-  authWitnessBuild,
-  broadcast,
-  getTxHash,
-  plan,
-  userDeniedTransaction,
-  witnessBuild,
-} from './helpers';
+import { planBuildBroadcast } from './helpers';
 import {
   Metadata,
   Value,
@@ -19,8 +12,7 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { getAddressByIndex } from '../fetchers/address';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
-import { errorToast, TransactionToast } from '@penumbra-zone/ui';
-import { Transaction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
+import { errorToast } from '@penumbra-zone/ui';
 import { SimulateTradeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { simulateClient } from '../clients';
 import {
@@ -138,9 +130,11 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
       });
 
       try {
-        const swapTx = await issueSwap(get().swap);
+        const swapReq = await assembleSwapRequest(get().swap);
+        const swapTx = await planBuildBroadcast('swap', swapReq);
         const swapCommitment = getSwapCommitmentFromTx(swapTx);
         await issueSwapClaim(swapCommitment);
+
         set(state => {
           state.swap.amount = '';
         });
@@ -185,56 +179,12 @@ const assembleSwapRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => 
   });
 };
 
-export const issueSwap = async (swapSlice: SwapSlice): Promise<Transaction | undefined> => {
-  const swapToast = new TransactionToast('swap');
-  swapToast.onStart();
-
-  try {
-    const swapReq = await assembleSwapRequest(swapSlice);
-    const swapPlan = await plan(swapReq);
-    const swapTx = await authWitnessBuild({ transactionPlan: swapPlan }, status =>
-      swapToast.onBuildStatus(status),
-    );
-    const swapTxHash = await getTxHash(swapTx);
-    swapToast.txHash(swapTxHash);
-    await broadcast({ awaitDetection: true, transaction: swapTx }, status =>
-      swapToast.onBroadcastStatus(status),
-    );
-    swapToast.onSuccess();
-    return swapTx;
-  } catch (e) {
-    if (userDeniedTransaction(e)) {
-      swapToast.onDenied();
-      return undefined;
-    } else {
-      swapToast.onFailure(e);
-      return undefined;
-    }
-  }
-};
-
 // Swap claims don't need authenticationData, so `witnessAndBuild` is used.
 // This way it won't trigger a second, unnecessary approval popup.
 // @see https://protocol.penumbra.zone/main/zswap/swap.html#claiming-swap-outputs
 export const issueSwapClaim = async (swapCommitment: StateCommitment) => {
-  const toast = new TransactionToast('swapClaim');
-  toast.onStart();
-
-  try {
-    const swapClaimReq = new TransactionPlannerRequest({ swapClaims: [{ swapCommitment }] });
-    const transactionPlan = await plan(swapClaimReq);
-    const transaction = await witnessBuild({ transactionPlan }, status =>
-      toast.onBuildStatus(status),
-    );
-    const txHash = await getTxHash(transaction);
-    toast.txHash(txHash);
-    const { detectionHeight } = await broadcast({ transaction, awaitDetection: true }, status =>
-      toast.onBroadcastStatus(status),
-    );
-    toast.onSuccess(detectionHeight);
-  } catch (e) {
-    toast.onFailure(e);
-  }
+  const req = new TransactionPlannerRequest({ swapClaims: [{ swapCommitment }] });
+  await planBuildBroadcast('swapClaim', req, { skipAuth: true });
 };
 
 export const swapSelector = (state: AllSlices) => state.swap;

--- a/packages/router/src/grpc/custody/authorize.ts
+++ b/packages/router/src/grpc/custody/authorize.ts
@@ -44,7 +44,7 @@ export const authorize: Impl['authorize'] = async (req, ctx) => {
   if (!approveReq) throw new ConnectError('Approver not found', Code.Unavailable);
 
   const passwordKey = await sess.get('passwordKey');
-  if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unavailable);
+  if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unauthenticated);
 
   const wallets = await local.get('wallets');
   const {

--- a/packages/ui/lib/toast/transaction-toast.test.tsx
+++ b/packages/ui/lib/toast/transaction-toast.test.tsx
@@ -200,6 +200,23 @@ describe('TransactionToast', () => {
     });
   });
 
+  describe('.onUnauthenticated()', () => {
+    it('updates the toast to show the error', () => {
+      const toast = new TransactionToast('send');
+      toast.onStart();
+      toast.onUnauthenticated();
+
+      expect(mockToastFn.warning).toHaveBeenCalledWith(
+        'Not logged in',
+        expect.objectContaining({
+          duration: 5_000,
+          description: 'Please log into the extension to continue.',
+          id: MOCK_TOAST_ID,
+        }),
+      );
+    });
+  });
+
   describe('.onDenied()', () => {
     it('updates the toast to indicate that the transaction was canceled', () => {
       const toast = new TransactionToast('send');

--- a/packages/ui/lib/toast/transaction-toast.tsx
+++ b/packages/ui/lib/toast/transaction-toast.tsx
@@ -150,8 +150,18 @@ export class TransactionToast {
       .render();
   }
 
+  onUnauthenticated(): void {
+    this.toast
+      .warning()
+      .message('Not logged in')
+      .description('Please log into the extension to continue.')
+      .duration(5_000)
+      .render();
+  }
+
   /**
-   * Updates the toast to show that the user denied the transaction.
+   * Updates the toast to show that the user denied the transaction, or closed
+   * the approval popup without approving.
    */
   onDenied(): void {
     this.toast


### PR DESCRIPTION
`planBuildBroadcast` is back! 😆  

We've refactored our Zustand actions a number of times and we're back to the point where there's a ton of shared code between them. I extracted the bits that are general to pretty much any transaction: managing toasts, planning then building then broadcasting, etc. The rest gets passed in.

I manually tested:
- [x] A send transaction
- [x] A swap + swap claim transaction
- [x] A delegate transaction
- [x] An undelegate transaction
- [x] An undelegate claim transaction

And they all worked :)

Closes #717