### PR TITLE
generate tx view in slice

### DIFF
--- a/apps/extension/src/approve-transaction.ts
+++ b/apps/extension/src/approve-transaction.ts
@@ -1,4 +1,3 @@
-import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1/custody_pb';
 import { PartialMessage } from '@bufbuild/protobuf';
 import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
@@ -7,10 +6,8 @@ import { popup } from './popup';
 
 export const approveTransaction = async (
   partialAuthorizeRequest: PartialMessage<AuthorizeRequest>,
-  partialTransactionView: PartialMessage<TransactionView>,
 ) => {
   const authorizeRequest = new AuthorizeRequest(partialAuthorizeRequest);
-  const transactionView = new TransactionView(partialTransactionView);
 
   const popupResponse = await popup<TxApproval>({
     type: PopupType.TxApproval,
@@ -18,18 +15,13 @@ export const approveTransaction = async (
       authorizeRequest: new AuthorizeRequest(
         authorizeRequest,
       ).toJson() as Jsonified<AuthorizeRequest>,
-      transactionView: new TransactionView(transactionView).toJson() as Jsonified<TransactionView>,
     },
   });
 
   if (popupResponse) {
     const resAuthorizeRequest = AuthorizeRequest.fromJson(popupResponse.authorizeRequest);
-    const resTransactionView = TransactionView.fromJson(popupResponse.transactionView);
 
-    if (
-      !authorizeRequest.equals(resAuthorizeRequest) ||
-      !transactionView.equals(resTransactionView)
-    )
+    if (!authorizeRequest.equals(resAuthorizeRequest))
       throw new Error('Invalid response from popup');
   }
 

--- a/apps/extension/src/message/popup.ts
+++ b/apps/extension/src/message/popup.ts
@@ -1,4 +1,3 @@
-import type { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import type { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1/custody_pb';
 import type {
   InternalMessage,
@@ -28,11 +27,9 @@ export type TxApproval = InternalMessage<
   PopupType.TxApproval,
   {
     authorizeRequest: Jsonified<AuthorizeRequest>;
-    transactionView: Jsonified<TransactionView>;
   },
   null | {
     authorizeRequest: Jsonified<AuthorizeRequest>;
-    transactionView: Jsonified<TransactionView>;
     choice: UserChoice;
   }
 >;

--- a/packages/perspective/plan/view-action-plan.test.ts
+++ b/packages/perspective/plan/view-action-plan.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { viewActionPlan } from './view-action-plan';
 import {
   ActionPlan,
@@ -13,31 +13,25 @@ import {
 import {
   AssetId,
   Metadata,
-  ValueView_KnownAssetId,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import {
-  BatchSwapOutputData,
   SwapPlaintext,
+  BatchSwapOutputData,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
-import { JsonObject } from '@bufbuild/protobuf';
 import {
   Delegate,
   Undelegate,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
-import { bech32AssetId, bech32ToAddress } from '@penumbra-zone/bech32';
-import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
+import { bech32ToAddress } from '@penumbra-zone/bech32';
 
 describe('viewActionPlan()', () => {
   const addressAsBech32 =
     'penumbra147mfall0zr6am5r45qkwht7xqqrdsp50czde7empv7yq2nk3z8yyfh9k9520ddgswkmzar22vhz9dwtuem7uxw0qytfpv7lk3q9dp8ccaw2fn5c838rfackazmgf3ahh09cxmz';
   const address = new Address({ inner: bech32ToAddress(addressAsBech32) });
   const assetId = new AssetId({ inner: new Uint8Array() });
-  const assetIdAsString = bech32AssetId(assetId);
   const metadata = new Metadata({ penumbraAssetId: assetId });
-  const metadataByAssetId = {
-    [assetIdAsString]: metadata.toJson() as Jsonified<Metadata>,
-  };
+  const metadataByAssetId = vi.fn(() => Promise.resolve(metadata));
   const mockFvk =
     'penumbrafullviewingkey1vzfytwlvq067g2kz095vn7sgcft47hga40atrg5zu2crskm6tyyjysm28qg5nth2fqmdf5n0q530jreumjlsrcxjwtfv6zdmfpe5kqsa5lg09';
 
@@ -57,7 +51,7 @@ describe('viewActionPlan()', () => {
       },
     });
 
-    test('throws if the address is missing', () => {
+    test('throws if the address is missing', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'spend',
@@ -67,11 +61,13 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(() => viewActionPlan({}, mockFvk)(actionPlan)).toThrow('No address in spend plan');
+      await expect(viewActionPlan(metadataByAssetId, mockFvk)(actionPlan)).rejects.toThrow(
+        'No address in spend plan',
+      );
     });
 
-    test('includes the amount', () => {
-      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(validSpendActionPlan);
+    test('includes the amount', async () => {
+      const actionView = await viewActionPlan(metadataByAssetId, mockFvk)(validSpendActionPlan);
       const spendView = actionView.actionView.value as SpendView;
       const spendViewVisible = spendView.spendView.value as SpendView_Visible;
 
@@ -81,7 +77,7 @@ describe('viewActionPlan()', () => {
       });
     });
 
-    test('throws if the amount is missing', () => {
+    test('throws if the amount is missing', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'spend',
@@ -93,19 +89,20 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(() => viewActionPlan({}, mockFvk)(actionPlan)).toThrow('No value in note');
+      await expect(viewActionPlan(metadataByAssetId, mockFvk)(actionPlan)).rejects.toThrow(
+        'No value in note',
+      );
     });
 
-    test('includes the denom metadata', () => {
-      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(validSpendActionPlan);
-      const spendView = actionView.actionView.value as SpendView;
-      const spendViewVisible = spendView.spendView.value as SpendView_Visible;
-      const valueView = spendViewVisible.note!.value?.valueView.value as ValueView_KnownAssetId;
+    test('includes the denom metadata', () =>
+      expect(
+        viewActionPlan(metadataByAssetId, mockFvk)(validSpendActionPlan),
+      ).resolves.toHaveProperty(
+        'actionView.value.spendView.value.note.value.valueView.value.metadata',
+        metadata,
+      ));
 
-      expect(valueView.metadata?.toJson()).toEqual(metadata.toJson());
-    });
-
-    test('throws if the asset ID is missing', () => {
+    test('throws if the asset ID is missing', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'spend',
@@ -118,7 +115,9 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(() => viewActionPlan({}, mockFvk)(actionPlan)).toThrow('No asset ID in value');
+      await expect(viewActionPlan(metadataByAssetId, mockFvk)(actionPlan)).rejects.toThrow(
+        'No asset ID in value',
+      );
     });
   });
 
@@ -139,15 +138,15 @@ describe('viewActionPlan()', () => {
       },
     });
 
-    test('includes the destAddress', () => {
-      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(validOutputActionPlan);
+    test('includes the destAddress', async () => {
+      const actionView = await viewActionPlan(metadataByAssetId, mockFvk)(validOutputActionPlan);
       const outputView = actionView.actionView.value as OutputView;
       const outputViewVisible = outputView.outputView.value as OutputView_Visible;
 
       expect(outputViewVisible.note?.address?.addressView.value?.address).toEqual(destAddress);
     });
 
-    test('throws if the destAddress is missing', () => {
+    test('throws if the destAddress is missing', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'output',
@@ -160,13 +159,13 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(() => viewActionPlan({}, mockFvk)(actionPlan)).toThrow(
+      await expect(viewActionPlan(metadataByAssetId, mockFvk)(actionPlan)).rejects.toThrow(
         'No destAddress in output plan',
       );
     });
 
-    test('includes the amount', () => {
-      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(validOutputActionPlan);
+    test('includes the amount', async () => {
+      const actionView = await viewActionPlan(metadataByAssetId, mockFvk)(validOutputActionPlan);
       const outputView = actionView.actionView.value as OutputView;
       const outputViewVisible = outputView.outputView.value as OutputView_Visible;
 
@@ -176,7 +175,7 @@ describe('viewActionPlan()', () => {
       });
     });
 
-    test('throws if the amount is missing', () => {
+    test('throws if the amount is missing', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'output',
@@ -186,19 +185,20 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(() => viewActionPlan({}, mockFvk)(actionPlan)).toThrow('No value to view');
+      await expect(viewActionPlan(metadataByAssetId, mockFvk)(actionPlan)).rejects.toThrow(
+        'No value to view',
+      );
     });
 
-    test('includes the denom metadata', () => {
-      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(validOutputActionPlan);
-      const outputView = actionView.actionView.value as OutputView;
-      const outputViewVisible = outputView.outputView.value as OutputView_Visible;
-      const valueView = outputViewVisible.note!.value?.valueView.value as ValueView_KnownAssetId;
+    test('includes the denom metadata', () =>
+      expect(
+        viewActionPlan(metadataByAssetId, mockFvk)(validOutputActionPlan),
+      ).resolves.toHaveProperty(
+        'actionView.value.outputView.value.note.value.valueView.value.metadata',
+        metadata,
+      ));
 
-      expect(valueView.metadata?.toJson()).toEqual(metadata.toJson());
-    });
-
-    test('throws if the asset ID is missing', () => {
+    test('throws if the asset ID is missing', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'output',
@@ -211,12 +211,14 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(() => viewActionPlan({}, mockFvk)(actionPlan)).toThrow('No asset ID in value');
+      await expect(viewActionPlan(metadataByAssetId, mockFvk)(actionPlan)).rejects.toThrow(
+        'No asset ID in value',
+      );
     });
   });
 
   describe('`swap` action', () => {
-    test('returns an action view with the `swap` case', () => {
+    test('returns an action view with the `swap` case', async () => {
       const swapPlaintext = new SwapPlaintext({
         claimAddress: {
           inner: new Uint8Array([0, 1, 2, 3]),
@@ -261,7 +263,7 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      const actionView = viewActionPlan({}, mockFvk)(actionPlan);
+      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
 
       const expected = new ActionView({
         actionView: {
@@ -284,20 +286,17 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      expect(actionView.equals(expected)).toBe(true);
+      await expect(actionView).resolves.toEqual(expected);
     });
   });
 
   describe('`swapClaim` action', () => {
-    test('returns an action view with the `swapClaim` case', () => {
+    test('returns an action view with the `swapClaim` case', async () => {
       const asset1Id = new AssetId({ inner: new Uint8Array([0, 1, 2, 3]) });
       const asset2Id = new AssetId({ inner: new Uint8Array([4, 5, 6, 7]) });
-      const asset1IdAsString = bech32AssetId(asset1Id);
-      const asset2IdAsString = bech32AssetId(asset2Id);
-      const metadataByAssetId = {
-        [asset1IdAsString]: new Metadata({ penumbraAssetId: asset1Id }).toJson() as JsonObject,
-        [asset2IdAsString]: new Metadata({ penumbraAssetId: asset2Id }).toJson() as JsonObject,
-      };
+      const metadataByAssetId = vi.fn((id: AssetId) =>
+        Promise.resolve(new Metadata({ penumbraAssetId: id })),
+      );
 
       const swapPlaintext = new SwapPlaintext({
         claimAddress: address,
@@ -357,7 +356,7 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
+      const actionView = await viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
 
       const expected = new ActionView({
         actionView: {
@@ -381,7 +380,7 @@ describe('viewActionPlan()', () => {
                       case: 'knownAssetId',
                       value: {
                         amount: outputData.lambda1,
-                        metadata: Metadata.fromJson(metadataByAssetId[asset1IdAsString]!),
+                        metadata: await metadataByAssetId(asset1Id),
                       },
                     },
                   },
@@ -401,7 +400,7 @@ describe('viewActionPlan()', () => {
                       case: 'knownAssetId',
                       value: {
                         amount: outputData.lambda2,
-                        metadata: Metadata.fromJson(metadataByAssetId[asset2IdAsString]!),
+                        metadata: await metadataByAssetId(asset2Id),
                       },
                     },
                   },
@@ -427,7 +426,7 @@ describe('viewActionPlan()', () => {
   });
 
   describe('`withdrawal` action', () => {
-    test('returns an action view with the `ics20Withdrawal` case as-is', () => {
+    test('returns an action view with the `ics20Withdrawal` case as-is', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'ics20Withdrawal',
@@ -435,23 +434,21 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      const actionView = viewActionPlan({}, mockFvk)(actionPlan);
+      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
 
-      expect(
-        actionView.equals(
-          new ActionView({
-            actionView: {
-              case: 'ics20Withdrawal',
-              value: { amount: { hi: 1n, lo: 0n } },
-            },
-          }),
-        ),
-      ).toBe(true);
+      await expect(actionView).resolves.toEqual(
+        new ActionView({
+          actionView: {
+            case: 'ics20Withdrawal',
+            value: { amount: { hi: 1n, lo: 0n } },
+          },
+        }),
+      );
     });
   });
 
   describe('`delegate` action', () => {
-    test('returns an action view with the action as-is', () => {
+    test('returns an action view with the action as-is', async () => {
       const delegate = new Delegate({
         epochIndex: 0n,
         delegationAmount: { hi: 123n, lo: 456n },
@@ -463,23 +460,21 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      const actionView = viewActionPlan({}, mockFvk)(actionPlan);
+      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
 
-      expect(
-        actionView.equals(
-          new ActionView({
-            actionView: {
-              case: 'delegate',
-              value: delegate,
-            },
-          }),
-        ),
-      ).toBe(true);
+      await expect(actionView).resolves.toEqual(
+        new ActionView({
+          actionView: {
+            case: 'delegate',
+            value: delegate,
+          },
+        }),
+      );
     });
   });
 
   describe('`undelegate` action', () => {
-    test('returns an action view with the action as-is', () => {
+    test('returns an action view with the action as-is', async () => {
       const undelegate = new Undelegate({
         startEpochIndex: 0n,
         delegationAmount: { hi: 123n, lo: 456n },
@@ -491,23 +486,21 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      const actionView = viewActionPlan({}, mockFvk)(actionPlan);
+      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
 
-      expect(
-        actionView.equals(
-          new ActionView({
-            actionView: {
-              case: 'undelegate',
-              value: undelegate,
-            },
-          }),
-        ),
-      ).toBe(true);
+      await expect(actionView).resolves.toEqual(
+        new ActionView({
+          actionView: {
+            case: 'undelegate',
+            value: undelegate,
+          },
+        }),
+      );
     });
   });
 
   describe('all other action cases', () => {
-    test('returns an action view with the case but no value', () => {
+    test('returns an action view with the case but no value', async () => {
       const actionPlan = new ActionPlan({
         action: {
           case: 'proposalSubmit',
@@ -515,18 +508,16 @@ describe('viewActionPlan()', () => {
         },
       });
 
-      const actionView = viewActionPlan({}, mockFvk)(actionPlan);
+      const actionView = viewActionPlan(metadataByAssetId, mockFvk)(actionPlan);
 
-      expect(
-        actionView.equals(
-          new ActionView({
-            actionView: {
-              case: 'proposalSubmit',
-              value: {},
-            },
-          }),
-        ),
-      ).toBe(true);
+      await expect(actionView).resolves.toEqual(
+        new ActionView({
+          actionView: {
+            case: 'proposalSubmit',
+            value: {},
+          },
+        }),
+      );
     });
   });
 });

--- a/packages/router/src/ctx/approver.ts
+++ b/packages/router/src/ctx/approver.ts
@@ -1,12 +1,10 @@
 import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1/custody_pb';
-import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { createContextKey } from '@connectrpc/connect';
 import { PartialMessage } from '@bufbuild/protobuf';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
 
 export type TxApprovalFn = (
   authorizeRequest: PartialMessage<AuthorizeRequest>,
-  transactionView: PartialMessage<TransactionView>,
 ) => Promise<UserChoice>;
 
 export const approverCtx = createContextKey<TxApprovalFn | undefined>(undefined);

--- a/packages/router/src/grpc/custody/authorize.test.ts
+++ b/packages/router/src/grpc/custody/authorize.test.ts
@@ -131,7 +131,7 @@ describe('Authorize request handler', () => {
     await expect(authorize(req, mockCtx)).rejects.toThrow('User must login to extension');
   });
 
-  test('should fail if local context not include FVK', async () => {
+  test.skip('should fail if local context not include FVK', async () => {
     mockExtLocalCtx.get.mockImplementation(() => {
       return Promise.resolve([
         {

--- a/packages/router/src/grpc/custody/authorize.test.ts
+++ b/packages/router/src/grpc/custody/authorize.test.ts
@@ -131,23 +131,6 @@ describe('Authorize request handler', () => {
     await expect(authorize(req, mockCtx)).rejects.toThrow('User must login to extension');
   });
 
-  test.skip('should fail if local context not include FVK', async () => {
-    mockExtLocalCtx.get.mockImplementation(() => {
-      return Promise.resolve([
-        {
-          custody: {
-            encryptedSeedPhrase: {
-              cipherText: '1MUyDW2GHSeZYVF4f=',
-              nonce: 'MUyDW2GHSeZYVF4f',
-            },
-          },
-          fullViewingKey: undefined,
-        },
-      ]);
-    });
-    await expect(authorize(req, mockCtx)).rejects.toThrow('Unable to get full viewing key');
-  });
-
   test('should fail if incorrect password is used', async () => {
     mockExtSessionCtx.get.mockImplementation(() => {
       return Promise.resolve({

--- a/packages/router/src/grpc/custody/authorize.ts
+++ b/packages/router/src/grpc/custody/authorize.ts
@@ -7,36 +7,34 @@ import { Box } from '@penumbra-zone/types/src/box';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
 
 export const authorize: Impl['authorize'] = async (req, ctx) => {
-  const { plan } = req;
-  if (!plan) throw new ConnectError('No plan included in request', Code.InvalidArgument);
+  if (!req.plan) throw new ConnectError('No plan included in request', Code.InvalidArgument);
 
   const approveReq = ctx.values.get(approverCtx);
   const sess = ctx.values.get(extSessionCtx);
   const local = ctx.values.get(extLocalCtx);
 
   if (!approveReq) throw new ConnectError('Approver not found', Code.Unavailable);
-  const choice = approveReq(req);
 
-  const authData = (async () => {
-    const passwordKey = await sess.get('passwordKey');
-    if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unauthenticated);
+  const passwordKey = await sess.get('passwordKey');
+  if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unauthenticated);
 
-    const wallets = await local.get('wallets');
-    const {
-      custody: { encryptedSeedPhrase },
-    } = wallets[0]!;
+  const wallets = await local.get('wallets');
+  const {
+    custody: { encryptedSeedPhrase },
+  } = wallets[0]!;
 
-    const key = await Key.fromJson(passwordKey);
-    const decryptedSeedPhrase = await key.unseal(Box.fromJson(encryptedSeedPhrase));
+  const key = await Key.fromJson(passwordKey);
+  const decryptedSeedPhrase = await key.unseal(Box.fromJson(encryptedSeedPhrase));
 
-    if (!decryptedSeedPhrase)
-      throw new ConnectError('Unable to decrypt seed phrase with password', Code.Unauthenticated);
-    const spendKey = generateSpendKey(decryptedSeedPhrase);
-    return authorizePlan(spendKey, plan);
-  })();
+  if (!decryptedSeedPhrase)
+    throw new ConnectError('Unable to decrypt seed phrase with password', Code.Unauthenticated);
 
-  if ((await choice) !== UserChoice.Approved)
+  const choice = await approveReq(req);
+  if (choice !== UserChoice.Approved)
     throw new ConnectError('Transaction was not approved', Code.PermissionDenied);
 
-  return { data: await authData };
+  const spendKey = generateSpendKey(decryptedSeedPhrase);
+  const data = authorizePlan(spendKey, req.plan);
+
+  return { data };
 };

--- a/packages/router/src/grpc/custody/authorize.ts
+++ b/packages/router/src/grpc/custody/authorize.ts
@@ -1,79 +1,42 @@
 import type { Impl } from '.';
-import { approverCtx, extLocalCtx, extSessionCtx, servicesCtx } from '../../ctx';
+import { approverCtx, extLocalCtx, extSessionCtx } from '../../ctx';
 import { authorizePlan, generateSpendKey } from '@penumbra-zone/wasm';
 import { Key } from '@penumbra-zone/crypto-web';
-import { Code, ConnectError, HandlerContext } from '@connectrpc/connect';
-import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { viewTransactionPlan } from '@penumbra-zone/perspective/plan';
-import { bech32AssetId } from '@penumbra-zone/bech32';
-import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { Box } from '@penumbra-zone/types/src/box';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
 
-/**
- * @todo As more asset types get used, the amount of asset metadata we store
- * will grow. Loading all the asset metadata into memory for the purpose of
- * compiling a transaction view may not be sustainable in the long term.
- * Eventually, we may want to scan through the transaction plan, extract all the
- * asset IDs in it, and then query just those from IndexedDB instead of grabbing
- * all of them.
- */
-const getMetadataByAssetId = async (ctx: HandlerContext) => {
-  const services = ctx.values.get(servicesCtx);
-  const walletServices = await services.getWalletServices();
-
-  const assetsMetadata: Metadata[] = [];
-  for await (const metadata of walletServices.indexedDb.iterateAssetsMetadata()) {
-    assetsMetadata.push(metadata);
-  }
-  return assetsMetadata.reduce<Record<string, Jsonified<Metadata>>>((prev, curr) => {
-    if (curr.penumbraAssetId) {
-      prev[bech32AssetId(curr.penumbraAssetId)] = curr.toJson() as Jsonified<Metadata>;
-    }
-    return prev;
-  }, {});
-};
-
 export const authorize: Impl['authorize'] = async (req, ctx) => {
-  if (!req.plan) throw new ConnectError('No plan included in request', Code.InvalidArgument);
+  const { plan } = req;
+  if (!plan) throw new ConnectError('No plan included in request', Code.InvalidArgument);
 
   const approveReq = ctx.values.get(approverCtx);
   const sess = ctx.values.get(extSessionCtx);
   const local = ctx.values.get(extLocalCtx);
 
   if (!approveReq) throw new ConnectError('Approver not found', Code.Unavailable);
+  const choice = approveReq(req);
 
-  const passwordKey = await sess.get('passwordKey');
-  if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unauthenticated);
+  const authData = (async () => {
+    const passwordKey = await sess.get('passwordKey');
+    if (!passwordKey) throw new ConnectError('User must login to extension', Code.Unauthenticated);
 
-  const wallets = await local.get('wallets');
-  const {
-    custody: { encryptedSeedPhrase },
-    fullViewingKey,
-  } = wallets[0]!;
+    const wallets = await local.get('wallets');
+    const {
+      custody: { encryptedSeedPhrase },
+    } = wallets[0]!;
 
-  if (!fullViewingKey)
-    throw new ConnectError('Unable to get full viewing key', Code.Unauthenticated);
+    const key = await Key.fromJson(passwordKey);
+    const decryptedSeedPhrase = await key.unseal(Box.fromJson(encryptedSeedPhrase));
 
-  const key = await Key.fromJson(passwordKey);
-  const decryptedSeedPhrase = await key.unseal(Box.fromJson(encryptedSeedPhrase));
+    if (!decryptedSeedPhrase)
+      throw new ConnectError('Unable to decrypt seed phrase with password', Code.Unauthenticated);
+    const spendKey = generateSpendKey(decryptedSeedPhrase);
+    return authorizePlan(spendKey, plan);
+  })();
 
-  if (!decryptedSeedPhrase)
-    throw new ConnectError('Unable to decrypt seed phrase with password', Code.Unauthenticated);
-
-  const denomMetadataByAssetId = await getMetadataByAssetId(ctx);
-  const transactionViewFromPlan = viewTransactionPlan(
-    req.plan,
-    denomMetadataByAssetId,
-    fullViewingKey,
-  );
-
-  const choice = await approveReq(req, transactionViewFromPlan);
-  if (choice !== UserChoice.Approved)
+  if ((await choice) !== UserChoice.Approved)
     throw new ConnectError('Transaction was not approved', Code.PermissionDenied);
 
-  const spendKey = generateSpendKey(decryptedSeedPhrase);
-  const data = authorizePlan(spendKey, req.plan);
-
-  return { data };
+  return { data: await authData };
 };


### PR DESCRIPTION
pulled out of work refactoring custody/authorize.

tx view generation tools are now in their own package. we use these tools in the tx approval slice now, and query the view rpc for metadata when necessary, instead of serializing all metadata and posting it with the request message. the slice accesses the fvk directly, meaning the custody rpc no longer requires fvk at all.