### PR TITLE
Fix zustand race condition

### DIFF
--- a/apps/extension/src/routes/popup/home/index.tsx
+++ b/apps/extension/src/routes/popup/home/index.tsx
@@ -3,7 +3,7 @@ import { IndexHeader } from './index-header';
 import { useStore } from '../../../state';
 import { BlockSync } from './block-sync';
 import { localExtStorage } from '@penumbra-zone/storage';
-import { addrByIndexSelector } from '../../../state/wallets';
+import { addrByIndexSelector, getActiveWallet } from '../../../state/wallets';
 import { needsLogin } from '../popup-needs';
 
 export interface PopupLoaderData {
@@ -17,13 +17,14 @@ export const popupIndexLoader = async (): Promise<Response | PopupLoaderData> =>
   (await needsLogin()) ?? { fullSyncHeight: await localExtStorage.get('fullSyncHeight') };
 
 export const PopupIndex = () => {
+  const activeWallet = useStore(getActiveWallet);
   const getAddrByIndex = useStore(addrByIndexSelector);
 
   return (
     <div className='flex h-full grow flex-col items-stretch justify-start bg-logo bg-left-bottom px-[30px]'>
       <IndexHeader />
       <div className='my-32'>
-        <SelectAccount getAddrByIndex={getAddrByIndex} />
+        {activeWallet && <SelectAccount getAddrByIndex={getAddrByIndex} />}
       </div>
       <BlockSync />
     </div>

--- a/packages/ui/components/ui/block-sync-status/large.tsx
+++ b/packages/ui/components/ui/block-sync-status/large.tsx
@@ -104,7 +104,7 @@ const FullySyncedState = ({ latestKnownBlockHeight, fullSyncHeight }: SyncingSta
             width='50'
             color='var(--teal)'
             wrapperClass={cn(
-              'transition-all duration-300 absolute bottom-0 right-3',
+              'transition-all duration-300 absolute bottom-0 -left-7',
               showLoader ? 'opacity-100' : 'opacity-0',
             )}
           />


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/747

Checks first if a wallet is available before rendering UI. At the moment, zustand data loading from storage is sometimes slower than react rendering.