### PR TITLE
Fix layout and resizing issues in the extension popup

### DIFF
--- a/apps/extension/src/routes/popup/approval/approve-deny.tsx
+++ b/apps/extension/src/routes/popup/approval/approve-deny.tsx
@@ -17,7 +17,7 @@ export const ApproveDeny = ({
   useEffect(startCountdown, [startCountdown]);
 
   return (
-    <div className='fixed inset-x-0 bottom-0 flex flex-row flex-wrap justify-center gap-4 bg-black p-4 shadow-lg'>
+    <div className='flex flex-row flex-wrap justify-center gap-4 bg-black p-4 shadow-lg'>
       <Button variant='gradient' className='w-full' size='lg' onClick={approve} disabled={!!count}>
         Approve {count !== 0 && `(${count})`}
       </Button>

--- a/apps/extension/src/routes/popup/approval/origin.tsx
+++ b/apps/extension/src/routes/popup/approval/origin.tsx
@@ -98,7 +98,9 @@ export const OriginApproval = () => {
             </div>
           </div>
         </div>
-        <ApproveDeny approve={approve} deny={deny} ignore={lastRequest && ignore} wait={3} />
+        <div className='flex grow flex-col justify-end'>
+          <ApproveDeny approve={approve} deny={deny} ignore={lastRequest && ignore} wait={3} />
+        </div>
       </div>
     </FadeTransition>
   );

--- a/apps/extension/src/routes/popup/approval/transaction/index.tsx
+++ b/apps/extension/src/routes/popup/approval/transaction/index.tsx
@@ -32,8 +32,8 @@ export const TransactionApproval = () => {
   };
 
   return (
-    <div className='flex h-screen flex-col justify-between'>
-      <div className='grow overflow-auto p-[30px] pb-44 pt-10'>
+    <div className='flex h-screen flex-col'>
+      <div className='grow overflow-auto p-[30px] pt-10'>
         <p className='bg-text-linear bg-clip-text pb-2 font-headline text-2xl font-bold text-transparent'>
           Confirm transaction
         </p>
@@ -49,6 +49,7 @@ export const TransactionApproval = () => {
           <JsonViewer jsonObj={authorizeRequest.toJson() as Jsonified<AuthorizeRequest>} />
         </div>
       </div>
+
       <ApproveDeny approve={approve} deny={deny} wait={3} />
     </div>
   );

--- a/apps/extension/src/routes/popup/popup-layout.tsx
+++ b/apps/extension/src/routes/popup/popup-layout.tsx
@@ -12,7 +12,7 @@ import { Outlet } from 'react-router-dom';
  * then removing the hard-coded width from `globals.css`.
  */
 export const PopupLayout = () => (
-  <div className='flex min-h-full flex-col bg-card-radial'>
+  <div className='flex grow flex-col bg-card-radial'>
     <Outlet />
   </div>
 );

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -59,8 +59,11 @@
   }
 
   #popup-root {
-    width: 400px;
-    height: 600px;
+    min-width: 400px;
+    min-height: 600px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     @apply bg-charcoal;
   }
 


### PR DESCRIPTION
Explanation for changes are inline. In short:
- I made the popup root div have a _min_ width/height instead of a hard-coded width/height, thus allowing it to scale with the popup window size.
- I fixed the issue where the scrollbars were hidden behind the fixed-position approve/deny buttons, by removing the fixed positioning and using flexbox instead.
- You may notice in the screencap that there is still some strange scrolling behavior when you shrink the window _below_ 400px wide or 600px tall. That's due to the min widths that we apparently need for the attached window height. I believe that, to work around this, we'd need to make a separate root for detached vs. attached popup windows. We could do that, but I'd suggest we make that a separate PR (if reviewers even think it's necessary), since that'll require quite a bit of extra work.

https://github.com/penumbra-zone/web/assets/1121544/f30622fc-3798-4e04-bca1-6c440c31509c


Closes #779