### PR TITLE
794 improve pricing method

### DIFF
--- a/apps/extension/src/service-worker.ts
+++ b/apps/extension/src/service-worker.ts
@@ -74,7 +74,6 @@ const startServices = async () => {
     grpcEndpoint,
     walletId: WalletId.fromJsonString(wallet0.id),
     fullViewingKey: FullViewingKey.fromJsonString(wallet0.fullViewingKey),
-    numeraireAssetId: USDC_ASSET_ID,
   });
   await services.initialize();
   return services;

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -9,6 +9,11 @@ export const localAssets: Metadata[] = LocalAssetRegistry.map(a =>
 export const NUMERAIRE_DENOMS: string[] = ['test_usd', 'usdc'];
 export const NUMERAIRES: Metadata[] = localAssets.filter(m => NUMERAIRE_DENOMS.includes(m.display));
 
+export const PRICE_RELEVANCE_THRESHOLDS = {
+  delegationToken: 719,
+  default: 200,
+  // Додайте інші типи токенів та їх пороги тут
+};
 export const STAKING_TOKEN = 'penumbra';
 export const STAKING_TOKEN_METADATA = localAssets.find(
   metadata => metadata.display === STAKING_TOKEN,

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -9,10 +9,13 @@ export const localAssets: Metadata[] = LocalAssetRegistry.map(a =>
 export const NUMERAIRE_DENOMS: string[] = ['test_usd', 'usdc'];
 export const NUMERAIRES: Metadata[] = localAssets.filter(m => NUMERAIRE_DENOMS.includes(m.display));
 
+// PRICE_RELEVANCE_THRESHOLDS defines how long prices for different asset types remain relevant (in blocks)
+// 1 block = 5 seconds, 200 blocks approximately equals 17 minutes
 export const PRICE_RELEVANCE_THRESHOLDS = {
   delegationToken: 719,
   default: 200,
 };
+
 export const STAKING_TOKEN = 'penumbra';
 export const STAKING_TOKEN_METADATA = localAssets.find(
   metadata => metadata.display === STAKING_TOKEN,

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -12,7 +12,6 @@ export const NUMERAIRES: Metadata[] = localAssets.filter(m => NUMERAIRE_DENOMS.i
 export const PRICE_RELEVANCE_THRESHOLDS = {
   delegationToken: 719,
   default: 200,
-  // Додайте інші типи токенів та їх пороги тут
 };
 export const STAKING_TOKEN = 'penumbra';
 export const STAKING_TOKEN_METADATA = localAssets.find(

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -6,6 +6,9 @@ export const localAssets: Metadata[] = LocalAssetRegistry.map(a =>
   Metadata.fromJson(a as JsonValue),
 );
 
+export const NUMERAIRE_DENOMS: string[] = ['test_usd', 'usdc'];
+export const NUMERAIRES: Metadata[] = localAssets.filter(m => NUMERAIRE_DENOMS.includes(m.display));
+
 export const STAKING_TOKEN = 'penumbra';
 export const STAKING_TOKEN_METADATA = localAssets.find(
   metadata => metadata.display === STAKING_TOKEN,

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -33,7 +33,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { bech32IdentityKey } from '@penumbra-zone/bech32/src/identity-key';
 import { getAssetId } from '@penumbra-zone/getters/src/metadata';
-import { STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
+import {NUMERAIRES, STAKING_TOKEN_METADATA} from '@penumbra-zone/constants/src/assets';
 import { toDecimalExchangeRate } from '@penumbra-zone/types/src/amount';
 import { ValidatorInfoResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
@@ -48,7 +48,6 @@ interface QueryClientProps {
   querier: RootQuerier;
   indexedDb: IndexedDbInterface;
   viewServer: ViewServerInterface;
-  numeraireAssetId: string;
 }
 
 const blankTxSource = new CommitmentSource({
@@ -60,14 +59,12 @@ export class BlockProcessor implements BlockProcessorInterface {
   private readonly indexedDb: IndexedDbInterface;
   private readonly viewServer: ViewServerInterface;
   private readonly abortController: AbortController = new AbortController();
-  private readonly numeraireAssetId: string;
   private syncPromise: Promise<void> | undefined;
 
-  constructor({ indexedDb, viewServer, querier, numeraireAssetId }: QueryClientProps) {
+  constructor({ indexedDb, viewServer, querier }: QueryClientProps) {
     this.indexedDb = indexedDb;
     this.viewServer = viewServer;
     this.querier = querier;
-    this.numeraireAssetId = numeraireAssetId;
   }
 
   // If syncBlocks() is called multiple times concurrently, they'll all wait for
@@ -267,7 +264,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       if (compactBlock.swapOutputs.length) {
         await updatePricesFromSwaps(
           this.indexedDb,
-          this.numeraireAssetId,
+          NUMERAIRES,
           compactBlock.swapOutputs,
           compactBlock.height,
         );

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -33,7 +33,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { bech32IdentityKey } from '@penumbra-zone/bech32/src/identity-key';
 import { getAssetId } from '@penumbra-zone/getters/src/metadata';
-import {NUMERAIRES, STAKING_TOKEN_METADATA} from '@penumbra-zone/constants/src/assets';
+import { NUMERAIRES, STAKING_TOKEN_METADATA } from '@penumbra-zone/constants/src/assets';
 import { toDecimalExchangeRate } from '@penumbra-zone/types/src/amount';
 import { ValidatorInfoResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';

--- a/packages/query/src/price-indexer.test.ts
+++ b/packages/query/src/price-indexer.test.ts
@@ -2,17 +2,20 @@ import { updatePricesFromSwaps } from './price-indexer';
 import { BatchSwapOutputData } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { IndexedDbInterface } from '@penumbra-zone/types/src/indexed-db';
-import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import {AssetId, Metadata} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { base64ToUint8Array } from '@penumbra-zone/types/src/base64';
 
 describe('updatePricesFromSwaps()', () => {
   let indexedDbMock: IndexedDbInterface;
   const updatePriceMock: Mock = vi.fn();
   const height = 123n;
-  const numeraireAssetId = 'reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg=';
-  const numeraireAsset: AssetId = new AssetId({
-    inner: base64ToUint8Array(numeraireAssetId),
-  });
+  const numeraireAssetId =   new AssetId({
+    inner: base64ToUint8Array('reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg='),
+  })
+  const numeraires: Metadata [] = [ new Metadata({
+    penumbraAssetId: numeraireAssetId
+  })];
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -27,7 +30,7 @@ describe('updatePricesFromSwaps()', () => {
       new BatchSwapOutputData({
         tradingPair: {
           asset1: asset1,
-          asset2: numeraireAsset,
+          asset2: numeraireAssetId,
         },
         delta1: { lo: 250n },
         lambda2: { lo: 1200n },
@@ -35,9 +38,9 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraireAssetId, swapOutputs, height);
+    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(1);
-    expect(updatePriceMock).toBeCalledWith(asset1, numeraireAsset, 4.8, height);
+    expect(updatePriceMock).toBeCalledWith(asset1, numeraireAssetId, 4.8, height);
   });
 
   it('should update prices correctly for a swapOutput with NUMERAIRE as swapAsset1', async () => {
@@ -45,7 +48,7 @@ describe('updatePricesFromSwaps()', () => {
     const swapOutputs: BatchSwapOutputData[] = [
       new BatchSwapOutputData({
         tradingPair: {
-          asset1: numeraireAsset,
+          asset1: numeraireAssetId,
           asset2: asset1,
         },
         delta2: { lo: 40n },
@@ -54,9 +57,9 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraireAssetId, swapOutputs, height);
+    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(1);
-    expect(updatePriceMock).toBeCalledWith(asset1, numeraireAsset, 318.5, height);
+    expect(updatePriceMock).toBeCalledWith(asset1, numeraireAssetId, 318.5, height);
   });
 
   it('should not update prices if delta is zero', async () => {
@@ -64,7 +67,7 @@ describe('updatePricesFromSwaps()', () => {
     const swapOutputs: BatchSwapOutputData[] = [
       new BatchSwapOutputData({
         tradingPair: {
-          asset1: numeraireAsset,
+          asset1: numeraireAssetId,
           asset2: asset1,
         },
         delta2: { lo: 0n },
@@ -73,7 +76,7 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraireAssetId, swapOutputs, height);
+    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(0);
   });
 
@@ -83,16 +86,16 @@ describe('updatePricesFromSwaps()', () => {
       new BatchSwapOutputData({
         tradingPair: {
           asset1: asset1,
-          asset2: numeraireAsset,
+          asset2: numeraireAssetId,
         },
         delta1: { lo: 250n },
         lambda2: { lo: 1200n },
         unfilled1: { lo: 100n },
       }),
     ];
-    await updatePricesFromSwaps(indexedDbMock, numeraireAssetId, swapOutputs, height);
+    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(1);
-    expect(updatePriceMock).toBeCalledWith(asset1, numeraireAsset, 8, height);
+    expect(updatePriceMock).toBeCalledWith(asset1, numeraireAssetId, 8, height);
   });
 
   it('should not update prices if swap is fully unfilled', async () => {
@@ -100,7 +103,7 @@ describe('updatePricesFromSwaps()', () => {
     const swapOutputs: BatchSwapOutputData[] = [
       new BatchSwapOutputData({
         tradingPair: {
-          asset1: numeraireAsset,
+          asset1: numeraireAssetId,
           asset2: asset1,
         },
         delta2: { lo: 100n },
@@ -109,7 +112,7 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraireAssetId, swapOutputs, height);
+    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(0);
   });
 });

--- a/packages/query/src/price-indexer.test.ts
+++ b/packages/query/src/price-indexer.test.ts
@@ -1,20 +1,17 @@
-import { updatePricesFromSwaps } from './price-indexer';
+import { deriveAndSavePriceFromBSOD } from './price-indexer';
 import { BatchSwapOutputData } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { IndexedDbInterface } from '@penumbra-zone/types/src/indexed-db';
-import {AssetId, Metadata} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { base64ToUint8Array } from '@penumbra-zone/types/src/base64';
 
 describe('updatePricesFromSwaps()', () => {
   let indexedDbMock: IndexedDbInterface;
   const updatePriceMock: Mock = vi.fn();
   const height = 123n;
-  const numeraireAssetId =   new AssetId({
+  const numeraireAssetId = new AssetId({
     inner: base64ToUint8Array('reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg='),
-  })
-  const numeraires: Metadata [] = [ new Metadata({
-    penumbraAssetId: numeraireAssetId
-  })];
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,7 +35,7 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
+    await deriveAndSavePriceFromBSOD(indexedDbMock, numeraireAssetId, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(1);
     expect(updatePriceMock).toBeCalledWith(asset1, numeraireAssetId, 4.8, height);
   });
@@ -57,7 +54,7 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
+    await deriveAndSavePriceFromBSOD(indexedDbMock, numeraireAssetId, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(1);
     expect(updatePriceMock).toBeCalledWith(asset1, numeraireAssetId, 318.5, height);
   });
@@ -76,7 +73,7 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
+    await deriveAndSavePriceFromBSOD(indexedDbMock, numeraireAssetId, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(0);
   });
 
@@ -93,7 +90,7 @@ describe('updatePricesFromSwaps()', () => {
         unfilled1: { lo: 100n },
       }),
     ];
-    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
+    await deriveAndSavePriceFromBSOD(indexedDbMock, numeraireAssetId, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(1);
     expect(updatePriceMock).toBeCalledWith(asset1, numeraireAssetId, 8, height);
   });
@@ -112,7 +109,7 @@ describe('updatePricesFromSwaps()', () => {
       }),
     ];
 
-    await updatePricesFromSwaps(indexedDbMock, numeraires, swapOutputs, height);
+    await deriveAndSavePriceFromBSOD(indexedDbMock, numeraireAssetId, swapOutputs, height);
     expect(updatePriceMock).toBeCalledTimes(0);
   });
 });

--- a/packages/query/src/price-indexer.ts
+++ b/packages/query/src/price-indexer.ts
@@ -39,16 +39,6 @@ export const calculatePrice = (delta: Amount, unfilled: Amount, lambda: Amount):
     : divideAmounts(lambda, filledAmount).toNumber();
 };
 
-/**
- * Each 'BatchSwapOutputData' (BSOD) can generate up to two prices
- * Each BSOD in block has a unique trading pair
- * Trading pair has a canonical ordering, there's only one trading pair per pair of assets
- * Each BSOD can generate up to two prices
- * 1. pricedAsset -> numeraire (selling price)
- * 2. numeraire -> pricedAsset (buying price)
- * This function processes only (1) price and ignores (2) price
- * We can get a BSOD with zero deltas(inputs), and we shouldn't save the price in that case
- */
 export const updatePricesFromSwaps = async (
   indexedDb: IndexedDbInterface,
   numeraires: Metadata[],
@@ -61,6 +51,16 @@ export const updatePricesFromSwaps = async (
   }
 };
 
+/**
+ * Each 'BatchSwapOutputData' (BSOD) can generate up to two prices
+ * Each BSOD in block has a unique trading pair
+ * Trading pair has a canonical ordering, there's only one trading pair per pair of assets
+ * Each BSOD can generate up to two prices
+ * 1. pricedAsset -> numeraire (selling price)
+ * 2. numeraire -> pricedAsset (buying price)
+ * This function processes only (1) price and ignores (2) price
+ * We can get a BSOD with zero deltas(inputs), and we shouldn't save the price in that case
+ */
 export const deriveAndSavePriceFromBSOD = async (
   indexedDb: IndexedDbInterface,
   numeraireAssetId: AssetId,

--- a/packages/query/src/price-indexer.ts
+++ b/packages/query/src/price-indexer.ts
@@ -53,8 +53,8 @@ export const updatePricesFromSwaps = async (
   height: bigint,
 ) => {
   for (const numeraireMetadata of numeraires) {
-    let numeraireAssetId = getAssetId(numeraireMetadata);
-    deriveAndSavePriceFromBSOD(indexedDb, numeraireAssetId, swapOutputs, height);
+    const numeraireAssetId = getAssetId(numeraireMetadata);
+    await deriveAndSavePriceFromBSOD(indexedDb, numeraireAssetId, swapOutputs, height);
   }
 
 };

--- a/packages/query/src/price-indexer.ts
+++ b/packages/query/src/price-indexer.ts
@@ -1,7 +1,10 @@
 import { BatchSwapOutputData } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { IndexedDbInterface } from '@penumbra-zone/types/src/indexed-db';
 import { divideAmounts, isZero, subtractAmounts } from '@penumbra-zone/types/src/amount';
-import {AssetId, Metadata} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import {
+  AssetId,
+  Metadata,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import {
   getDelta1Amount,
@@ -48,7 +51,7 @@ export const calculatePrice = (delta: Amount, unfilled: Amount, lambda: Amount):
  */
 export const updatePricesFromSwaps = async (
   indexedDb: IndexedDbInterface,
-  numeraires: Metadata [],
+  numeraires: Metadata[],
   swapOutputs: BatchSwapOutputData[],
   height: bigint,
 ) => {
@@ -56,11 +59,14 @@ export const updatePricesFromSwaps = async (
     const numeraireAssetId = getAssetId(numeraireMetadata);
     await deriveAndSavePriceFromBSOD(indexedDb, numeraireAssetId, swapOutputs, height);
   }
-
 };
 
-const deriveAndSavePriceFromBSOD = async (indexedDb: IndexedDbInterface, numeraireAssetId: AssetId, swapOutputs: BatchSwapOutputData[], height:bigint) => {
-
+export const deriveAndSavePriceFromBSOD = async (
+  indexedDb: IndexedDbInterface,
+  numeraireAssetId: AssetId,
+  swapOutputs: BatchSwapOutputData[],
+  height: bigint,
+) => {
   for (const swapOutput of swapOutputs) {
     const swapAsset1 = getSwapAsset1(swapOutput);
     const swapAsset2 = getSwapAsset2(swapOutput);
@@ -73,9 +79,9 @@ const deriveAndSavePriceFromBSOD = async (indexedDb: IndexedDbInterface, numerai
       pricedAsset = swapAsset1;
       // numerairePerUnit = lambda2/(delta1-unfilled1)
       numerairePerUnit = calculatePrice(
-          getDelta1Amount(swapOutput),
-          getUnfilled1Amount(swapOutput),
-          getLambda2Amount(swapOutput),
+        getDelta1Amount(swapOutput),
+        getUnfilled1Amount(swapOutput),
+        getLambda2Amount(swapOutput),
       );
     }
     // case for trading pair <numéraire,pricedAsset>
@@ -83,9 +89,9 @@ const deriveAndSavePriceFromBSOD = async (indexedDb: IndexedDbInterface, numerai
       pricedAsset = swapAsset2;
       // numerairePerUnit = lambda1/(delta2-unfilled2)
       numerairePerUnit = calculatePrice(
-          getDelta2Amount(swapOutput),
-          getUnfilled2Amount(swapOutput),
-          getLambda1Amount(swapOutput),
+        getDelta2Amount(swapOutput),
+        getUnfilled2Amount(swapOutput),
+        getLambda1Amount(swapOutput),
       );
     }
 
@@ -93,4 +99,4 @@ const deriveAndSavePriceFromBSOD = async (indexedDb: IndexedDbInterface, numerai
 
     await indexedDb.updatePrice(pricedAsset, numeraireAssetId, numerairePerUnit, height);
   }
-}
+};

--- a/packages/query/src/price-indexer.ts
+++ b/packages/query/src/price-indexer.ts
@@ -16,7 +16,7 @@ import {
   getUnfilled1Amount,
   getUnfilled2Amount,
 } from '@penumbra-zone/getters/src/batch-swap-output-data';
-import { getAssetId } from '@penumbra-zone/getters/dist/metadata';
+import { getAssetId } from '@penumbra-zone/getters/src/metadata';
 
 /**
  *

--- a/packages/router/src/grpc/view-protocol-server/balances.test.ts
+++ b/packages/router/src/grpc/view-protocol-server/balances.test.ts
@@ -13,7 +13,7 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { Services } from '@penumbra-zone/services/src/index';
-import { IndexedDbMock, MockServices, testFullViewingKey } from '../test-utils';
+import { IndexedDbMock, MockServices, TendermintMock, testFullViewingKey } from '../test-utils';
 import {
   AssetId,
   EquivalentValue,
@@ -47,6 +47,7 @@ describe('Balances request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
   let mockIndexedDb: IndexedDbMock;
+  let mockTendermint: TendermintMock;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -70,6 +71,10 @@ describe('Balances request handler', () => {
       fullViewingKey: testFullViewingKey,
     };
 
+    mockTendermint = {
+      latestBlockHeight: vi.fn(),
+    };
+
     mockServices = {
       // @ts-expect-error TODO: Improve mocking types
       getWalletServices: vi.fn(() =>
@@ -78,6 +83,7 @@ describe('Balances request handler', () => {
           viewServer: mockViewServer,
           querier: {
             shieldedPool: mockShieldedPool,
+            tendermint: mockTendermint,
           },
         }),
       ) as MockServices['getWalletServices'],

--- a/packages/router/src/grpc/view-protocol-server/balances.ts
+++ b/packages/router/src/grpc/view-protocol-server/balances.ts
@@ -28,16 +28,17 @@ import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/nu
 import { Base64Str, uint8ArrayToBase64 } from '@penumbra-zone/types/src/base64';
 import { addLoHi } from '@penumbra-zone/types/src/lo-hi';
 import { IndexedDbInterface } from '@penumbra-zone/types/src/indexed-db';
-import { getAssetId } from '@penumbra-zone/getters/src/metadata';
 import { multiplyAmountByNumber } from '@penumbra-zone/types/src/amount';
 import { Stringified } from '@penumbra-zone/types/src/jsonified';
 
 // Handles aggregating amounts and filtering by account number/asset id
 export const balances: Impl['balances'] = async function* (req, ctx) {
   const services = ctx.values.get(servicesCtx);
-  const { indexedDb } = await services.getWalletServices();
+  const { indexedDb, querier } = await services.getWalletServices();
 
-  const aggregator = new BalancesAggregator(ctx, indexedDb);
+  const latestBlockHeight = await querier.tendermint.latestBlockHeight();
+
+  const aggregator = new BalancesAggregator(ctx, indexedDb, latestBlockHeight);
 
   for await (const noteRecord of indexedDb.iterateSpendableNotes()) {
     if (noteRecord.heightSpent !== 0n) continue;
@@ -72,7 +73,8 @@ class BalancesAggregator {
   constructor(
     private readonly ctx: HandlerContext,
     private readonly indexedDb: IndexedDbInterface,
-  ) {}
+    private readonly latestBlockHeight: bigint
+) {}
 
   async add(n: SpendableNoteRecord) {
     const accountNumber = n.addressIndex?.account ?? 0;
@@ -180,9 +182,9 @@ class BalancesAggregator {
         valueView: { case: 'unknownAssetId', value: { assetId, amount: new Amount() } },
       });
     } else {
-      const assetId = getAssetId.optional()(new Metadata(denomMetadata));
+      const assetMetadata = new Metadata(denomMetadata);
       if (assetId?.inner && !this.estimatedPriceByPricedAsset[uint8ArrayToBase64(assetId.inner)]) {
-        const prices = await this.indexedDb.getPricesForAsset(new AssetId(assetId));
+        const prices = await this.indexedDb.getPricesForAsset(assetMetadata, this.latestBlockHeight);
         this.estimatedPriceByPricedAsset[uint8ArrayToBase64(assetId.inner)] = prices;
       }
 

--- a/packages/router/src/grpc/view-protocol-server/balances.ts
+++ b/packages/router/src/grpc/view-protocol-server/balances.ts
@@ -73,8 +73,8 @@ class BalancesAggregator {
   constructor(
     private readonly ctx: HandlerContext,
     private readonly indexedDb: IndexedDbInterface,
-    private readonly latestBlockHeight: bigint
-) {}
+    private readonly latestBlockHeight: bigint,
+  ) {}
 
   async add(n: SpendableNoteRecord) {
     const accountNumber = n.addressIndex?.account ?? 0;
@@ -183,8 +183,11 @@ class BalancesAggregator {
       });
     } else {
       const assetMetadata = new Metadata(denomMetadata);
-      if (assetId?.inner && !this.estimatedPriceByPricedAsset[uint8ArrayToBase64(assetId.inner)]) {
-        const prices = await this.indexedDb.getPricesForAsset(assetMetadata, this.latestBlockHeight);
+      if (!this.estimatedPriceByPricedAsset[uint8ArrayToBase64(assetId.inner)]) {
+        const prices = await this.indexedDb.getPricesForAsset(
+          assetMetadata,
+          this.latestBlockHeight,
+        );
         this.estimatedPriceByPricedAsset[uint8ArrayToBase64(assetId.inner)] = prices;
       }
 

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -25,10 +25,7 @@ export interface ServicesConfig {
 }
 
 const isCompleteServicesConfig = (c: Partial<ServicesConfig>): c is Required<ServicesConfig> =>
-  c.grpcEndpoint != null &&
-  c.idbVersion != null &&
-  c.walletId != null &&
-  c.fullViewingKey != null;
+  c.grpcEndpoint != null && c.idbVersion != null && c.walletId != null && c.fullViewingKey != null;
 
 export class Services implements ServicesInterface {
   private walletServicesPromise: Promise<WalletServices> | undefined;

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -22,15 +22,13 @@ export interface ServicesConfig {
   readonly grpcEndpoint?: string;
   readonly walletId?: WalletId;
   readonly fullViewingKey?: FullViewingKey;
-  readonly numeraireAssetId: string;
 }
 
 const isCompleteServicesConfig = (c: Partial<ServicesConfig>): c is Required<ServicesConfig> =>
   c.grpcEndpoint != null &&
   c.idbVersion != null &&
   c.walletId != null &&
-  c.fullViewingKey != null &&
-  c.numeraireAssetId != null;
+  c.fullViewingKey != null;
 
 export class Services implements ServicesInterface {
   private walletServicesPromise: Promise<WalletServices> | undefined;

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -96,7 +96,7 @@ export class Services implements ServicesInterface {
   }
 
   private async initializeWalletServices(): Promise<WalletServices> {
-    const { walletId, fullViewingKey, idbVersion: dbVersion, numeraireAssetId } = await this.config;
+    const { walletId, fullViewingKey, idbVersion: dbVersion } = await this.config;
     const params = await this.querier.app.appParams();
     if (!params.sctParams?.epochDuration) throw new Error('Epoch duration unknown');
     const {
@@ -123,7 +123,6 @@ export class Services implements ServicesInterface {
       viewServer,
       querier: this.querier,
       indexedDb,
-      numeraireAssetId,
     });
 
     return { viewServer, blockProcessor, indexedDb, querier: this.querier };

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -24,7 +24,11 @@ import {
   IdentityKey,
   WalletId,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
-import { assetPatterns, localAssets } from '@penumbra-zone/constants/src/assets';
+import {
+  assetPatterns,
+  localAssets,
+  PRICE_RELEVANCE_THRESHOLDS,
+} from '@penumbra-zone/constants/src/assets';
 import {
   Position,
   PositionId,
@@ -56,7 +60,7 @@ import { uint8ArrayToBase64 } from '@penumbra-zone/types/src/base64';
 import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
 import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
 import { bech32WalletId } from '@penumbra-zone/bech32/src/wallet-id';
-import {getAssetId} from "@penumbra-zone/getters/dist/metadata";
+import { getAssetId } from '@penumbra-zone/getters/dist/metadata';
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
@@ -584,11 +588,26 @@ export class IndexedDb implements IndexedDbInterface {
     });
   }
 
-  async getPricesForAsset(assetMetadata: Metadata): Promise<EstimatedPrice[]> {
+  async getPricesForAsset(
+    assetMetadata: Metadata,
+    latestBlockHeight: bigint,
+  ): Promise<EstimatedPrice[]> {
     const base64AssetId = uint8ArrayToBase64(getAssetId(assetMetadata).inner);
     const results = await this.db.getAllFromIndex('PRICES', 'pricedAsset', base64AssetId);
 
-    return results.map(price => EstimatedPrice.fromJson(price));
+    const priceRelevanceThreshold = this.determinePriceRelevanceThresholdForAsset(assetMetadata);
+    const minHeight = latestBlockHeight - BigInt(priceRelevanceThreshold);
+
+    return results
+      .map(price => EstimatedPrice.fromJson(price))
+      .filter(price => price.asOfHeight >= minHeight);
+  }
+
+  private determinePriceRelevanceThresholdForAsset(assetMetadata: Metadata): number {
+    if (assetPatterns.delegationToken.capture(assetMetadata.display)) {
+      return PRICE_RELEVANCE_THRESHOLDS.delegationToken;
+    }
+    return PRICE_RELEVANCE_THRESHOLDS.default;
   }
 
   private addSctUpdates(txs: IbdUpdates, sctUpdates: ScanBlockResult['sctUpdates']): void {

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -60,7 +60,7 @@ import { uint8ArrayToBase64 } from '@penumbra-zone/types/src/base64';
 import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
 import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
 import { bech32WalletId } from '@penumbra-zone/bech32/src/wallet-id';
-import { getAssetId } from '@penumbra-zone/getters/dist/metadata';
+import { getAssetId } from '@penumbra-zone/getters/src/metadata';
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -588,6 +588,11 @@ export class IndexedDb implements IndexedDbInterface {
     });
   }
 
+  /**
+   * Uses priceRelevanceThreshold to return only actual prices
+   * If more than priceRelevanceThreshold blocks have passed since the price was saved, such price is not returned
+   * priceRelevanceThreshold depends on the type of assets, for example, for delegation tokens the relevance lasts longer
+   */
   async getPricesForAsset(
     assetMetadata: Metadata,
     latestBlockHeight: bigint,

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -56,6 +56,7 @@ import { uint8ArrayToBase64 } from '@penumbra-zone/types/src/base64';
 import type { Jsonified } from '@penumbra-zone/types/src/jsonified';
 import { uint8ArrayToHex } from '@penumbra-zone/types/src/hex';
 import { bech32WalletId } from '@penumbra-zone/bech32/src/wallet-id';
+import {getAssetId} from "@penumbra-zone/getters/dist/metadata";
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
@@ -583,8 +584,8 @@ export class IndexedDb implements IndexedDbInterface {
     });
   }
 
-  async getPricesForAsset(assetId: AssetId): Promise<EstimatedPrice[]> {
-    const base64AssetId = uint8ArrayToBase64(assetId.inner);
+  async getPricesForAsset(assetMetadata: Metadata): Promise<EstimatedPrice[]> {
+    const base64AssetId = uint8ArrayToBase64(getAssetId(assetMetadata).inner);
     const results = await this.db.getAllFromIndex('PRICES', 'pricedAsset', base64AssetId);
 
     return results.map(price => EstimatedPrice.fromJson(price));

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -99,7 +99,7 @@ export interface IndexedDbInterface {
     numerairePerUnit: number,
     height: bigint,
   ): Promise<void>;
-  getPricesForAsset(assetId: AssetId): Promise<EstimatedPrice[]>;
+  getPricesForAsset(assetMetadata: Metadata, latestBlockHeight: bigint): Promise<EstimatedPrice[]>;
 }
 
 export interface PenumbraDb extends DBSchema {


### PR DESCRIPTION
This PR contains some improvements on asset pricing 
- added support for multiple NUMERAIRES, allowing customers to determine for themselves which price estimate to use for display 
- added price relevance threshold depending on asset type. Crypto assets are very volatile and we can't use too old prices to display estimated values 

Close #794 