### PR TITLE
Expand toasts by default

### DIFF
--- a/packages/ui/components/ui/toaster.tsx
+++ b/packages/ui/components/ui/toaster.tsx
@@ -5,7 +5,7 @@ import './toaster.css';
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  return <Sonner theme='dark' richColors {...props} />;
+  return <Sonner theme='dark' richColors expand {...props} />;
 };
 
 export { Toaster };


### PR DESCRIPTION
Instead of using Sonner's default UI, which hides old toasts behind new ones, this PR expands all toasts by default. That way, when doing a swap + swap claim, you can clearly see both notifications:

![image](https://github.com/penumbra-zone/web/assets/1121544/78ec8a1d-35b3-48b1-8e61-bec0441a2d08)

I actually think this is a better UI choice anyway. There isn't really a compelling need to hide old toasts behind new ones.

Closes #830 