### PR TITLE
suggested wasm updates

### DIFF
--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -384,9 +384,7 @@ export class BlockProcessor implements BlockProcessorInterface {
   // This is expensive to do every block, so should only be done in development.
   // @ts-expect-error Only used ad-hoc in dev
   private async assertRootValid(blockHeight: bigint): Promise<void> {
-    const sourceOfTruth: Uint8Array = await this.querier.cnidarium.keyValue(
-      `sct/anchor/${blockHeight}`,
-    );
+    const sourceOfTruth = await this.querier.cnidarium.keyValue(`sct/anchor/${blockHeight}`);
     const inMemoryRoot = this.viewServer.getSctRoot();
     if (!validSctRoot({ inner: sourceOfTruth }))
       throw new Error(`Block height: ${blockHeight}. Remote cnidarium provided invalid SCT root.`);

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -1,7 +1,7 @@
 import { RootQuerier } from './root-querier';
 import { sha256Hash } from '@penumbra-zone/crypto-web/src/sha256';
 import { computePositionId, getLpNftMetadata } from '@penumbra-zone/wasm/src/dex';
-import { validSctRoot as validSctRoot } from '@penumbra-zone/wasm/src/sct';
+import { validSctRoot } from '@penumbra-zone/wasm/src/sct';
 
 import {
   getExchangeRateFromValidatorInfoResponse,

--- a/packages/wasm/crate/src/keys.rs
+++ b/packages/wasm/crate/src/keys.rs
@@ -10,7 +10,6 @@ use penumbra_proof_params::{
 use penumbra_proto::{core::keys::v1 as pb, serializers::bech32str, DomainType};
 use rand_core::OsRng;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::js_sys::Uint8Array;
 
 use crate::error::WasmResult;
 use crate::utils;
@@ -21,10 +20,7 @@ use crate::utils;
 /// function will additionally require downloading the proving key parameter `.bin`
 /// file for each key type.
 #[wasm_bindgen]
-pub fn load_proving_key(parameters: JsValue, key_type: &str) -> WasmResult<()> {
-    // Deserialize JsValue into Vec<u8>.
-    let parameters_bytes: Vec<u8> = Uint8Array::new(&parameters).to_vec();
-
+pub fn load_proving_key(key: Vec<u8>, key_type: &str) -> WasmResult<()> {
     // Map key type with proving keys.
     let proving_key_map = match key_type {
         "spend" => &SPEND_PROOF_PROVING_KEY,
@@ -37,7 +33,7 @@ pub fn load_proving_key(parameters: JsValue, key_type: &str) -> WasmResult<()> {
     };
 
     // Load proving key.
-    proving_key_map.try_load_unchecked(&parameters_bytes)?;
+    proving_key_map.try_load_unchecked(&key)?;
     Ok(())
 }
 

--- a/packages/wasm/crate/src/lib.rs
+++ b/packages/wasm/crate/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod keys;
 pub mod note_record;
 pub mod planner;
+pub mod sct;
 pub mod storage;
 pub mod swap_record;
 pub mod tx;

--- a/packages/wasm/crate/src/sct.rs
+++ b/packages/wasm/crate/src/sct.rs
@@ -1,0 +1,12 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use penumbra_proto::DomainType;
+
+/// check validity of SCT root by attempting to parse it
+/// Arguments:
+///     root: `Uint8Array representing sct root hash`
+/// Returns: boolean
+#[wasm_bindgen]
+pub fn valid_sct_root(root: Vec<u8>) -> bool {
+    return penumbra_tct::Root::decode(root.as_slice()).is_ok();
+}

--- a/packages/wasm/crate/src/utils.rs
+++ b/packages/wasm/crate/src/utils.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::wasm_bindgen;
-use wasm_bindgen::JsValue;
 
 use penumbra_proto::DomainType;
 
@@ -19,14 +18,11 @@ pub fn set_panic_hook() {
 
 /// decode SCT root
 /// Arguments:
-///     tx_bytes: `HEX string`
-/// Returns: `penumbra_tct::Root`
+///     txId: `Uint8Array representing the hash of a transaction (TransactionId)`
+/// Returns: `Uint8Array representing a penumbra_tct::Root`
 #[wasm_bindgen]
-pub fn decode_sct_root(tx_bytes: &str) -> WasmResult<JsValue> {
+pub fn decode_sct_root(tx: Vec<u8>) -> WasmResult<Vec<u8>> {
     utils::set_panic_hook();
-
-    let tx_vec: Vec<u8> = hex::decode(tx_bytes)?;
-    let root = penumbra_tct::Root::decode(tx_vec.as_slice())?;
-    let result = serde_wasm_bindgen::to_value(&root)?;
-    Ok(result)
+    let root = penumbra_tct::Root::decode(tx.as_slice())?;
+    Ok(root.encode_to_vec())
 }

--- a/packages/wasm/crate/src/utils.rs
+++ b/packages/wasm/crate/src/utils.rs
@@ -1,10 +1,3 @@
-use wasm_bindgen::prelude::wasm_bindgen;
-
-use penumbra_proto::DomainType;
-
-use crate::error::WasmResult;
-use crate::utils;
-
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
@@ -14,15 +7,4 @@ pub fn set_panic_hook() {
     // https://github.com/rustwasm/console_error_panic_hook#readme
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
-}
-
-/// decode SCT root
-/// Arguments:
-///     txId: `Uint8Array representing the hash of a transaction (TransactionId)`
-/// Returns: `Uint8Array representing a penumbra_tct::Root`
-#[wasm_bindgen]
-pub fn decode_sct_root(tx: Vec<u8>) -> WasmResult<Vec<u8>> {
-    utils::set_panic_hook();
-    let root = penumbra_tct::Root::decode(tx.as_slice())?;
-    Ok(root.encode_to_vec())
 }

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -55,23 +55,14 @@ mod tests {
             include_bytes!("../../../../apps/extension/bin/swapclaim_pk.bin");
         let convert_key: &[u8] = include_bytes!("../../../../apps/extension/bin/convert_pk.bin");
 
-        // Serialize &[u8] to JsValue.
-        let spend_key_js: JsValue = serde_wasm_bindgen::to_value(&spend_key).unwrap();
-        let output_key_js: JsValue = serde_wasm_bindgen::to_value(&output_key).unwrap();
-        let delegator_vote_key_js: JsValue =
-            serde_wasm_bindgen::to_value(&delegator_vote_key).unwrap();
-        let swap_key_js: JsValue = serde_wasm_bindgen::to_value(&swap_key).unwrap();
-        let swapclaim_key_js: JsValue = serde_wasm_bindgen::to_value(&swapclaim_key).unwrap();
-        let convert_key_js: JsValue = serde_wasm_bindgen::to_value(&convert_key).unwrap();
-
         // Dynamically load the proving keys at runtime for each key type.
-        load_proving_key(spend_key_js, "spend").expect("can load spend key");
-        load_proving_key(output_key_js, "output").expect("can load output key");
-        load_proving_key(delegator_vote_key_js, "delegator_vote")
+        load_proving_key(spend_key.to_vec(), "spend").expect("can load spend key");
+        load_proving_key(output_key.to_vec(), "output").expect("can load output key");
+        load_proving_key(delegator_vote_key.to_vec(), "delegator_vote")
             .expect("can load delegator vote key");
-        load_proving_key(swap_key_js, "swap").expect("can load swap key");
-        load_proving_key(swapclaim_key_js, "swapclaim").expect("can load swapclaim key");
-        load_proving_key(convert_key_js, "convert").expect("can load convert key");
+        load_proving_key(swap_key.to_vec(), "swap").expect("can load swap key");
+        load_proving_key(swapclaim_key.to_vec(), "swapclaim").expect("can load swapclaim key");
+        load_proving_key(convert_key.to_vec(), "convert").expect("can load convert key");
 
         // Define database parameters.
         #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/packages/wasm/src/build.ts
+++ b/packages/wasm/src/build.ts
@@ -61,6 +61,6 @@ const loadProvingKey = async (actionType: ActionType) => {
   if (!keyType) return;
 
   const res = await fetch(`bin/${keyType}_pk.bin`);
-  const keyBin = await res.arrayBuffer();
+  const keyBin = new Uint8Array(await res.arrayBuffer());
   load_proving_key(keyBin, keyType);
 };

--- a/packages/wasm/src/sct.test.ts
+++ b/packages/wasm/src/sct.test.ts
@@ -1,17 +1,31 @@
-import { describe, expect, it } from 'vitest';
-import { decodeSctRoot } from './sct';
+import { describe, expect, test } from 'vitest';
+import { validSctRoot } from './sct';
+import { valid_sct_root } from '../wasm';
 
-describe('tct', () => {
-  describe('decodeSctRoot()', () => {
-    it('does not raise zod validation error', () => {
-      const root = new Uint8Array([
-        10, 32, 50, 68, 201, 21, 142, 211, 35, 124, 216, 158, 24, 100, 137, 54, 212, 195, 130, 17,
-        160, 58, 0, 158, 208, 124, 120, 162, 25, 141, 214, 66, 221, 3,
-      ]);
+describe('sct', () => {
+  const valid = new Uint8Array([
+    10, 32, 50, 68, 201, 21, 142, 211, 35, 124, 216, 158, 24, 100, 137, 54, 212, 195, 130, 17, 160,
+    58, 0, 158, 208, 124, 120, 162, 25, 141, 214, 66, 221, 3,
+  ]);
 
-      expect(() => {
-        decodeSctRoot(root);
-      }).not.toThrow();
-    });
+  describe('valid_sct_root', () => {
+    test('detects valid root hash', () => expect(valid_sct_root(valid)).toEqual(true));
+    test('detects invalid root hash', () =>
+      expect(valid_sct_root(new Uint8Array())).toEqual(false));
+  });
+
+  describe('validSctRoot()', () => {
+    test('detects valid root hash', () =>
+      expect(
+        validSctRoot({
+          inner: valid,
+        }),
+      ).toEqual(true));
+    test('detects invalid root hash', () =>
+      expect(
+        validSctRoot({
+          inner: new Uint8Array(),
+        }),
+      ).toEqual(false));
   });
 });

--- a/packages/wasm/src/sct.ts
+++ b/packages/wasm/src/sct.ts
@@ -1,7 +1,5 @@
-import { decode_sct_root } from '../wasm';
+import { valid_sct_root } from '../wasm';
 import { MerkleRoot } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
-import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
 import { PlainMessage } from '@bufbuild/protobuf';
 
-export const decodeSctRoot = (txId: PlainMessage<TransactionId>): MerkleRoot =>
-  new MerkleRoot({ inner: decode_sct_root(txId.inner) });
+export const validSctRoot = (root: PlainMessage<MerkleRoot>): boolean => valid_sct_root(root.inner);

--- a/packages/wasm/src/sct.ts
+++ b/packages/wasm/src/sct.ts
@@ -1,10 +1,7 @@
 import { decode_sct_root } from '../wasm';
 import { MerkleRoot } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
-import { JsonValue } from '@bufbuild/protobuf';
-import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
+import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
+import { PlainMessage } from '@bufbuild/protobuf';
 
-export const decodeSctRoot = (hash: Uint8Array): MerkleRoot => {
-  const hexString = uint8ArrayToHex(hash);
-  const result = decode_sct_root(hexString) as JsonValue;
-  return MerkleRoot.fromJson(result);
-};
+export const decodeSctRoot = (txId: PlainMessage<TransactionId>): MerkleRoot =>
+  new MerkleRoot({ inner: decode_sct_root(txId.inner) });


### PR DESCRIPTION
many signatures like this could be updated

edit: okay, now this contains fixes and fn rename `decodeSctRoot` -> `validSctRoot`