### PR TITLE
DRY up extension settings code; extract a `<SettingsScreen />` component for all settings screens in the extension

### DIFF
--- a/apps/extension/src/routes/popup/padding-wrapper.tsx
+++ b/apps/extension/src/routes/popup/padding-wrapper.tsx
@@ -1,9 +1,0 @@
-import { ReactNode } from 'react';
-
-/**
- * Wrap this around any top-level components that should have horizontal and
- * bottom padding in the extension popup.
- */
-export const PaddingWrapper = ({ children }: { children: ReactNode }) => {
-  return <div className='px-[30px] pb-[30px]'>{children}</div>;
-};

--- a/apps/extension/src/routes/popup/settings/settings-advanced.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-advanced.tsx
@@ -1,10 +1,9 @@
 import { TrashIcon } from '@radix-ui/react-icons';
 import { CustomLink } from '../../../shared/components/link';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
 import { DashboardGradientIcon } from '../../../icons/dashboard-gradient';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
+import { SettingsScreen } from './settings-screen';
 
 const links = [
   // TODO: Enable when ready
@@ -24,23 +23,12 @@ export const SettingsAdvanced = () => {
   const navigate = usePopupNav();
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Advanced' />
-        <div className='mx-auto size-20'>
-          <DashboardGradientIcon />
-        </div>
-        <div className='flex flex-1 flex-col items-start gap-2 px-[30px]'>
-          {links.map(i => (
-            <CustomLink
-              key={i.href}
-              title={i.title}
-              icon={i.icon}
-              onClick={() => navigate(i.href)}
-            />
-          ))}
-        </div>
+    <SettingsScreen title='Advanced' IconComponent={DashboardGradientIcon}>
+      <div className='flex flex-1 flex-col items-start gap-2'>
+        {links.map(i => (
+          <CustomLink key={i.href} title={i.title} icon={i.icon} onClick={() => navigate(i.href)} />
+        ))}
       </div>
-    </FadeTransition>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-auto-lock.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-auto-lock.tsx
@@ -1,32 +1,23 @@
 import { Button } from '@penumbra-zone/ui/components/ui/button';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
 import { Input } from '@penumbra-zone/ui/components/ui/input';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { TimerGradientIcon } from '../../../icons/time-gradient';
+import { SettingsScreen } from './settings-screen';
 
 export const SettingsAutoLock = () => {
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Auto-lock timer' />
-        <div className='mx-auto size-20'>
-          <TimerGradientIcon />
+    <SettingsScreen title='Auto-lock timer' IconComponent={TimerGradientIcon}>
+      <div className='flex flex-1 flex-col items-start justify-between'>
+        <div className='flex flex-col gap-1'>
+          <p className='mb-1 font-headline text-base font-semibold'>Auto - lock timer (minutes)</p>
+          <p className='text-muted-foreground'>
+            Set the inactivity time in the coming minutes before Penumbra is blocked.
+          </p>
+          <Input />
         </div>
-        <div className='flex flex-1 flex-col items-start justify-between px-[30px] pb-5'>
-          <div className='flex flex-col gap-1'>
-            <p className='mb-1 font-headline text-base font-semibold'>
-              Auto - lock timer (minutes)
-            </p>
-            <p className='text-muted-foreground'>
-              Set the inactivity time in the coming minutes before Penumbra is blocked.
-            </p>
-            <Input />
-          </div>
-          <Button variant='gradient' size='lg' className='w-full'>
-            Save
-          </Button>
-        </div>
+        <Button variant='gradient' size='lg' className='w-full'>
+          Save
+        </Button>
       </div>
-    </FadeTransition>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-clear-cache.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-clear-cache.tsx
@@ -1,13 +1,12 @@
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { Button } from '@penumbra-zone/ui/components/ui/button';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { TrashGradientIcon } from '../../../icons/trash-gradient';
 import { ServicesMessage } from '@penumbra-zone/types/src/services';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
 import { useStore } from '../../../state';
 import { useState } from 'react';
+import { SettingsScreen } from './settings-screen';
 
 const useCacheClear = () => {
   const navigate = usePopupNav();
@@ -30,35 +29,30 @@ const useCacheClear = () => {
 
 export const SettingsClearCache = () => {
   const { handleCacheClear, loading } = useCacheClear();
+
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Clear cache' />
-        <div className='mx-auto size-20'>
-          <TrashGradientIcon />
+    <SettingsScreen title='Clear cache' IconComponent={TrashGradientIcon}>
+      <div className='flex flex-1 flex-col items-start justify-between px-[30px] pb-5'>
+        <div className='flex flex-col items-center gap-2'>
+          <p className='font-headline text-base font-semibold'>Are you sure?</p>
+          <p className='text-center text-muted-foreground'>
+            Do you really want to clear cache? All local data will be deleted and resynchronized.
+          </p>
+          <p className='mt-2 flex items-center gap-2 font-headline text-base font-semibold text-rust'>
+            <ExclamationTriangleIcon className='size-[30px] text-rust' /> You private keys won’t be
+            lost!
+          </p>
         </div>
-        <div className='flex flex-1 flex-col items-start justify-between px-[30px] pb-5'>
-          <div className='flex flex-col items-center gap-2'>
-            <p className='font-headline text-base font-semibold'>Are you sure?</p>
-            <p className='text-center text-muted-foreground'>
-              Do you really want to clear cache? All local data will be deleted and resynchronized.
-            </p>
-            <p className='mt-2 flex items-center gap-2 font-headline text-base font-semibold text-rust'>
-              <ExclamationTriangleIcon className='size-[30px] text-rust' /> You private keys won’t
-              be lost!
-            </p>
-          </div>
-          <Button
-            disabled={loading}
-            variant='gradient'
-            size='lg'
-            className='w-full'
-            onClick={handleCacheClear}
-          >
-            {loading ? 'Clearing cache...' : 'Confirm'}
-          </Button>
-        </div>
+        <Button
+          disabled={loading}
+          variant='gradient'
+          size='lg'
+          className='w-full'
+          onClick={handleCacheClear}
+        >
+          {loading ? 'Clearing cache...' : 'Confirm'}
+        </Button>
       </div>
-    </FadeTransition>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-connected-sites.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-connected-sites.tsx
@@ -1,15 +1,14 @@
 import { Link1Icon, LinkBreak1Icon, MagnifyingGlassIcon, TrashIcon } from '@radix-ui/react-icons';
 import { useEffect } from 'react';
 import { Button } from '@penumbra-zone/ui/components/ui/button';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
 import { Input } from '@penumbra-zone/ui/components/ui/input';
 import { LinkGradientIcon } from '../../../icons/link-gradient';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { OriginRecord } from '@penumbra-zone/storage/src/chrome/types';
 import { DisplayOriginURL } from '../../../shared/components/display-origin-url';
 import { useStore } from '../../../state';
 import { connectedSitesSelector } from '../../../state/connected-sites';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
+import { SettingsScreen } from './settings-screen';
 
 export const SettingsConnectedSites = () => {
   const {
@@ -29,72 +28,64 @@ export const SettingsConnectedSites = () => {
   const discard = (site: OriginRecord) => void discardKnownSite(site);
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Connected sites' />
-        <div className='mx-auto size-20'>
-          <LinkGradientIcon />
+    <SettingsScreen title='Connected sites' IconComponent={LinkGradientIcon}>
+      <div className='relative mt-5 flex w-full items-center justify-center'>
+        <div className='absolute inset-y-0 left-3 flex items-center'>
+          <MagnifyingGlassIcon className='size-5 text-muted-foreground' />
         </div>
-        <div className='px-[30px]'>
-          <div className='relative my-5 flex w-full items-center justify-center'>
-            <div className='absolute inset-y-0 left-3 flex items-center'>
-              <MagnifyingGlassIcon className='size-5 text-muted-foreground' />
-            </div>
-            <Input
-              disabled={!knownSites.length}
-              variant={filter && noFilterMatch ? 'warn' : null}
-              className='pl-10'
-              onChange={e => setFilter(e.target.value)}
-              placeholder='Search by origin...'
-            />
+        <Input
+          disabled={!knownSites.length}
+          variant={filter && noFilterMatch ? 'warn' : null}
+          className='pl-10'
+          onChange={e => setFilter(e.target.value)}
+          placeholder='Search by origin...'
+        />
+      </div>
+      <div className='text-muted-foreground'>
+        {!knownSites.length ? (
+          <div className='py-[2em] text-center text-lg font-bold'>no known sites</div>
+        ) : filter && noFilterMatch ? (
+          <div className='py-[2em] text-center text-lg font-bold text-yellow-500'>
+            all known sites filtered
           </div>
-          <div className='text-muted-foreground'>
-            {!knownSites.length ? (
-              <div className='py-[2em] text-center text-lg font-bold'>no known sites</div>
-            ) : filter && noFilterMatch ? (
-              <div className='py-[2em] text-center text-lg font-bold text-yellow-500'>
-                all known sites filtered
-              </div>
-            ) : (
+        ) : (
+          <>
+            {!!approvedSites.length && (
               <>
-                {!!approvedSites.length && (
-                  <>
-                    <div className='ml-4 font-headline'>Approved sites</div>
-                    <div role='list'>
-                      {approvedSites.map(site => (
-                        <SiteRecord key={site.origin} site={site} discard={discard} />
-                      ))}
-                    </div>
-                  </>
-                )}
-                {!!deniedSites.length && (
-                  <>
-                    {!!approvedSites.length && <hr className='my-2' />}
-                    <div className='ml-4 font-headline'>Denied sites</div>
-                    <div role='list'>
-                      {deniedSites.map(site => (
-                        <SiteRecord key={site.origin} site={site} discard={discard} />
-                      ))}
-                    </div>
-                  </>
-                )}
-                {!!ignoredSites.length && (
-                  <>
-                    {!!(approvedSites.length || deniedSites.length) && <hr className='my-2' />}
-                    <div className='ml-4 font-headline'>Ignored sites</div>
-                    <div role='list'>
-                      {ignoredSites.map(site => (
-                        <SiteRecord key={site.origin} site={site} discard={discard} />
-                      ))}
-                    </div>
-                  </>
-                )}
+                <div className='ml-4 font-headline'>Approved sites</div>
+                <div role='list'>
+                  {approvedSites.map(site => (
+                    <SiteRecord key={site.origin} site={site} discard={discard} />
+                  ))}
+                </div>
               </>
             )}
-          </div>
-        </div>
+            {!!deniedSites.length && (
+              <>
+                {!!approvedSites.length && <hr className='my-2' />}
+                <div className='ml-4 font-headline'>Denied sites</div>
+                <div role='list'>
+                  {deniedSites.map(site => (
+                    <SiteRecord key={site.origin} site={site} discard={discard} />
+                  ))}
+                </div>
+              </>
+            )}
+            {!!ignoredSites.length && (
+              <>
+                {!!(approvedSites.length || deniedSites.length) && <hr className='my-2' />}
+                <div className='ml-4 font-headline'>Ignored sites</div>
+                <div role='list'>
+                  {ignoredSites.map(site => (
+                    <SiteRecord key={site.origin} site={site} discard={discard} />
+                  ))}
+                </div>
+              </>
+            )}
+          </>
+        )}
       </div>
-    </FadeTransition>
+    </SettingsScreen>
   );
 };
 

--- a/apps/extension/src/routes/popup/settings/settings-full-viewing-key.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-full-viewing-key.tsx
@@ -1,15 +1,14 @@
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 import { Button } from '@penumbra-zone/ui/components/ui/button';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
 import { CopyToClipboard } from '@penumbra-zone/ui/components/ui/copy-to-clipboard';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { PasswordInput } from '../../../shared/components/password-input';
 import { useStore } from '../../../state';
 import { passwordSelector } from '../../../state/password';
 import { KeyGradientIcon } from '../../../icons/key-gradient';
 import { walletsSelector } from '../../../state/wallets';
 import { bech32FullViewingKey } from '@penumbra-zone/bech32/src/full-viewing-key';
+import { SettingsScreen } from './settings-screen';
 
 export const SettingsFullViewingKey = () => {
   const { isPassword } = useStore(passwordSelector);
@@ -32,65 +31,54 @@ export const SettingsFullViewingKey = () => {
   };
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Full Viewing Key' />
-        <div className='mx-auto size-20'>
-          <KeyGradientIcon />
-        </div>
-        <form
-          className='flex flex-1 flex-col items-start justify-between px-[30px] pb-5'
-          onSubmit={submit}
-        >
-          <div className='flex flex-col gap-4'>
-            {!fullViewingKey ? (
-              <PasswordInput
-                passwordValue={password}
-                label={
-                  <p className='font-headline font-semibold text-muted-foreground'>Password</p>
-                }
-                onChange={e => {
-                  setPassword(e.target.value);
-                  setEnteredIncorrect(false);
-                }}
-                validations={[
-                  {
-                    type: 'error',
-                    issue: 'wrong password',
-                    checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
-                  },
-                ]}
-              />
-            ) : (
-              <div className='break-all rounded-lg border bg-background px-[18px] py-[14px] text-muted-foreground'>
-                {fullViewingKey}
-              </div>
-            )}
-            {fullViewingKey && (
-              <CopyToClipboard
-                text={fullViewingKey}
-                label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
-                className='m-auto mb-2'
-                isSuccessCopyText
-              />
-            )}
-            <p className='flex items-center gap-2 text-rust'>
-              <span>
-                <ExclamationTriangleIcon />
-              </span>
-              Warning: never reveal this key. Anyone with your keys can steal any assets held in
-              your account.
-            </p>
-          </div>
+    <SettingsScreen title='Full viewing key' IconComponent={KeyGradientIcon}>
+      <form className='flex flex-1 flex-col items-start justify-between' onSubmit={submit}>
+        <div className='flex flex-col gap-4'>
           {!fullViewingKey ? (
-            <Button variant='gradient' size='lg' className='w-full' type='submit'>
-              Confirm
-            </Button>
+            <PasswordInput
+              passwordValue={password}
+              label={<p className='font-headline font-semibold text-muted-foreground'>Password</p>}
+              onChange={e => {
+                setPassword(e.target.value);
+                setEnteredIncorrect(false);
+              }}
+              validations={[
+                {
+                  type: 'error',
+                  issue: 'wrong password',
+                  checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
+                },
+              ]}
+            />
           ) : (
-            <></>
+            <div className='break-all rounded-lg border bg-background px-[18px] py-[14px] text-muted-foreground'>
+              {fullViewingKey}
+            </div>
           )}
-        </form>
-      </div>
-    </FadeTransition>
+          {fullViewingKey && (
+            <CopyToClipboard
+              text={fullViewingKey}
+              label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
+              className='m-auto mb-2'
+              isSuccessCopyText
+            />
+          )}
+          <p className='flex items-center gap-2 text-rust'>
+            <span>
+              <ExclamationTriangleIcon />
+            </span>
+            Warning: never reveal this key. Anyone with your keys can steal any assets held in your
+            account.
+          </p>
+        </div>
+        {!fullViewingKey ? (
+          <Button variant='gradient' size='lg' className='w-full' type='submit'>
+            Confirm
+          </Button>
+        ) : (
+          <></>
+        )}
+      </form>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-passphrase.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-passphrase.tsx
@@ -2,13 +2,12 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 import { Button } from '@penumbra-zone/ui/components/ui/button';
 import { CopyToClipboard } from '@penumbra-zone/ui/components/ui/copy-to-clipboard';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
 import { FileTextGradientIcon } from '../../../icons/file-text-gradient';
 import { PasswordInput } from '../../../shared/components/password-input';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { useStore } from '../../../state';
 import { passwordSelector } from '../../../state/password';
 import { walletsSelector } from '../../../state/wallets';
+import { SettingsScreen } from './settings-screen';
 
 export const SettingsPassphrase = () => {
   const { isPassword } = useStore(passwordSelector);
@@ -31,71 +30,60 @@ export const SettingsPassphrase = () => {
   };
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Recovery Passphrase' />
-        <div className='mx-auto size-20'>
-          <FileTextGradientIcon />
-        </div>
-        <form
-          className='flex flex-1 flex-col items-start justify-between px-[30px] pb-5'
-          onSubmit={sumbit}
-        >
-          <div className='flex flex-col gap-3'>
-            <p className='text-muted-foreground'>
-              If you change browser or switch to another computer, you will need this recovery
-              passphrase to access your accounts.
-            </p>
-            <p className='mb-3 flex items-center gap-2 text-rust'>
-              <ExclamationTriangleIcon /> Don’t share this phrase with anyone
-            </p>
-            {!phrase.length ? (
-              <PasswordInput
-                passwordValue={password}
-                label={
-                  <p className='font-headline font-semibold text-muted-foreground'>Password</p>
-                }
-                onChange={e => {
-                  setPassword(e.target.value);
-                  setEnteredIncorrect(false);
-                }}
-                validations={[
-                  {
-                    type: 'error',
-                    issue: 'wrong password',
-                    checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
-                  },
-                ]}
-              />
-            ) : (
-              <div className='flex flex-col gap-2'>
-                <p className='font-headline text-base font-semibold'>Recovery secret phrase</p>
-                <div className='mb-[6px] grid grid-cols-3 gap-4 rounded-lg border bg-background p-5'>
-                  {phrase.map((word, i) => (
-                    <div className='flex' key={i}>
-                      <p className='w-5 text-left text-muted-foreground'>{i + 1}.</p>
-                      <p className='text-muted-foreground'>{word}</p>
-                    </div>
-                  ))}
-                </div>
-                <CopyToClipboard
-                  text={phrase.join(' ')}
-                  label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
-                  className='m-auto'
-                  isSuccessCopyText
-                />
-              </div>
-            )}
-          </div>
+    <SettingsScreen title='Recovery passphrase' IconComponent={FileTextGradientIcon}>
+      <form className='flex flex-1 flex-col items-start justify-between' onSubmit={sumbit}>
+        <div className='flex flex-col gap-3'>
+          <p className='text-muted-foreground'>
+            If you change browser or switch to another computer, you will need this recovery
+            passphrase to access your accounts.
+          </p>
+          <p className='mb-3 flex items-center gap-2 text-rust'>
+            <ExclamationTriangleIcon /> Don’t share this phrase with anyone
+          </p>
           {!phrase.length ? (
-            <Button variant='gradient' size='lg' className='w-full' type='submit'>
-              Confirm
-            </Button>
+            <PasswordInput
+              passwordValue={password}
+              label={<p className='font-headline font-semibold text-muted-foreground'>Password</p>}
+              onChange={e => {
+                setPassword(e.target.value);
+                setEnteredIncorrect(false);
+              }}
+              validations={[
+                {
+                  type: 'error',
+                  issue: 'wrong password',
+                  checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
+                },
+              ]}
+            />
           ) : (
-            <></>
+            <div className='flex flex-col gap-2'>
+              <p className='font-headline text-base font-semibold'>Recovery secret phrase</p>
+              <div className='mb-[6px] grid grid-cols-3 gap-4 rounded-lg border bg-background p-5'>
+                {phrase.map((word, i) => (
+                  <div className='flex' key={i}>
+                    <p className='w-5 text-left text-muted-foreground'>{i + 1}.</p>
+                    <p className='text-muted-foreground'>{word}</p>
+                  </div>
+                ))}
+              </div>
+              <CopyToClipboard
+                text={phrase.join(' ')}
+                label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
+                className='m-auto'
+                isSuccessCopyText
+              />
+            </div>
           )}
-        </form>
-      </div>
-    </FadeTransition>
+        </div>
+        {!phrase.length ? (
+          <Button variant='gradient' size='lg' className='w-full' type='submit'>
+            Confirm
+          </Button>
+        ) : (
+          <></>
+        )}
+      </form>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-rpc.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-rpc.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
 import { ShareGradientIcon } from '../../../icons/share-gradient';
-import { SettingsHeader } from '../../../shared/components/settings-header';
-import '@penumbra-zone/polyfills/src/Promise.withResolvers';
 import { GrpcEndpointForm } from '../../../shared/components/grpc-endpoint-form';
-import { PaddingWrapper } from '../padding-wrapper';
+import { SettingsScreen } from './settings-screen';
+import '@penumbra-zone/polyfills/src/Promise.withResolvers';
 
 export const SettingsRPC = () => {
   const [countdownTime, setCountdownTime] = useState<number>();
@@ -29,17 +27,8 @@ export const SettingsRPC = () => {
   };
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='RPC' />
-        <div className='mx-auto size-20'>
-          <ShareGradientIcon />
-        </div>
-
-        <PaddingWrapper>
-          <GrpcEndpointForm submitButtonLabel={submitButtonLabel} onSuccess={onSuccess} />
-        </PaddingWrapper>
-      </div>
-    </FadeTransition>
+    <SettingsScreen title='RPC' IconComponent={ShareGradientIcon}>
+      <GrpcEndpointForm submitButtonLabel={submitButtonLabel} onSuccess={onSuccess} />
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-screen/index.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-screen/index.tsx
@@ -25,7 +25,7 @@ export const SettingsScreen = ({
           </div>
         )}
 
-        <div className='px-[30px] pb-[30px]'>{children}</div>
+        <div className='flex grow flex-col px-[30px] pb-[30px]'>{children}</div>
       </div>
     </FadeTransition>
   );

--- a/apps/extension/src/routes/popup/settings/settings-screen/index.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-screen/index.tsx
@@ -1,0 +1,32 @@
+import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
+import { SettingsHeader } from './settings-header';
+import { ReactNode } from 'react';
+
+/**
+ * A base settings screen template.
+ */
+export const SettingsScreen = ({
+  title,
+  IconComponent,
+  children,
+}: {
+  title: string;
+  IconComponent?: () => JSX.Element;
+  children: ReactNode;
+}) => {
+  return (
+    <FadeTransition>
+      <div className='flex min-h-screen w-screen flex-col gap-6'>
+        <SettingsHeader title={title} />
+
+        {!!IconComponent && (
+          <div className='mx-auto size-20'>
+            <IconComponent />
+          </div>
+        )}
+
+        <div className='px-[30px] pb-[30px]'>{children}</div>
+      </div>
+    </FadeTransition>
+  );
+};

--- a/apps/extension/src/routes/popup/settings/settings-screen/settings-header.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-screen/settings-header.tsx
@@ -1,5 +1,5 @@
 import { BackIcon } from '@penumbra-zone/ui/components/ui/back-icon';
-import { usePopupNav } from '../../utils/navigate';
+import { usePopupNav } from '../../../../utils/navigate';
 
 export const SettingsHeader = ({ title }: { title: string }) => {
   const navigate = usePopupNav();

--- a/apps/extension/src/routes/popup/settings/settings-security.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-security.tsx
@@ -1,10 +1,9 @@
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
 import { EyeGradientIcon } from '../../../icons/eye-gradient';
 import { FileTextIcon } from '../../../icons/file-text';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { CustomLink } from '../../../shared/components/link';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
+import { SettingsScreen } from './settings-screen';
 
 const links = [
   {
@@ -29,23 +28,12 @@ export const SettingsSecurity = () => {
   const navigate = usePopupNav();
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Security & Privacy' />
-        <div className='mx-auto size-20'>
-          <EyeGradientIcon />
-        </div>
-        <div className='flex flex-1 flex-col items-start gap-4 px-[30px]'>
-          {links.map(i => (
-            <CustomLink
-              key={i.href}
-              title={i.title}
-              icon={i.icon}
-              onClick={() => navigate(i.href)}
-            />
-          ))}
-        </div>
+    <SettingsScreen title='Security & Privacy' IconComponent={EyeGradientIcon}>
+      <div className='flex flex-1 flex-col items-start gap-4'>
+        {links.map(i => (
+          <CustomLink key={i.href} title={i.title} icon={i.icon} onClick={() => navigate(i.href)} />
+        ))}
       </div>
-    </FadeTransition>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings-spend-key.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-spend-key.tsx
@@ -2,14 +2,13 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 import { Button } from '@penumbra-zone/ui/components/ui/button';
 import { CopyToClipboard } from '@penumbra-zone/ui/components/ui/copy-to-clipboard';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { PasswordInput } from '../../../shared/components/password-input';
 import { useStore } from '../../../state';
 import { passwordSelector } from '../../../state/password';
 import { AccountKeyGradientIcon } from '../../../icons/account-key-gradient';
 import { walletsSelector } from '../../../state/wallets';
 import { bech32SpendKey } from '@penumbra-zone/bech32/src/spend-key';
+import { SettingsScreen } from './settings-screen';
 
 export const SettingsSpendKey = () => {
   const { isPassword } = useStore(passwordSelector);
@@ -32,65 +31,54 @@ export const SettingsSpendKey = () => {
   };
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col gap-6'>
-        <SettingsHeader title='Spending Key' />
-        <div className='mx-auto size-20'>
-          <AccountKeyGradientIcon />
-        </div>
-        <form
-          className='flex flex-1 flex-col items-start justify-between px-[30px] pb-5'
-          onSubmit={submit}
-        >
-          <div className='flex flex-col gap-4'>
-            {!spendKey ? (
-              <PasswordInput
-                passwordValue={password}
-                label={
-                  <p className='font-headline font-semibold text-muted-foreground'>Password</p>
-                }
-                onChange={e => {
-                  setPassword(e.target.value);
-                  setEnteredIncorrect(false);
-                }}
-                validations={[
-                  {
-                    type: 'error',
-                    issue: 'wrong password',
-                    checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
-                  },
-                ]}
-              />
-            ) : (
-              <div className='break-all rounded-lg border bg-background px-[18px] py-[14px] text-muted-foreground'>
-                {spendKey}
-              </div>
-            )}
-            {spendKey && (
-              <CopyToClipboard
-                text={spendKey}
-                label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
-                className='m-auto mb-2'
-                isSuccessCopyText
-              />
-            )}
-            <p className='flex items-center gap-2 text-rust'>
-              <span>
-                <ExclamationTriangleIcon />
-              </span>
-              Warning: never reveal this key. Anyone with your keys can steal any assets held in
-              your account.
-            </p>
-          </div>
+    <SettingsScreen title='Spending key' IconComponent={AccountKeyGradientIcon}>
+      <form className='flex flex-1 flex-col items-start justify-between' onSubmit={submit}>
+        <div className='flex flex-col gap-4'>
           {!spendKey ? (
-            <Button variant='gradient' size='lg' className='w-full' type='submit'>
-              Confirm
-            </Button>
+            <PasswordInput
+              passwordValue={password}
+              label={<p className='font-headline font-semibold text-muted-foreground'>Password</p>}
+              onChange={e => {
+                setPassword(e.target.value);
+                setEnteredIncorrect(false);
+              }}
+              validations={[
+                {
+                  type: 'error',
+                  issue: 'wrong password',
+                  checkFn: (txt: string) => Boolean(txt) && enteredIncorrect,
+                },
+              ]}
+            />
           ) : (
-            <></>
+            <div className='break-all rounded-lg border bg-background px-[18px] py-[14px] text-muted-foreground'>
+              {spendKey}
+            </div>
           )}
-        </form>
-      </div>
-    </FadeTransition>
+          {spendKey && (
+            <CopyToClipboard
+              text={spendKey}
+              label={<span className='font-bold text-muted-foreground'>Copy to clipboard</span>}
+              className='m-auto mb-2'
+              isSuccessCopyText
+            />
+          )}
+          <p className='flex items-center gap-2 text-rust'>
+            <span>
+              <ExclamationTriangleIcon />
+            </span>
+            Warning: never reveal this key. Anyone with your keys can steal any assets held in your
+            account.
+          </p>
+        </div>
+        {!spendKey ? (
+          <Button variant='gradient' size='lg' className='w-full' type='submit'>
+            Confirm
+          </Button>
+        ) : (
+          <></>
+        )}
+      </form>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings.tsx
+++ b/apps/extension/src/routes/popup/settings/settings.tsx
@@ -6,12 +6,11 @@ import {
   Share1Icon,
 } from '@radix-ui/react-icons';
 import { CustomLink } from '../../../shared/components/link';
-import { SettingsHeader } from '../../../shared/components/settings-header';
 import { useStore } from '../../../state';
 import { passwordSelector } from '../../../state/password';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
-import { FadeTransition } from '@penumbra-zone/ui/components/ui/fade-transition';
+import { SettingsScreen } from './settings-screen';
 
 const links = [
   {
@@ -41,30 +40,22 @@ export const Settings = () => {
   const { clearSessionPassword } = useStore(passwordSelector);
 
   return (
-    <FadeTransition>
-      <div className='flex min-h-screen w-screen flex-col justify-between gap-6'>
-        <SettingsHeader title='Settings' />
-        <div className='flex flex-1 flex-col items-start gap-5 px-[30px]'>
-          {links.map(i => (
-            <CustomLink
-              key={i.href}
-              title={i.title}
-              icon={i.icon}
-              onClick={() => navigate(i.href)}
-            />
-          ))}
-        </div>
-        <div className='h-[66px] border-t border-[rgba(75,75,75,0.50)] px-5 pb-[30px] pt-2'>
-          <CustomLink
-            title='Lock Wallet'
-            icon={<ExitIcon className='size-5 text-muted-foreground' />}
-            onClick={() => {
-              clearSessionPassword();
-              navigate(PopupPath.LOGIN);
-            }}
-          />
-        </div>
+    <SettingsScreen title='Settings'>
+      <div className='flex flex-1 flex-col items-start gap-5'>
+        {links.map(i => (
+          <CustomLink key={i.href} title={i.title} icon={i.icon} onClick={() => navigate(i.href)} />
+        ))}
       </div>
-    </FadeTransition>
+      <div className='mt-5 border-t border-[rgba(75,75,75,0.50)] pt-5'>
+        <CustomLink
+          title='Lock Wallet'
+          icon={<ExitIcon className='size-5 text-muted-foreground' />}
+          onClick={() => {
+            clearSessionPassword();
+            navigate(PopupPath.LOGIN);
+          }}
+        />
+      </div>
+    </SettingsScreen>
   );
 };

--- a/apps/extension/src/routes/popup/settings/settings.tsx
+++ b/apps/extension/src/routes/popup/settings/settings.tsx
@@ -41,20 +41,28 @@ export const Settings = () => {
 
   return (
     <SettingsScreen title='Settings'>
-      <div className='flex flex-1 flex-col items-start gap-5'>
-        {links.map(i => (
-          <CustomLink key={i.href} title={i.title} icon={i.icon} onClick={() => navigate(i.href)} />
-        ))}
-      </div>
-      <div className='mt-5 border-t border-[rgba(75,75,75,0.50)] pt-5'>
-        <CustomLink
-          title='Lock Wallet'
-          icon={<ExitIcon className='size-5 text-muted-foreground' />}
-          onClick={() => {
-            clearSessionPassword();
-            navigate(PopupPath.LOGIN);
-          }}
-        />
+      <div className='flex grow flex-col justify-between'>
+        <div className='flex flex-1 flex-col items-start gap-5'>
+          {links.map(i => (
+            <CustomLink
+              key={i.href}
+              title={i.title}
+              icon={i.icon}
+              onClick={() => navigate(i.href)}
+            />
+          ))}
+        </div>
+
+        <div className='mx-[-30px] border-t border-[rgba(75,75,75,0.50)] p-[30px] pb-0'>
+          <CustomLink
+            title='Lock Wallet'
+            icon={<ExitIcon className='size-5 text-muted-foreground' />}
+            onClick={() => {
+              clearSessionPassword();
+              navigate(PopupPath.LOGIN);
+            }}
+          />
+        </div>
       </div>
     </SettingsScreen>
   );


### PR DESCRIPTION
🚨 I'd recommend viewing this PR with the "Hide whitespace" setting turned on.


In #877, I created a `<PaddingWrapper />` component for use throughout the various settings screens. But then I realized that all the settings screens had a lot more in common than just the padding, so in this PR I deleted `<PaddingWrapper />` and extracted a `<SettingsScreen />` component to take care of the common elements of settings screens (header, back button, padding, icon, etc.).

The only visual difference in this PR is that "Lock wallet" is now listed along with other menu options, rather than being pushed all the way to the bottom:
<img width="432" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/9c60de4d-995e-45fa-b46e-31c993641393">
