### PR TITLE
Show a nicer UI when minifront can't connect to the extension, and for other errors

### DIFF
--- a/apps/minifront/src/components/extension-unavailable.tsx
+++ b/apps/minifront/src/components/extension-unavailable.tsx
@@ -1,6 +1,9 @@
 import { SplashPage } from '@penumbra-zone/ui';
 import { HeadTag } from './metadata/head-tag';
 
+const NODE_STATUS_PAGE_URL =
+  window.location.hostname === 'localhost' ? 'http://localhost:5174' : '/';
+
 export const ExtensionUnavailable = () => {
   return (
     <>
@@ -8,7 +11,12 @@ export const ExtensionUnavailable = () => {
 
       <SplashPage title='Penumbra extension unavailble'>
         {`We can't currently connect to the Penumbra extension. This could be because the RPC node
-        that you're connected to is down. Please try reloading this page; and if that doesn't work,
+        that you're connected to is down. Please check `}
+        <a href={NODE_STATUS_PAGE_URL} className='underline'>
+          the node&apos;s status page
+        </a>
+        ;
+        {` and if that doesn't work,
         please consider using a different RPC node.`}
       </SplashPage>
     </>

--- a/apps/minifront/src/components/extension-unavailable.tsx
+++ b/apps/minifront/src/components/extension-unavailable.tsx
@@ -10,14 +10,19 @@ export const ExtensionUnavailable = () => {
       <HeadTag />
 
       <SplashPage title='Penumbra extension unavailble'>
-        {`We can't currently connect to the Penumbra extension. This could be because the RPC node
-        that you're connected to is down. Please check `}
-        <a href={NODE_STATUS_PAGE_URL} className='underline'>
-          the node&apos;s status page
-        </a>
-        ;
-        {` and if that doesn't work,
-        please consider using a different RPC node.`}
+        <p className='mb-2'>We can&apos;t currently connect to the Penumbra extension.</p>
+        <p className='mb-2'>
+          This page may have been left open for too long, causing a timeout. Please reload this page
+          and see if that fixes the issue.
+        </p>
+        <p>
+          If it doesn&apos;t, the RPC node that you&apos;re connected to could be down. Check{' '}
+          <a href={NODE_STATUS_PAGE_URL} className='underline'>
+            the node&apos;s status page
+          </a>{' '}
+          and, if it is down, consider switching to a different RPC URL in the Penumbra
+          extension&apos;s settings.
+        </p>
       </SplashPage>
     </>
   );

--- a/apps/minifront/src/components/extension-unavailable.tsx
+++ b/apps/minifront/src/components/extension-unavailable.tsx
@@ -1,0 +1,16 @@
+import { SplashPage } from '@penumbra-zone/ui';
+import { HeadTag } from './metadata/head-tag';
+
+export const ExtensionUnavailable = () => {
+  return (
+    <>
+      <HeadTag />
+
+      <SplashPage title='Penumbra extension unavailble'>
+        {`We can't currently connect to the Penumbra extension. This could be because the RPC node
+        that you're connected to is down. Please try reloading this page; and if that doesn't work,
+        please consider using a different RPC node.`}
+      </SplashPage>
+    </>
+  );
+};

--- a/apps/minifront/src/components/not-found.tsx
+++ b/apps/minifront/src/components/not-found.tsx
@@ -1,0 +1,5 @@
+import { SplashPage } from '@penumbra-zone/ui';
+
+export const NotFound = () => {
+  return <SplashPage title='404'>That page could not be found. </SplashPage>;
+};

--- a/apps/minifront/src/components/shared/error-boundary.tsx
+++ b/apps/minifront/src/components/shared/error-boundary.tsx
@@ -4,6 +4,7 @@ import { ExtensionNotConnected } from '../extension-not-connected';
 import { NotFound } from '../not-found';
 import { ExtensionUnavailable } from '../extension-unavailable';
 import { Code, ConnectError } from '@connectrpc/connect';
+import { SplashPage } from '@penumbra-zone/ui';
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
@@ -16,8 +17,8 @@ export const ErrorBoundary = () => {
   console.error('ErrorBoundary caught error:', error);
 
   return (
-    <div className='text-red'>
-      <h1 className='text-xl'>{String(error)}</h1>
-    </div>
+    <SplashPage title='Uh-oh!' description='Looks like there was an error.'>
+      {String(error)}
+    </SplashPage>
   );
 };

--- a/apps/minifront/src/components/shared/error-boundary.tsx
+++ b/apps/minifront/src/components/shared/error-boundary.tsx
@@ -1,13 +1,15 @@
-import { useRouteError } from 'react-router-dom';
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
 import { PraxNotConnectedError } from '@penumbra-zone/client';
 import { ExtensionNotConnected } from '../extension-not-connected';
+import { NotFound } from '../not-found';
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
 
   if (error instanceof PraxNotConnectedError) return <ExtensionNotConnected />;
+  if (isRouteErrorResponse(error) && error.status === 404) return <NotFound />;
 
-  console.error(error);
+  console.error('ErrorBoundary caught error:', error);
 
   return (
     <div className='text-red'>

--- a/apps/minifront/src/components/shared/error-boundary.tsx
+++ b/apps/minifront/src/components/shared/error-boundary.tsx
@@ -2,10 +2,14 @@ import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
 import { PraxNotConnectedError } from '@penumbra-zone/client';
 import { ExtensionNotConnected } from '../extension-not-connected';
 import { NotFound } from '../not-found';
+import { ExtensionUnavailable } from '../extension-unavailable';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
 
+  if (error instanceof ConnectError && error.code === Code.Unavailable)
+    return <ExtensionUnavailable />;
   if (error instanceof PraxNotConnectedError) return <ExtensionNotConnected />;
   if (isRouteErrorResponse(error) && error.status === 404) return <NotFound />;
 

--- a/apps/minifront/src/components/shared/error-boundary.tsx
+++ b/apps/minifront/src/components/shared/error-boundary.tsx
@@ -9,8 +9,9 @@ import { SplashPage } from '@penumbra-zone/ui';
 export const ErrorBoundary = () => {
   const error = useRouteError();
 
-  if (error instanceof ConnectError && error.code === Code.Unavailable)
+  if (error instanceof ConnectError && error.code === Code.Unavailable) {
     return <ExtensionUnavailable />;
+  }
   if (error instanceof PraxNotConnectedError) return <ExtensionNotConnected />;
   if (isRouteErrorResponse(error) && error.status === 404) return <NotFound />;
 

--- a/apps/minifront/src/components/shared/error-boundary.tsx
+++ b/apps/minifront/src/components/shared/error-boundary.tsx
@@ -18,7 +18,7 @@ export const ErrorBoundary = () => {
   console.error('ErrorBoundary caught error:', error);
 
   return (
-    <SplashPage title='Uh-oh!' description='Looks like there was an error.'>
+    <SplashPage title='Error' description='Something went wrong while loading this page.'>
       {String(error)}
     </SplashPage>
   );

--- a/apps/minifront/src/fetchers/chain-id.ts
+++ b/apps/minifront/src/fetchers/chain-id.ts
@@ -1,8 +1,6 @@
 import { viewClient } from '../clients';
 
-export const getChainId = async (): Promise<string> => {
+export const getChainId = async (): Promise<string | undefined> => {
   const { parameters } = await viewClient.appParameters({});
-  if (!parameters?.chainId) throw new Error('No chainId in response');
-
-  return parameters.chainId;
+  return parameters?.chainId;
 };

--- a/apps/node-status/src/components/error-boundary.tsx
+++ b/apps/node-status/src/components/error-boundary.tsx
@@ -7,7 +7,7 @@ export const ErrorBoundary = () => {
   console.error('ErrorBoundary caught error:', error);
 
   return (
-    <SplashPage title='Uh-oh!' description='Looks like there was an error.'>
+    <SplashPage title='Error' description='Something went wrong while loading this page.'>
       {String(error)}
     </SplashPage>
   );

--- a/apps/node-status/src/components/error-boundary.tsx
+++ b/apps/node-status/src/components/error-boundary.tsx
@@ -1,13 +1,14 @@
+import { SplashPage } from '@penumbra-zone/ui';
 import { useRouteError } from 'react-router-dom';
 
 export const ErrorBoundary = () => {
   const error = useRouteError();
 
-  console.error(error);
+  console.error('ErrorBoundary caught error:', error);
 
   return (
-    <div className='text-red'>
-      <h1 className='text-xl'>{String(error)}</h1>
-    </div>
+    <SplashPage title='Uh-oh!' description='Looks like there was an error.'>
+      {String(error)}
+    </SplashPage>
   );
 };


### PR DESCRIPTION
Previously, when the RPC node was unavailable, the `<ErrorBoundary />` component would catch the error, stringify it, and render it to the screen.

Now, we detect whether the given error is specific to the RPC being unavailable, and we show a message for that case.

## Before
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/a5ec06b0-f876-40ae-9fb0-b76103e66b02">


## After
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/5d732993-54aa-472b-85df-42e82b13d4a5">

I also prettified the `<ErrorBoundary />` in both the minifront and node-status apps to show other types of errors inside a `<SplashPage />` — e.g.:

<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/373ece88-ca72-4347-93d2-eddf891f9b35">

And lastly, I created a 404 page:
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/ddb277cf-4e36-484f-b2a6-d03aca3edc63">


Closes #571 
Closes #339