### PR TITLE
Use accessible design for approve/deny buttons

### DIFF
--- a/apps/extension/src/routes/popup/approval/approve-deny.tsx
+++ b/apps/extension/src/routes/popup/approval/approve-deny.tsx
@@ -6,13 +6,11 @@ export const ApproveDeny = ({
   approve,
   deny,
   ignore,
-  variants,
   wait = 0,
 }: {
   approve: () => void;
   deny: () => void;
   ignore?: () => void;
-  variants?: Parameters<typeof Button>[0]['variant'][];
   wait?: number;
 }) => {
   const [count, { startCountdown }] = useCountdown({ countStart: wait });
@@ -20,19 +18,13 @@ export const ApproveDeny = ({
 
   return (
     <div className='fixed inset-x-0 bottom-0 flex flex-row flex-wrap justify-center gap-4 bg-black p-4 shadow-lg'>
-      <Button
-        variant={variants?.[0] ?? 'default'}
-        className='w-full'
-        size='lg'
-        onClick={approve}
-        disabled={!!count}
-      >
+      <Button variant='gradient' className='w-full' size='lg' onClick={approve} disabled={!!count}>
         Approve {count !== 0 && `(${count})`}
       </Button>
       <Button
-        className='min-w-[50%] grow hover:bg-destructive/90'
+        className='min-w-[50%] grow items-center gap-2 hover:bg-destructive/90'
         size='lg'
-        variant={variants?.[1] ?? 'destructive'}
+        variant='destructiveSecondary'
         onClick={deny}
       >
         Deny
@@ -41,7 +33,7 @@ export const ApproveDeny = ({
         <Button
           className='w-1/3 hover:bg-destructive/90'
           size='lg'
-          variant={variants?.[2] ?? 'secondary'}
+          variant='secondary'
           onClick={ignore}
         >
           Ignore Site

--- a/apps/extension/src/routes/popup/approval/origin.tsx
+++ b/apps/extension/src/routes/popup/approval/origin.tsx
@@ -3,7 +3,6 @@ import { useStore } from '../../../state';
 import { originApprovalSelector } from '../../../state/origin-approval';
 import { ApproveDeny } from './approve-deny';
 import { LinkGradientIcon } from '../../../icons/link-gradient';
-import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { DisplayOriginURL } from '../../../shared/components/display-origin-url';
 import { cn } from '@penumbra-zone/ui/lib/utils';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
@@ -89,14 +88,9 @@ export const OriginApproval = () => {
                 </div>
               </div>
             </div>
-            <div className='mt-3 flex flex-col gap-3'>
-              <div className='text-center text-muted-foreground'>
-                This host wants to connect to your wallet.
-              </div>
-              <div className='flex items-center gap-2 text-rust'>
-                <ExclamationTriangleIcon />
-                Approval will allow this host to see your balance and transaction history.
-              </div>
+            <div className='mt-3 flex flex-col gap-3 text-muted-foreground'>
+              <p>This host wants to connect to your wallet.</p>
+              <p>Approval will allow this host to see your balance and transaction history.</p>
             </div>
           </div>
         </div>

--- a/apps/extension/src/routes/popup/approval/origin.tsx
+++ b/apps/extension/src/routes/popup/approval/origin.tsx
@@ -100,13 +100,7 @@ export const OriginApproval = () => {
             </div>
           </div>
         </div>
-        <ApproveDeny
-          variants={['gradient']}
-          approve={approve}
-          deny={deny}
-          ignore={lastRequest && ignore}
-          wait={3}
-        />
+        <ApproveDeny approve={approve} deny={deny} ignore={lastRequest && ignore} wait={3} />
       </div>
     </FadeTransition>
   );

--- a/apps/extension/src/routes/popup/approval/origin.tsx
+++ b/apps/extension/src/routes/popup/approval/origin.tsx
@@ -6,6 +6,7 @@ import { LinkGradientIcon } from '../../../icons/link-gradient';
 import { DisplayOriginURL } from '../../../shared/components/display-origin-url';
 import { cn } from '@penumbra-zone/ui/lib/utils';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
+import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 
 export const OriginApproval = () => {
   const { requestOrigin, favIconUrl, title, lastRequest, setChoice, sendResponse } =
@@ -90,7 +91,10 @@ export const OriginApproval = () => {
             </div>
             <div className='mt-3 flex flex-col gap-3 text-muted-foreground'>
               <p>This host wants to connect to your wallet.</p>
-              <p>Approval will allow this host to see your balance and transaction history.</p>
+              <p className='text-rust-600'>
+                <ExclamationTriangleIcon className='mr-2 inline-block' /> Approval will allow this
+                host to see your balance and transaction history.
+              </p>
             </div>
           </div>
         </div>

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -25,5 +25,8 @@ const config = {
   docs: {
     autodocs: 'tag',
   },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
 };
 export default config;

--- a/packages/ui/components/ui/button.stories.tsx
+++ b/packages/ui/components/ui/button.stories.tsx
@@ -6,7 +6,6 @@ const meta: Meta<typeof Button> = {
   component: Button,
   title: 'Button',
   tags: ['autodocs'],
-  argTypes: {},
 };
 export default meta;
 

--- a/packages/ui/components/ui/button.stories.tsx
+++ b/packages/ui/components/ui/button.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Button } from './button';
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  title: 'Button',
+  tags: ['autodocs'],
+  argTypes: {},
+};
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Basic: Story = {
+  args: {
+    children: 'Save',
+    variant: 'default',
+    size: 'default',
+    asChild: false,
+  },
+};

--- a/packages/ui/components/ui/button.tsx
+++ b/packages/ui/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-lg font-bold ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center rounded-lg px-4 font-bold ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -14,6 +14,8 @@ const buttonVariants = cva(
         secondary:
           'before:border-mask before:background-size-200 relative before:absolute before:inset-0 before:rounded-lg before:bg-button-gradient before:p-px before:transition-all before:duration-500 before:content-[""] before:hover:bg-right-center',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        destructiveSecondary:
+          'before:border-mask before:background-size-200 relative text-destructive before:absolute before:inset-0 before:rounded-lg before:bg-destructive before:p-px before:transition-all before:duration-500 before:content-[""] hover:text-white before:hover:bg-right-center',
         outline:
           'rounded-none border-b border-border-secondary bg-background font-body font-bold text-muted-foreground hover:opacity-50',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
@@ -37,6 +39,11 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
+  /**
+   * Merges its props onto its immediate child.
+   *
+   * @see https://www.radix-ui.com/primitives/docs/utilities/slot#slot
+   */
   asChild?: boolean;
 }
 


### PR DESCRIPTION
<img width="512" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/df0cf609-999e-42e3-96a2-9456ffeee1e9">

## In this PR
- Add a `destructiveSecondary` variant to the `<Button />` component.
- Create a Storybook story for the `<Button />` component.
- Use the new variant in `<ApproveDeny />`, and simplify that component to always use the same design.

Closes #711