### PR TITLE
Update core dependencies to v0.70.3

### DIFF
--- a/.changeset/red-geese-care.md
+++ b/.changeset/red-geese-care.md
@@ -1,0 +1,9 @@
+---
+"@penumbra-zone/wasm": minor
+"@penumbra-zone/constants": patch
+"@penumbra-zone/storage": patch
+"@penumbra-zone/query": patch
+"@penumbra-zone/ui": patch
+---
+
+Account for changes to core

--- a/.changeset/red-geese-care.md
+++ b/.changeset/red-geese-care.md
@@ -1,9 +1,9 @@
 ---
-"@penumbra-zone/wasm": minor
-"@penumbra-zone/constants": patch
-"@penumbra-zone/storage": patch
-"@penumbra-zone/query": patch
-"@penumbra-zone/ui": patch
+'@penumbra-zone/wasm': minor
+'@penumbra-zone/constants': patch
+'@penumbra-zone/storage': patch
+'@penumbra-zone/query': patch
+'@penumbra-zone/ui': patch
 ---
 
 Account for changes to core

--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -1,6 +1,6 @@
 
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe
-IDB_VERSION=30
+IDB_VERSION=31
 USDC_ASSET_ID="reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
 MINIFRONT_URL=https://app.testnet.penumbra.zone/
 PENUMBRA_NODE_PD_URL=https://grpc.testnet.penumbra.zone/

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -63,8 +63,12 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
     const authorizeRequest = AuthorizeRequest.fromJson(authReqJson);
 
     const getMetadata = async (assetId: AssetId) => {
-      const { denomMetadata } = await viewClient.assetMetadataById({ assetId });
-      return denomMetadata ?? new Metadata();
+      try {
+        const { denomMetadata } = await viewClient.assetMetadataById({ assetId });
+        return denomMetadata ?? new Metadata();
+      } catch {
+        return new Metadata();
+      }
     };
 
     const wallets = await localExtStorage.get('wallets');

