### PR TITLE
Show equivalent values in the assets table

### DIFF
--- a/apps/minifront/src/components/dashboard/assets-table/equivalent-values.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/equivalent-values.tsx
@@ -1,0 +1,21 @@
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { asValueView } from '@penumbra-zone/getters/src/equivalent-value';
+import {
+  getDisplayDenomFromView,
+  getEquivalentValues,
+} from '@penumbra-zone/getters/src/value-view';
+import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
+
+export const EquivalentValues = ({ valueView }: { valueView?: ValueView }) => {
+  const equivalentValuesAsValueViews = (getEquivalentValues.optional()(valueView) ?? []).map(
+    asValueView,
+  );
+
+  return equivalentValuesAsValueViews.map(equivalentValueAsValueView => (
+    <ValueViewComponent
+      key={getDisplayDenomFromView(equivalentValueAsValueView)}
+      view={equivalentValueAsValueView}
+      variant='equivalent'
+    />
+  ));
+};

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -53,7 +53,7 @@ export default function AssetsTable() {
               {a.balances.map((assetBalance, index) => (
                 <TableRow key={index}>
                   <TableCell>
-                    <div className='flex gap-2'>
+                    <div className='flex flex-wrap gap-2'>
                       <ValueViewComponent view={assetBalance.balanceView} />
                       <EquivalentValues valueView={assetBalance.balanceView} />
                     </div>

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -1,10 +1,11 @@
 import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { AddressIcon } from '@penumbra-zone/ui/components/ui/address-icon';
 import { AddressComponent } from '@penumbra-zone/ui/components/ui/address-component';
-import { BalancesByAccount, getBalancesByAccount } from '../../fetchers/balances/by-account';
+import { BalancesByAccount, getBalancesByAccount } from '../../../fetchers/balances/by-account';
 import { Table, TableBody, TableCell, TableRow } from '@penumbra-zone/ui/components/ui/table';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 import { throwIfPraxNotConnectedTimeout } from '@penumbra-zone/client';
+import { EquivalentValues } from './equivalent-values';
 
 export const AssetsLoader: LoaderFunction = async (): Promise<BalancesByAccount[]> => {
   await throwIfPraxNotConnectedTimeout();
@@ -52,7 +53,10 @@ export default function AssetsTable() {
               {a.balances.map((assetBalance, index) => (
                 <TableRow key={index}>
                   <TableCell>
-                    <ValueViewComponent view={assetBalance.balanceView} />
+                    <div className='flex gap-2'>
+                      <ValueViewComponent view={assetBalance.balanceView} />
+                      <EquivalentValues valueView={assetBalance.balanceView} />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))}

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -7,6 +7,8 @@ import { CopyIcon } from '@radix-ui/react-icons';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { fromBaseUnitAmount } from '@penumbra-zone/types/src/amount';
 import { Pill } from '../../../pill';
+import { ConditionalWrap } from '../../../conditional-wrap';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../../tooltip';
 
 interface ValueViewProps {
   view: ValueView | undefined;
@@ -41,24 +43,36 @@ export const ValueViewComponent = ({
     const symbol = metadata.symbol || 'Unknown Asset';
 
     return (
-      <Pill variant={variant === 'default' ? 'default' : 'dashed'}>
-        <div className='flex min-w-0 items-center gap-1'>
-          {showIcon && (
-            <div className='-ml-2 mr-1 flex size-6 items-center justify-center rounded-full'>
-              <AssetIcon metadata={metadata} />
-            </div>
-          )}
-          {showValue && (
-            <span className='leading-[15px]'>
-              {variant === 'equivalent' && <>~ </>}
-              {formattedAmount}
-            </span>
-          )}
-          {showDenom && (
-            <span className='truncate font-mono text-xs text-muted-foreground'>{symbol}</span>
-          )}
-        </div>
-      </Pill>
+      <ConditionalWrap
+        condition={variant === 'equivalent'}
+        wrap={children => (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>{children}</TooltipTrigger>
+              <TooltipContent>Estimated equivalent value</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      >
+        <Pill variant={variant === 'default' ? 'default' : 'dashed'}>
+          <div className='flex min-w-0 items-center gap-1'>
+            {showIcon && (
+              <div className='-ml-2 mr-1 flex size-6 items-center justify-center rounded-full'>
+                <AssetIcon metadata={metadata} />
+              </div>
+            )}
+            {showValue && (
+              <span className='leading-[15px]'>
+                {variant === 'equivalent' && <>~ </>}
+                {formattedAmount}
+              </span>
+            )}
+            {showDenom && (
+              <span className='truncate font-mono text-xs text-muted-foreground'>{symbol}</span>
+            )}
+          </div>
+        </Pill>
+      </ConditionalWrap>
     );
   }
 


### PR DESCRIPTION
Pretty straightforward. I also added a tooltip for equivalent values to make it clear what they represent:

<img width="571" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/e3c55ca9-48e8-4811-a84d-904af6e35c84">
