### PR TITLE
Improve memo rendering with rows

### DIFF
--- a/packages/ui/components/ui/tx/view/action-details.tsx
+++ b/packages/ui/components/ui/tx/view/action-details.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { IncognitoIcon } from '../../icons/incognito';
 
 /**
  * Render key/value pairs inside a `<ViewBox />`.
@@ -31,18 +32,32 @@ const ActionDetailsRow = ({
   label,
   children,
   truncate,
+  isOpaque,
 }: {
   label: string;
-  children: ReactNode;
+  children?: ReactNode;
   /**
    * If `children` is a string, passing `truncate` will automatically truncate
    * the text if it doesn't fit in a single line.
    */
   truncate?: boolean;
+  /**
+   * If set to true, add styles indicating that the row's data is _not_ visible.
+   */
+  isOpaque?: boolean;
 }) => {
   return (
     <div className='flex items-center justify-between'>
-      <span className='whitespace-nowrap break-keep'>{label}</span>
+      {isOpaque ? (
+        <span className='flex items-center whitespace-nowrap text-gray-600'>
+          <span className='mx-2'>
+            <IncognitoIcon fill='#4b5563' />
+          </span>
+          <span>{label}</span>
+        </span>
+      ) : (
+        <span className='whitespace-nowrap break-keep'>{label}</span>
+      )}
 
       <Separator />
 

--- a/packages/ui/components/ui/tx/view/memo-view.tsx
+++ b/packages/ui/components/ui/tx/view/memo-view.tsx
@@ -1,36 +1,32 @@
 import { MemoView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { AddressViewComponent } from './address-view';
-import { ViewBox, ViewSection } from './viewbox';
+import { ViewBox } from './viewbox';
+import { ActionDetails } from './action-details';
 
 export const MemoViewComponent = ({ memo: { memoView } }: { memo: MemoView }) => {
   switch (memoView.case) {
     case 'visible':
       return (
-        <ViewSection heading='Memo'>
-          <ViewBox
-            label='Memo Text'
-            visibleContent={
-              <div>
-                {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-                {memoView.value.plaintext?.text || (
-                  <span className='italic text-gray-600'>== none ==</span>
-                )}
-              </div>
-            }
-          />
-          <ViewBox
-            label='Sender Return Address'
-            visibleContent={<AddressViewComponent view={memoView.value.plaintext!.returnAddress} />}
-          />
-        </ViewSection>
+        <ViewBox
+          label='Memo'
+          visibleContent={
+            <div className='flex flex-col gap-4'>
+              <ActionDetails>
+                <ActionDetails.Row label='Sender Return Address'>
+                  <AddressViewComponent view={memoView.value.plaintext!.returnAddress} />
+                </ActionDetails.Row>
+                <ActionDetails.Row label='Memo Text'>
+                  <span className='italic' style={{ wordBreak: 'normal' }}>
+                    {memoView.value.plaintext?.text}
+                  </span>
+                </ActionDetails.Row>
+              </ActionDetails>
+            </div>
+          }
+        />
       );
     case 'opaque':
-      return (
-        <ViewSection heading='Memo'>
-          <ViewBox label='Memo Text' />
-          <ViewBox label='Sender Return Address' />
-        </ViewSection>
-      );
+      return <ViewBox label='Memo' isOpaque={true} />;
     default:
       return <span>Invalid MemoView: &quot;{memoView.case}&quot;</span>;
   }

--- a/packages/ui/components/ui/tx/view/viewbox.tsx
+++ b/packages/ui/components/ui/tx/view/viewbox.tsx
@@ -7,22 +7,25 @@ import { IncognitoIcon } from '../../icons/incognito';
 export interface ViewBoxProps {
   label: string;
   visibleContent?: React.ReactElement;
+  isOpaque?: boolean;
 }
 
 const Label = ({ label }: { label: string }) => <span className='text-lg'>{label}</span>;
 
-export const ViewBox = ({ label, visibleContent }: ViewBoxProps) => {
+export const ViewBox = ({ label, visibleContent, isOpaque }: ViewBoxProps) => {
+  // if isOpaque is undefined, set it to !visibleContent
+  isOpaque = isOpaque ?? !visibleContent;
   return (
     <div
       className={cn(
         'bg-background px-4 pt-3 pb-4 rounded-lg border flex flex-col gap-1 break-all overflow-hidden',
-        !visibleContent ? 'cursor-not-allowed' : '',
+        isOpaque ? 'cursor-not-allowed' : '',
       )}
     >
       <div className='flex items-center gap-2 self-start'>
-        <span className={cn('text-base font-bold', !visibleContent ? 'text-gray-600' : '')}>
-          {visibleContent && <Label label={label} />}
-          {!visibleContent && (
+        <span className={cn('text-base font-bold', isOpaque ? 'text-gray-600' : '')}>
+          {!isOpaque && <Label label={label} />}
+          {isOpaque && (
             <div className='flex gap-2'>
               <IncognitoIcon fill='#4b5563' />
               <Label label={label} />


### PR DESCRIPTION
Uses the rows component to render the entire memo as one object (since it is one object). Also fixes formatting for empty memos.

<img width="669" alt="Screenshot 2024-04-04 at 7 28 05 PM" src="https://github.com/penumbra-zone/web/assets/44879/c7abb2c4-cbce-47fe-a988-1bf390a7aa81">
<img width="672" alt="Screenshot 2024-04-04 at 7 27 39 PM" src="https://github.com/penumbra-zone/web/assets/44879/09aa92db-2cb3-479b-84b0-315521cb1a7e">
<img width="666" alt="Screenshot 2024-04-04 at 7 26 20 PM" src="https://github.com/penumbra-zone/web/assets/44879/3767a8a4-853a-406a-8f1b-303fad0f25a9">
<img width="678" alt="Screenshot 2024-04-04 at 7 26 13 PM" src="https://github.com/penumbra-zone/web/assets/44879/64d520bf-38d4-4f19-93b6-f151dacd00de">

As a side effect to doing this, I added configuration to mark individual rows as visible or not. I originally used this to make a version of the "opaque" memo that showed that individual fields were opaque, and then concluded that it wasn't a good design.

However, I left them in the code since they'll be useful for making rendered views of actions that can show that some fields are present while others are opaque.