--- a/apps/extension/src/utils/download-proving-keys.ts
+++ b/apps/extension/src/utils/download-proving-keys.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { provingKeys } from '@penumbra-zone/wasm/src/proving-keys';
 
 const main = () => {
-  const VERSION_TAG = 'v0.68.0';
+  const VERSION_TAG = 'v0.70.3';
 
   const githubSourceDir = `https://github.com/penumbra-zone/penumbra/raw/${VERSION_TAG}/crates/crypto/proof-params/src/gen/`;
 

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -18,10 +18,10 @@ const getUndelegateClaimPlannerRequest =
     const validatorIdentityKeyAsBech32String =
       getValidatorIdentityKeyAsBech32StringFromValueView(unbondingToken);
     const identityKey = asIdentityKey(validatorIdentityKeyAsBech32String);
-    const startEpochIndex = await sctClient.epochByHeight({ height: unbondingStartHeight });
+    const { epoch: startEpoch } = await sctClient.epochByHeight({ height: unbondingStartHeight });
 
     const { penalty } = await stakeClient.validatorPenalty({
-      startEpochIndex: startEpochIndex.epoch?.index,
+      startEpochIndex: startEpoch?.index,
       endEpochIndex,
       identityKey,
     });

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@buf/cosmos_ibc.bufbuild_es": "1.8.0-20240327103030-e2006674271c.2",
     "@buf/cosmos_ibc.connectrpc_es": "1.4.0-20240327103030-e2006674271c.2",
-    "@buf/penumbra-zone_penumbra.bufbuild_es": "1.8.0-20240326223351-a25fff24022e.2",
-    "@buf/penumbra-zone_penumbra.connectrpc_es": "1.4.0-20240326223351-a25fff24022e.2",
+    "@buf/penumbra-zone_penumbra.bufbuild_es": "1.8.0-20240327192233-658f3904024e.2",
+    "@buf/penumbra-zone_penumbra.connectrpc_es": "1.4.0-20240327192233-658f3904024e.2",
     "@buf/tendermint_tendermint.bufbuild_es": "1.8.0-20231117195010-33ed361a9051.2",
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@buf/cosmos_ibc.bufbuild_es": "1.8.0-20240327103030-e2006674271c.2",
     "@buf/cosmos_ibc.connectrpc_es": "1.4.0-20240327103030-e2006674271c.2",
-    "@buf/penumbra-zone_penumbra.bufbuild_es": "1.8.0-20240327192233-658f3904024e.2",
-    "@buf/penumbra-zone_penumbra.connectrpc_es": "1.4.0-20240327192233-658f3904024e.2",
+    "@buf/penumbra-zone_penumbra.bufbuild_es": "1.8.0-20240327223130-72af6abcb670.2",
+    "@buf/penumbra-zone_penumbra.connectrpc_es": "1.4.0-20240327223130-72af6abcb670.2",
     "@buf/tendermint_tendermint.bufbuild_es": "1.8.0-20231117195010-33ed361a9051.2",
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",

--- a/packages/constants/src/assets.test.ts
+++ b/packages/constants/src/assets.test.ts
@@ -41,13 +41,13 @@ describe('assetPatterns', () => {
   describe('unbondingTokenPattern', () => {
     it('matches when a string is a valid unbonding token name', () => {
       expect(
-        assetPatterns.unbondingToken.matches('uunbonding_start_at_1_penumbravalid1abc123'),
+        assetPatterns.unbondingToken.matches('unbonding_start_at_1_penumbravalid1abc123'),
       ).toBe(true);
     });
 
     it('captures the unbonding start height', () => {
       const match = assetPatterns.unbondingToken.capture(
-        'uunbonding_start_at_1_penumbravalid1abc123',
+        'unbonding_start_at_1_penumbravalid1abc123',
       );
       expect(match?.startAt).toBe('1');
     });
@@ -55,7 +55,7 @@ describe('assetPatterns', () => {
     it('does not match when a string contains, but does not begin with, a valid unbonding token name', () => {
       expect(
         assetPatterns.unbondingToken.matches(
-          'ibc-transfer/channel-1234/uunbonding_start_at_1_penumbravalid1abc123',
+          'ibc-transfer/channel-1234/unbonding_start_at_1_penumbravalid1abc123',
         ),
       ).toBe(false);
     });

--- a/packages/constants/src/assets.test.ts
+++ b/packages/constants/src/assets.test.ts
@@ -40,15 +40,22 @@ describe('assetPatterns', () => {
 
   describe('unbondingTokenPattern', () => {
     it('matches when a string is a valid unbonding token name', () => {
-      expect(assetPatterns.unbondingToken.matches('uunbonding_epoch_1_penumbravalid1abc123')).toBe(
-        true,
+      expect(
+        assetPatterns.unbondingToken.matches('uunbonding_start_at_1_penumbravalid1abc123'),
+      ).toBe(true);
+    });
+
+    it('captures the unbonding start height', () => {
+      const match = assetPatterns.unbondingToken.capture(
+        'uunbonding_start_at_1_penumbravalid1abc123',
       );
+      expect(match?.startAt).toBe('1');
     });
 
     it('does not match when a string contains, but does not begin with, a valid unbonding token name', () => {
       expect(
         assetPatterns.unbondingToken.matches(
-          'ibc-transfer/channel-1234/uunbonding_epoch_1_penumbravalid1abc123',
+          'ibc-transfer/channel-1234/uunbonding_start_at_1_penumbravalid1abc123',
         ),
       ).toBe(false);
     });

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -73,12 +73,8 @@ export const assetPatterns: AssetPatterns = {
     /^delegation_(?<bech32IdentityKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,
   ),
   proposalNft: new RegexMatcher(/^proposal_/),
-  /**
-   * Unbonding tokens have only one denom unit, which is the base denom. Hence
-   * the extra `u` at the beginning.
-   */
   unbondingToken: new RegexMatcher(
-    /^uunbonding_start_at_(?<startAt>[0-9]+)_(?<bech32IdentityKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,
+    /^unbonding_start_at_(?<startAt>[0-9]+)_(?<bech32IdentityKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,
   ),
   votingReceipt: new RegexMatcher(/^voted_on_/),
   ibc: new RegexMatcher(/^transfer\/(?<channel>channel-\d+)\/(?<denom>.*)/),

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -22,7 +22,7 @@ export interface DelegationCaptureGroups {
 }
 
 export interface UnbondingCaptureGroups {
-  epoch: string;
+  startAt: string;
   id: string;
   bech32IdentityKey: string;
 }
@@ -78,7 +78,7 @@ export const assetPatterns: AssetPatterns = {
    * the extra `u` at the beginning.
    */
   unbondingToken: new RegexMatcher(
-    /^uunbonding_epoch_(?<epoch>[0-9]+)_(?<bech32IdentityKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,
+    /^uunbonding_start_at_(?<startAt>[0-9]+)_(?<bech32IdentityKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,
   ),
   votingReceipt: new RegexMatcher(/^voted_on_/),
   ibc: new RegexMatcher(/^transfer\/(?<channel>channel-\d+)\/(?<denom>.*)/),

--- a/packages/getters/src/metadata.test.ts
+++ b/packages/getters/src/metadata.test.ts
@@ -2,7 +2,7 @@ import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { describe, expect, it } from 'vitest';
 import {
   getDisplayDenomExponent,
-  getStartEpochIndex,
+  getUnbondingStartHeight,
   getValidatorIdentityKeyAsBech32String,
 } from './metadata';
 
@@ -30,21 +30,21 @@ describe('getDisplayDenomExponent()', () => {
   });
 });
 
-describe('getStartEpochIndex()', () => {
-  it("gets the epoch index, coerced to a `BigInt`, from an unbonding token's asset ID", () => {
-    const metadata = new Metadata({ display: 'uunbonding_epoch_123_penumbravalid1abc123' });
+describe('getUnbondingStartHeight()', () => {
+  it("gets the unbonding start height, coerced to a `BigInt`, from an unbonding token's asset ID", () => {
+    const metadata = new Metadata({ display: 'uunbonding_start_at_123_penumbravalid1abc123' });
 
-    expect(getStartEpochIndex(metadata)).toBe(123n);
+    expect(getUnbondingStartHeight(metadata)).toBe(123n);
   });
 
   it("returns `undefined` for a non-unbonding token's metadata", () => {
     const metadata = new Metadata({ display: 'penumbra' });
 
-    expect(getStartEpochIndex.optional()(metadata)).toBeUndefined();
+    expect(getUnbondingStartHeight.optional()(metadata)).toBeUndefined();
   });
 
   it('returns `undefined` for undefined metadata', () => {
-    expect(getStartEpochIndex.optional()(undefined)).toBeUndefined();
+    expect(getUnbondingStartHeight.optional()(undefined)).toBeUndefined();
   });
 });
 
@@ -58,7 +58,7 @@ describe('getValidatorIdentityKeyAsBech32String()', () => {
   });
 
   describe('when passed metadata of an unbonding token', () => {
-    const metadata = new Metadata({ display: 'uunbonding_epoch_123_penumbravalid1abc123' });
+    const metadata = new Metadata({ display: 'uunbonding_start_at_123_penumbravalid1abc123' });
 
     it("returns the bech32 representation of the validator's identity key", () => {
       expect(getValidatorIdentityKeyAsBech32String(metadata)).toBe('penumbravalid1abc123');

--- a/packages/getters/src/metadata.test.ts
+++ b/packages/getters/src/metadata.test.ts
@@ -32,7 +32,7 @@ describe('getDisplayDenomExponent()', () => {
 
 describe('getUnbondingStartHeight()', () => {
   it("gets the unbonding start height, coerced to a `BigInt`, from an unbonding token's asset ID", () => {
-    const metadata = new Metadata({ display: 'uunbonding_start_at_123_penumbravalid1abc123' });
+    const metadata = new Metadata({ display: 'unbonding_start_at_123_penumbravalid1abc123' });
 
     expect(getUnbondingStartHeight(metadata)).toBe(123n);
   });
@@ -58,7 +58,7 @@ describe('getValidatorIdentityKeyAsBech32String()', () => {
   });
 
   describe('when passed metadata of an unbonding token', () => {
-    const metadata = new Metadata({ display: 'uunbonding_start_at_123_penumbravalid1abc123' });
+    const metadata = new Metadata({ display: 'unbonding_start_at_123_penumbravalid1abc123' });
 
     it("returns the bech32 representation of the validator's identity key", () => {
       expect(getValidatorIdentityKeyAsBech32String(metadata)).toBe('penumbravalid1abc123');

--- a/packages/getters/src/metadata.ts
+++ b/packages/getters/src/metadata.ts
@@ -23,19 +23,19 @@ export const getDisplayDenomExponent = createGetter(
 );
 
 /**
- * Get the start epoch index from the metadata of an unbonding token -- that is,
- * the epoch at which unbonding started.
+ * Get the unbonding start height index from the metadata of an unbonding token
+ * -- that is, the block height at which unbonding started.
  *
  * For metadata of a non-unbonding token, will return `undefined`.
  */
-export const getStartEpochIndex = createGetter((metadata?: Metadata) => {
+export const getUnbondingStartHeight = createGetter((metadata?: Metadata) => {
   if (!metadata) return undefined;
 
   const unbondingMatch = assetPatterns.unbondingToken.capture(metadata.display);
 
   if (unbondingMatch) {
-    const { epoch } = unbondingMatch;
-    if (epoch) return BigInt(epoch);
+    const { startAt } = unbondingMatch;
+    return BigInt(startAt);
   }
 
   return undefined;

--- a/packages/getters/src/undelegate-claim.ts
+++ b/packages/getters/src/undelegate-claim.ts
@@ -9,10 +9,12 @@ export const getBody = createGetter((undelegateClaim?: UndelegateClaim) => undel
 
 export const getValidatorIdentityFromUndelegateClaim = getBody.pipe(getValidatorIdentity);
 
-export const getStartEpochIndexFromUndelegateClaim = getBody.pipe(
+export const getUnbondingStartHeightFromUndelegateClaim = getBody.pipe(
   // Defining this inline rather than exporting `getStartEpochIndex` from
   // `undelegate-claim-body.ts`, since `getStartEpochIndex` is already defined
   // elsewhere and thus would result in a naming conflict in the exports from
   // this package.
-  createGetter((undelegateClaimBody?: UndelegateClaimBody) => undelegateClaimBody?.startEpochIndex),
+  createGetter(
+    (undelegateClaimBody?: UndelegateClaimBody) => undelegateClaimBody?.unbondingStartHeight,
+  ),
 );

--- a/packages/getters/src/undelegate-claim.ts
+++ b/packages/getters/src/undelegate-claim.ts
@@ -10,10 +10,10 @@ export const getBody = createGetter((undelegateClaim?: UndelegateClaim) => undel
 export const getValidatorIdentityFromUndelegateClaim = getBody.pipe(getValidatorIdentity);
 
 export const getUnbondingStartHeightFromUndelegateClaim = getBody.pipe(
-  // Defining this inline rather than exporting `getStartEpochIndex` from
-  // `undelegate-claim-body.ts`, since `getStartEpochIndex` is already defined
-  // elsewhere and thus would result in a naming conflict in the exports from
-  // this package.
+  // Defining this inline rather than exporting `getUnbondingStartHeight` from
+  // `undelegate-claim-body.ts`, since `getUnbondingStartHeight` is already
+  // defined elsewhere and thus would result in a naming conflict in the exports
+  // from this package.
   createGetter(
     (undelegateClaimBody?: UndelegateClaimBody) => undelegateClaimBody?.unbondingStartHeight,
   ),

--- a/packages/getters/src/value-view.ts
+++ b/packages/getters/src/value-view.ts
@@ -72,9 +72,10 @@ export const getAmount = createGetter(
 );
 
 /**
- * For a `ValueView` containing an unbonding token, gets the start epoch index.
+ * For a `ValueView` containing an unbonding token, gets the unbonding start
+ * height.
  */
-export const getStartEpochIndexFromValueView = getMetadata.pipe(getUnbondingStartHeight);
+export const getUnbondingStartHeightFromValueView = getMetadata.pipe(getUnbondingStartHeight);
 
 export const getDisplayDenomFromView = createGetter((view?: ValueView) => {
   if (view?.valueView.case === 'unknownAssetId') {

--- a/packages/getters/src/value-view.ts
+++ b/packages/getters/src/value-view.ts
@@ -3,7 +3,7 @@ import { createGetter } from './utils/create-getter';
 import { bech32AssetId } from '@penumbra-zone/bech32/src/asset';
 import {
   getDisplayDenomExponent,
-  getStartEpochIndex,
+  getUnbondingStartHeight,
   getValidatorIdentityKeyAsBech32String,
 } from './metadata';
 import { Any } from '@bufbuild/protobuf';
@@ -74,7 +74,7 @@ export const getAmount = createGetter(
 /**
  * For a `ValueView` containing an unbonding token, gets the start epoch index.
  */
-export const getStartEpochIndexFromValueView = getMetadata.pipe(getStartEpochIndex);
+export const getStartEpochIndexFromValueView = getMetadata.pipe(getUnbondingStartHeight);
 
 export const getDisplayDenomFromView = createGetter((view?: ValueView) => {
   if (view?.valueView.case === 'unknownAssetId') {

--- a/packages/router/src/grpc/view-protocol-server/asset-metadata-by-id.test.ts
+++ b/packages/router/src/grpc/view-protocol-server/asset-metadata-by-id.test.ts
@@ -75,11 +75,10 @@ describe('AssetMetadataById request handler', () => {
     expect(metadataByIdResponse.denomMetadata?.equals(metadataFromNode)).toBeTruthy();
   });
 
-  test('should return an empty response when metadata not found in idb and node', async () => {
+  test('should fail to get metadata when metadata not found in idb and node', async () => {
     mockIndexedDb.getAssetsMetadata?.mockResolvedValue(undefined);
     mockShieldedPool.assetMetadataById.mockResolvedValueOnce(undefined);
-    const response = new AssetMetadataByIdResponse(await assetMetadataById(request, mockCtx));
-    expect(response.equals(new AssetMetadataByIdResponse())).toBeTruthy();
+    await expect(assetMetadataById(request, mockCtx)).rejects.toThrow();
   });
 
   test('should fail if assetId is missing in request', async () => {

--- a/packages/router/src/grpc/view-protocol-server/asset-metadata-by-id.test.ts
+++ b/packages/router/src/grpc/view-protocol-server/asset-metadata-by-id.test.ts
@@ -75,10 +75,11 @@ describe('AssetMetadataById request handler', () => {
     expect(metadataByIdResponse.denomMetadata?.equals(metadataFromNode)).toBeTruthy();
   });
 
-  test('should fail to get metadata when metadata not found in idb and node', async () => {
+  test('should return an empty response when metadata not found in idb and node', async () => {
     mockIndexedDb.getAssetsMetadata?.mockResolvedValue(undefined);
     mockShieldedPool.assetMetadataById.mockResolvedValueOnce(undefined);
-    await expect(assetMetadataById(request, mockCtx)).rejects.toThrow();
+    const response = new AssetMetadataByIdResponse(await assetMetadataById(request, mockCtx));
+    expect(response.equals(new AssetMetadataByIdResponse())).toBeTruthy();
   });
 
   test('should fail if assetId is missing in request', async () => {

--- a/packages/router/src/grpc/view-protocol-server/helpers.ts
+++ b/packages/router/src/grpc/view-protocol-server/helpers.ts
@@ -25,6 +25,5 @@ export const getAssetMetadata = async (
     return nodeMetadata;
   }
 
-  // If the metadata is not found, throw an error with details about the asset.
-  throw new Error(`No denom metadata found for asset: ${JSON.stringify(targetAsset.toJson())}`);
+  return undefined;
 };

--- a/packages/router/src/grpc/view-protocol-server/helpers.ts
+++ b/packages/router/src/grpc/view-protocol-server/helpers.ts
@@ -25,5 +25,6 @@ export const getAssetMetadata = async (
     return nodeMetadata;
   }
 
-  return undefined;
+  // If the metadata is not found, throw an error with details about the asset.
+  throw new Error(`No denom metadata found for asset: ${JSON.stringify(targetAsset.toJson())}`);
 };

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -458,12 +458,14 @@ export class IndexedDb implements IndexedDbInterface {
     });
   }
 
-  async addEpoch(startHeight: bigint, index?: bigint): Promise<void> {
-    if (index === undefined) {
-      const cursor = await this.db.transaction('EPOCHS', 'readonly').store.openCursor(null, 'prev');
-      const previousEpoch = cursor?.value ? Epoch.fromJson(cursor.value) : undefined;
-      index = previousEpoch?.index !== undefined ? previousEpoch.index + 1n : 0n;
-    }
+  /**
+   * Adds a new epoch with the given start height. Automatically sets the epoch
+   * index by finding the previous epoch index, and adding 1n.
+   */
+  async addEpoch(startHeight: bigint): Promise<void> {
+    const cursor = await this.db.transaction('EPOCHS', 'readonly').store.openCursor(null, 'prev');
+    const previousEpoch = cursor?.value ? Epoch.fromJson(cursor.value) : undefined;
+    const index = previousEpoch?.index !== undefined ? previousEpoch.index + 1n : 0n;
 
     const newEpoch = {
       startHeight: startHeight.toString(),

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -489,8 +489,6 @@ export class IndexedDb implements IndexedDbInterface {
      */
     height: bigint,
   ): Promise<Epoch | undefined> {
-    let cursor = await this.db.transaction('EPOCHS', 'readonly').store.openCursor();
-
     let epoch: Epoch | undefined;
 
     /**
@@ -504,13 +502,11 @@ export class IndexedDb implements IndexedDbInterface {
      * '11' is greater than the string '100', for example). For now, then, we
      * have to just iterate over all epochs to find the correct starting height.
      */
-    while (cursor) {
+    for await (const cursor of this.db.transaction('EPOCHS', 'readonly').store) {
       const currentEpoch = Epoch.fromJson(cursor.value);
 
       if (currentEpoch.startHeight <= height) epoch = currentEpoch;
       else if (currentEpoch.startHeight > height) break;
-
-      cursor = await cursor.continue();
     }
 
     return epoch;

--- a/packages/types/src/customize-symbol.test.ts
+++ b/packages/types/src/customize-symbol.test.ts
@@ -15,10 +15,10 @@ describe('Customizing metadata', () => {
   test('should work for unbonding token', () => {
     const metadata = new Metadata({
       display:
-        'uunbonding_epoch_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
+        'uunbonding_start_at_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
     });
 
-    expect(customizeSymbol(metadata).symbol).toBe('unbondUMe29(fjuj67ay…)');
+    expect(customizeSymbol(metadata).symbol).toBe('unbondUMat29(fjuj67ay…)');
   });
 
   test('should do nothing if no matches', () => {

--- a/packages/types/src/customize-symbol.test.ts
+++ b/packages/types/src/customize-symbol.test.ts
@@ -15,7 +15,7 @@ describe('Customizing metadata', () => {
   test('should work for unbonding token', () => {
     const metadata = new Metadata({
       display:
-        'uunbonding_start_at_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
+        'unbonding_start_at_29_penumbravalid1fjuj67ayaqueqxg03d65ps5aah6m39u39qeacu3zv2cw3dzxssyq3yrcez',
     });
 
     expect(customizeSymbol(metadata).symbol).toBe('unbondUMat29(fjuj67ay…)');

--- a/packages/types/src/customize-symbol.ts
+++ b/packages/types/src/customize-symbol.ts
@@ -18,7 +18,7 @@ export const customizeSymbol = (metadata: Metadata) => {
   if (unbondingMatch) {
     const shortenedId = unbondingMatch.id.slice(0, SHORTENED_ID_LENGTH);
     const customized = metadata.clone();
-    customized.symbol = `unbondUMe${unbondingMatch.epoch}(${shortenedId}…)`;
+    customized.symbol = `unbondUMat${unbondingMatch.startAt}(${shortenedId}…)`;
     return customized;
   }
 

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -89,7 +89,7 @@ export interface IndexedDbInterface {
   ): AsyncGenerator<PositionId, void>;
   addPosition(positionId: PositionId, position: Position): Promise<void>;
   updatePosition(positionId: PositionId, newState: PositionState): Promise<void>;
-  addEpoch(startHeight: bigint, index?: bigint): Promise<void>;
+  addEpoch(startHeight: bigint): Promise<void>;
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
   upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;
   iterateValidatorInfos(): AsyncGenerator<ValidatorInfo, void>;

--- a/packages/ui/components/ui/tx/view/undelegate-claim.tsx
+++ b/packages/ui/components/ui/tx/view/undelegate-claim.tsx
@@ -3,14 +3,14 @@ import { ViewBox } from './viewbox';
 import { IdentityKeyComponent } from '../../identity-key-component';
 import { ActionDetails } from './action-details';
 import {
-  getStartEpochIndexFromUndelegateClaim,
+  getUnbondingStartHeightFromUndelegateClaim,
   getValidatorIdentityFromUndelegateClaim,
 } from '@penumbra-zone/getters/src/undelegate-claim';
 
 /** Render an `UndelegateClaim` action. */
 export const UndelegateClaimComponent = ({ value }: { value: UndelegateClaim }) => {
   const validatorIdentity = getValidatorIdentityFromUndelegateClaim(value);
-  const startEpochIndex = getStartEpochIndexFromUndelegateClaim(value);
+  const unbondingStartHeight = getUnbondingStartHeightFromUndelegateClaim(value);
 
   return (
     <ViewBox
@@ -21,8 +21,8 @@ export const UndelegateClaimComponent = ({ value }: { value: UndelegateClaim }) 
             <IdentityKeyComponent identityKey={validatorIdentity} />
           </ActionDetails.Row>
 
-          <ActionDetails.Row label='Unbonding start epoch'>
-            {startEpochIndex.toString()}
+          <ActionDetails.Row label='Unbonding start height'>
+            {unbondingStartHeight.toString()}
           </ActionDetails.Row>
         </ActionDetails>
       }

--- a/packages/ui/components/ui/tx/view/undelegate.tsx
+++ b/packages/ui/components/ui/tx/view/undelegate.tsx
@@ -13,10 +13,6 @@ export const UndelegateComponent = ({ value }: { value: Undelegate }) => {
       label='Undelegate'
       visibleContent={
         <ActionDetails>
-          <ActionDetails.Row label='Epoch index'>
-            {value.startEpochIndex.toString()}
-          </ActionDetails.Row>
-
           {!!value.delegationAmount && (
             <ActionDetails.Row label='Delegation amount'>
               {joinLoHiAmount(value.delegationAmount).toString()}

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -33,7 +33,7 @@ export const ValueViewComponent = ({
     const value = view.valueView.value;
     const metadata = view.valueView.value.metadata;
     const amount = value.amount ?? new Amount();
-    const exponent = getDisplayDenomExponent(metadata);
+    const exponent = getDisplayDenomExponent.optional()(metadata);
     // The regex trims trailing zeros which toFormat adds in
     const formattedAmount = fromBaseUnitAmount(amount, exponent)
       .toFormat(6)

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -15,21 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,66 +345,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base16ct"
@@ -851,8 +776,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -865,8 +790,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -1069,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1278,12 +1203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,25 +1211,6 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap 2.2.5",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1367,77 +1267,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1478,7 +1308,6 @@ dependencies = [
  "serde",
  "subtle-encoding",
  "tendermint-proto",
- "tonic",
 ]
 
 [[package]]
@@ -2017,12 +1846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,32 +1871,6 @@ checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
 dependencies = [
  "ahash",
  "portable-atomic",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2172,15 +1969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2299,8 +2087,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2337,8 +2125,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2367,8 +2155,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2399,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2451,8 +2239,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,8 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2490,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2509,8 +2297,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2561,8 +2349,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2594,8 +2382,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "aes",
  "anyhow",
@@ -2638,8 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2674,8 +2462,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2700,8 +2488,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,14 +2510,13 @@ dependencies = [
  "serde_json",
  "subtle-encoding",
  "tendermint",
- "tonic",
  "tracing",
 ]
 
 [[package]]
 name = "penumbra-sct"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2759,8 +2546,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2806,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2848,8 +2635,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2876,8 +2663,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2926,8 +2713,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.70.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
+version = "0.70.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -2952,8 +2739,6 @@ dependencies = [
  "penumbra-compact-block",
  "penumbra-dex",
  "penumbra-fee",
- "penumbra-governance",
- "penumbra-ibc",
  "penumbra-keys",
  "penumbra-num",
  "penumbra-proof-params",
@@ -2973,12 +2758,6 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -3357,12 +3136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,14 +3160,8 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -3670,16 +3437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
-name = "socket2"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,12 +3502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,7 +3516,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3890,56 +3641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3957,47 +3658,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4092,12 +3757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4158,15 +3817,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
 
 [[package]]
 name = "wasi"
@@ -4316,15 +3966,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -15,6 +15,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +360,66 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base16ct"
@@ -776,8 +851,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -790,8 +865,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -994,7 +1069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1203,6 +1278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1292,25 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.2.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1267,7 +1367,77 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1308,6 +1478,7 @@ dependencies = [
  "serde",
  "subtle-encoding",
  "tendermint-proto",
+ "tonic",
 ]
 
 [[package]]
@@ -1846,6 +2017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +2048,32 @@ checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
 dependencies = [
  "ahash",
  "portable-atomic",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1969,6 +2172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2087,8 +2299,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2125,8 +2337,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2155,8 +2367,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2187,8 +2399,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2239,8 +2451,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2255,8 +2467,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2278,8 +2490,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2297,8 +2509,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2322,6 +2534,7 @@ dependencies = [
  "pbjson-types",
  "penumbra-asset",
  "penumbra-community-pool",
+ "penumbra-dex",
  "penumbra-distributions",
  "penumbra-fee",
  "penumbra-funding",
@@ -2348,8 +2561,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2381,8 +2594,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "aes",
  "anyhow",
@@ -2425,8 +2638,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2461,8 +2674,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2487,8 +2700,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2509,13 +2722,14 @@ dependencies = [
  "serde_json",
  "subtle-encoding",
  "tendermint",
+ "tonic",
  "tracing",
 ]
 
 [[package]]
 name = "penumbra-sct"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2545,8 +2759,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2592,8 +2806,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2627,14 +2841,15 @@ dependencies = [
  "serde_unit_struct",
  "serde_with",
  "sha2 0.10.8",
+ "tap",
  "tendermint",
  "tracing",
 ]
 
 [[package]]
 name = "penumbra-tct"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2661,8 +2876,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2711,8 +2926,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.68.3"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.3#7633cee0d7567924bb6f0139b8853bb92cd0d6fe"
+version = "0.70.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.0#6aa6efab4c1af3d9ef7626e0e3a8ddc8b7dc51b2"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -2758,6 +2973,12 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -3136,6 +3357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,8 +3387,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -3437,6 +3670,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
+name = "socket2"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,6 +3745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3516,7 +3765,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3641,6 +3890,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,11 +3957,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3757,6 +4092,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +4158,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -3966,6 +4316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -776,8 +776,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -790,8 +790,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2087,8 +2087,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2125,8 +2125,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2155,8 +2155,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2187,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2239,8 +2239,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2255,8 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2278,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2297,8 +2297,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2349,8 +2349,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2382,8 +2382,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "aes",
  "anyhow",
@@ -2426,8 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2462,8 +2462,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2488,8 +2488,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2515,8 +2515,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2546,8 +2546,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2593,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2635,8 +2635,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2663,8 +2663,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2713,8 +2713,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.70.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
+version = "0.70.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.3#50d1643e91250617f4545b73ec50b1be6c0ff9a0"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -776,8 +776,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -790,8 +790,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2087,8 +2087,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2125,8 +2125,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2155,8 +2155,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2187,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2239,8 +2239,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2255,8 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2278,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2297,8 +2297,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2349,8 +2349,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2382,8 +2382,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "aes",
  "anyhow",
@@ -2426,8 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2462,8 +2462,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2488,8 +2488,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2515,8 +2515,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2546,8 +2546,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2593,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2635,8 +2635,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2663,8 +2663,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2713,8 +2713,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.70.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.1#b2d00750fb7cc2d1cd44590bac0594abca5bb134"
+version = "0.70.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.70.2#fe0202b79c85ae02ab16b81636d22d40bde3f297"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,19 +15,19 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-fee", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-transaction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-fee", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.3", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.80"
 ark-ff                   = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,21 +15,19 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-fee", default-features = false }
-penumbra-governance    = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-governance", default-features = false }
-penumbra-ibc           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-ibc", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-transaction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-fee", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.80"
 ark-ff                   = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,19 +15,19 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-fee", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.1", package = "penumbra-transaction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-fee", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.2", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.80"
 ark-ff                   = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,21 +15,21 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-fee", default-features = false }
-penumbra-governance    = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-governance", default-features = false }
-penumbra-ibc           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-ibc", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.3", package = "penumbra-transaction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-fee", default-features = false }
+penumbra-governance    = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-governance", default-features = false }
+penumbra-ibc           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-ibc", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.70.0", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.80"
 ark-ff                   = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -300,23 +300,29 @@ pub async fn plan_transaction(
     }
 
     for tpr::Delegate { amount, rate_data } in request.delegations {
+        let epoch = storage.get_latest_known_epoch().await?.unwrap();
         let amount = amount
             .ok_or_else(|| anyhow!("missing amount in delegation"))?
             .try_into()?;
         let rate_data: RateData = rate_data
             .ok_or_else(|| anyhow!("missing rate data in delegation"))?
             .try_into()?;
-        actions.push(rate_data.build_delegate(amount).into());
+        actions.push(rate_data.build_delegate(epoch.into(), amount).into());
     }
 
     for tpr::Undelegate { value, rate_data } in request.undelegations {
+        let epoch = storage.get_latest_known_epoch().await?.unwrap();
         let value: Value = value
             .ok_or_else(|| anyhow!("missing value in undelegation"))?
             .try_into()?;
         let rate_data: RateData = rate_data
             .ok_or_else(|| anyhow!("missing rate data in undelegation"))?
             .try_into()?;
-        actions.push(rate_data.build_undelegate(value.amount).into());
+        actions.push(
+            rate_data
+                .build_undelegate(epoch.into(), value.amount)
+                .into(),
+        );
     }
 
     for tpr::UndelegateClaim {

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -327,9 +327,10 @@ pub async fn plan_transaction(
 
     for tpr::UndelegateClaim {
         validator_identity,
-        start_epoch_index,
+        unbonding_start_height,
         penalty,
         unbonding_amount,
+        ..
     } in request.undelegation_claims
     {
         let validator_identity: IdentityKey = validator_identity
@@ -344,7 +345,7 @@ pub async fn plan_transaction(
 
         let undelegate_claim_plan = UndelegateClaimPlan {
             validator_identity,
-            start_epoch_index,
+            unbonding_start_height,
             penalty,
             unbonding_amount,
             balance_blinding: Fr::rand(&mut OsRng),

--- a/packages/wasm/crate/src/storage.rs
+++ b/packages/wasm/crate/src/storage.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
 use web_sys::IdbTransactionMode::Readwrite;
 
-use crate::error::{WasmError, WasmResult};
+use crate::error::WasmResult;
 use crate::note_record::SpendableNoteRecord;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/packages/wasm/crate/src/storage.rs
+++ b/packages/wasm/crate/src/storage.rs
@@ -39,6 +39,7 @@ pub struct Tables {
     pub fmd_parameters: String,
     pub app_parameters: String,
     pub gas_prices: String,
+    pub epochs: String,
 }
 
 pub struct IndexedDBStorage {

--- a/packages/wasm/crate/src/storage.rs
+++ b/packages/wasm/crate/src/storage.rs
@@ -311,15 +311,10 @@ impl IndexedDBStorage {
         let tx = self.db.transaction_on_one(&self.constants.tables.epochs)?;
         let store = tx.object_store(&self.constants.tables.epochs)?;
 
-        if let Some(cursor) = store
+        Ok(store
             .open_cursor_with_direction(web_sys::IdbCursorDirection::Prev)?
             .await?
-        {
-            // Return the first epoch index, since we're cursoring from the end.
-            let epoch: Epoch = serde_wasm_bindgen::from_value(cursor.value())?;
-            return Ok(Some(epoch));
-        }
-
-        Ok(None)
+            .map(|cursor| serde_wasm_bindgen::from_value(cursor.value()).ok())
+            .flatten())
     }
 }

--- a/packages/wasm/crate/src/storage.rs
+++ b/packages/wasm/crate/src/storage.rs
@@ -314,7 +314,6 @@ impl IndexedDBStorage {
         Ok(store
             .open_cursor_with_direction(web_sys::IdbCursorDirection::Prev)?
             .await?
-            .map(|cursor| serde_wasm_bindgen::from_value(cursor.value()).ok())
-            .flatten())
+            .and_then(|cursor| serde_wasm_bindgen::from_value(cursor.value()).ok()))
     }
 }

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -6,6 +6,7 @@ mod tests {
     use indexed_db_futures::prelude::{
         IdbDatabase, IdbObjectStore, IdbQuerySource, IdbTransaction, IdbTransactionMode,
     };
+    use penumbra_dex::DexParameters;
     use penumbra_proto::core::app::v1::AppParameters;
     use penumbra_proto::core::component::fee::v1::GasPrices;
     use penumbra_proto::view::v1::transaction_planner_request::Output;
@@ -114,8 +115,14 @@ mod tests {
         let sct_params = SctParameters {
             epoch_duration: 5u64,
         };
+        let dex_params = DexParameters {
+            fixed_candidates: Vec::new(),
+            is_enabled: true,
+            max_hops: 5u32,
+        };
 
         let app_params = AppParameters {
+            dex_params: Some(dex_params.to_proto()),
             chain_id,
             sct_params: Some(sct_params.to_proto()),
             community_pool_params: None,
@@ -388,6 +395,8 @@ mod tests {
         // -------------- 1. Query transaction plan performing a spend --------------
 
         let planner_request = TransactionPlannerRequest {
+            epoch: None,
+            epoch_index: 0,
             expiry_height: 0,
             memo: Some(memo),
             source: None,

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -91,6 +91,7 @@ mod tests {
             fmd_parameters: String,
             app_parameters: String,
             gas_prices: String,
+            epochs: String,
         }
 
         // Define `IndexDB` table parameters and constants.
@@ -102,6 +103,7 @@ mod tests {
             fmd_parameters: "FMD_PARAMETERS".to_string(),
             app_parameters: "APP_PARAMETERS".to_string(),
             gas_prices: "GAS_PRICES".to_string(),
+            epochs: "EPOCHS".to_string(),
         };
 
         let constants: IndexedDbConstants = IndexedDbConstants {

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -211,10 +211,10 @@ mod tests {
                 "lo": "1",
                 "hi": "0"
             },
-            "asset_id": { 
-                "inner": "nwPDkQq3OvLnBwGTD+nmv1Ifb2GEmFCgNHrU++9BsRE=", 
-                "alt_bech32m": "", 
-                "alt_base_denom": "" 
+            "asset_id": {
+                "inner": "nwPDkQq3OvLnBwGTD+nmv1Ifb2GEmFCgNHrU++9BsRE=",
+                "alt_bech32m": "",
+                "alt_base_denom": ""
             }
         }
         "#;
@@ -394,6 +394,7 @@ mod tests {
 
         // -------------- 1. Query transaction plan performing a spend --------------
 
+        #[allow(deprecated)] // Remove if/when `epoch_index` is removed
         let planner_request = TransactionPlannerRequest {
             epoch: None,
             epoch_index: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 1.4.0-20240327103030-e2006674271c.2
         version: 1.4.0-20240327103030-e2006674271c.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/penumbra-zone_penumbra.bufbuild_es':
-        specifier: 1.8.0-20240326223351-a25fff24022e.2
-        version: 1.8.0-20240326223351-a25fff24022e.2(@bufbuild/protobuf@1.8.0)
+        specifier: 1.8.0-20240327192233-658f3904024e.2
+        version: 1.8.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0)
       '@buf/penumbra-zone_penumbra.connectrpc_es':
-        specifier: 1.4.0-20240326223351-a25fff24022e.2
-        version: 1.4.0-20240326223351-a25fff24022e.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
+        specifier: 1.4.0-20240327192233-658f3904024e.2
+        version: 1.4.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/tendermint_tendermint.bufbuild_es':
         specifier: 1.8.0-20231117195010-33ed361a9051.2
         version: 1.8.0-20231117195010-33ed361a9051.2(@bufbuild/protobuf@1.8.0)
@@ -98,7 +98,7 @@ importers:
         version: 0.4.6(eslint@8.57.0)
       eslint-plugin-tailwindcss:
         specifier: ^3.15.1
-        version: 3.15.1(tailwindcss@3.4.1)
+        version: 3.15.1(tailwindcss@3.4.2)
       eslint-plugin-turbo:
         specifier: ^1.13.0
         version: 1.13.0(eslint@8.57.0)
@@ -2552,8 +2552,8 @@ packages:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/penumbra-zone_penumbra.bufbuild_es@1.7.2-20240326223351-a25fff24022e.1(@bufbuild/protobuf@1.8.0):
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.7.2-20240326223351-a25fff24022e.1.tgz}
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.7.2-20240327192233-658f3904024e.1(@bufbuild/protobuf@1.8.0):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.7.2-20240327192233-658f3904024e.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.7.2
     dependencies:
@@ -2580,8 +2580,22 @@ packages:
       '@bufbuild/protobuf': 1.8.0
     dev: false
 
-  /@buf/penumbra-zone_penumbra.connectrpc_es@1.4.0-20240326223351-a25fff24022e.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0):
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.4.0-20240326223351-a25fff24022e.2.tgz}
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.8.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.8.0-20240327192233-658f3904024e.2.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.8.0
+    dependencies:
+      '@buf/cosmos_cosmos-proto.bufbuild_es': 1.8.0-20211202220400-1935555c206d.2(@bufbuild/protobuf@1.8.0)
+      '@buf/cosmos_cosmos-sdk.bufbuild_es': 1.8.0-20230522115704-e7a85cef453e.2(@bufbuild/protobuf@1.8.0)
+      '@buf/cosmos_gogo-proto.bufbuild_es': 1.8.0-20221020125208-34d970b699f8.2(@bufbuild/protobuf@1.8.0)
+      '@buf/cosmos_ibc.bufbuild_es': 1.8.0-20230913112312-7ab44ae956a0.2(@bufbuild/protobuf@1.8.0)
+      '@buf/cosmos_ics23.bufbuild_es': 1.8.0-20221207100654-55085f7c710a.2(@bufbuild/protobuf@1.8.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 1.8.0-20221214150216-75b4300737fb.2(@bufbuild/protobuf@1.8.0)
+      '@bufbuild/protobuf': 1.8.0
+    dev: false
+
+  /@buf/penumbra-zone_penumbra.connectrpc_es@1.4.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.4.0-20240327192233-658f3904024e.2.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.4.0
     dependencies:
@@ -2591,7 +2605,7 @@ packages:
       '@buf/cosmos_ibc.connectrpc_es': 1.4.0-20230913112312-7ab44ae956a0.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/cosmos_ics23.connectrpc_es': 1.4.0-20221207100654-55085f7c710a.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/googleapis_googleapis.connectrpc_es': 1.4.0-20221214150216-75b4300737fb.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
-      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.7.2-20240326223351-a25fff24022e.1(@bufbuild/protobuf@1.8.0)
+      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.7.2-20240327192233-658f3904024e.1(@bufbuild/protobuf@1.8.0)
       '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.8.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
@@ -9129,7 +9143,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-tailwindcss@3.15.1(tailwindcss@3.4.1):
+  /eslint-plugin-tailwindcss@3.15.1(tailwindcss@3.4.2):
     resolution: {integrity: sha512-4RXRMIaMG07C2TBEW1k0VM4+dDazz1kxcZhkK4zirvmHGZTA4jnlSO2kq5mamuSPi+Wo17dh2SlC8IyFBuCd7Q==}
     engines: {node: '>=12.13.0'}
     peerDependencies:
@@ -9137,7 +9151,7 @@ packages:
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.38
-      tailwindcss: 3.4.1
+      tailwindcss: 3.4.2
     dev: true
 
   /eslint-plugin-turbo@1.13.0(eslint@8.57.0):
@@ -14835,6 +14849,37 @@ packages:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
+
+  /tailwindcss@3.4.2:
+    resolution: {integrity: sha512-1kIzVecynNKMhhX8mPTOwTkkVHupUTMbEvk4n1ByxdM8sQTJ8fE41Y4TdORG6GmiVXHhfZ/++0hiIFJFwfadsA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.38
+      postcss-import: 15.1.0(postcss@8.4.38)
+      postcss-js: 4.0.1(postcss@8.4.38)
+      postcss-load-config: 4.0.2(postcss@8.4.38)
+      postcss-nested: 6.0.1(postcss@8.4.38)
+      postcss-selector-parser: 6.0.16
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
 
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 1.4.0-20240327103030-e2006674271c.2
         version: 1.4.0-20240327103030-e2006674271c.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/penumbra-zone_penumbra.bufbuild_es':
-        specifier: 1.8.0-20240327192233-658f3904024e.2
-        version: 1.8.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0)
+        specifier: 1.8.0-20240327223130-72af6abcb670.2
+        version: 1.8.0-20240327223130-72af6abcb670.2(@bufbuild/protobuf@1.8.0)
       '@buf/penumbra-zone_penumbra.connectrpc_es':
-        specifier: 1.4.0-20240327192233-658f3904024e.2
-        version: 1.4.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
+        specifier: 1.4.0-20240327223130-72af6abcb670.2
+        version: 1.4.0-20240327223130-72af6abcb670.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/tendermint_tendermint.bufbuild_es':
         specifier: 1.8.0-20231117195010-33ed361a9051.2
         version: 1.8.0-20231117195010-33ed361a9051.2(@bufbuild/protobuf@1.8.0)
@@ -98,7 +98,7 @@ importers:
         version: 0.4.6(eslint@8.57.0)
       eslint-plugin-tailwindcss:
         specifier: ^3.15.1
-        version: 3.15.1(tailwindcss@3.4.2)
+        version: 3.15.1(tailwindcss@3.4.3)
       eslint-plugin-turbo:
         specifier: ^1.13.0
         version: 1.13.0(eslint@8.57.0)
@@ -2552,8 +2552,8 @@ packages:
       - '@bufbuild/protobuf'
     dev: false
 
-  /@buf/penumbra-zone_penumbra.bufbuild_es@1.7.2-20240327192233-658f3904024e.1(@bufbuild/protobuf@1.8.0):
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.7.2-20240327192233-658f3904024e.1.tgz}
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.7.2-20240327223130-72af6abcb670.1(@bufbuild/protobuf@1.8.0):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.7.2-20240327223130-72af6abcb670.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.7.2
     dependencies:
@@ -2580,8 +2580,8 @@ packages:
       '@bufbuild/protobuf': 1.8.0
     dev: false
 
-  /@buf/penumbra-zone_penumbra.bufbuild_es@1.8.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0):
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.8.0-20240327192233-658f3904024e.2.tgz}
+  /@buf/penumbra-zone_penumbra.bufbuild_es@1.8.0-20240327223130-72af6abcb670.2(@bufbuild/protobuf@1.8.0):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.8.0-20240327223130-72af6abcb670.2.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^1.8.0
     dependencies:
@@ -2594,8 +2594,8 @@ packages:
       '@bufbuild/protobuf': 1.8.0
     dev: false
 
-  /@buf/penumbra-zone_penumbra.connectrpc_es@1.4.0-20240327192233-658f3904024e.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0):
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.4.0-20240327192233-658f3904024e.2.tgz}
+  /@buf/penumbra-zone_penumbra.connectrpc_es@1.4.0-20240327223130-72af6abcb670.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.4.0-20240327223130-72af6abcb670.2.tgz}
     peerDependencies:
       '@connectrpc/connect': ^1.4.0
     dependencies:
@@ -2605,7 +2605,7 @@ packages:
       '@buf/cosmos_ibc.connectrpc_es': 1.4.0-20230913112312-7ab44ae956a0.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/cosmos_ics23.connectrpc_es': 1.4.0-20221207100654-55085f7c710a.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
       '@buf/googleapis_googleapis.connectrpc_es': 1.4.0-20221214150216-75b4300737fb.2(@bufbuild/protobuf@1.8.0)(@connectrpc/connect@1.4.0)
-      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.7.2-20240327192233-658f3904024e.1(@bufbuild/protobuf@1.8.0)
+      '@buf/penumbra-zone_penumbra.bufbuild_es': 1.7.2-20240327223130-72af6abcb670.1(@bufbuild/protobuf@1.8.0)
       '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.8.0)
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
@@ -9143,7 +9143,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-tailwindcss@3.15.1(tailwindcss@3.4.2):
+  /eslint-plugin-tailwindcss@3.15.1(tailwindcss@3.4.3):
     resolution: {integrity: sha512-4RXRMIaMG07C2TBEW1k0VM4+dDazz1kxcZhkK4zirvmHGZTA4jnlSO2kq5mamuSPi+Wo17dh2SlC8IyFBuCd7Q==}
     engines: {node: '>=12.13.0'}
     peerDependencies:
@@ -9151,7 +9151,7 @@ packages:
     dependencies:
       fast-glob: 3.3.2
       postcss: 8.4.38
-      tailwindcss: 3.4.2
+      tailwindcss: 3.4.3
     dev: true
 
   /eslint-plugin-turbo@1.13.0(eslint@8.57.0):
@@ -14850,8 +14850,8 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
-  /tailwindcss@3.4.2:
-    resolution: {integrity: sha512-1kIzVecynNKMhhX8mPTOwTkkVHupUTMbEvk4n1ByxdM8sQTJ8fE41Y4TdORG6GmiVXHhfZ/++0hiIFJFwfadsA==}
+  /tailwindcss@3.4.3:
+    resolution: {integrity: sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
## In this PR
- Update Cargo and NPM dependencies on core packages.
- Fix various places where we were previously using epochs, but are now using block heights.
  - This includes unbonding tokens. Unbonding tokens used to be named like `uunbonding_epoch_N_penumbravalid1abc123`. Now, unbonding tokens refer to a start _block height_, rather than a start _epoch_, so they're of the form `unbonding_start_at_N_penumbravalidabc123`. Also, they now have multiple denom units, so the display denom just starts with `unbonding_` rather than `uunbonding`.
- Fix a bug with how we stored epochs.
  - Previously, we stored new epochs only at epoch transitions. However, this meant that the first epoch (index 0) was missing! So, I updated the block processor to create an initial epoch if we're starting sync at block height 0.