### PR TITLE
capture unhandled promise rejections in offscreen

### DIFF
--- a/apps/extension/src/entry/offscreen-handler.ts
+++ b/apps/extension/src/entry/offscreen-handler.ts
@@ -7,13 +7,31 @@ import {
   isOffscreenRequest,
 } from '@penumbra-zone/types/src/internal-msg/offscreen';
 
+// propagates errors that occur in unawaited promises
+// see: https://stackoverflow.com/questions/39992417/how-to-bubble-a-web-worker-error-in-a-promise-via-worker-onerror
+const unhandledRejection = Promise.withResolvers<never>();
+self.addEventListener(
+  'unhandledrejection',
+  event => {
+    // the event object has two special properties:
+    // event.promise - the promise that generated the error
+    // event.reason  - the unhandled error object
+    unhandledRejection.reject(event.reason);
+  },
+  { once: true },
+);
+
 chrome.runtime.onMessage.addListener((req, _sender, respond) => {
   if (!isOffscreenRequest(req)) return false;
   const { type, request } = req;
   if (isActionBuildRequest(request)) {
     void (async () => {
       try {
-        const data = await spawnActionBuildWorker(request);
+        const data = await Promise.race([
+          spawnActionBuildWorker(request),
+          // this error might not correspond to the specific request it responds to
+          unhandledRejection.promise,
+        ]);
         respond({ type, data });
       } catch (e) {
         respond({
@@ -28,24 +46,28 @@ chrome.runtime.onMessage.addListener((req, _sender, respond) => {
 });
 
 const spawnActionBuildWorker = (req: ActionBuildRequest) => {
+  const { promise, resolve, reject } = Promise.withResolvers<ActionBuildResponse>();
+
   const worker = new Worker(new URL('../wasm-build-action.ts', import.meta.url));
-  return new Promise<ActionBuildResponse>((resolve, reject) => {
-    const onWorkerMessage = (e: MessageEvent) => resolve(e.data as ActionBuildResponse);
+  void promise.finally(() => worker.terminate());
 
-    const onWorkerError = ({ error, filename, lineno, colno, message }: ErrorEvent) =>
-      reject(
-        error instanceof Error
-          ? error
-          : new Error(`Worker ErrorEvent ${filename}:${lineno}:${colno} ${message}`),
-      );
+  const onWorkerMessage = (e: MessageEvent) => resolve(e.data as ActionBuildResponse);
 
-    const onWorkerMessageError = (ev: MessageEvent) => reject(ConnectError.from(ev.data ?? ev));
+  const onWorkerError = ({ error, filename, lineno, colno, message }: ErrorEvent) =>
+    reject(
+      error instanceof Error
+        ? error
+        : new Error(`Worker ErrorEvent ${filename}:${lineno}:${colno} ${message}`),
+    );
 
-    worker.addEventListener('message', onWorkerMessage, { once: true });
-    worker.addEventListener('error', onWorkerError, { once: true });
-    worker.addEventListener('messageerror', onWorkerMessageError, { once: true });
+  const onWorkerMessageError = (ev: MessageEvent) => reject(ConnectError.from(ev.data ?? ev));
 
-    // Send data to web worker
-    worker.postMessage(req);
-  }).finally(() => worker.terminate());
+  worker.addEventListener('message', onWorkerMessage, { once: true });
+  worker.addEventListener('error', onWorkerError, { once: true });
+  worker.addEventListener('messageerror', onWorkerMessageError, { once: true });
+
+  // Send data to web worker
+  worker.postMessage(req);
+
+  return promise;
 };

--- a/packages/services/src/offscreen-client.ts
+++ b/packages/services/src/offscreen-client.ts
@@ -64,7 +64,8 @@ const buildActions = (
 ): Promise<Action>[] => {
   const activation = activateOffscreen();
 
-  // this is a lot of binary -> base64 serialization, so just do it once and reuse
+  // this json serialization involves a lot of binary -> base64 which is slow,
+  // so just do it once and reuse
   const partialRequest = {
     transactionPlan: transactionPlan.toJson() as Jsonified<TransactionPlan>,
     witness: witness.toJson() as Jsonified<WitnessData>,


### PR DESCRIPTION
offscreen is rejecting a promise somewhere, but there is no mechanism to capture the failure