### PR TITLE
Validate zod only in dev

### DIFF
--- a/packages/types/src/validation.test.ts
+++ b/packages/types/src/validation.test.ts
@@ -1,18 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { isType, validateSchema } from './validation';
 
 describe('validation', () => {
   describe('validateSchema()', () => {
-    let mockLogger: Mock;
-
-    beforeEach(() => {
-      mockLogger = vi.fn();
-      vi.stubGlobal('console', {
-        error: mockLogger,
-      });
-    });
-
     afterEach(() => {
       vi.unstubAllEnvs();
       vi.unstubAllGlobals();
@@ -49,7 +40,6 @@ describe('validation', () => {
       expect(() => {
         validateSchema(z.string(), 123);
       }).not.toThrow();
-      expect(mockLogger).toHaveBeenCalledOnce();
     });
 
     it('Does not throw in chrome ext prod', () => {
@@ -69,7 +59,6 @@ describe('validation', () => {
       expect(() => {
         validateSchema(z.string(), 123);
       }).not.toThrow();
-      expect(mockLogger).toHaveBeenCalledOnce();
     });
 
     it('Does not throw in browser env', () => {
@@ -82,7 +71,6 @@ describe('validation', () => {
       expect(() => {
         validateSchema(z.string(), 123);
       }).not.toThrow();
-      expect(mockLogger).toHaveBeenCalledOnce();
     });
 
     it('Does not throw in unknown env', () => {
@@ -95,7 +83,6 @@ describe('validation', () => {
       expect(() => {
         validateSchema(z.string(), 123);
       }).not.toThrow();
-      expect(mockLogger).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -1,21 +1,13 @@
 import { z, ZodTypeAny } from 'zod';
 import { isDevEnv } from './environment';
 
-// In production, we do not want to throw validation errors, but log them.
-// Given the extension update cycle, we want to opt for grace degradation.
-// In our CI/CD, we'll throw validation errors so they can be fixed at build time.
+// Given performance critical nature of some features (like syncing),
+// we only validate in dev mode in attempts to catch any schema variance
 export const validateSchema = <T>(schema: z.ZodSchema<T>, data: unknown): T => {
-  const result = schema.safeParse(data);
-
-  if (result.success) {
-    return result.data;
+  if (isDevEnv()) {
+    return schema.parse(data);
   } else {
-    if (isDevEnv()) {
-      throw result.error;
-    } else {
-      console.error(result.error);
-      return data as T;
-    }
+    return data as T;
   }
 };
 


### PR DESCRIPTION
Given we do this on each block save and block sync is performance critical, we should only validate in dev mode. I don't notice a difference (at least on my machine), but still best to do. 

See discord for context: https://discord.com/channels/824484045370818580/1044457038886998137/1220036483612807298