### PR TITLE
Animate validators as they render

### DIFF
--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -12,11 +12,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@penumbra-zone/bech32": "workspace:*",
     "@penumbra-zone/client": "workspace:*",
     "@penumbra-zone/constants": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
-    "@penumbra-zone/bech32": "workspace:*",
     "@penumbra-zone/perspective": "workspace:*",
     "@penumbra-zone/transport-dom": "workspace:*",
     "@penumbra-zone/types": "workspace:*",
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.26.3",
     "bignumber.js": "^9.1.2",
     "date-fns": "^3.4.0",
+    "framer-motion": "^11.0.14",
     "immer": "^10.0.4",
     "lodash": "^4.17.21",
     "react": "^18.2.0",

--- a/apps/minifront/src/components/staking/account/delegations.tsx
+++ b/apps/minifront/src/components/staking/account/delegations.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion } from 'framer-motion';
 import { AllSlices } from '../../../state';
 import { DelegationValueView } from './delegation-value-view';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
@@ -23,17 +24,24 @@ export const Delegations = () => {
 
   return (
     <div className='mt-8 flex flex-col gap-8'>
-      {delegations.map(delegation => (
-        <DelegationValueView
-          key={bech32IdentityKey(getIdentityKeyFromValueView(delegation))}
-          valueView={delegation}
-          unstakedTokens={unstakedTokens}
-          votingPowerAsIntegerPercentage={getVotingPowerAsIntegerPercentage(
-            votingPowerByValidatorInfo,
-            delegation,
-          )}
-        />
-      ))}
+      <AnimatePresence>
+        {delegations.map(delegation => (
+          <motion.div
+            key={bech32IdentityKey(getIdentityKeyFromValueView(delegation))}
+            layout
+            className='bg-charcoal'
+          >
+            <DelegationValueView
+              valueView={delegation}
+              unstakedTokens={unstakedTokens}
+              votingPowerAsIntegerPercentage={getVotingPowerAsIntegerPercentage(
+                votingPowerByValidatorInfo,
+                delegation,
+              )}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
       date-fns:
         specifier: ^3.4.0
         version: 3.4.0
+      framer-motion:
+        specifier: ^11.0.14
+        version: 11.0.14(react-dom@18.2.0)(react@18.2.0)
       immer:
         specifier: ^10.0.4
         version: 10.0.4
@@ -10232,6 +10235,25 @@ packages:
 
   /framer-motion@11.0.13(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-zDjUj7dBiB6WklCvklKH06mwbYO0hzWrq5Rdz/DgeBFsCVQRmb9Zv7I9dPM7lX5c8eMxxba5D6sEVIv1kj/Ttg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    dev: false
+
+  /framer-motion@11.0.14(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-RFjo2hB1MTW0EWsHQaXgVn0AEUDGxAs0ZL2vVjTTJJu3N7wFiLkmqTn5ysLjL+qKZ9jvfpKXDb9waN9AyLqk8g==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0


### PR DESCRIPTION
Well, that was easy.


https://github.com/penumbra-zone/web/assets/1121544/fb21c0b5-5edc-4192-9f99-7736c669a845


(Note that I had to install `framer-motion` inside `minifront`. This shouldn't actually add to the bundle size, though, since it's also installed in `packages/ui`, which is used by `minifront`. That said, we could probably save a bit of bundle size by not using framer-motion at all and rolling our own animations, or using the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API).)