### PR TITLE
Fix: Syncing genesis state causes unresponsive minifront

### DIFF
--- a/apps/minifront/src/components/header/top-row.tsx
+++ b/apps/minifront/src/components/header/top-row.tsx
@@ -11,6 +11,8 @@ import {
 import { Network } from '@penumbra-zone/ui/components/ui/network';
 import { PagePath } from '../metadata/paths';
 import { TabletNavMenu } from './tablet-nav-menu';
+import { useEffect, useState } from 'react';
+import { getChainId } from '../../fetchers/chain-id';
 import { LayoutLoaderResult } from '../layout';
 
 // Infinite-expiry invite link to the #web-ext-feedback channel. Provided by
@@ -18,8 +20,19 @@ import { LayoutLoaderResult } from '../layout';
 // if there are any problems with this link.
 const WEB_EXT_FEEDBACK_DISCORD_CHANNEL = 'https://discord.gg/XDNcrhKVwV';
 
+const useChainId = (): string | undefined => {
+  const { isInstalled, isConnected } = useLoaderData() as LayoutLoaderResult;
+  const [chainId, setChainId] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (isInstalled && isConnected) void getChainId().then(setChainId);
+  }, [isInstalled, isConnected]);
+
+  return chainId;
+};
+
 export const TopRow = () => {
-  const result = useLoaderData() as LayoutLoaderResult;
+  const chainId = useChainId();
 
   return (
     <div className='flex w-full flex-col items-center justify-between px-6 md:h-[82px] md:flex-row md:gap-12 md:px-12'>
@@ -62,9 +75,9 @@ export const TopRow = () => {
           </TooltipProvider>
         </div>
 
-        {'chainId' in result ? (
+        {chainId ? (
           <div className='order-2 flex grow justify-center md:order-none'>
-            <Network name={result.chainId} />
+            <Network name={chainId} />
           </div>
         ) : null}
       </div>

--- a/apps/minifront/src/components/layout.tsx
+++ b/apps/minifront/src/components/layout.tsx
@@ -1,5 +1,4 @@
 import { LoaderFunction, Outlet, useLoaderData } from 'react-router-dom';
-import { getChainId } from '../fetchers/chain-id';
 import { HeadTag } from './metadata/head-tag';
 import { Header } from './header/header';
 import { Toaster } from '@penumbra-zone/ui/components/ui/toaster';
@@ -9,21 +8,16 @@ import { Footer } from './footer/footer';
 import { isPraxConnected, isPraxConnectedTimeout, isPraxAvailable } from '@penumbra-zone/client';
 import '@penumbra-zone/ui/styles/globals.css';
 
-export type LayoutLoaderResult =
-  | { isInstalled: boolean; isConnected: boolean }
-  | {
-      isInstalled: true;
-      isConnected: true;
-      chainId: string;
-    };
+export interface LayoutLoaderResult {
+  isInstalled: boolean;
+  isConnected: boolean;
+}
 
 export const LayoutLoader: LoaderFunction = async (): Promise<LayoutLoaderResult> => {
   const isInstalled = isPraxAvailable();
   if (!isInstalled) return { isInstalled, isConnected: false };
   const isConnected = isPraxConnected() || (await isPraxConnectedTimeout(1000));
-  if (!isConnected) return { isInstalled, isConnected };
-  const chainId = await getChainId();
-  return { isInstalled, isConnected, chainId };
+  return { isInstalled, isConnected };
 };
 
 export const Layout = () => {


### PR DESCRIPTION
Per #921, the entire minifront layout is blank while syncing genesis state. Since genesis state is large and may take a long time to sync, the user experience while syncing genesis state is pretty poor.

Fortunately, the fix was easy. It turns out that the root layout loader was querying for the chain ID. Since the chain ID query wouldn't respond until the extension was done syncing genesis state, the query was blocking the layout component from rendering. So I moved the chain ID query to the header (which is where it's used), so that the chain ID no longer blocks the layout.

(I wonder if we should stop putting queries into our loaders, as the loaders block their routes from rendering until loading is complete — which creates UX problems like this.)

## Manual testing
I added a 1,000-second timeout to the block processor before it syncs the first block by adding this line...
```ts
    await new Promise(resolve => setTimeout(resolve, 1_000_000));
```

...just before the `for await (const compactBlock...` line here:

https://github.com/penumbra-zone/web/blob/main/packages/query/src/block-processor.ts#L165

Then I opened the extension and cleared the cache. This got it to stay stuck in the "Syncing genesis state" state for 1,000 seconds, allowing me to test that the minifront UI still loaded.

Closes #921 