### PR TITLE
Add price impact to swap estimate

### DIFF
--- a/apps/minifront/src/components/swap/asset-out-box.tsx
+++ b/apps/minifront/src/components/swap/asset-out-box.tsx
@@ -18,7 +18,7 @@ import { cn } from '@penumbra-zone/ui/lib/utils';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 
-import { isZero } from '@penumbra-zone/types/src/amount';
+import { formatNumber, isZero } from '@penumbra-zone/types/src/amount';
 import { getAmount } from '@penumbra-zone/getters/src/value-view';
 
 const findMatchingBalance = (
@@ -56,7 +56,7 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
       <div className='mb-2 flex items-center justify-between gap-1 md:gap-2'>
         <p className='text-sm font-bold md:text-base'>Swap into</p>
       </div>
-      <div className='flex flex-col gap-4'>
+      <div className='flex justify-between gap-4'>
         <div className='flex items-start justify-start'>
           {simulateOutResult ? (
             <Result result={simulateOutResult} />
@@ -64,12 +64,10 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
             <EstimateButton simulateFn={simulateSwap} loading={simulateOutLoading} />
           )}
         </div>
-        <div>
-          <AssetOutSelector
-            balances={balances}
-            assetOut={matchingBalance}
-            setAssetOut={setAssetOut}
-          />
+        <div className='flex flex-col'>
+          <div className='ml-auto w-auto shrink-0'>
+            <AssetOutSelector assetOut={matchingBalance} setAssetOut={setAssetOut} />
+          </div>
           <div className='mt-[6px] flex items-start justify-between'>
             <div />
             <div className='flex items-start gap-1'>
@@ -84,14 +82,12 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
 };
 
 // The price hit the user takes as a consequence of moving the market with the size of their trade
