### PR TITLE
Remove trailing slash from MINIFRONT_URL

### DIFF
--- a/apps/extension/.env
+++ b/apps/extension/.env
@@ -2,5 +2,5 @@
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe
 IDB_VERSION=34
 USDC_ASSET_ID="reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
-MINIFRONT_URL=https://app.testnet.penumbra.zone/
+MINIFRONT_URL=https://app.testnet.penumbra.zone
 PENUMBRA_NODE_PD_URL=https://grpc.testnet.penumbra.zone/

--- a/apps/extension/src/utils/tests-setup.js
+++ b/apps/extension/src/utils/tests-setup.js
@@ -35,5 +35,5 @@ global.chrome = {
 };
 
 global.DEFAULT_GRPC_URL = 'https://rpc.example.com/';
-global.MINIFRONT_URL = 'https://app.example.com/';
+global.MINIFRONT_URL = 'https://app.example.com';
 global.PRAX = 'thisisnotarealextensionid';

--- a/packages/router/tests-setup.js
+++ b/packages/router/tests-setup.js
@@ -22,4 +22,4 @@ global.chrome = {
 };
 
 global.DEFAULT_GRPC_URL = 'https://rpc.example.com/';
-global.MINIFRONT_URL = 'https://app.example.com/';
+global.MINIFRONT_URL = 'https://app.example.com';

--- a/packages/storage/src/chrome/test-utils/tests-setup.js
+++ b/packages/storage/src/chrome/test-utils/tests-setup.js
@@ -22,4 +22,4 @@ globalThis.chrome = {
 };
 
 globalThis.DEFAULT_GRPC_URL = 'https://rpc.example.com/';
-globalThis.MINIFRONT_URL = 'https://app.example.com/';
+globalThis.MINIFRONT_URL = 'https://app.example.com';


### PR DESCRIPTION
We are currently defaulting to approving `app.testnet.penumbra.zone` as a connected site when the user first installs Prax.

However, the extension wasn't recognizing it as a pre-approved site because of the trailing slash in `MINIFRONT_URL`. Thus, you'd still have to click the "Connect" button when visiting minifront at that origin.

This PR fixes that. Lotttts of digging for a 4-line change 😆 

Closes #866