### PR TITLE
Account for error where delegation was prepared for different epoch

### DIFF
--- a/packages/query/src/queriers/tendermint.ts
+++ b/packages/query/src/queriers/tendermint.ts
@@ -12,6 +12,7 @@ const knownTendermintErrors = [
   'is not a valid SCT root',
   'cannot claim unbonding tokens before the end epoch',
   'undelegation was prepared for next epoch',
+  'delegation was prepared for epoch',
 ];
 
 export class TendermintQuerier implements TendermintQuerierInterface {


### PR DESCRIPTION
This should almost never happen. Basically, this should only happen when the user opens the web app in one epoch, then the epoch changes, then the user tries to delegate to a validator. In that case, we should at least show the error to the user rather than hanging indefinitely on "waiting for confirmation."