-const PriceImpact = ({ amount }: { amount?: number }) => {
-  if (!amount) return <></>;
-
+const PriceImpact = ({ amount = 0 }: { amount?: number }) => {
   // e.g .041234245245 becomes 4.123
-  const percent = (amount * 100).toFixed(3);
+  const percent = formatNumber(amount * 100, { precision: 3 });
 
   return (
-    <div className={cn('flex flex-col text-gray-500', amount < -0.1 && 'text-orange-400')}>
+    <div className={cn('flex flex-col text-gray-500 text-sm', amount < -0.1 && 'text-orange-400')}>
       <div>Price impact:</div>
       <div>{percent}%</div>
     </div>
@@ -103,7 +99,9 @@ const Result = ({ result: { output, unfilled, priceImpact } }: { result: Simulat
   if (isZero(getAmount(unfilled))) {
     return (
       <div className='flex flex-col gap-2'>
-        <ValueViewComponent view={output} showDenom={false} showIcon={false} />
+        <div>
+          <ValueViewComponent view={output} showDenom={false} showIcon={false} />
+        </div>
         <PriceImpact amount={priceImpact} />
       </div>
     );

--- a/apps/minifront/src/components/swap/asset-out-box.tsx
+++ b/apps/minifront/src/components/swap/asset-out-box.tsx
@@ -56,33 +56,57 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
       <div className='mb-2 flex items-center justify-between gap-1 md:gap-2'>
         <p className='text-sm font-bold md:text-base'>Swap into</p>
       </div>
-      <div className='flex items-center justify-between gap-4'>
-        {simulateOutResult ? (
-          <Result result={simulateOutResult} />
-        ) : (
-          <EstimateButton simulateFn={simulateSwap} loading={simulateOutLoading} />
-        )}
-        <AssetOutSelector
-          balances={balances}
-          assetOut={matchingBalance}
-          setAssetOut={setAssetOut}
-        />
-      </div>
-      <div className='mt-[6px] flex items-start justify-between'>
-        <div />
-        <div className='flex items-start gap-1'>
-          <img src='./wallet.svg' alt='Wallet' className='size-5' />
-          <ValueViewComponent view={matchingBalance} showIcon={false} />
+      <div className='flex flex-col gap-4'>
+        <div className='flex items-start justify-start'>
+          {simulateOutResult ? (
+            <Result result={simulateOutResult} />
+          ) : (
+            <EstimateButton simulateFn={simulateSwap} loading={simulateOutLoading} />
+          )}
+        </div>
+        <div>
+          <AssetOutSelector
+            balances={balances}
+            assetOut={matchingBalance}
+            setAssetOut={setAssetOut}
+          />
+          <div className='mt-[6px] flex items-start justify-between'>
+            <div />
+            <div className='flex items-start gap-1'>
+              <img src='./wallet.svg' alt='Wallet' className='size-5' />
+              <ValueViewComponent view={matchingBalance} showIcon={false} />
+            </div>
+          </div>
         </div>
       </div>
     </div>
   );
 };
 
-const Result = ({ result: { output, unfilled } }: { result: SimulateSwapResult }) => {
+// The price hit the user takes as a consequence of moving the market with the size of their trade
+const PriceImpact = ({ amount }: { amount?: number }) => {
+  if (!amount) return <></>;
+
+  // e.g .041234245245 becomes 4.123
+  const percent = (amount * 100).toFixed(3);
+
+  return (
+    <div className={cn('flex flex-col text-gray-500', amount < -0.1 && 'text-orange-400')}>
+      <div>Price impact:</div>
+      <div>{percent}%</div>
+    </div>
+  );
+};
+
+const Result = ({ result: { output, unfilled, priceImpact } }: { result: SimulateSwapResult }) => {
   // If no part unfilled, just show plain output amount (no label)
   if (isZero(getAmount(unfilled))) {
-    return <ValueViewComponent view={output} showDenom={false} showIcon={false} />;
+    return (
+      <div className='flex flex-col gap-2'>
+        <ValueViewComponent view={output} showDenom={false} showIcon={false} />
+        <PriceImpact amount={priceImpact} />
+      </div>
+    );
   }
 
   // Else is partially filled, show amounts with labels
@@ -96,6 +120,7 @@ const Result = ({ result: { output, unfilled } }: { result: SimulateSwapResult }
         <ValueViewComponent view={unfilled} showIcon={false} />
         <span className='font-mono text-[12px] italic text-gray-500'>Unfilled amount</span>
       </div>
+      <PriceImpact amount={priceImpact} />
     </div>
   );
 };

--- a/apps/minifront/src/components/swap/asset-out-selector.tsx
+++ b/apps/minifront/src/components/swap/asset-out-selector.tsx
@@ -11,20 +11,18 @@ import {
   ValueView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { localAssets } from '@penumbra-zone/constants/src/assets';
-import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 
 interface AssetOutSelectorProps {
-  balances: BalancesResponse[];
   assetOut: ValueView | undefined;
   setAssetOut: (metadata: Metadata) => void;
 }
 
 /** @todo Refactor to use `SelectTokenModal` */
-export const AssetOutSelector = ({ balances, setAssetOut, assetOut }: AssetOutSelectorProps) => {
+export const AssetOutSelector = ({ setAssetOut, assetOut }: AssetOutSelectorProps) => {
   return (
     <Dialog>
-      <DialogTrigger disabled={!balances.length}>
+      <DialogTrigger>
         <div className='flex h-9 min-w-[100px] max-w-[150px] items-center justify-center gap-2 rounded-lg bg-light-brown px-2'>
           <ValueViewComponent view={assetOut} showValue={false} />
         </div>

--- a/apps/minifront/src/components/swap/swap-form.tsx
+++ b/apps/minifront/src/components/swap/swap-form.tsx
@@ -2,7 +2,7 @@ import { Button } from '@penumbra-zone/ui/components/ui/button';
 import InputToken from '../shared/input-token';
 import { useLoaderData } from 'react-router-dom';
 import { useStore } from '../../state';
-import { swapSelector } from '../../state/swap';
+import { swapSelector, swapValidationErrors } from '../../state/swap';
 import { AssetOutBox } from './asset-out-box';
 import { SwapLoaderResponse } from './swap-loader';
 
@@ -10,6 +10,7 @@ export const SwapForm = () => {
   const { assetBalances } = useLoaderData() as SwapLoaderResponse;
   const { assetIn, setAssetIn, amount, setAmount, initiateSwapTx, txInProgress } =
     useStore(swapSelector);
+  const validationErrs = useStore(swapValidationErrors);
 
   return (
     <form
@@ -30,11 +31,23 @@ export const SwapForm = () => {
           if (Number(e.target.value) < 0) return;
           setAmount(e.target.value);
         }}
-        validations={[]}
+        validations={[
+          {
+            type: 'error',
+            issue: 'insufficient funds',
+            checkFn: () => validationErrs.amountErr,
+          },
+        ]}
         balances={assetBalances}
       />
       <AssetOutBox balances={assetBalances} />
-      <Button type='submit' variant='gradient' className='mt-3' size='lg' disabled={txInProgress}>
+      <Button
+        type='submit'
+        variant='gradient'
+        className='mt-3'
+        size='lg'
+        disabled={txInProgress || Object.values(validationErrs).find(Boolean)}
+      >
         Swap
       </Button>
     </form>

--- a/apps/minifront/src/state/ibc.ts
+++ b/apps/minifront/src/state/ibc.ts
@@ -16,7 +16,7 @@ import { getAddressIndex } from '@penumbra-zone/getters/src/address-view';
 import { typeRegistry } from '@penumbra-zone/types/src/registry';
 import { toBaseUnit } from '@penumbra-zone/types/src/lo-hi';
 import { planBuildBroadcast } from './helpers';
-import { validateAmount } from './send';
+import { amountMoreThanBalance } from './send';
 import { IbcLoaderResponse } from '../components/ibc/ibc-loader';
 import { getAssetId } from '@penumbra-zone/getters/src/metadata';
 import {
@@ -163,7 +163,9 @@ export const ibcValidationErrors = (state: AllSlices) => {
     recipientErr: !state.ibc.destinationChainAddress
       ? false
       : !validateAddress(state.ibc.chain, state.ibc.destinationChainAddress),
-    amountErr: !state.ibc.selection ? false : validateAmount(state.ibc.selection, state.ibc.amount),
+    amountErr: !state.ibc.selection
+      ? false
+      : amountMoreThanBalance(state.ibc.selection, state.ibc.amount),
   };
 };
 

--- a/apps/minifront/src/state/send.ts
+++ b/apps/minifront/src/state/send.ts
@@ -144,7 +144,7 @@ const assembleRequest = ({ amount, feeTier, recipient, selection, memo }: SendSl
   });
 };
 
-export const validateAmount = (
+export const amountMoreThanBalance = (
   asset: BalancesResponse,
   /**
    * The amount that a user types into the interface will always be in the
@@ -173,7 +173,7 @@ export const sendValidationErrors = (
 ): SendValidationFields => {
   return {
     recipientErr: Boolean(recipient) && !isPenumbraAddr(recipient),
-    amountErr: !asset ? false : validateAmount(asset, amount),
+    amountErr: !asset ? false : amountMoreThanBalance(asset, amount),
     // The memo cannot exceed 512 bytes
     // return address uses 80 bytes
     // so 512-80=432 bytes for memo text

--- a/apps/minifront/src/state/swap.test.ts
+++ b/apps/minifront/src/state/swap.test.ts
@@ -73,7 +73,11 @@ describe('Swap Slice', () => {
   test('changing assetIn clears simulation', () => {
     expect(useStore.getState().swap.simulateOutResult).toBeUndefined();
     useStore.setState(state => {
-      state.swap.simulateOutResult = { output: new ValueView(), unfilled: new ValueView() };
+      state.swap.simulateOutResult = {
+        output: new ValueView(),
+        unfilled: new ValueView(),
+        priceImpact: undefined,
+      };
       return state;
     });
     expect(useStore.getState().swap.simulateOutResult).toBeDefined();
@@ -84,7 +88,11 @@ describe('Swap Slice', () => {
   test('changing assetOut clears simulation', () => {
     expect(useStore.getState().swap.simulateOutResult).toBeUndefined();
     useStore.setState(state => {
-      state.swap.simulateOutResult = { output: new ValueView(), unfilled: new ValueView() };
+      state.swap.simulateOutResult = {
+        output: new ValueView(),
+        unfilled: new ValueView(),
+        priceImpact: undefined,
+      };
       return state;
     });
     expect(useStore.getState().swap.simulateOutResult).toBeDefined();
@@ -95,7 +103,11 @@ describe('Swap Slice', () => {
   test('changing amount clears simulation', () => {
     expect(useStore.getState().swap.simulateOutResult).toBeUndefined();
     useStore.setState(state => {
-      state.swap.simulateOutResult = { output: new ValueView(), unfilled: new ValueView() };
+      state.swap.simulateOutResult = {
+        output: new ValueView(),
+        unfilled: new ValueView(),
+        priceImpact: undefined,
+      };
       return state;
     });
     expect(useStore.getState().swap.simulateOutResult).toBeDefined();

--- a/apps/minifront/src/state/swap.ts
+++ b/apps/minifront/src/state/swap.ts
@@ -31,6 +31,7 @@ import { toBaseUnit } from '@penumbra-zone/types/src/lo-hi';
 import { getAmountFromValue, getAssetIdFromValue } from '@penumbra-zone/getters/src/value';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { divideAmounts } from '@penumbra-zone/types/src/amount';
+import { amountMoreThanBalance } from './send';
 
 export interface SimulateSwapResult {
   output: ValueView;
@@ -233,6 +234,14 @@ const getMatchingAmount = (values: Value[], toMatch: AssetId): Amount => {
   if (!match?.amount) throw new Error('No match in values array found');
 
   return match.amount;
+};
+
+export const swapValidationErrors = ({ swap }: AllSlices) => {
+  return {
+    assetInErr: !swap.assetIn,
+    assetOutErr: !swap.assetOut,
+    amountErr: (swap.assetIn && amountMoreThanBalance(swap.assetIn, swap.amount)) ?? false,
+  };
 };
 
 export const swapSelector = (state: AllSlices) => state.swap;

--- a/apps/minifront/src/state/swap.ts
+++ b/apps/minifront/src/state/swap.ts
@@ -5,6 +5,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { planBuildBroadcast } from './helpers';
 import {
+  AssetId,
   Metadata,
   Value,
   ValueView,
@@ -13,7 +14,10 @@ import { BigNumber } from 'bignumber.js';
 import { getAddressByIndex } from '../fetchers/address';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
 import { errorToast } from '@penumbra-zone/ui/lib/toast/presets';
-import { SimulateTradeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
+import {
+  SimulateTradeRequest,
+  SwapExecution,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { simulateClient } from '../clients';
 import {
   getAssetIdFromValueView,
@@ -24,10 +28,14 @@ import { getAssetId } from '@penumbra-zone/getters/src/metadata';
 import { getSwapCommitmentFromTx } from '@penumbra-zone/getters/src/transaction';
 import { getAddressIndex } from '@penumbra-zone/getters/src/address-view';
 import { toBaseUnit } from '@penumbra-zone/types/src/lo-hi';
+import { getAmountFromValue, getAssetIdFromValue } from '@penumbra-zone/getters/src/value';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { divideAmounts } from '@penumbra-zone/types/src/amount';
 
 export interface SimulateSwapResult {
   output: ValueView;
   unfilled: ValueView;
+  priceImpact: number | undefined;
 }
 
 export interface SwapSlice {
@@ -114,7 +122,11 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get) => {
         });
 
         set(({ swap }) => {
-          swap.simulateOutResult = { output, unfilled };
+          swap.simulateOutResult = {
+            output,
+            unfilled,
+            priceImpact: calculatePriceImpact(res.output),
+          };
         });
       } catch (e) {
         errorToast(e, 'Error estimating swap').render();
@@ -185,6 +197,42 @@ const assembleSwapRequest = async ({ assetIn, amount, assetOut }: SwapSlice) => 
 export const issueSwapClaim = async (swapCommitment: StateCommitment) => {
   const req = new TransactionPlannerRequest({ swapClaims: [{ swapCommitment }] });
   await planBuildBroadcast('swapClaim', req, { skipAuth: true });
+};
+
+/*
+  Price impact is the change in price as a consequence of the trade's size. In SwapExecution, the \
+  first trace in the array is the best execution for the swap. To calculate price impact, take
+  the price of the trade and see the % diff off the best execution trace.
+ */
+const calculatePriceImpact = (swapExec?: SwapExecution): number | undefined => {
+  if (!swapExec?.traces.length || !swapExec.output || !swapExec.input) return undefined;
+
+  // Get the price of the estimate for the swap total
+  const inputAmount = getAmountFromValue(swapExec.input);
+  const outputAmount = getAmountFromValue(swapExec.output);
+  const swapEstimatePrice = divideAmounts(outputAmount, inputAmount);
+
+  // Get the price in the best execution trace
+  const inputAssetId = getAssetIdFromValue(swapExec.input);
+  const outputAssetId = getAssetIdFromValue(swapExec.output);
+  const bestTrace = swapExec.traces[0]!;
+  const bestInputAmount = getMatchingAmount(bestTrace.value, inputAssetId);
+  const bestOutputAmount = getMatchingAmount(bestTrace.value, outputAssetId);
+  const bestTraceEstimatedPrice = divideAmounts(bestOutputAmount, bestInputAmount);
+
+  // Difference = (priceB - priceA) / priceA
+  const percentDifference = swapEstimatePrice
+    .minus(bestTraceEstimatedPrice)
+    .div(bestTraceEstimatedPrice);
+
+  return percentDifference.toNumber();
+};
+
+const getMatchingAmount = (values: Value[], toMatch: AssetId): Amount => {
+  const match = values.find(v => toMatch.equals(v.assetId));
+  if (!match?.amount) throw new Error('No match in values array found');
+
+  return match.amount;
 };
 
 export const swapSelector = (state: AllSlices) => state.swap;

--- a/packages/getters/src/value.ts
+++ b/packages/getters/src/value.ts
@@ -1,0 +1,6 @@
+import { Value } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { createGetter } from './utils/create-getter';
+
+export const getAssetIdFromValue = createGetter((value?: Value) => value?.assetId);
+
+export const getAmountFromValue = createGetter((value?: Value) => value?.amount);

--- a/packages/getters/vite.config.ts
+++ b/packages/getters/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         'validator-info-response': './src/validator-info-response.ts',
         'validator-state': './src/validator-state.ts',
         'validator-status': './src/validator-status.ts',
+        value: './src/value.ts',
         'value-view': './src/value-view.ts',
       },
       formats: ['es'],

--- a/packages/types/src/amount.test.ts
+++ b/packages/types/src/amount.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   addAmounts,
-  displayAmount,
-  displayUsd,
   divideAmounts,
+  formatNumber,
   fromBaseUnitAmount,
   fromValueView,
   isZero,
@@ -180,62 +179,6 @@ describe('divideAmounts', () => {
   });
 });
 
-describe('Formatting', () => {
-  describe('displayAmount()', () => {
-    it('no decimals', () => {
-      expect(displayAmount(2000)).toBe('2,000');
-    });
-
-    it('one decimal place', () => {
-      expect(displayAmount(2001.1)).toBe('2,001.1');
-    });
-
-    it('many decimals, if above 1, rounds to three places', () => {
-      expect(displayAmount(2001.124125)).toBe('2,001.124');
-    });
-
-    it('many decimals, if less than 1, shows all places', () => {
-      expect(displayAmount(0.000012)).toBe('0.000012');
-    });
-
-    it('negative numbers work too', () => {
-      expect(displayAmount(-2001.124125)).toBe('-2,001.124');
-    });
-  });
-
-  describe('displayUsd()', () => {
-    it('should format numbers with no decimals', () => {
-      expect(displayUsd(2000)).toBe('2,000.00');
-    });
-
-    it('should format numbers with one decimal place', () => {
-      expect(displayUsd(2001.1)).toBe('2,001.10');
-    });
-
-    it('should format numbers with two decimal places', () => {
-      expect(displayUsd(2001.12)).toBe('2,001.12');
-    });
-
-    it('should round numbers with more than two decimal places', () => {
-      expect(displayUsd(2001.124)).toBe('2,001.12');
-      expect(displayUsd(2001.125)).toBe('2,001.13'); // testing rounding
-    });
-
-    it('should format numbers less than one', () => {
-      expect(displayUsd(0.1)).toBe('0.10');
-      expect(displayUsd(0.01)).toBe('0.01');
-      expect(displayUsd(0.001)).toBe('0.00'); // testing rounding
-    });
-
-    it('should format negative numbers', () => {
-      expect(displayUsd(-2001)).toBe('-2,001.00');
-      expect(displayUsd(-2001.1)).toBe('-2,001.10');
-      expect(displayUsd(-2001.12)).toBe('-2,001.12');
-      expect(displayUsd(-2001.125)).toBe('-2,001.13'); // testing rounding
-    });
-  });
-});
-
 describe('isZero', () => {
   it('works with zero amount', () => {
     const amount = new Amount({ lo: 0n, hi: 0n });
@@ -286,5 +229,27 @@ describe('multiplyAmountByNumber()', () => {
         lo: 111n,
       }),
     );
+  });
+});
+
+describe('formatNumber', () => {
+  it('formats number with zero precision', () => {
+    expect(formatNumber(123.456, { precision: 0 })).toBe('123');
+  });
+
+  it('formats number with non-zero precision', () => {
+    expect(formatNumber(123.456, { precision: 2 })).toBe('123.46');
+  });
+
+  it('handles zero value with non-zero precision', () => {
+    expect(formatNumber(0, { precision: 2 })).toBe('0');
+  });
+
+  it('removes unnecessary trailing zeros', () => {
+    expect(formatNumber(123.4, { precision: 3 })).toBe('123.4');
+  });
+
+  it('formats negative number correctly', () => {
+    expect(formatNumber(-123.456, { precision: 2 })).toBe('-123.46');
   });
 });

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -48,13 +48,13 @@ export const multiplyAmountByNumber = (amount: Amount, multiplier: number): Amou
   return new Amount(loHi);
 };
 
-export const divideAmounts = (dividend: Amount, divider: Amount): BigNumber => {
-  if (isZero(divider)) throw new Error('Division by zero');
+export const divideAmounts = (dividend: Amount, divisor: Amount): BigNumber => {
+  if (isZero(divisor)) throw new Error('Division by zero');
 
   const joinedDividend = new BigNumber(joinLoHiAmount(dividend).toString());
-  const joinedDivider = new BigNumber(joinLoHiAmount(divider).toString());
+  const joinedDivisor = new BigNumber(joinLoHiAmount(divisor).toString());
 
-  return joinedDividend.dividedBy(joinedDivider);
+  return joinedDividend.dividedBy(joinedDivisor);
 };
 
 // This function takes a number and formats it in a display-friendly way (en-US locale)

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -57,38 +57,17 @@ export const divideAmounts = (dividend: Amount, divisor: Amount): BigNumber => {
   return joinedDividend.dividedBy(joinedDivisor);
 };
 
-// This function takes a number and formats it in a display-friendly way (en-US locale)
-// Examples:
-//    2000        -> 2,000
-//    2001.1      -> 2,000.1
-//    2001.124125 -> 2,001.124
-//    0.000012    -> 0.000012
-export const displayAmount = (num: number): string => {
-  const split = num.toString().split('.');
-  const integer = parseInt(split[0]!);
-  let decimal = split[1];
+interface FormatOptions {
+  precision: number;
+}
 
-  const formattedInt = new Intl.NumberFormat('en-US').format(integer);
+export const formatNumber = (number: number, options: FormatOptions): string => {
+  const { precision } = options;
 
-  if (!decimal) return formattedInt;
-
-  if (Math.abs(num) >= 1) {
-    decimal = decimal.slice(0, 3);
-  }
-
-  return `${formattedInt}.${decimal}`;
-};
-
-// Takes a number and represents it as a formatted $usd value
-//    2000        -> 2,000
-//    2001.1      -> 2,000.10
-//    2001.124125 -> 2,001.12
-//    0.000012    -> 0.00
-export const displayUsd = (number: number): string => {
-  return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(number);
+  // Use toFixed to set the precision and then remove unnecessary trailing zeros
+  return precision === 0
+    ? number.toFixed(precision)
+    : parseFloat(number.toFixed(precision)).toString();
 };
 
 /**


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/735 <--- turns out this isn't a slippage thing, but a price impact one
Closes https://github.com/penumbra-zone/web/issues/829

When a user makes a swap, the size of their trade could impact the price of the asset in the market. This `price impact` percentage is something we want to display to the user when they are estimating the swap they are about to take. This is especially important in low-liquidity pools where users may not want to take that kind of hit.

Zero price impact:
<img width="400" alt="Screenshot 2024-03-25 at 9 57 46 PM" src="https://github.com/penumbra-zone/web/assets/16624263/1a294898-aa9f-4069-b22f-6abe1519ce63">

Price impact present:
<img width="387" alt="Screenshot 2024-03-25 at 9 57 54 PM" src="https://github.com/penumbra-zone/web/assets/16624263/2135fa4a-4290-44b0-94d6-bf20dddefd31">

Price impact worse than 10%
<img width="391" alt="Screenshot 2024-03-25 at 9 58 06 PM" src="https://github.com/penumbra-zone/web/assets/16624263/9271a845-3888-456b-aa4b-600cd0e22518">
