### PR TITLE
Create a script to zip minifront/node-status dist directories for deploying to core

### DIFF
--- a/.github/ISSUE_TEMPLATE/deployment.md
+++ b/.github/ISSUE_TEMPLATE/deployment.md
@@ -17,7 +17,7 @@ labels: deployment
   - This step will publish updated npm packages.
 - [ ] Update [manifest version](https://github.com/penumbra-zone/web/blob/main/apps/extension/public/manifest.json#L4) based on the extension's newly updated [`package.json` version](https://github.com/penumbra-zone/web/blob/main/apps/extension/package.json) in the extension.
 - [ ] [Create repo release](https://github.com/penumbra-zone/web/releases/new) with `vX.X.X` tag. Triggers approval to run chrome extension publishing.
-- [ ] Run `pnpm build` in the web repo's root. Then take minifront & node-status `dist` output and make PR against core repo to update node's frontends.
+- [ ] In the repo root, run `sh ./scripts/build-for-deployment.sh`. It will create two .zip files. Use those files to open a PR against core repo to update [the node's frontends](https://github.com/penumbra-zone/penumbra/tree/main/assets).
 - [ ] Wait 1-3 days until new extension version is live on [chrome web store](https://chromewebstore.google.com/detail/penumbra-wallet/lkpmkhpnhknhmibgnmmhdhgdilepfghe)
 - [ ] Run `Deploy Static Site` [github action](https://github.com/penumbra-zone/web/actions/workflows/deploy-firebase-dapp.yml)
 - [ ] Work with comms team for relevant discord announcements and social posts for new features we want to amplify

--- a/scripts/build-for-deployment.sh
+++ b/scripts/build-for-deployment.sh
@@ -4,7 +4,7 @@
 # node-status so that they can be PRed to the core repo.
 #
 # Usage:
-# sh ./scripts/zip-frontends -o /tmp
+# sh ./scripts/build-for-deployment -o /tmp
 #
 # Options:
 # -o Output directory for the zipped files. (default: present directory)

--- a/scripts/zip-frontends.sh
+++ b/scripts/zip-frontends.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Runs `pnpm build`, then zips the `dist` directories for both minifront and
+# node-status so that they can be PRed to the core repo.
+#
+# Usage:
+# sh ./scripts/zip-frontends -o /tmp
+#
+# Options:
+# -o Output directory for the zipped files. (default: present directory)
+# -r Root directory of the repo, if you're not running this script from the repo
+# root. (default: present directory)
+
+OUTPUT_DIR=$(pwd)
+REPO_ROOT=$(pwd)
+
+while getopts "o:r:" opt; do
+  case $opt in
+    o) OUTPUT_DIR="$OPTARG"
+    ;;
+    r) REPO_ROOT="$OPTARG"
+    ;;
+  esac
+done
+
+cd $REPO_ROOT
+pnpm build
+
+cd $REPO_ROOT/apps/minifront/dist
+zip -r minifront.zip *
+mv minifront.zip ${OUTPUT_DIR}
+
+cd $REPO_ROOT/apps/node-status/dist
+zip -r node-status.zip *
+mv node-status.zip ${OUTPUT_DIR}


### PR DESCRIPTION
This PR creates a script to build and ZIP the dist directories of minifront and node-status, so as to prevent human error and ease the deployment process.

Closes #857