### PR TITLE
better type in rethrow wrapper

### DIFF
--- a/packages/types/src/base64.test.ts
+++ b/packages/types/src/base64.test.ts
@@ -6,7 +6,7 @@ import {
   InnerBase64Schema,
   uint8ArrayToBase64,
 } from './base64';
-import { SafeParseError } from 'zod/lib/types';
+import type { SafeParseError } from 'zod';
 
 describe('Base64StringSchema', () => {
   it('validates base64 strings', () => {


### PR DESCRIPTION
instead of weirdly reaching into the cjs build of connectrpc we can just declare an equivalent type.

this change has zero behavioral effect but helps with packaging