### PR TITLE
Clear cache fix & added sync states

### DIFF
--- a/apps/extension/src/routes/popup/home/index.tsx
+++ b/apps/extension/src/routes/popup/home/index.tsx
@@ -7,14 +7,20 @@ import { addrByIndexSelector, getActiveWallet } from '../../../state/wallets';
 import { needsLogin } from '../popup-needs';
 
 export interface PopupLoaderData {
-  fullSyncHeight: number;
+  fullSyncHeight?: number;
 }
 
 // Because Zustand initializes default empty (prior to persisted storage synced),
 // We need to manually check storage for accounts & password in the loader.
 // Will redirect to onboarding or password check if necessary.
-export const popupIndexLoader = async (): Promise<Response | PopupLoaderData> =>
-  (await needsLogin()) ?? { fullSyncHeight: await localExtStorage.get('fullSyncHeight') };
+export const popupIndexLoader = async (): Promise<Response | PopupLoaderData> => {
+  const redirect = await needsLogin();
+  if (redirect) return redirect;
+
+  return {
+    fullSyncHeight: await localExtStorage.get('fullSyncHeight'),
+  };
+};
 
 export const PopupIndex = () => {
   const activeWallet = useStore(getActiveWallet);

--- a/apps/extension/src/routes/popup/settings/settings-clear-cache.tsx
+++ b/apps/extension/src/routes/popup/settings/settings-clear-cache.tsx
@@ -6,9 +6,30 @@ import { TrashGradientIcon } from '../../../icons/trash-gradient';
 import { ServicesMessage } from '@penumbra-zone/types/src/services';
 import { usePopupNav } from '../../../utils/navigate';
 import { PopupPath } from '../paths';
+import { useStore } from '../../../state';
+import { useState } from 'react';
+
+const useCacheClear = () => {
+  const navigate = usePopupNav();
+  const [loading, setLoading] = useState(false);
+
+  const handleCacheClear = () => {
+    setLoading(true);
+
+    void (async function () {
+      await chrome.runtime.sendMessage(ServicesMessage.ClearCache);
+      useStore.setState(state => {
+        state.network.fullSyncHeight = undefined;
+      });
+      navigate(PopupPath.INDEX);
+    })();
+  };
+
+  return { handleCacheClear, loading };
+};
 
 export const SettingsClearCache = () => {
-  const navigate = usePopupNav();
+  const { handleCacheClear, loading } = useCacheClear();
   return (
     <FadeTransition>
       <div className='flex min-h-screen w-screen flex-col gap-6'>
@@ -28,15 +49,13 @@ export const SettingsClearCache = () => {
             </p>
           </div>
           <Button
+            disabled={loading}
             variant='gradient'
             size='lg'
             className='w-full'
-            onClick={() => {
-              void chrome.runtime.sendMessage(ServicesMessage.ClearCache);
-              navigate(PopupPath.INDEX);
-            }}
+            onClick={handleCacheClear}
           >
-            Confirm
+            {loading ? 'Clearing cache...' : 'Confirm'}
           </Button>
         </div>
       </div>

--- a/apps/extension/src/state/network.test.ts
+++ b/apps/extension/src/state/network.test.ts
@@ -19,7 +19,7 @@ describe('Network Slice', () => {
 
   test('the default is empty, false or undefined', () => {
     expect(useStore.getState().network.grpcEndpoint).toBeUndefined();
-    expect(useStore.getState().network.fullSyncHeight).toBe(0);
+    expect(useStore.getState().network.fullSyncHeight).toBeUndefined();
   });
 
   describe('setGRPCEndpoint', () => {

--- a/apps/extension/src/state/network.ts
+++ b/apps/extension/src/state/network.ts
@@ -4,7 +4,7 @@ import { AllSlices, SliceCreator } from '.';
 
 export interface NetworkSlice {
   grpcEndpoint: string | undefined;
-  fullSyncHeight: number;
+  fullSyncHeight?: number;
   setGRPCEndpoint: (endpoint: string) => Promise<void>;
 }
 
@@ -13,7 +13,7 @@ export const createNetworkSlice =
   set => {
     return {
       grpcEndpoint: undefined,
-      fullSyncHeight: 0,
+      fullSyncHeight: undefined,
       setGRPCEndpoint: async (endpoint: string) => {
         set(state => {
           state.network.grpcEndpoint = endpoint;

--- a/packages/storage/src/chrome/local.ts
+++ b/packages/storage/src/chrome/local.ts
@@ -11,7 +11,7 @@ declare const MINIFRONT_URL: string;
 
 export const localDefaults: LocalStorageState = {
   wallets: [],
-  fullSyncHeight: 0,
+  fullSyncHeight: undefined,
   knownSites: [{ origin: MINIFRONT_URL, choice: UserChoice.Approved, date: Date.now() }],
 };
 

--- a/packages/storage/src/chrome/types.ts
+++ b/packages/storage/src/chrome/types.ts
@@ -17,6 +17,6 @@ export interface LocalStorageState {
   wallets: WalletJson[];
   grpcEndpoint?: string;
   passwordKeyPrint?: KeyPrintJson;
-  fullSyncHeight: number;
+  fullSyncHeight?: number;
   knownSites: OriginRecord[];
 }

--- a/packages/ui/components/ui/block-sync-status/large.tsx
+++ b/packages/ui/components/ui/block-sync-status/large.tsx
@@ -12,7 +12,7 @@ export const LargeBlockSyncStatus = ({
   error,
 }: BlockSyncProps) => {
   if (error) return <BlockSyncErrorState error={error} />;
-  if (!latestKnownBlockHeight || !fullSyncHeight) {
+  if (latestKnownBlockHeight === undefined || fullSyncHeight === undefined) {
     return <AwaitingState genesisSyncing={!fullSyncHeight} />;
   }
 
@@ -61,7 +61,7 @@ const AwaitingState = ({ genesisSyncing }: { genesisSyncing: boolean }) => {
       <div className='flex items-center justify-center'>
         <div className='flex items-center'>
           <p className='font-headline text-xl font-semibold text-stone-500'>
-            {genesisSyncing ? 'Genesis block syncing...' : 'Loading sync state...'}
+            {genesisSyncing ? 'Genesis state syncing...' : 'Loading sync state...'}
           </p>
         </div>
       </div>

--- a/packages/ui/components/ui/block-sync-status/large.tsx
+++ b/packages/ui/components/ui/block-sync-status/large.tsx
@@ -12,7 +12,9 @@ export const LargeBlockSyncStatus = ({
   error,
 }: BlockSyncProps) => {
   if (error) return <BlockSyncErrorState error={error} />;
-  if (!latestKnownBlockHeight || !fullSyncHeight) return <div />;
+  if (!latestKnownBlockHeight || !fullSyncHeight) {
+    return <AwaitingState genesisSyncing={!fullSyncHeight} />;
+  }
 
   const isSyncing = latestKnownBlockHeight - fullSyncHeight > 10;
 
@@ -47,6 +49,38 @@ const BlockSyncErrorState = ({ error }: { error: unknown }) => {
   );
 };
 
+// Not having a fullSyncHeight indicates we are doing a fresh sync.
+// The genesis block is particularly large, so we have special text to indicate that.
+const AwaitingState = ({ genesisSyncing }: { genesisSyncing: boolean }) => {
+  return (
+    <motion.div
+      className='flex w-full flex-col gap-1'
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1, transition: { duration: 0.3, ease: 'easeOut', delay: 0.75 } }}
+    >
+      <div className='flex items-center justify-center'>
+        <div className='flex items-center'>
+          <p className='font-headline text-xl font-semibold text-stone-500'>
+            {genesisSyncing ? 'Genesis block syncing...' : 'Loading sync state...'}
+          </p>
+        </div>
+      </div>
+      <Progress status='loading' value={100} />
+      <div className='-ml-3 flex justify-center'>
+        <div className='relative'>
+          <LineWave
+            visible={true}
+            height='50'
+            width='50'
+            color='#71717a'
+            wrapperClass='transition-all duration-300 -mt-5 -mr-5 text-stone-500'
+          />
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
 const SyncingState = ({ fullSyncHeight, latestKnownBlockHeight }: SyncingStateProps) => {
   const { formattedTimeRemaining, confident } = useSyncProgress(
     fullSyncHeight,
@@ -56,7 +90,7 @@ const SyncingState = ({ fullSyncHeight, latestKnownBlockHeight }: SyncingStatePr
   return (
     <motion.div
       className='flex w-full flex-col items-center gap-1'
-      initial={{ opacity: 1 }}
+      initial={{ opacity: 0 }}
       animate={{ opacity: 1, transition: { duration: 0.3, ease: 'easeOut' } }}
     >
       <p className='font-headline text-xl font-semibold text-sand'>Syncing blocks...</p>

--- a/packages/ui/components/ui/progress.tsx
+++ b/packages/ui/components/ui/progress.tsx
@@ -11,6 +11,7 @@ const progressVariants = cva('', {
       'in-progress': 'bg-sand',
       done: 'bg-teal',
       error: 'bg-red-900',
+      loading: 'bg-stone-500',
     },
     background: {
       black: 'bg-black',


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/824

Does two main things:
- On cache clearing, waits for db to clear before transitioning back to index. Sometimes takes a bit, so added a loading state for the button.
- Added genesis and normal loading states for block sync bar. Gives users an indication something is happening. At the moment, it simply doesn't render when its in the loading state.


https://github.com/penumbra-zone/web/assets/16624263/ef6dbfb7-bf07-4a80-a147-c83e7a77eed0

