### PR TITLE
Render the assets table as an actual table

### DIFF
--- a/apps/minifront/src/components/dashboard/assets-table/equivalent-values.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/equivalent-values.tsx
@@ -11,11 +11,15 @@ export const EquivalentValues = ({ valueView }: { valueView?: ValueView }) => {
     asValueView,
   );
 
-  return equivalentValuesAsValueViews.map(equivalentValueAsValueView => (
-    <ValueViewComponent
-      key={getDisplayDenomFromView(equivalentValueAsValueView)}
-      view={equivalentValueAsValueView}
-      variant='equivalent'
-    />
-  ));
+  return (
+    <div className='flex flex-wrap gap-2'>
+      {equivalentValuesAsValueViews.map(equivalentValueAsValueView => (
+        <ValueViewComponent
+          key={getDisplayDenomFromView(equivalentValueAsValueView)}
+          view={equivalentValueAsValueView}
+          variant='equivalent'
+        />
+      ))}
+    </div>
+  );
 };

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -2,7 +2,14 @@ import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { AddressIcon } from '@penumbra-zone/ui/components/ui/address-icon';
 import { AddressComponent } from '@penumbra-zone/ui/components/ui/address-component';
 import { BalancesByAccount, getBalancesByAccount } from '../../../fetchers/balances/by-account';
-import { Table, TableBody, TableCell, TableRow } from '@penumbra-zone/ui/components/ui/table';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@penumbra-zone/ui/components/ui/table';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 import { throwIfPraxNotConnectedTimeout } from '@penumbra-zone/client';
 import { EquivalentValues } from './equivalent-values';
@@ -13,9 +20,9 @@ export const AssetsLoader: LoaderFunction = async (): Promise<BalancesByAccount[
 };
 
 export default function AssetsTable() {
-  const data = useLoaderData() as BalancesByAccount[];
+  const balancesByAccount = useLoaderData() as BalancesByAccount[];
 
-  if (data.length === 0) {
+  if (balancesByAccount.length === 0) {
     return (
       <div className='flex flex-col gap-6'>
         <p>
@@ -30,40 +37,45 @@ export default function AssetsTable() {
   }
 
   return (
-    <div className='flex flex-col gap-6'>
-      {data.map((a, index) => (
-        <div key={index} className='flex flex-col gap-4'>
-          <div className='flex flex-col items-center justify-center'>
-            <div className='flex max-w-full flex-col justify-center gap-2 md:flex-row'>
-              <div className='flex items-center justify-center gap-2'>
-                <AddressIcon address={a.address} size={20} />
-                <h2 className='whitespace-nowrap font-bold md:text-base xl:text-xl'>
-                  Account #{a.account}
-                </h2>
-              </div>
+    <Table>
+      {balancesByAccount.map(account => (
+        <>
+          <TableHeader key={account.account} className='group'>
+            <TableRow>
+              <TableHead colSpan={2}>
+                <div className='flex max-w-full flex-col justify-center gap-2 md:flex-row pt-8 group-[:first-of-type]:pt-0'>
+                  <div className='flex items-center justify-center gap-2'>
+                    <AddressIcon address={account.address} size={20} />
+                    <h2 className='whitespace-nowrap font-bold md:text-base xl:text-xl'>
+                      Account #{account.account}
+                    </h2>
+                  </div>
 
-              <div className='max-w-72 truncate'>
-                <AddressComponent address={a.address} />
-              </div>
-            </div>
-          </div>
-
-          <Table className='md:table'>
-            <TableBody>
-              {a.balances.map((assetBalance, index) => (
-                <TableRow key={index}>
-                  <TableCell>
-                    <div className='flex flex-wrap gap-2'>
-                      <ValueViewComponent view={assetBalance.balanceView} />
-                      <EquivalentValues valueView={assetBalance.balanceView} />
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+                  <div className='max-w-72 truncate'>
+                    <AddressComponent address={account.address} />
+                  </div>
+                </div>
+              </TableHead>
+            </TableRow>
+            <TableRow>
+              <TableHead>Balance</TableHead>
+              <TableHead>Estimated equivalent(s)</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {account.balances.map((assetBalance, index) => (
+              <TableRow key={index}>
+                <TableCell>
+                  <ValueViewComponent view={assetBalance.balanceView} />
+                </TableCell>
+                <TableCell>
+                  <EquivalentValues valueView={assetBalance.balanceView} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </>
       ))}
-    </div>
+    </Table>
   );
 }

--- a/packages/ui/components/ui/table.tsx
+++ b/packages/ui/components/ui/table.tsx
@@ -50,7 +50,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-10 text-left align-top text-lg leading-[26px] font-headline font-semibold [&:has([role=checkbox])]:pr-0',
+      'py-4 text-left align-top text-lg leading-[26px] font-headline font-semibold [&:has([role=checkbox])]:pr-0',
       className,
     )}
     {...props}

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -7,8 +7,6 @@ import { CopyIcon } from '@radix-ui/react-icons';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { fromBaseUnitAmount } from '@penumbra-zone/types/src/amount';
 import { Pill } from '../../../pill';
-import { ConditionalWrap } from '../../../conditional-wrap';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../../tooltip';
 
 interface ValueViewProps {
   view: ValueView | undefined;
@@ -43,36 +41,24 @@ export const ValueViewComponent = ({
     const symbol = metadata.symbol || 'Unknown Asset';
 
     return (
-      <ConditionalWrap
-        condition={variant === 'equivalent'}
-        wrap={children => (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>{children}</TooltipTrigger>
-              <TooltipContent>Estimated equivalent value</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-      >
-        <Pill variant={variant === 'default' ? 'default' : 'dashed'}>
-          <div className='flex min-w-0 items-center gap-1'>
-            {showIcon && (
-              <div className='-ml-2 mr-1 flex size-6 items-center justify-center rounded-full'>
-                <AssetIcon metadata={metadata} />
-              </div>
-            )}
-            {showValue && (
-              <span className='leading-[15px]'>
-                {variant === 'equivalent' && <>~ </>}
-                {formattedAmount}
-              </span>
-            )}
-            {showDenom && (
-              <span className='truncate font-mono text-xs text-muted-foreground'>{symbol}</span>
-            )}
-          </div>
-        </Pill>
-      </ConditionalWrap>
+      <Pill variant={variant === 'default' ? 'default' : 'dashed'}>
+        <div className='flex min-w-0 items-center gap-1'>
+          {showIcon && (
+            <div className='-ml-2 mr-1 flex size-6 items-center justify-center rounded-full'>
+              <AssetIcon metadata={metadata} />
+            </div>
+          )}
+          {showValue && (
+            <span className='leading-[15px]'>
+              {variant === 'equivalent' && <>~ </>}
+              {formattedAmount}
+            </span>
+          )}
+          {showDenom && (
+            <span className='truncate font-mono text-xs text-muted-foreground'>{symbol}</span>
+          )}
+        </div>
+      </Pill>
     );
   }
 


### PR DESCRIPTION
🚨 I'd recommend reviewing this [with the "hide whitespace" feature turned on](https://github.com/penumbra-zone/web/pull/897/files?diff=split&w=1).

In response to @grod220 's [comment](https://github.com/penumbra-zone/web/pull/886#pullrequestreview-1981798384), I did a quick spike on rendering the assets table using an actual `<table>`:

<img width="1003" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/e2c0d0cf-318f-4320-8171-d2f47beee0e7">


Here's how it'd look with multiple equivalent values:

<img width="961" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/2e493ae0-eb5e-471a-953d-cf0383f8fa39">
