### PR TITLE
Fix how we handle various errors from the extension

### DIFF
--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -5,6 +5,7 @@ import type {
 } from '@penumbra-zone/types/src/internal-msg/shared';
 import { PopupMessage, PopupRequest, PopupResponse, PopupType } from './message/popup';
 import { PopupPath } from './routes/popup/paths';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 export const popup = async <M extends PopupMessage>(
   req: PopupRequest<M>,
@@ -58,7 +59,7 @@ const spawnPopup = async (pop: PopupType) => {
   if (!loggedIn) {
     popUrl.hash = PopupPath.LOGIN;
     void spawnExtensionPopup(popUrl.href);
-    throw Error('User must login to extension');
+    throw new ConnectError('User must login to extension', Code.Unauthenticated);
   }
 
   switch (pop) {

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -102,6 +102,7 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
       choice,
       transactionView: transactionViewString,
       authorizeRequest: authorizeRequestString,
+      handleCloseWindow,
     } = get().txApproval;
 
     if (!responder) throw new Error('No responder');
@@ -143,6 +144,8 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
         state.txApproval.asPublic = undefined;
         state.txApproval.transactionClassification = undefined;
       });
+
+      if (window.onbeforeunload === handleCloseWindow) window.onbeforeunload = null;
     }
   },
 });

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -37,6 +37,7 @@ export interface TxApprovalSlice {
     req: InternalRequest<TxApproval>,
     responder: (m: InternalResponse<TxApproval>) => void,
   ) => Promise<void>;
+  handleCloseWindow: () => void;
 
   setChoice: (choice: UserChoice) => void;
 
@@ -78,6 +79,15 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
 
       state.txApproval.choice = undefined;
     });
+
+    window.onbeforeunload = get().txApproval.handleCloseWindow;
+  },
+
+  handleCloseWindow: () => {
+    set(state => {
+      state.txApproval.choice = UserChoice.Ignored;
+    });
+    get().txApproval.sendResponse();
   },
 
   setChoice: choice => {

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -160,7 +160,7 @@ const getTxId = (tx: Transaction | PartialMessage<Transaction>) =>
  * Code.PermissionDenied`.
  */
 export const userDeniedTransaction = (e: unknown): boolean =>
-  e instanceof ConnectError && e.message.includes('[permission_denied]');
+  typeof e === 'string' && e.includes('[permission_denied]');
 
 export const unauthenticated = (e: unknown): boolean =>
   typeof e === 'string' && e.includes('[unauthenticated]');

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -16,7 +16,6 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
 import { PartialMessage } from '@bufbuild/protobuf';
-import { ConnectError } from '@connectrpc/connect';
 import { TransactionToast } from '@penumbra-zone/ui';
 
 /**

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -62,6 +62,8 @@ export const planBuildBroadcast = async (
   } catch (e) {
     if (userDeniedTransaction(e)) {
       toast.onDenied();
+    } else if (unauthenticated(e)) {
+      toast.onUnauthenticated();
     } else {
       toast.onFailure(e);
       throw e;
@@ -159,3 +161,6 @@ const getTxId = (tx: Transaction | PartialMessage<Transaction>) =>
  */
 export const userDeniedTransaction = (e: unknown): boolean =>
   e instanceof ConnectError && e.message.includes('[permission_denied]');
+
+export const unauthenticated = (e: unknown): boolean =>
+  typeof e === 'string' && e.includes('[unauthenticated]');

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -152,12 +152,11 @@ const getTxId = (tx: Transaction | PartialMessage<Transaction>) =>
  * @todo: The error flow between extension <-> webapp needs to be refactored a
  * bit. Right now, if we throw a `ConnectError` with `Code.PermissionDenied` (as
  * we do in the approver), it gets swallowed by ConnectRPC's internals and
- * rethrown via `ConnectError.from()`.  This means that the original code is
- * lost, although the stringified error message still contains
- * `[permission_denied]`. So we'll (somewhat hackily) check the stringified
- * error message for now; but in the future, we need ot get the error flow
- * working properly so that we can actually check `e.code ===
- * Code.PermissionDenied`.
+ * rethrown as a string.  This means that the original code is lost, although
+ * the stringified error message still contains `[permission_denied]`. So we'll
+ * (somewhat hackily) check the stringified error message for now; but in the
+ * future, we need ot get the error flow working properly so that we can
+ * actually check `e.code === Code.PermissionDenied`.
  */
 export const userDeniedTransaction = (e: unknown): boolean =>
   typeof e === 'string' && e.includes('[permission_denied]');

--- a/packages/router/src/grpc/custody/authorize.ts
+++ b/packages/router/src/grpc/custody/authorize.ts
@@ -43,7 +43,7 @@ export const authorize: Impl['authorize'] = async (req, ctx) => {
   if (!approveReq) throw new ConnectError('Approver not found', Code.Unavailable);
 
   const passwordKey = await sess.get('passwordKey');
-  if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unavailable);
+  if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unauthenticated);
 
   const wallets = await local.get('wallets');
   const {

--- a/packages/ui/lib/toast/transaction-toast.test.tsx
+++ b/packages/ui/lib/toast/transaction-toast.test.tsx
@@ -200,6 +200,23 @@ describe('TransactionToast', () => {
     });
   });
 
+  describe('.onUnauthenticated()', () => {
+    it('updates the toast to show the error', () => {
+      const toast = new TransactionToast('send');
+      toast.onStart();
+      toast.onUnauthenticated();
+
+      expect(mockToastFn.warning).toHaveBeenCalledWith(
+        'Not logged in',
+        expect.objectContaining({
+          duration: 5_000,
+          description: 'Please log into the extension to continue.',
+          id: MOCK_TOAST_ID,
+        }),
+      );
+    });
+  });
+
   describe('.onDenied()', () => {
     it('updates the toast to indicate that the transaction was canceled', () => {
       const toast = new TransactionToast('send');

--- a/packages/ui/lib/toast/transaction-toast.tsx
+++ b/packages/ui/lib/toast/transaction-toast.tsx
@@ -150,8 +150,18 @@ export class TransactionToast {
       .render();
   }
 
+  onUnauthenticated(): void {
+    this.toast
+      .warning()
+      .message('Not logged in')
+      .description('Please log into the extension to continue.')
+      .duration(5_000)
+      .render();
+  }
+
   /**
-   * Updates the toast to show that the user denied the transaction.
+   * Updates the toast to show that the user denied the transaction, or closed
+   * the approval popup without approving.
    */
   onDenied(): void {
     this.toast


### PR DESCRIPTION


https://github.com/penumbra-zone/web/assets/1121544/de6001fa-0d69-43bc-9619-f3d3566efe12



There were a number of issues with how we were handling errors coming from the extension. This PR fixes the following:

1. Show a nicer message when the user is not logged into the extension (closes #349).
2. Show a nicer message when the user closes the approval popup without approving or denying (closes #519).
3. Show a nicer message when the user denies authorization (re-fixes #517, which recently had a regression)