### PR TITLE
Fix id increasing version test

### DIFF
--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -121,6 +121,9 @@ export class IndexedDb implements IndexedDbInterface {
     await instance.addEpoch(0n); // Create first epoch
     return instance;
   }
+  close(): void {
+    this.db.close();
+  }
 
   constants(): IdbConstants {
     return this.c;

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -100,7 +100,7 @@ describe('IndexedDb', () => {
         chainId: 'test',
         accountAddr: 'penumbra123xyz',
         dbVersion: 2,
-        walletId: version1Props.walletId
+        walletId: version1Props.walletId,
       };
       const dbB = await IndexedDb.initialize(version2Props);
       expect((await dbB.getAssetsMetadata(metadataA.penumbraAssetId!))?.name).toBeUndefined();

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -94,16 +94,14 @@ describe('IndexedDb', () => {
       const version1Props = generateInitialProps();
       const dbA = await IndexedDb.initialize(version1Props);
       await dbA.saveAssetsMetadata(metadataA);
+      dbA.close();
 
       const version2Props = {
         chainId: 'test',
         accountAddr: 'penumbra123xyz',
         dbVersion: 2,
-        walletId: new WalletId({
-          inner: Uint8Array.from({ length: 8 }, () => Math.floor(Math.random() * 256)),
-        }),
+        walletId: version1Props.walletId
       };
-
       const dbB = await IndexedDb.initialize(version2Props);
       expect((await dbB.getAssetsMetadata(metadataA.penumbraAssetId!))?.name).toBeUndefined();
     });


### PR DESCRIPTION
The indexed-db version increase test was not correct. 
In fact, instead of increasing the version of the existing db, we created a new db with a different random name 