### PR TITLE
Update login redirect logic

### DIFF
--- a/apps/extension/src/popup.ts
+++ b/apps/extension/src/popup.ts
@@ -1,11 +1,9 @@
-import { sessionExtStorage } from '@penumbra-zone/storage';
 import { PopupMessage, PopupRequest, PopupResponse, PopupType } from './message/popup';
 import { PopupPath } from './routes/popup/paths';
 import type {
   InternalRequest,
   InternalResponse,
 } from '@penumbra-zone/types/src/internal-msg/shared';
-import { Code, ConnectError } from '@connectrpc/connect';
 import { isChromeResponderDroppedError } from '@penumbra-zone/types/src/internal-msg/chrome-error';
 
 export const popup = async <M extends PopupMessage>(
@@ -22,16 +20,6 @@ export const popup = async <M extends PopupMessage>(
       };
     else throw e;
   });
-};
-
-const spawnExtensionPopup = async (path: string) => {
-  try {
-    await throwIfAlreadyOpen(path);
-    await chrome.action.setPopup({ popup: path });
-    await chrome.action.openPopup({});
-  } finally {
-    void chrome.action.setPopup({ popup: 'popup.html' });
-  }
 };
 
 const spawnDetachedPopup = async (path: string) => {
@@ -64,13 +52,13 @@ const throwIfAlreadyOpen = (path: string) =>
 const spawnPopup = async (pop: PopupType) => {
   const popUrl = new URL(chrome.runtime.getURL('popup.html'));
 
-  const loggedIn = Boolean(await sessionExtStorage.get('passwordKey'));
-
-  if (!loggedIn) {
-    popUrl.hash = PopupPath.LOGIN;
-    void spawnExtensionPopup(popUrl.href);
-    throw new ConnectError('User must login to extension', Code.Unauthenticated);
-  }
+  // const loggedIn = Boolean(await sessionExtStorage.get('passwordKey'));
+  //
+  // if (!loggedIn) {
+  //   popUrl.hash = PopupPath.LOGIN;
+  //   void spawnExtensionPopup(popUrl.href);
+  //   throw new ConnectError('User must login to extension', Code.Unauthenticated);
+  // }
 
   switch (pop) {
     case PopupType.OriginApproval:

--- a/apps/extension/src/routes/popup/approval/origin.tsx
+++ b/apps/extension/src/routes/popup/approval/origin.tsx
@@ -7,6 +7,12 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { DisplayOriginURL } from '../../../shared/components/display-origin-url';
 import { cn } from '@penumbra-zone/ui/lib/utils';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
+import { needsLogin } from '../popup-needs';
+import { PopupPath } from '../paths';
+
+export const originApprovalLoader = async (): Promise<Response | null> => {
+  return await needsLogin(PopupPath.ORIGIN_APPROVAL);
+};
 
 export const OriginApproval = () => {
   const { requestOrigin, favIconUrl, title, lastRequest, setChoice, sendResponse } =

--- a/apps/extension/src/routes/popup/approval/transaction/index.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction/index.tsx
@@ -8,6 +8,12 @@ import { ViewTabs } from './view-tabs';
 import { ApproveDeny } from '../approve-deny';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
 import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
+import { needsLogin } from '../../popup-needs';
+import { PopupPath } from '../../paths';
+
+export const transactionApprovalLoader = async (): Promise<Response | null> => {
+  return await needsLogin(PopupPath.TRANSACTION_APPROVAL);
+};
 
 export const TransactionApproval = () => {
   const { authorizeRequest: authReqString, setChoice, sendResponse } = useStore(txApprovalSelector);

--- a/apps/extension/src/routes/popup/home/index.tsx
+++ b/apps/extension/src/routes/popup/home/index.tsx
@@ -5,6 +5,7 @@ import { BlockSync } from './block-sync';
 import { localExtStorage } from '@penumbra-zone/storage';
 import { addrByIndexSelector } from '../../../state/wallets';
 import { needsLogin } from '../popup-needs';
+import { PopupPath } from '../paths';
 
 export interface PopupLoaderData {
   fullSyncHeight: number;
@@ -13,8 +14,16 @@ export interface PopupLoaderData {
 // Because Zustand initializes default empty (prior to persisted storage synced),
 // We need to manually check storage for accounts & password in the loader.
 // Will redirect to onboarding or password check if necessary.
-export const popupIndexLoader = async (): Promise<Response | PopupLoaderData> =>
-  (await needsLogin()) ?? { fullSyncHeight: await localExtStorage.get('fullSyncHeight') };
+export const popupIndexLoader = async (): Promise<Response | PopupLoaderData> => {
+  // Redirect if logged out
+  const loggedOut = await needsLogin(PopupPath.INDEX);
+  if (loggedOut) return loggedOut;
+
+  // If logged in, query for page data
+  return {
+    fullSyncHeight: await localExtStorage.get('fullSyncHeight'),
+  };
+};
 
 export const PopupIndex = () => {
   const getAddrByIndex = useStore(addrByIndexSelector);

--- a/apps/extension/src/routes/popup/login.tsx
+++ b/apps/extension/src/routes/popup/login.tsx
@@ -7,11 +7,19 @@ import { passwordSelector } from '../../state/password';
 import { FormEvent, useState } from 'react';
 import { PopupPath } from './paths';
 import { needsOnboard } from './popup-needs';
+import { useSearchParams } from 'react-router-dom';
+
+export const REDIRECT_PARAM_KEY = 'redirect';
 
 export const popupLoginLoader = () => needsOnboard();
 
 export const Login = () => {
   const navigate = usePopupNav();
+  const [params] = useSearchParams();
+
+  // Optional query param informing the path navigated to after login
+  // If none, go to popup index
+  const redirectPath = (params.get(REDIRECT_PARAM_KEY) as PopupPath | undefined) ?? PopupPath.INDEX;
 
   const { isPassword, setSessionPassword } = useStore(passwordSelector);
   const [input, setInputValue] = useState('');
@@ -23,7 +31,7 @@ export const Login = () => {
     void (async function () {
       if (await isPassword(input)) {
         await setSessionPassword(input); // saves to session state
-        navigate(PopupPath.INDEX);
+        navigate(redirectPath);
       } else {
         setEnteredIncorrect(true);
       }

--- a/apps/extension/src/routes/popup/popup-needs.ts
+++ b/apps/extension/src/routes/popup/popup-needs.ts
@@ -1,12 +1,13 @@
 import { redirect } from 'react-router-dom';
-import { PopupPath } from './paths';
 import { localExtStorage, sessionExtStorage } from '@penumbra-zone/storage';
+import { PopupPath } from './paths';
+import { REDIRECT_PARAM_KEY } from './login';
 
-export const needsLogin = async (): Promise<Response | null> => {
+export const needsLogin = async (path: PopupPath): Promise<Response | null> => {
   const password = await sessionExtStorage.get('passwordKey');
   if (password) return null;
 
-  return redirect(PopupPath.LOGIN);
+  return redirect(`${PopupPath.LOGIN}?${REDIRECT_PARAM_KEY}=${path}`);
 };
 
 export const needsOnboard = async () => {

--- a/apps/extension/src/routes/popup/router.tsx
+++ b/apps/extension/src/routes/popup/router.tsx
@@ -5,8 +5,8 @@ import { PopupPath } from './paths';
 import { PopupLayout } from './popup-layout';
 import { Settings } from './settings';
 import { settingsRoutes } from './settings/routes';
-import { TransactionApproval } from './approval/transaction';
-import { OriginApproval } from './approval/origin';
+import { TransactionApproval, transactionApprovalLoader } from './approval/transaction';
+import { OriginApproval, originApprovalLoader } from './approval/origin';
 
 export const popupRoutes: RouteObject[] = [
   {
@@ -30,10 +30,12 @@ export const popupRoutes: RouteObject[] = [
       {
         path: PopupPath.TRANSACTION_APPROVAL,
         element: <TransactionApproval />,
+        loader: transactionApprovalLoader,
       },
       {
         path: PopupPath.ORIGIN_APPROVAL,
         element: <OriginApproval />,
+        loader: originApprovalLoader,
       },
     ],
   },


### PR DESCRIPTION
`chrome.action.openPopup` does not appear to be a function on my machine (latest version of chrome). This prevents the connection popup from triggering if logged out.

Some ideas here on how to handle login re-directs. Works for connection approvals but for transaction approvals, seems to kill the popup redirect for some reason (frontend just gets an error). Need to debug.