### PR TITLE
Check for an existing start epoch before creating one

### DIFF
--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -1,6 +1,6 @@
 
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe
-IDB_VERSION=31
+IDB_VERSION=32
 USDC_ASSET_ID="reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
 MINIFRONT_URL=https://app.testnet.penumbra.zone/
 PENUMBRA_NODE_PD_URL=https://grpc.testnet.penumbra.zone/

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -154,9 +154,6 @@ export class BlockProcessor implements BlockProcessorInterface {
       // beginning of sync as well, and force the rest of sync to wait until
       // it's done.
       await this.updateValidatorInfos(0n);
-
-      const existingStartEpoch = await this.indexedDb.getEpochByHeight(0n);
-      if (!existingStartEpoch) await this.indexedDb.addEpoch(0n);
     }
 
     // this is an indefinite stream of the (compact) chain from the network

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -155,7 +155,8 @@ export class BlockProcessor implements BlockProcessorInterface {
       // it's done.
       await this.updateValidatorInfos(0n);
 
-      await this.indexedDb.addEpoch(0n);
+      const existingStartEpoch = await this.indexedDb.getEpochByHeight(0n);
+      if (!existingStartEpoch) await this.indexedDb.addEpoch(0n);
     }
 
     // this is an indefinite stream of the (compact) chain from the network

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -115,6 +115,7 @@ export class IndexedDb implements IndexedDbInterface {
 
     const instance = new this(db, new IbdUpdater(db), constants, chainId);
     await instance.saveLocalAssetsMetadata(); // Pre-load asset metadata
+    await instance.addEpoch(0n); // Create first epoch
     return instance;
   }
 

--- a/packages/storage/src/indexed-db/indexed-db.test-data.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test-data.ts
@@ -703,16 +703,16 @@ export const tradingPairGmGn = TradingPair.fromJson({
 });
 
 export const epoch1 = new Epoch({
-  index: 0n,
-  startHeight: 0n,
-});
-
-export const epoch2 = new Epoch({
   index: 1n,
   startHeight: 100n,
 });
 
-export const epoch3 = new Epoch({
+export const epoch2 = new Epoch({
   index: 2n,
   startHeight: 200n,
+});
+
+export const epoch3 = new Epoch({
+  index: 3n,
+  startHeight: 300n,
 });

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -514,31 +514,46 @@ describe('IndexedDb', () => {
 
     beforeEach(async () => {
       db = await IndexedDb.initialize({ ...generateInitialProps() });
-      await db.addEpoch(epoch1.startHeight);
-      await db.addEpoch(epoch2.startHeight);
-      await db.addEpoch(epoch3.startHeight);
+    });
+
+    it('prepopulates the 0th epoch', async () => {
+      const epoch = await db.getEpochByHeight(0n);
+      expect(epoch?.index).toBe(0n);
+      expect(epoch?.startHeight).toBe(0n);
     });
 
     describe('addEpoch', () => {
-      it('auto-increments the epoch index if one is not provided', async () => {
+      beforeEach(async () => {
+        await db.addEpoch(epoch1.startHeight);
+        await db.addEpoch(epoch2.startHeight);
+        await db.addEpoch(epoch3.startHeight);
+      });
+
+      it('auto-increments the epoch index', async () => {
         const [result1, result2, result3] = await Promise.all([
-          db.getEpochByHeight(50n),
           db.getEpochByHeight(150n),
           db.getEpochByHeight(250n),
+          db.getEpochByHeight(350n),
         ]);
 
-        expect(result1?.index).toBe(0n);
-        expect(result2?.index).toBe(1n);
-        expect(result3?.index).toBe(2n);
+        expect(result1?.index).toBe(1n);
+        expect(result2?.index).toBe(2n);
+        expect(result3?.index).toBe(3n);
       });
     });
 
     describe('getEpochByHeight', () => {
+      beforeEach(async () => {
+        await db.addEpoch(epoch1.startHeight);
+        await db.addEpoch(epoch2.startHeight);
+        await db.addEpoch(epoch3.startHeight);
+      });
+
       it('returns the epoch containing the given block height', async () => {
         const [result1, result2, result3] = await Promise.all([
-          db.getEpochByHeight(50n),
           db.getEpochByHeight(150n),
           db.getEpochByHeight(250n),
+          db.getEpochByHeight(350n),
         ]);
 
         expect(result1?.toJson()).toEqual(epoch1.toJson());


### PR DESCRIPTION
This fixes a bug we had before where, for some reason (probably related to exponential back-off), the start epoch with index 0 was being saved multiple times. This threw off the count for epochs, making delegate actions fail (since they use epoch indexes). To fix this, we create epoch 0 outside of the syncAndStore method, at DB initialization.

Closes #865 