### PR TITLE
Generate unbonding token metadata on the fly for the approval dialog

### DIFF
--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -1,6 +1,6 @@
 
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe
-IDB_VERSION=32
+IDB_VERSION=33
 USDC_ASSET_ID="reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
 MINIFRONT_URL=https://app.testnet.penumbra.zone/
 PENUMBRA_NODE_PD_URL=https://grpc.testnet.penumbra.zone/

--- a/apps/extension/src/state/tx-approval.ts
+++ b/apps/extension/src/state/tx-approval.ts
@@ -66,9 +66,9 @@ export const createTxApprovalSlice = (): SliceCreator<TxApprovalSlice> => (set, 
     const getMetadata = async (assetId: AssetId) => {
       try {
         const { denomMetadata } = await viewClient.assetMetadataById({ assetId });
-        return denomMetadata ?? new Metadata();
+        return denomMetadata ?? new Metadata({ penumbraAssetId: assetId });
       } catch {
-        return new Metadata();
+        return new Metadata({ penumbraAssetId: assetId });
       }
     };
 

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -118,7 +118,10 @@ export class IndexedDb implements IndexedDbInterface {
 
     const instance = new this(db, new IbdUpdater(db), constants, chainId);
     await instance.saveLocalAssetsMetadata(); // Pre-load asset metadata
-    await instance.addEpoch(0n); // Create first epoch
+
+    const existing0thEpoch = await instance.getEpochByHeight(0n);
+    if (!existing0thEpoch) await instance.addEpoch(0n); // Create first epoch
+
     return instance;
   }
   close(): void {

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -219,4 +219,5 @@ export const IDB_TABLES: Tables = {
   prices: 'PRICES',
   validator_infos: 'VALIDATOR_INFOS',
   transactions: 'TRANSACTIONS',
+  full_sync_height: 'FULL_SYNC_HEIGHT',
 };

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -2750,6 +2750,7 @@ dependencies = [
  "penumbra-transaction",
  "prost",
  "rand_core",
+ "regex",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -38,6 +38,7 @@ hex                      = "0.4.3"
 indexed_db_futures       = "0.4.1"
 prost                    = "0.12.3"
 rand_core                = { version = "0.6.4", features = ["getrandom"] }
+regex                    = { version = "1.8.1" }
 serde                    = { version = "1.0.197", features = ["derive"] }
 serde-wasm-bindgen       = "0.6.5"
 thiserror                = "1.0"

--- a/packages/wasm/crate/src/error.rs
+++ b/packages/wasm/crate/src/error.rs
@@ -42,6 +42,9 @@ pub enum WasmError {
 
     #[error("{0}")]
     Wasm(#[from] serde_wasm_bindgen::Error),
+
+    #[error("{0}")]
+    RegexError(#[from] regex::Error),
 }
 
 impl From<WasmError> for serde_wasm_bindgen::Error {

--- a/packages/wasm/crate/src/lib.rs
+++ b/packages/wasm/crate/src/lib.rs
@@ -8,6 +8,7 @@ pub mod build;
 pub mod dex;
 pub mod error;
 pub mod keys;
+pub mod metadata;
 pub mod note_record;
 pub mod planner;
 pub mod storage;

--- a/packages/wasm/crate/src/metadata.rs
+++ b/packages/wasm/crate/src/metadata.rs
@@ -1,42 +1,63 @@
-use penumbra_proto::core::asset::v1::Metadata;
+use anyhow::anyhow;
+use penumbra_asset::asset::Metadata as MetadataDomainType;
+use penumbra_proto::{core::asset::v1::Metadata, DomainType};
 use regex::Regex;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::{error::WasmResult, utils};
 
 pub static UNBONDING_TOKEN_REGEX: &str = "^uunbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>penumbravalid1(?P<id>[a-zA-HJ-NP-Z0-9]+)))$";
 pub static DELEGATION_TOKEN_REGEX: &str =
     "^udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$";
 pub static SHORTENED_ID_LENGTH: usize = 8;
 
-pub fn customize_symbol(metadata: Metadata) -> Metadata {
-    if let Some(unbonding_match) = Regex::new(UNBONDING_TOKEN_REGEX)
-        .expect("regex is valid")
-        .captures(&metadata.base)
-    {
-        let id_match = unbonding_match.name("id").unwrap().as_str();
-        let shortened_id = id_match
-            .chars()
-            .take(SHORTENED_ID_LENGTH)
-            .collect::<String>();
-        let start_match = unbonding_match.name("start").unwrap().as_str();
+#[wasm_bindgen]
+pub fn customize_symbol(metadata_bytes: &[u8]) -> WasmResult<Vec<u8>> {
+    utils::set_panic_hook();
 
-        Metadata {
-            symbol: format!("unbondUMat{start_match}({shortened_id}…)"),
-            ..metadata
-        }
-    } else if let Some(delegation_match) = Regex::new(DELEGATION_TOKEN_REGEX)
-        .expect("regex is valid")
-        .captures(&metadata.base)
-    {
-        let id_match = delegation_match.name("id").unwrap().as_str();
-        let shortened_id = id_match
-            .chars()
-            .take(SHORTENED_ID_LENGTH)
-            .collect::<String>();
+    let metadata_domain_type = MetadataDomainType::decode(metadata_bytes)?;
+    let metadata_proto = customize_symbol_inner(metadata_domain_type.to_proto())?;
 
-        Metadata {
-            symbol: format!("delUM({shortened_id}…)"),
-            ..metadata
-        }
-    } else {
-        metadata
+    match MetadataDomainType::try_from(metadata_proto) {
+        Ok(customized_metadata_domain_type) => Ok(customized_metadata_domain_type.encode_to_vec()),
+        Err(error) => Err(error.into()),
     }
+}
+
+pub fn customize_symbol_inner(metadata: Metadata) -> WasmResult<Metadata> {
+    let unbonding_re = Regex::new(UNBONDING_TOKEN_REGEX)?;
+    let delegation_re = Regex::new(DELEGATION_TOKEN_REGEX)?;
+
+    if let Some(captures) = unbonding_re.captures(&metadata.base) {
+        let shortened_id = shorten_id(&captures)?;
+        let start_match = captures
+            .name("start")
+            .ok_or_else(|| anyhow!("<start> not matched in unbonding token regex"))?
+            .as_str();
+
+        return Ok(Metadata {
+            symbol: format!("unbondUMat{start_match}({shortened_id}...)"),
+            ..metadata
+        });
+    } else if let Some(captures) = delegation_re.captures(&metadata.base) {
+        let shortened_id = shorten_id(&captures)?;
+
+        return Ok(Metadata {
+            symbol: format!("delUM({shortened_id}...)"),
+            ..metadata
+        });
+    }
+
+    Ok(metadata)
+}
+
+fn shorten_id(captures: &regex::Captures) -> WasmResult<String> {
+    let id_match = captures
+        .name("id")
+        .ok_or_else(|| anyhow!("<id> not matched in staking token regex"))?;
+    Ok(id_match
+        .as_str()
+        .chars()
+        .take(SHORTENED_ID_LENGTH)
+        .collect())
 }

--- a/packages/wasm/crate/src/metadata.rs
+++ b/packages/wasm/crate/src/metadata.rs
@@ -1,0 +1,47 @@
+use penumbra_proto::core::asset::v1::Metadata;
+use regex::Regex;
+
+pub static UNBONDING_TOKEN_REGEX: &str = "^uunbonding_(?P<data>start_at_(?P<start>[0-9]+)_(?P<validator>penumbravalid1(?P<id>[a-zA-HJ-NP-Z0-9]+)))$";
+pub static DELEGATION_TOKEN_REGEX: &str =
+    "^udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$";
+pub static SHORTENED_ID_LENGTH: usize = 8;
+
+pub fn customize_symbol(metadata: Metadata) -> Metadata {
+    if let Some(unbonding_match) = Regex::new(UNBONDING_TOKEN_REGEX)
+        .expect("regex is valid")
+        .captures(&metadata.base)
+    {
+        let id_match = unbonding_match.name(&"id").unwrap().as_str();
+        let shortened_id = id_match
+            .chars()
+            .take(SHORTENED_ID_LENGTH)
+            .collect::<String>();
+        let start_match = unbonding_match.name(&"start").unwrap().as_str();
+
+        let customized = Metadata {
+            symbol: format!("unbondUMat{start_match}({shortened_id}…)"),
+            ..metadata
+        };
+
+        return customized;
+    } else if let Some(delegation_match) = Regex::new(DELEGATION_TOKEN_REGEX)
+        .expect("regex is valid")
+        .captures(&metadata.base)
+    {
+        let id_match = delegation_match.name(&"id").unwrap().as_str();
+        let shortened_id = id_match
+            .chars()
+            .take(SHORTENED_ID_LENGTH)
+            .collect::<String>();
+
+        // let customized = metadata.clone();
+        let customized = Metadata {
+            symbol: format!("delUM({shortened_id}…)"),
+            ..metadata
+        };
+
+        return customized;
+    } else {
+        metadata
+    }
+}

--- a/packages/wasm/crate/src/metadata.rs
+++ b/packages/wasm/crate/src/metadata.rs
@@ -11,36 +11,31 @@ pub fn customize_symbol(metadata: Metadata) -> Metadata {
         .expect("regex is valid")
         .captures(&metadata.base)
     {
-        let id_match = unbonding_match.name(&"id").unwrap().as_str();
+        let id_match = unbonding_match.name("id").unwrap().as_str();
         let shortened_id = id_match
             .chars()
             .take(SHORTENED_ID_LENGTH)
             .collect::<String>();
-        let start_match = unbonding_match.name(&"start").unwrap().as_str();
+        let start_match = unbonding_match.name("start").unwrap().as_str();
 
-        let customized = Metadata {
+        Metadata {
             symbol: format!("unbondUMat{start_match}({shortened_id}…)"),
             ..metadata
-        };
-
-        return customized;
+        }
     } else if let Some(delegation_match) = Regex::new(DELEGATION_TOKEN_REGEX)
         .expect("regex is valid")
         .captures(&metadata.base)
     {
-        let id_match = delegation_match.name(&"id").unwrap().as_str();
+        let id_match = delegation_match.name("id").unwrap().as_str();
         let shortened_id = id_match
             .chars()
             .take(SHORTENED_ID_LENGTH)
             .collect::<String>();
 
-        // let customized = metadata.clone();
-        let customized = Metadata {
+        Metadata {
             symbol: format!("delUM({shortened_id}…)"),
             ..metadata
-        };
-
-        return customized;
+        }
     } else {
         metadata
     }

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -325,7 +325,6 @@ pub async fn plan_transaction(
         let undelegate = rate_data.build_undelegate(epoch.into(), value.amount);
 
         let metadata = undelegate.unbonding_token().denom();
-
         if storage.get_asset(&metadata.id()).await?.is_none() {
             let metadata_proto = metadata.to_proto();
             let customized_metadata_proto = customize_symbol(metadata_proto);

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -326,7 +326,7 @@ pub async fn plan_transaction(
 
         let metadata = undelegate.unbonding_token().denom();
 
-        if let None = storage.get_asset(&metadata.id()).await? {
+        if storage.get_asset(&metadata.id()).await?.is_none() {
             let metadata_proto = metadata.to_proto();
             let customized_metadata_proto = customize_symbol(metadata_proto);
             let customized_metadata = Metadata::try_from(customized_metadata_proto)?;

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -32,7 +32,7 @@ use rand_core::OsRng;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
-use crate::metadata::customize_symbol;
+use crate::metadata::customize_symbol_inner;
 use crate::note_record::SpendableNoteRecord;
 use crate::storage::IndexedDBStorage;
 use crate::utils;
@@ -498,7 +498,7 @@ async fn save_unbonding_token_metadata_if_needed(
 
     if storage.get_asset(&metadata.id()).await?.is_none() {
         let metadata_proto = metadata.to_proto();
-        let customized_metadata_proto = customize_symbol(metadata_proto);
+        let customized_metadata_proto = customize_symbol_inner(metadata_proto)?;
         let customized_metadata = Metadata::try_from(customized_metadata_proto)?;
         storage.add_asset(&customized_metadata).await
     } else {

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -324,10 +324,14 @@ pub async fn plan_transaction(
 
         let undelegate = rate_data.build_undelegate(epoch.into(), value.amount);
 
-        let metadata_proto = undelegate.unbonding_token().denom().to_proto();
-        let customized_metadata_proto = customize_symbol(metadata_proto);
-        let customized_metadata = Metadata::try_from(customized_metadata_proto)?;
-        storage.add_asset(&customized_metadata).await?;
+        let metadata = undelegate.unbonding_token().denom();
+
+        if let None = storage.get_asset(&metadata.id()).await? {
+            let metadata_proto = metadata.to_proto();
+            let customized_metadata_proto = customize_symbol(metadata_proto);
+            let customized_metadata = Metadata::try_from(customized_metadata_proto)?;
+            storage.add_asset(&customized_metadata).await?;
+        }
 
         actions.push(undelegate.into());
     }

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -86,6 +86,7 @@ mod tests {
             gas_prices: String,
             epochs: String,
             transactions: String,
+            full_sync_height: String,
         }
 
         // Define `IndexDB` table parameters and constants.
@@ -99,6 +100,7 @@ mod tests {
             gas_prices: "GAS_PRICES".to_string(),
             epochs: "EPOCHS".to_string(),
             transactions: "TRANSACTIONS".to_string(),
+            full_sync_height: "FULL_SYNC_HEIGHT".to_string(),
         };
 
         let constants: IndexedDbConstants = IndexedDbConstants {


### PR DESCRIPTION
When a user undelegates from a validator — meaning, they want to unbond their delegation tokens so that they can reclaim those tokens as UM — Penumbra issues "unbonding" tokens. These unbonding tokens are tied to the specific validator that the user is undelegating from, as well as to the block height at which the user made the undelegate transaction. (It just so happens that Penumbra's current implementation clamps the block height to the start of the current epoch; but this could change in the future, so we treat it as though it's tied to a block height, rather than tied to an epoch.)

Because unbonding tokens are so specific, there often is no metadata for them in the database when a user wishes to undelegate from a validator. (The only way there _would_ be metadata for them in the database is if the user had already undelegated from that same validator at that same block height at least once before. Since the block height is clamped to the start of the epoch, this is technically possible; but the user would still face this issue the first time they undelegate from that validator during that epoch.) As a result, the transaction approval dialog would show "Unknown asset" for the "Output" action that outputs unbonding tokens. This is a confusing experience for users, who would have no way of knowing that the "Unknown asset" they're getting is the unbonding token.

This PR fixes that issue by generating and saving asset metadata to the database _while planning the transaction_. This means that, by the time the transaction approval dialog displays the transaction plan, the metadata will exist in the database, and thus the dialog will correctly show the asset metadata.

The (very slight) downside to this approach is that, if the user cancels the transaction and never attempts another undelegation at that block height, IndexedDB will contain metadata for an asset that doesn't actually exist for the user on-chain. i.e., if the user clicks "Undelegate" for a validator — which pops open the transaction approval dialog and saves the generated asset metadata for the unbonding tokens — and then cancels the transaction, the generated metadata will still exist in the database even if it never gets "used" for any unbonding tokens. This seems like an OK trade-off, however.

Closes #856 
