### PR TITLE
Create issue template for deployments

### DIFF
--- a/.github/ISSUE_TEMPLATE/deployment.md
+++ b/.github/ISSUE_TEMPLATE/deployment.md
@@ -13,7 +13,8 @@ labels: deployment
   - [ ] IBC
   - [ ] Tx details
   - [x] ~Do a full sync with with [assertRootValid()](https://github.com/penumbra-zone/web/blob/main/packages/query/src/block-processor.ts#L383-L395) enabled. Will throw if TCT roots are not correct.~ (Ignore for now.)
-- [ ] Merge changlist PR or manually run `pnpm changeset version`. Will publish updated npm packages.
+- [ ] If there is already a changelist PR (like [this one](https://github.com/penumbra-zone/web/pull/799)), merge it. Otherwise, manually run `pnpm changeset version`.
+  - This step will publish updated npm packages.
 - [ ] Update [npm package version](https://github.com/penumbra-zone/web/blob/main/package.json#L3)
 - [ ] Update [manifest version](https://github.com/penumbra-zone/web/blob/main/apps/extension/public/manifest.json#L4) based on the extension's newly updated [`package.json` version](https://github.com/penumbra-zone/web/blob/main/apps/extension/package.json) in the extension.
 - [ ] Create repo release with `vX.X.X` tag. Triggers approval to run chrome extension publishing.

--- a/.github/ISSUE_TEMPLATE/deployment.md
+++ b/.github/ISSUE_TEMPLATE/deployment.md
@@ -1,0 +1,23 @@
+---
+name: Deployment
+about: Use this template when you're going to deploy a new release of the extension and web app.
+title: Publish vX.X.X extension + web app
+labels: deployment
+---
+
+- [ ] Manual testing to confirm extension works with main flows
+  - [ ] Balances
+  - [ ] Send
+  - [ ] Swap
+  - [ ] Staking
+  - [ ] IBC
+  - [ ] Tx details
+  - [x] ~Do a full sync with with [assertRootValid()](https://github.com/penumbra-zone/web/blob/main/packages/query/src/block-processor.ts#L383-L395) enabled. Will throw if TCT roots are not correct.~ (Ignore for now.)
+- [ ] Merge changlist PR or manually run `pnpm changeset version`. Will publish updated npm packages.
+- [ ] Update [npm package version](https://github.com/penumbra-zone/web/blob/main/package.json#L3)
+- [ ] Update [manifest version](https://github.com/penumbra-zone/web/blob/main/apps/extension/public/manifest.json#L4) based on the extension's newly updated [`package.json` version](https://github.com/penumbra-zone/web/blob/main/apps/extension/package.json) in the extension.
+- [ ] Create repo release with `vX.X.X` tag. Triggers approval to run chrome extension publishing.
+- [ ] Run `pnpm build` in the web repo's root. Then take minifront & node-status `dist` output and make PR against core repo to update node's frontends.
+- [ ] Wait 1-3 days until new extension version is live on [chrome web store](https://chromewebstore.google.com/detail/penumbra-wallet/lkpmkhpnhknhmibgnmmhdhgdilepfghe)
+- [ ] Run `Deploy Static Site` [github action](https://github.com/penumbra-zone/web/actions/workflows/deploy-firebase-dapp.yml)
+- [ ] Make `@channel` announcement in Discord #web-ext-feedback channel if there are any relevant features to announce.

--- a/.github/ISSUE_TEMPLATE/deployment.md
+++ b/.github/ISSUE_TEMPLATE/deployment.md
@@ -17,7 +17,7 @@ labels: deployment
   - This step will publish updated npm packages.
 - [ ] Update [npm package version](https://github.com/penumbra-zone/web/blob/main/package.json#L3)
 - [ ] Update [manifest version](https://github.com/penumbra-zone/web/blob/main/apps/extension/public/manifest.json#L4) based on the extension's newly updated [`package.json` version](https://github.com/penumbra-zone/web/blob/main/apps/extension/package.json) in the extension.
-- [ ] Create repo release with `vX.X.X` tag. Triggers approval to run chrome extension publishing.
+- [ ] [Create repo release](https://github.com/penumbra-zone/web/releases/new) with `vX.X.X` tag. Triggers approval to run chrome extension publishing.
 - [ ] Run `pnpm build` in the web repo's root. Then take minifront & node-status `dist` output and make PR against core repo to update node's frontends.
 - [ ] Wait 1-3 days until new extension version is live on [chrome web store](https://chromewebstore.google.com/detail/penumbra-wallet/lkpmkhpnhknhmibgnmmhdhgdilepfghe)
 - [ ] Run `Deploy Static Site` [github action](https://github.com/penumbra-zone/web/actions/workflows/deploy-firebase-dapp.yml)

--- a/.github/ISSUE_TEMPLATE/deployment.md
+++ b/.github/ISSUE_TEMPLATE/deployment.md
@@ -12,8 +12,8 @@ labels: deployment
   - [ ] Staking
   - [ ] IBC
   - [ ] Tx details
-  - [x] ~Do a full sync with with [assertRootValid()](https://github.com/penumbra-zone/web/blob/main/packages/query/src/block-processor.ts#L383-L395) enabled. Will throw if TCT roots are not correct.~ (Ignore for now.)
-- [ ] If there is already a changelist PR (like [this one](https://github.com/penumbra-zone/web/pull/799)), merge it. Otherwise, manually run `pnpm changeset version`.
+  - [ ] Test sync with [assertRootValid()](https://github.com/penumbra-zone/web/blob/992bc2d975ef55537dac95db4e29c49715bf740b/docs/debugging.md) enabled. Will throw if TCT roots are not correct.
+- [ ] If there is already a changelist PR (like [this one](https://github.com/penumbra-zone/web/pull/799)), merge it. Otherwise, manually run `pnpm changeset` to bump packages as needed (would require work looking through PRs since last version) and run `pnpm changeset version` after. You'll have local changes that will require a PR to merge.
   - This step will publish updated npm packages.
 - [ ] Update [npm package version](https://github.com/penumbra-zone/web/blob/main/package.json#L3)
 - [ ] Update [manifest version](https://github.com/penumbra-zone/web/blob/main/apps/extension/public/manifest.json#L4) based on the extension's newly updated [`package.json` version](https://github.com/penumbra-zone/web/blob/main/apps/extension/package.json) in the extension.
@@ -21,4 +21,4 @@ labels: deployment
 - [ ] Run `pnpm build` in the web repo's root. Then take minifront & node-status `dist` output and make PR against core repo to update node's frontends.
 - [ ] Wait 1-3 days until new extension version is live on [chrome web store](https://chromewebstore.google.com/detail/penumbra-wallet/lkpmkhpnhknhmibgnmmhdhgdilepfghe)
 - [ ] Run `Deploy Static Site` [github action](https://github.com/penumbra-zone/web/actions/workflows/deploy-firebase-dapp.yml)
-- [ ] Make `@channel` announcement in Discord #web-ext-feedback channel if there are any relevant features to announce.
+- [ ] Work with comms team for relevant discord announcements and social posts for new features we want to amplify

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 ### Prax Chrome Extension
 
-Create a [github issue deployment template](<https://github.com/penumbra-zone/web/issues/new?title=Publish%20vX.X.X%20extension%20%2B%20web%20app&body=-%20%5B%20%5D%20Manual%20testing%20to%20confirm%20extension%20works%20with%20main%20flows%0A%20%20-%20%5B%20%5D%20Balances%0A%20%20-%20%5B%20%5D%20Send%0A%20%20-%20%5B%20%5D%20Swap%0A%20%20-%20%5B%20%5D%20Staking%0A%20%20-%20%5B%20%5D%20IBC%0A%20%20-%20%5B%20%5D%20Tx%20details%0A-%20%5B%20%5D%20Update%20%5Bmanifest%20version%5D(https://github.com/penumbra-zone/web/blob/main/apps/extension/public/manifest.json%23L4)%20%0A-%20%5B%20%5D%20Update%20%5Bnpm%20package%20version%5D(https://github.com/penumbra-zone/web/blob/main/package.json%23L3)%0A-%20%5B%20%5D%20Create%20repo%20release%20with%20%60vX.X.X%60%20tag.%20Triggers%20approval%20to%20run%20chrome%20extension%20publishing.%0A-%20%5B%20%5D%20Wait%201-3%20days%20until%20new%20extension%20version%20is%20live%20on%20%5Bchrome%20web%20store%5D(https://chromewebstore.google.com/detail/penumbra-wallet/lkpmkhpnhknhmibgnmmhdhgdilepfghe)%0A-%20%5B%20%5D%20Run%20%60Deploy%20Static%20Site%60%20%5Bgithub%20action%5D(https://github.com/penumbra-zone/web/actions/workflows/deploy-firebase-dapp.yml)%0A-%20%5B%20%5D%20Make%20%60%40channel%60%20announcement%20to%20Discord%20about%20new%20swap%20feature>) to track deployment progress and steps.
+Create a [github issue deployment issue](https://github.com/penumbra-zone/web/issues/new?template=deployment) to track deployment progress and steps.
 
 Upon a new [git tag](https://github.com/penumbra-zone/web/releases/tag/v4.2.0) being pushed to the repo,
 a [workflow](../.github/workflows/extension-publish.yml) is kicked off. It then requests permission to


### PR DESCRIPTION
Previously, the deployment docs pointed to a link that had the issue template embedded in the query string, which made it hard to update. This PR extracts that template to an issue template markdown file, and updates the link. Note that this can only really be tested once it's merged, since the link in the deployment docs points to a template that won't exist until this is merged.