### PR TITLE
Make unimplemented views clear

### DIFF
--- a/packages/perspective/translators/action-view.test.ts
+++ b/packages/perspective/translators/action-view.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test, vi } from 'vitest';
 describe('asPublicActionView()', () => {
   describe('when passed `undefined`', () => {
     test('returns an empty action view', () => {
-      expect(asPublicActionView(undefined).equals(new ActionView())).toBe(true);
+      expect(asPublicActionView(undefined)).toBeUndefined();
     });
   });
 
@@ -208,7 +208,7 @@ describe('asReceiverActionView()', () => {
       const isControlledAddress = vi.fn();
       const result = await asReceiverActionView(undefined, { isControlledAddress });
 
-      expect(result.equals(new ActionView())).toBe(true);
+      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/perspective/translators/action-view.ts
+++ b/packages/perspective/translators/action-view.ts
@@ -22,21 +22,11 @@ export const asPublicActionView: Translator<ActionView> = actionView => {
         },
       });
 
-    case 'delegate':
-    case 'undelegate':
-    case 'undelegateClaim':
-    case 'ics20Withdrawal':
-      return actionView;
-
+    // Currently defaulting to displaying that all data is public as it's better
+    // to err on communicating private data as public than the other way around
+    // TODO: Do proper audit of what data for each action is public
     default:
-      return new ActionView({
-        actionView: actionView?.actionView.case
-          ? {
-              case: actionView.actionView.case,
-              value: {},
-            }
-          : { case: undefined },
-      });
+      return actionView!;
   }
 };
 

--- a/packages/ui/components/ui/tx/view/action-view.tsx
+++ b/packages/ui/components/ui/tx/view/action-view.tsx
@@ -1,13 +1,13 @@
-import { ViewBox } from './viewbox';
 import { SpendViewComponent } from './spend';
 import { OutputViewComponent } from './output';
 import { ActionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
-import { SwapViewComponent } from './swap';
 import { SwapClaimViewComponent } from './swap-claim';
 import { DelegateComponent } from './delegate';
 import { UndelegateComponent } from './undelegate';
 import { UndelegateClaimComponent } from './undelegate-claim';
 import { Ics20WithdrawalComponent } from './isc20-withdrawal';
+import { UnimplementedView } from './unimplemented-view';
+import { SwapViewComponent } from './swap';
 
 const CASE_TO_LABEL: Record<string, string> = {
   daoDeposit: 'DAO Deposit',
@@ -68,48 +68,48 @@ export const ActionViewComponent = ({ av: { actionView } }: { av: ActionView }) 
       return <UndelegateClaimComponent value={actionView.value} />;
 
     case 'validatorDefinition':
-      return <ViewBox label='Validator Definition' />;
+      return <UnimplementedView label='Validator Definition' />;
 
     case 'ibcRelayAction':
-      return <ViewBox label='IBC Relay Action' />;
+      return <UnimplementedView label='IBC Relay Action' />;
 
     case 'proposalSubmit':
-      return <ViewBox label='Proposal Submit' />;
+      return <UnimplementedView label='Proposal Submit' />;
 
     case 'proposalWithdraw':
-      return <ViewBox label='Proposal Withdraw' />;
+      return <UnimplementedView label='Proposal Withdraw' />;
 
     case 'validatorVote':
-      return <ViewBox label='Validator Vote' />;
+      return <UnimplementedView label='Validator Vote' />;
 
     case 'delegatorVote':
-      return <ViewBox label='Delegator Vote' />;
+      return <UnimplementedView label='Delegator Vote' />;
 
     case 'proposalDepositClaim':
-      return <ViewBox label='Proposal Deposit Claim' />;
+      return <UnimplementedView label='Proposal Deposit Claim' />;
 
     case 'positionOpen':
-      return <ViewBox label='Position Open' />;
+      return <UnimplementedView label='Position Open' />;
 
     case 'positionClose':
-      return <ViewBox label='Position Close' />;
+      return <UnimplementedView label='Position Close' />;
 
     case 'positionWithdraw':
-      return <ViewBox label='Position Withdraw' />;
+      return <UnimplementedView label='Position Withdraw' />;
 
     case 'positionRewardClaim':
-      return <ViewBox label='Position Reward Claim' />;
+      return <UnimplementedView label='Position Reward Claim' />;
 
     case 'communityPoolSpend':
-      return <ViewBox label='Community Spend' />;
+      return <UnimplementedView label='Community Spend' />;
 
     case 'communityPoolOutput':
-      return <ViewBox label='Community Output' />;
+      return <UnimplementedView label='Community Output' />;
 
     case 'communityPoolDeposit':
-      return <ViewBox label='Community Deposit' />;
+      return <UnimplementedView label='Community Deposit' />;
 
     default:
-      return <ViewBox label={getLabelForActionCase(actionView.case)} />;
+      return <UnimplementedView label={getLabelForActionCase(actionView.case)} />;
   }
 };

--- a/packages/ui/components/ui/tx/view/swap-claim.tsx
+++ b/packages/ui/components/ui/tx/view/swap-claim.tsx
@@ -10,6 +10,7 @@ import { getAmount } from '@penumbra-zone/getters/src/value-view';
 import { isZero } from '@penumbra-zone/types/src/amount';
 import { ValueViewComponent } from './value';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { UnimplementedView } from './unimplemented-view';
 
 const getClaimLabel = (
   output1Amount?: Amount,
@@ -58,7 +59,7 @@ export const SwapClaimViewComponent = ({ value }: { value: SwapClaimView }) => {
   }
 
   if (value.swapClaimView.case === 'opaque') {
-    return <ViewBox label='Swap Claim' />;
+    return <UnimplementedView label='Swap Claim' />;
   }
 
   return <div>Invalid SpendView</div>;

--- a/packages/ui/components/ui/tx/view/swap/index.tsx
+++ b/packages/ui/components/ui/tx/view/swap/index.tsx
@@ -15,6 +15,7 @@ import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core
 import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
 import { Fee } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1/fee_pb';
 import { ActionDetails } from '../action-details';
+import { UnimplementedView } from '../unimplemented-view';
 
 const getClaimFeeValueView = (claimFee: Fee) =>
   new ValueView({
@@ -72,7 +73,7 @@ export const SwapViewComponent = ({ value }: { value: SwapView }) => {
   }
 
   if (value.swapView.case === 'opaque') {
-    return <ViewBox label='Swap' />;
+    return <UnimplementedView label='Swap' />;
   }
 
   return <div>Invalid SwapView</div>;

--- a/packages/ui/components/ui/tx/view/unimplemented-view.tsx
+++ b/packages/ui/components/ui/tx/view/unimplemented-view.tsx
@@ -1,0 +1,16 @@
+import { TriangleAlert } from 'lucide-react';
+import { ViewBox } from './viewbox';
+
+export const UnimplementedView = ({ label }: { label: string }) => {
+  return (
+    <ViewBox
+      label={label}
+      visibleContent={
+        <div className='flex gap-2 text-sm text-yellow-600'>
+          <TriangleAlert className='w-4' />
+          <span className='mt-1'>Unimplemented view</span>
+        </div>
+      }
+    />
+  );
+};


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/642

At the moment, unimplemented views are seen as incognito. This is a mistaken default. This creates a view that communicates to the user that we haven't got to creating a view for it.

<img width="959" alt="Screenshot 2024-04-03 at 3 26 48 PM" src="https://github.com/penumbra-zone/web/assets/16624263/b58b8ea4-8104-4fc2-bba0-2d7d33cd7576">

Up next, will create an issue to audit our action views (especially the opaque ones). 