### PR TITLE
Split out claimable vs. not-yet-claimable unbonding tokens in the UI

### DIFF
--- a/apps/minifront/src/components/staking/account/header/constants.ts
+++ b/apps/minifront/src/components/staking/account/header/constants.ts
@@ -1,0 +1,16 @@
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
+
+/**
+ * A default `ValueView` to render when we don't have any balance data for a
+ * particular token.
+ */
+export const ZERO_BALANCE_UM = new ValueView({
+  valueView: {
+    case: 'knownAssetId',
+    value: {
+      amount: { hi: 0n, lo: 0n },
+      metadata: STAKING_TOKEN_METADATA,
+    },
+  },
+});

--- a/apps/minifront/src/components/staking/account/header/index.tsx
+++ b/apps/minifront/src/components/staking/account/header/index.tsx
@@ -52,6 +52,7 @@ export const Header = () => {
 
             <Stat label='Unbonding amount'>
               <UnbondingTokens
+                helpText='Total amount of UM you will receive, assuming no slashing, when you claim your unbonding tokens that are currently still in their unbonding period.'
                 tokens={unbondingTokens?.notYetClaimable.tokens}
                 total={unbondingTokens?.notYetClaimable.total}
               />
@@ -59,6 +60,7 @@ export const Header = () => {
 
             <Stat label='Claimable amount'>
               <UnbondingTokens
+                helpText='Total amount of UM you will receive, assuming no slashing, when you claim your unbonding tokens that are currently eligible for claiming.'
                 tokens={unbondingTokens?.claimable.tokens}
                 total={unbondingTokens?.claimable.total}
               >
@@ -67,7 +69,7 @@ export const Header = () => {
                     className='self-end px-4 text-white'
                     onClick={() => void undelegateClaim()}
                   >
-                    Claim
+                    Claim now
                   </Button>
                 )}
               </UnbondingTokens>

--- a/apps/minifront/src/components/staking/account/header/index.tsx
+++ b/apps/minifront/src/components/staking/account/header/index.tsx
@@ -5,9 +5,9 @@ import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/valu
 import { Stat } from './stat';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
-import { accountsSelector, stakingSelector } from '../../../../state/staking';
-import { useStore } from '../../../../state';
+import { AllSlices } from '../../../../state';
 import { UnbondingTokens } from './unbonding-tokens';
+import { useStoreShallow } from '../../../../utils/use-store-shallow';
 
 /**
  * A default `ValueView` to render when we don't have any balance data for a
@@ -23,6 +23,15 @@ const zeroBalanceUm = new ValueView({
   },
 });
 
+const headerSelector = (state: AllSlices) => ({
+  account: state.staking.account,
+  setAccount: state.staking.setAccount,
+  accountSwitcherFilter: state.staking.accountSwitcherFilter,
+  unstakedTokensByAccount: state.staking.unstakedTokensByAccount,
+  unbondingTokensByAccount: state.staking.unbondingTokensByAccount,
+  undelegateClaim: state.staking.undelegateClaim,
+});
+
 /**
  * The header of the account view, with an account switcher and balances of
  * various token types related to staking.
@@ -31,13 +40,13 @@ export const Header = () => {
   const {
     account,
     setAccount,
+    accountSwitcherFilter,
     unstakedTokensByAccount,
     unbondingTokensByAccount,
     undelegateClaim,
-  } = useStore(stakingSelector);
+  } = useStoreShallow(headerSelector);
   const unstakedTokens = unstakedTokensByAccount.get(account);
   const unbondingTokens = unbondingTokensByAccount.get(account);
-  const accountSwitcherFilter = useStore(accountsSelector);
 
   return (
     <Card gradient>

--- a/apps/minifront/src/components/staking/account/header/index.tsx
+++ b/apps/minifront/src/components/staking/account/header/index.tsx
@@ -3,25 +3,10 @@ import { Card, CardContent } from '@penumbra-zone/ui/components/ui/card';
 import { AccountSwitcher } from '@penumbra-zone/ui/components/ui/account-switcher';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 import { Stat } from './stat';
-import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
 import { AllSlices } from '../../../../state';
 import { UnbondingTokens } from './unbonding-tokens';
 import { useStoreShallow } from '../../../../utils/use-store-shallow';
-
-/**
- * A default `ValueView` to render when we don't have any balance data for a
- * particular token in the given account.
- */
-const zeroBalanceUm = new ValueView({
-  valueView: {
-    case: 'knownAssetId',
-    value: {
-      amount: { hi: 0n, lo: 0n },
-      metadata: STAKING_TOKEN_METADATA,
-    },
-  },
-});
+import { ZERO_BALANCE_UM } from './constants';
 
 const headerSelector = (state: AllSlices) => ({
   account: state.staking.account,
@@ -56,7 +41,7 @@ export const Header = () => {
 
           <div className='flex items-start justify-center gap-8'>
             <Stat label='Available to delegate'>
-              <ValueViewComponent view={unstakedTokens ?? zeroBalanceUm} />
+              <ValueViewComponent view={unstakedTokens ?? ZERO_BALANCE_UM} />
             </Stat>
 
             <Stat label='Unbonding amount'>

--- a/apps/minifront/src/components/staking/account/header/index.tsx
+++ b/apps/minifront/src/components/staking/account/header/index.tsx
@@ -1,11 +1,5 @@
 import { Button } from '@penumbra-zone/ui/components/ui/button';
 import { Card, CardContent } from '@penumbra-zone/ui/components/ui/card';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@penumbra-zone/ui/components/ui/tooltip';
 import { AccountSwitcher } from '@penumbra-zone/ui/components/ui/account-switcher';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 import { Stat } from './stat';
@@ -13,7 +7,7 @@ import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core
 import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
 import { accountsSelector, stakingSelector } from '../../../../state/staking';
 import { useStore } from '../../../../state';
-import { getDisplayDenomFromView } from '@penumbra-zone/getters/src/value-view';
+import { UnbondingTokens } from './unbonding-tokens';
 
 /**
  * A default `ValueView` to render when we don't have any balance data for a
@@ -57,35 +51,26 @@ export const Header = () => {
             </Stat>
 
             <Stat label='Unbonding amount'>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <ValueViewComponent view={unbondingTokens?.total ?? zeroBalanceUm} />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className='flex flex-col gap-4'>
-                      <div className='max-w-[250px]'>
-                        Total amount of UM you will receive when all your unbonding tokens are
-                        claimed, assuming no slashing.
-                      </div>
-                      {unbondingTokens?.tokens.length && (
-                        <>
-                          {unbondingTokens.tokens.map(token => (
-                            <ValueViewComponent key={getDisplayDenomFromView(token)} view={token} />
-                          ))}
+              <UnbondingTokens
+                tokens={unbondingTokens?.notYetClaimable.tokens}
+                total={unbondingTokens?.notYetClaimable.total}
+              />
+            </Stat>
 
-                          <Button
-                            className='self-end px-4 text-white'
-                            onClick={() => void undelegateClaim()}
-                          >
-                            Claim
-                          </Button>
-                        </>
-                      )}
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+            <Stat label='Claimable amount'>
+              <UnbondingTokens
+                tokens={unbondingTokens?.claimable.tokens}
+                total={unbondingTokens?.claimable.total}
+              >
+                {!!unbondingTokens?.claimable.tokens.length && (
+                  <Button
+                    className='self-end px-4 text-white'
+                    onClick={() => void undelegateClaim()}
+                  >
+                    Claim
+                  </Button>
+                )}
+              </UnbondingTokens>
             </Stat>
           </div>
         </div>

--- a/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
+++ b/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
@@ -27,10 +27,12 @@ const zeroBalanceUm = new ValueView({
 export const UnbondingTokens = ({
   total,
   tokens,
+  helpText,
   children,
 }: {
   total?: ValueView;
   tokens?: ValueView[];
+  helpText: string;
   children?: ReactNode;
 }) => {
   return (
@@ -41,10 +43,7 @@ export const UnbondingTokens = ({
         </TooltipTrigger>
         <TooltipContent>
           <div className='flex flex-col gap-4'>
-            <div className='max-w-[250px]'>
-              Total amount of UM you will receive when all your unbonding tokens are claimed,
-              assuming no slashing.
-            </div>
+            <div className='max-w-[250px]'>{helpText}</div>
 
             {!!tokens?.length &&
               tokens.map(token => (

--- a/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
+++ b/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
@@ -1,5 +1,4 @@
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
 import { getDisplayDenomFromView } from '@penumbra-zone/getters/src/value-view';
 import {
   TooltipProvider,
@@ -9,20 +8,7 @@ import {
 } from '@penumbra-zone/ui/components/ui/tooltip';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 import { ReactNode } from 'react';
-
-/**
- * A default `ValueView` to render when we don't have any balance data for a
- * particular token in the given account.
- */
-const zeroBalanceUm = new ValueView({
-  valueView: {
-    case: 'knownAssetId',
-    value: {
-      amount: { hi: 0n, lo: 0n },
-      metadata: STAKING_TOKEN_METADATA,
-    },
-  },
-});
+import { ZERO_BALANCE_UM } from './constants';
 
 export const UnbondingTokens = ({
   total,
@@ -39,7 +25,7 @@ export const UnbondingTokens = ({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger>
-          <ValueViewComponent view={total ?? zeroBalanceUm} />
+          <ValueViewComponent view={total ?? ZERO_BALANCE_UM} />
         </TooltipTrigger>
         <TooltipContent>
           <div className='flex flex-col gap-4'>

--- a/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
+++ b/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
@@ -1,0 +1,60 @@
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
+import { getDisplayDenomFromView } from '@penumbra-zone/getters/src/value-view';
+import {
+  TooltipProvider,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from '@penumbra-zone/ui/components/ui/tooltip';
+import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
+import { ReactNode } from 'react';
+
+/**
+ * A default `ValueView` to render when we don't have any balance data for a
+ * particular token in the given account.
+ */
+const zeroBalanceUm = new ValueView({
+  valueView: {
+    case: 'knownAssetId',
+    value: {
+      amount: { hi: 0n, lo: 0n },
+      metadata: STAKING_TOKEN_METADATA,
+    },
+  },
+});
+
+export const UnbondingTokens = ({
+  total,
+  tokens,
+  children,
+}: {
+  total?: ValueView;
+  tokens?: ValueView[];
+  children?: ReactNode;
+}) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <ValueViewComponent view={total ?? zeroBalanceUm} />
+        </TooltipTrigger>
+        <TooltipContent>
+          <div className='flex flex-col gap-4'>
+            <div className='max-w-[250px]'>
+              Total amount of UM you will receive when all your unbonding tokens are claimed,
+              assuming no slashing.
+            </div>
+
+            {!!tokens?.length &&
+              tokens.map(token => (
+                <ValueViewComponent key={getDisplayDenomFromView(token)} view={token} />
+              ))}
+
+            {children}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/apps/minifront/src/components/staking/layout.tsx
+++ b/apps/minifront/src/components/staking/layout.tsx
@@ -7,7 +7,7 @@ import { Account } from './account';
 export const StakingLoader = async () => {
   await throwIfPraxNotConnectedTimeout();
   // Await to avoid screen flicker.
-  await useStore.getState().staking.loadUnstakedTokensByAccount();
+  await useStore.getState().staking.loadAndReduceBalances();
 
   return null;
 };

--- a/apps/minifront/src/components/staking/layout.tsx
+++ b/apps/minifront/src/components/staking/layout.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { useStore } from '../../state';
-import { stakingSelector } from '../../state/staking';
+import { AllSlices, useStore } from '../../state';
 import { throwIfPraxNotConnectedTimeout } from '@penumbra-zone/client';
 import { Account } from './account';
+import { useStoreShallow } from '../../utils/use-store-shallow';
 
 export const StakingLoader = async () => {
   await throwIfPraxNotConnectedTimeout();
@@ -12,9 +12,15 @@ export const StakingLoader = async () => {
   return null;
 };
 
+const stakingLayoutSelector = (state: AllSlices) => ({
+  account: state.staking.account,
+  loadDelegationsForCurrentAccount: state.staking.loadDelegationsForCurrentAccount,
+  loadUnbondingTokensForCurrentAccount: state.staking.loadUnbondingTokensForCurrentAccount,
+});
+
 export const StakingLayout = () => {
   const { account, loadDelegationsForCurrentAccount, loadUnbondingTokensForCurrentAccount } =
-    useStore(stakingSelector);
+    useStoreShallow(stakingLayoutSelector);
 
   /** Load delegations every time the account changes. */
   useEffect(() => {

--- a/apps/minifront/src/components/staking/layout.tsx
+++ b/apps/minifront/src/components/staking/layout.tsx
@@ -7,19 +7,20 @@ import { Account } from './account';
 export const StakingLoader = async () => {
   await throwIfPraxNotConnectedTimeout();
   // Await to avoid screen flicker.
-  await useStore.getState().staking.loadUnstakedAndUnbondingTokensByAccount();
+  await useStore.getState().staking.loadUnstakedTokensByAccount();
 
   return null;
 };
 
 export const StakingLayout = () => {
-  const { account, loadDelegationsForCurrentAccount } = useStore(stakingSelector);
+  const { account, loadDelegationsForCurrentAccount, loadUnbondingTokensForCurrentAccount } =
+    useStore(stakingSelector);
 
   /** Load delegations every time the account changes. */
-  useEffect(
-    () => void loadDelegationsForCurrentAccount(),
-    [account, loadDelegationsForCurrentAccount],
-  );
+  useEffect(() => {
+    void loadDelegationsForCurrentAccount();
+    void loadUnbondingTokensForCurrentAccount();
+  }, [account, loadDelegationsForCurrentAccount, loadUnbondingTokensForCurrentAccount]);
 
   return <Account />;
 };

--- a/apps/minifront/src/state/staking/index.test.ts
+++ b/apps/minifront/src/state/staking/index.test.ts
@@ -238,7 +238,8 @@ describe('Staking Slice', () => {
       unbondingTokensByAccount: new Map(),
       setAccount: expect.any(Function) as unknown,
       loadDelegationsForCurrentAccount: expect.any(Function) as unknown,
-      loadUnstakedAndUnbondingTokensByAccount: expect.any(Function) as unknown,
+      loadUnbondingTokensForCurrentAccount: expect.any(Function) as unknown,
+      loadUnstakedTokensByAccount: expect.any(Function) as unknown,
       delegate: expect.any(Function) as unknown,
       undelegate: expect.any(Function) as unknown,
       undelegateClaim: expect.any(Function) as unknown,
@@ -304,8 +305,20 @@ describe('Staking Slice', () => {
 
           unbondingTokensByAccount: new Map([
             // Leave unsorted for the sake of the sorting test below.
-            [6, { total: new ValueView(), tokens: [new ValueView()] }],
-            [5, { total: new ValueView(), tokens: [new ValueView()] }],
+            [
+              6,
+              {
+                claimable: { total: new ValueView(), tokens: [new ValueView()] },
+                notYetClaimable: { total: new ValueView(), tokens: [] },
+              },
+            ],
+            [
+              5,
+              {
+                claimable: { total: new ValueView(), tokens: [new ValueView()] },
+                notYetClaimable: { total: new ValueView(), tokens: [] },
+              },
+            ],
           ]),
         },
       });

--- a/apps/minifront/src/state/staking/index.test.ts
+++ b/apps/minifront/src/state/staking/index.test.ts
@@ -12,7 +12,7 @@ import {
   AddressView,
   IdentityKey,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
-import { accountsSelector, THROTTLE_MS } from '.';
+import { THROTTLE_MS } from '.';
 import { DelegationsByAddressIndexResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 
 const validator1IdentityKey = new IdentityKey({ ik: new Uint8Array([1, 2, 3]) });
@@ -87,6 +87,7 @@ vi.mock('../../fetchers/balances', () => ({
               index: {
                 account: 0,
               },
+              address: {},
             },
           },
         }),
@@ -114,6 +115,7 @@ vi.mock('../../fetchers/balances', () => ({
               index: {
                 account: 0,
               },
+              address: {},
             },
           },
         }),
@@ -137,6 +139,7 @@ vi.mock('../../fetchers/balances', () => ({
               index: {
                 account: 0,
               },
+              address: {},
             },
           },
         }),
@@ -230,6 +233,7 @@ describe('Staking Slice', () => {
   it('has correct initial state', () => {
     expect(useStore.getState().staking).toEqual({
       account: 0,
+      accountSwitcherFilter: [],
       action: undefined,
       amount: '',
       validatorInfo: undefined,
@@ -239,7 +243,7 @@ describe('Staking Slice', () => {
       setAccount: expect.any(Function) as unknown,
       loadDelegationsForCurrentAccount: expect.any(Function) as unknown,
       loadUnbondingTokensForCurrentAccount: expect.any(Function) as unknown,
-      loadUnstakedTokensByAccount: expect.any(Function) as unknown,
+      loadAndReduceBalances: expect.any(Function) as unknown,
       delegate: expect.any(Function) as unknown,
       undelegate: expect.any(Function) as unknown,
       undelegateClaim: expect.any(Function) as unknown,
@@ -280,78 +284,13 @@ describe('Staking Slice', () => {
     expect(Object.values(getState().staking.votingPowerByValidatorInfo).length).toBe(4);
   });
 
-  describe('accountsSelector return value', () => {
-    let result: number[];
-
-    beforeEach(() => {
-      const state = useStore.getState();
-
-      useStore.setState({
-        ...state,
-        staking: {
-          ...state.staking,
-          unstakedTokensByAccount: new Map([
-            // Leave unsorted for the sake of the sorting test below.
-            [1, new ValueView()],
-            [2, undefined],
-            [0, new ValueView()],
-          ]),
-
-          delegationsByAccount: new Map([
-            [3, []],
-            [4, [new ValueView()]],
-            [5, []],
-          ]),
-
-          unbondingTokensByAccount: new Map([
-            // Leave unsorted for the sake of the sorting test below.
-            [
-              6,
-              {
-                claimable: { total: new ValueView(), tokens: [new ValueView()] },
-                notYetClaimable: { total: new ValueView(), tokens: [] },
-              },
-            ],
-            [
-              5,
-              {
-                claimable: { total: new ValueView(), tokens: [new ValueView()] },
-                notYetClaimable: { total: new ValueView(), tokens: [] },
-              },
-            ],
-          ]),
-        },
-      });
-
-      result = accountsSelector(useStore.getState());
+  describe('loadAndReduceBalances()', () => {
+    beforeEach(async () => {
+      await useStore.getState().staking.loadAndReduceBalances();
     });
 
-    it('includes accounts that have only unstaked tokens', () => {
-      expect(result).toContain(0);
-    });
-
-    it('includes accounts that have only delegation tokens', () => {
-      expect(result).toContain(4);
-    });
-
-    it('includes accounts that have only unbonding tokens', () => {
-      expect(result).toContain(6);
-    });
-
-    it('includes accounts that have empty delegations but populated unbonding tokens', () => {
-      expect(result).toContain(5);
-    });
-
-    it('excludes accounts that only have undefined unstaked tokens', () => {
-      expect(result).not.toContain(2);
-    });
-
-    it('excludes accounts that only have empty delegation tokens', () => {
-      expect(result).not.toContain(3);
-    });
-
-    it('excludes accounts that have no relevant tokens', () => {
-      expect(result).not.toContain(7);
+    it('includes accounts with tokens relevant to staking', () => {
+      expect(useStore.getState().staking.accountSwitcherFilter).toEqual([0]);
     });
   });
 });

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -40,6 +40,7 @@ import { viewClient } from '../../clients';
 import { getValueView as getValueViewFromDelegationsByAddressIndexResponse } from '@penumbra-zone/getters/src/delegations-by-address-index-response';
 import { getValueView as getValueViewFromUnbondingTokensByAddressIndexResponse } from '@penumbra-zone/getters/src/unbonding-tokens-by-address-index-response';
 import Array from '@penumbra-zone/polyfills/src/Array.fromAsync';
+import { ZERO_BALANCE_UM } from '../../components/staking/account/header/constants';
 
 const STAKING_TOKEN_DISPLAY_DENOM_EXPONENT = (() => {
   const stakingAsset = localAssets.find(asset => asset.display === STAKING_TOKEN);
@@ -298,30 +299,8 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
     const unbondingTokensForAccount = responses.reduce<UnbondingTokensForAccount>(
       toUnbondingTokensForAccount,
       {
-        claimable: {
-          total: new ValueView({
-            valueView: {
-              case: 'knownAssetId',
-              value: {
-                amount: { hi: 0n, lo: 0n },
-                metadata: STAKING_TOKEN_METADATA,
-              },
-            },
-          }),
-          tokens: [],
-        },
-        notYetClaimable: {
-          total: new ValueView({
-            valueView: {
-              case: 'knownAssetId',
-              value: {
-                amount: { hi: 0n, lo: 0n },
-                metadata: STAKING_TOKEN_METADATA,
-              },
-            },
-          }),
-          tokens: [],
-        },
+        claimable: { total: ZERO_BALANCE_UM, tokens: [] },
+        notYetClaimable: { total: ZERO_BALANCE_UM, tokens: [] },
       },
     );
 

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -1,5 +1,5 @@
 import { ValidatorInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
-import { AllSlices, SliceCreator } from '..';
+import { SliceCreator } from '..';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/src/metadata';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { BalancesByAccount, getBalancesByAccount } from '../../fetchers/balances/by-account';
@@ -423,8 +423,6 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
   error: undefined,
   votingPowerByValidatorInfo: {},
 });
-
-export const stakingSelector = (state: AllSlices) => state.staking;
 
 const assembleDelegateRequest = ({ account, amount, validatorInfo }: StakingSlice) => {
   return new TransactionPlannerRequest({

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -363,6 +363,7 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
       // balances.
       void get().staking.loadDelegationsForCurrentAccount();
       void get().staking.loadUnstakedTokensByAccount();
+      void get().staking.loadUnbondingTokensForCurrentAccount();
     } finally {
       set(state => {
         state.staking.amount = '';
@@ -390,6 +391,7 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
       // Reload unbonding tokens and unstaked tokens to reflect their updated
       // balances.
       void get().staking.loadUnstakedTokensByAccount();
+      void get().staking.loadUnbondingTokensForCurrentAccount();
     } finally {
       set(state => {
         state.staking.amount = '';

--- a/packages/getters/src/unbonding-tokens-by-address-index-response.ts
+++ b/packages/getters/src/unbonding-tokens-by-address-index-response.ts
@@ -5,8 +5,3 @@ export const getValueView = createGetter(
   (unbondingTokensByAddressIndexResponse?: UnbondingTokensByAddressIndexResponse) =>
     unbondingTokensByAddressIndexResponse?.valueView,
 );
-
-export const getClaimable = createGetter(
-  (unbondingTokensByAddressIndexResponse?: UnbondingTokensByAddressIndexResponse) =>
-    unbondingTokensByAddressIndexResponse?.claimable,
-);

--- a/packages/getters/src/unbonding-tokens-by-address-index-response.ts
+++ b/packages/getters/src/unbonding-tokens-by-address-index-response.ts
@@ -1,0 +1,12 @@
+import { UnbondingTokensByAddressIndexResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { createGetter } from './utils/create-getter';
+
+export const getValueView = createGetter(
+  (unbondingTokensByAddressIndexResponse?: UnbondingTokensByAddressIndexResponse) =>
+    unbondingTokensByAddressIndexResponse?.valueView,
+);
+
+export const getClaimable = createGetter(
+  (unbondingTokensByAddressIndexResponse?: UnbondingTokensByAddressIndexResponse) =>
+    unbondingTokensByAddressIndexResponse?.claimable,
+);


### PR DESCRIPTION
We've been showing a user's unbonding tokens in a single group. When they click the `Claim` button, we create a single transaction with undelegate claims for every unbonding token that user holds. This means that the entire transaction (and all its undelegate claims) will fail if _any_ undelegate claim fails, since they're all batched into the same transaction.

With this PR, we use the new `ViewService#unbondingTokensByAddressIndex` endpoint to determine which unbonding tokens are claimable and which are not yet claimable. We only show the `Claim` button for claimable tokens, and we show the claimable and not-yet-claimable tokens separately.

<img width="1012" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/b0556f46-fb8a-4fdc-9878-90ed9c8384d7">

<img width="1012" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/ff27305c-3699-41d8-bf5d-fefeb9dee0bc">

## In this PR
- Use the new `ViewService#unbondingTokensByAddressIndex` to load unbonding tokens into state.
- Fix a bug where some accounts were incorrectly filtered out of the account switcher.
  - It used to be that the account switcher was being filtered via the `accountSelector`, which looked at a few different state properties to determine which accounts were eligible to be included on the staking page.

    The problem was, it only took staking and unbonding tokens into account. Which means that, if you had only delegation tokens in a given account, that account would not be accessible via the account switcher.
    
    So I created a method, `loadAndReduceBalances`, which a) puts the user's staking token balances into state, and b) determines which of the user's accounts are relevant to staking (i.e., because they contain staking, delegation, or unbonding tokens).
- Extract an `<UnbondingTokens />` component that shows the user's balance of unbonding tokens for either claimable or not-yet-claimable tokens.


Closes #739