### PR TITLE
Align symbol with amount

### DIFF
--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -13,6 +13,7 @@ import {
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
 import { throwIfPraxNotConnectedTimeout } from '@penumbra-zone/client';
 import { EquivalentValues } from './equivalent-values';
+import { Fragment } from 'react';
 
 export const AssetsLoader: LoaderFunction = async (): Promise<BalancesByAccount[]> => {
   await throwIfPraxNotConnectedTimeout();
@@ -39,8 +40,8 @@ export default function AssetsTable() {
   return (
     <Table>
       {balancesByAccount.map(account => (
-        <>
-          <TableHeader key={account.account} className='group'>
+        <Fragment key={account.account}>
+          <TableHeader className='group'>
             <TableRow>
               <TableHead colSpan={2}>
                 <div className='flex max-w-full flex-col justify-center gap-2 pt-8 group-[:first-of-type]:pt-0 md:flex-row'>
@@ -74,7 +75,7 @@ export default function AssetsTable() {
               </TableRow>
             ))}
           </TableBody>
-        </>
+        </Fragment>
       ))}
     </Table>
   );

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -49,7 +49,7 @@ export const ValueViewComponent = ({
             </div>
           )}
           {showValue && (
-            <span className='leading-[15px]'>
+            <span className='-mb-0.5 leading-[15px]'>
               {variant === 'equivalent' && <>~ </>}
               {formattedAmount}
             </span>
@@ -68,7 +68,7 @@ export const ValueViewComponent = ({
     const encodedAssetId = getDisplayDenomFromView(view);
     return (
       <div className='flex font-mono'>
-        <p className='truncate text-[15px] leading-[22px]'>
+        <p className='-mb-0.5 truncate text-[15px] leading-[22px]'>
           {fromBaseUnitAmount(amount, 0).toFormat()}
         </p>
         <span className='truncate font-mono text-sm italic text-foreground'>{encodedAssetId}</span>


### PR DESCRIPTION
At the moment, amounts in the value view are not really lined up with the token symbol. The amount is too "high" comparatively. 
<img width="396" alt="Screenshot 2024-04-11 at 4 33 37 PM" src="https://github.com/penumbra-zone/web/assets/16624263/05e07226-e56d-402e-975c-3ced9e1ecb54">

This PR drops it by a few pixels so they share the same baseline
<img width="383" alt="Screenshot 2024-04-11 at 4 35 22 PM" src="https://github.com/penumbra-zone/web/assets/16624263/da5142ee-451c-47b9-8a29-e26c30ce2fea">
