### PR TITLE
context key for full viewing key

### DIFF
--- a/packages/services/src/ctx/full-viewing-key.ts
+++ b/packages/services/src/ctx/full-viewing-key.ts
@@ -1,0 +1,4 @@
+import { createContextKey } from '@connectrpc/connect';
+import { FullViewingKey } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+
+export const fvkCtx = createContextKey<FullViewingKey | undefined>(undefined);

--- a/packages/services/src/custody-service/authorize/index.test.ts
+++ b/packages/services/src/custody-service/authorize/index.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { approverCtx } from '../../ctx/approver';
 import { extLocalCtx, extSessionCtx, servicesCtx } from '../../ctx/prax';
-import { IndexedDbMock, MockExtLocalCtx, MockExtSessionCtx, MockServices } from '../../test-utils';
+import {
+  IndexedDbMock,
+  MockExtLocalCtx,
+  MockExtSessionCtx,
+  MockServices,
+  testFullViewingKey,
+} from '../../test-utils';
 import { authorize } from '.';
 import { AuthorizeRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/custody/v1/custody_pb';
 import { CustodyService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/custody/v1/custody_connect';
@@ -13,6 +19,7 @@ import {
 import { Services } from '@penumbra-zone/services-context';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { UserChoice } from '@penumbra-zone/types/src/user-choice';
+import { fvkCtx } from '../../ctx/full-viewing-key';
 
 describe('Authorize request handler', () => {
   let mockServices: MockServices;
@@ -36,7 +43,7 @@ describe('Authorize request handler', () => {
 
     mockServices = {
       getWalletServices: vi.fn(() =>
-        Promise.resolve({ indexedDb: mockIndexedDb, viewServer: { fullViewingKey: 'fvk' } }),
+        Promise.resolve({ indexedDb: mockIndexedDb }),
       ) as MockServices['getWalletServices'],
     };
 
@@ -92,7 +99,8 @@ describe('Authorize request handler', () => {
         .set(extLocalCtx, mockExtLocalCtx as unknown)
         .set(approverCtx, mockApproverCtx as unknown)
         .set(extSessionCtx, mockExtSessionCtx as unknown)
-        .set(servicesCtx, mockServices as unknown as Services),
+        .set(servicesCtx, mockServices as unknown as Services)
+        .set(fvkCtx, testFullViewingKey),
     });
 
     for (const record of testAssetsMetadata) {

--- a/packages/services/src/custody-service/authorize/index.ts
+++ b/packages/services/src/custody-service/authorize/index.ts
@@ -66,7 +66,7 @@ export const authorize: Impl['authorize'] = async (req, ctx) => {
 const assertValidRequest = (req: AuthorizeRequest, ctx: HandlerContext): void => {
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
   assertSwapClaimAddressesBelongToCurrentUser(req.plan!, address =>
     isControlledAddress(fullViewingKey, address),

--- a/packages/services/src/view-service/address-by-index.test.ts
+++ b/packages/services/src/view-service/address-by-index.test.ts
@@ -5,33 +5,22 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
-import { servicesCtx } from '../ctx/prax';
 import { addressByIndex } from './address-by-index';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
-import type { ServicesInterface } from '@penumbra-zone/types/src/services';
 import { testFullViewingKey } from '../test-utils';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 describe('AddressByIndex request handler', () => {
-  let mockServices: ServicesInterface;
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
-    mockServices = {
-      getWalletServices: () =>
-        Promise.resolve({
-          viewServer: {
-            fullViewingKey: testFullViewingKey,
-          },
-        }),
-    } as ServicesInterface;
-
     mockCtx = createHandlerContext({
       service: ViewService,
       method: ViewService.methods.addressByIndex,
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(servicesCtx, mockServices),
+      contextValues: createContextValues().set(fvkCtx, testFullViewingKey),
     });
   });
 

--- a/packages/services/src/view-service/address-by-index.ts
+++ b/packages/services/src/view-service/address-by-index.ts
@@ -1,14 +1,13 @@
 import type { Impl } from '.';
-import { servicesCtx } from '../ctx/prax';
 
 import { getAddressByIndex } from '@penumbra-zone/wasm/src/keys';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
-export const addressByIndex: Impl['addressByIndex'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
-  const {
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
-
+export const addressByIndex: Impl['addressByIndex'] = (req, ctx) => {
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
   const address = getAddressByIndex(fullViewingKey, req.addressIndex?.account ?? 0);
 
   return { address };

--- a/packages/services/src/view-service/address-by-index.ts
+++ b/packages/services/src/view-service/address-by-index.ts
@@ -6,7 +6,7 @@ import { fvkCtx } from '../ctx/full-viewing-key';
 export const addressByIndex: Impl['addressByIndex'] = (req, ctx) => {
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
   const address = getAddressByIndex(fullViewingKey, req.addressIndex?.account ?? 0);
 

--- a/packages/services/src/view-service/address-by-index.ts
+++ b/packages/services/src/view-service/address-by-index.ts
@@ -2,6 +2,7 @@ import type { Impl } from '.';
 
 import { getAddressByIndex } from '@penumbra-zone/wasm/src/keys';
 import { fvkCtx } from '../ctx/full-viewing-key';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 export const addressByIndex: Impl['addressByIndex'] = (req, ctx) => {
   const fullViewingKey = ctx.values.get(fvkCtx);

--- a/packages/services/src/view-service/authorize-and-build.ts
+++ b/packages/services/src/view-service/authorize-and-build.ts
@@ -4,6 +4,7 @@ import { optimisticBuild } from './util/build-tx';
 import { custodyAuthorize } from './util/custody-authorize';
 import { getWitness } from '@penumbra-zone/wasm/src/build';
 import { Code, ConnectError } from '@connectrpc/connect';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 export const authorizeAndBuild: Impl['authorizeAndBuild'] = async function* (
   { transactionPlan },
@@ -12,10 +13,12 @@ export const authorizeAndBuild: Impl['authorizeAndBuild'] = async function* (
   const services = ctx.values.get(servicesCtx);
   if (!transactionPlan) throw new ConnectError('No tx plan in request', Code.InvalidArgument);
 
-  const {
-    indexedDb,
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
+  const { indexedDb } = await services.getWalletServices();
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
+
   const sct = await indexedDb.getStateCommitmentTree();
   const witnessData = getWitness(transactionPlan, sct);
 

--- a/packages/services/src/view-service/authorize-and-build.ts
+++ b/packages/services/src/view-service/authorize-and-build.ts
@@ -16,7 +16,7 @@ export const authorizeAndBuild: Impl['authorizeAndBuild'] = async function* (
   const { indexedDb } = await services.getWalletServices();
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
 
   const sct = await indexedDb.getStateCommitmentTree();

--- a/packages/services/src/view-service/balances.test.ts
+++ b/packages/services/src/view-service/balances.test.ts
@@ -12,7 +12,7 @@ import {
 
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { Services } from '@penumbra-zone/services-context/src/index';
+import { Services } from '@penumbra-zone/services-context';
 import { IndexedDbMock, MockServices, TendermintMock, testFullViewingKey } from '../test-utils';
 import {
   AssetId,
@@ -29,6 +29,7 @@ import {
 import { getAddressIndex } from '@penumbra-zone/getters/src/address-view';
 import { base64ToUint8Array } from '@penumbra-zone/types/src/base64';
 import { multiplyAmountByNumber } from '@penumbra-zone/types/src/amount';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 const assertOnlyUniqueAssetIds = (responses: BalancesResponse[], accountId: number) => {
   const account0Res = responses.filter(
@@ -67,10 +68,6 @@ describe('Balances request handler', () => {
       assetMetadata: vi.fn(),
     };
 
-    const mockViewServer = {
-      fullViewingKey: testFullViewingKey,
-    };
-
     mockTendermint = {
       latestBlockHeight: vi.fn(),
     };
@@ -80,7 +77,6 @@ describe('Balances request handler', () => {
       getWalletServices: vi.fn(() =>
         Promise.resolve({
           indexedDb: mockIndexedDb,
-          viewServer: mockViewServer,
           querier: {
             shieldedPool: mockShieldedPool,
             tendermint: mockTendermint,
@@ -95,7 +91,9 @@ describe('Balances request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(servicesCtx, mockServices as unknown as Services),
+      contextValues: createContextValues()
+        .set(servicesCtx, mockServices as unknown as Services)
+        .set(fvkCtx, testFullViewingKey),
     });
 
     for (const record of testData) {

--- a/packages/services/src/view-service/ephemeral-address.test.ts
+++ b/packages/services/src/view-service/ephemeral-address.test.ts
@@ -5,33 +5,22 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
-import { servicesCtx } from '../ctx/prax';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import { ephemeralAddress } from './ephemeral-address';
-import type { ServicesInterface } from '@penumbra-zone/types/src/services';
 import { testFullViewingKey } from '../test-utils';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 describe('EphemeralAddress request handler', () => {
-  let mockServices: ServicesInterface;
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
-    mockServices = {
-      getWalletServices: () =>
-        Promise.resolve({
-          viewServer: {
-            fullViewingKey: testFullViewingKey,
-          },
-        }),
-    } as ServicesInterface;
-
     mockCtx = createHandlerContext({
       service: ViewService,
       method: ViewService.methods.ephemeralAddress,
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(servicesCtx, mockServices),
+      contextValues: createContextValues().set(fvkCtx, testFullViewingKey),
     });
   });
 
@@ -43,8 +32,8 @@ describe('EphemeralAddress request handler', () => {
     expect(ephemeralAddressResponse.address).toBeInstanceOf(Address);
   });
 
-  test('should get an error if addressIndex is missing', async () => {
-    await expect(ephemeralAddress(new EphemeralAddressRequest(), mockCtx)).rejects.toThrow(
+  test('should get an error if addressIndex is missing', () => {
+    expect(() => ephemeralAddress(new EphemeralAddressRequest(), mockCtx)).toThrowError(
       'Missing address index',
     );
   });

--- a/packages/services/src/view-service/ephemeral-address.ts
+++ b/packages/services/src/view-service/ephemeral-address.ts
@@ -2,6 +2,7 @@ import type { Impl } from '.';
 
 import { getEphemeralByIndex } from '@penumbra-zone/wasm/src/keys';
 import { fvkCtx } from '../ctx/full-viewing-key';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 export const ephemeralAddress: Impl['ephemeralAddress'] = (req, ctx) => {
   if (!req.addressIndex) {
@@ -9,7 +10,7 @@ export const ephemeralAddress: Impl['ephemeralAddress'] = (req, ctx) => {
   }
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
   const address = getEphemeralByIndex(fullViewingKey, req.addressIndex.account);
 

--- a/packages/services/src/view-service/ephemeral-address.ts
+++ b/packages/services/src/view-service/ephemeral-address.ts
@@ -1,16 +1,15 @@
 import type { Impl } from '.';
-import { servicesCtx } from '../ctx/prax';
 
 import { getEphemeralByIndex } from '@penumbra-zone/wasm/src/keys';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
-export const ephemeralAddress: Impl['ephemeralAddress'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
-  const {
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
-
+export const ephemeralAddress: Impl['ephemeralAddress'] = (req, ctx) => {
   if (!req.addressIndex) {
     throw new Error('Missing address index');
+  }
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
   }
   const address = getEphemeralByIndex(fullViewingKey, req.addressIndex.account);
 

--- a/packages/services/src/view-service/index-by-address.test.ts
+++ b/packages/services/src/view-service/index-by-address.test.ts
@@ -2,36 +2,25 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import { IndexByAddressRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
-import { servicesCtx } from '../ctx/prax';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import { indexByAddress } from './index-by-address';
 import { getAddressByIndex, getEphemeralByIndex } from '@penumbra-zone/wasm/src/keys';
-import type { ServicesInterface } from '@penumbra-zone/types/src/services';
 import { bech32ToFullViewingKey } from '@penumbra-zone/bech32/src/full-viewing-key';
 import { testFullViewingKey } from '../test-utils';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 describe('IndexByAddress request handler', () => {
-  let mockServices: ServicesInterface;
   let mockCtx: HandlerContext;
   let testAddress: Address;
 
   beforeEach(() => {
-    mockServices = {
-      getWalletServices: () =>
-        Promise.resolve({
-          viewServer: {
-            fullViewingKey: testFullViewingKey,
-          },
-        }),
-    } as ServicesInterface;
-
     mockCtx = createHandlerContext({
       service: ViewService,
       method: ViewService.methods.indexByAddress,
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(servicesCtx, mockServices),
+      contextValues: createContextValues().set(fvkCtx, testFullViewingKey),
     });
 
     testAddress = getAddressByIndex(testFullViewingKey, 0);

--- a/packages/services/src/view-service/index-by-address.ts
+++ b/packages/services/src/view-service/index-by-address.ts
@@ -9,7 +9,7 @@ export const indexByAddress: Impl['indexByAddress'] = (req, ctx) => {
   if (!req.address) throw new ConnectError('no address given in request', Code.InvalidArgument);
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
   const addressIndex = getAddressIndexByAddress(fullViewingKey, req.address);
 

--- a/packages/services/src/view-service/index-by-address.ts
+++ b/packages/services/src/view-service/index-by-address.ts
@@ -1,17 +1,16 @@
 import type { Impl } from '.';
-import { servicesCtx } from '../ctx/prax';
 
 import { getAddressIndexByAddress } from '@penumbra-zone/wasm/src/address';
 
 import { Code, ConnectError } from '@connectrpc/connect';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
-export const indexByAddress: Impl['indexByAddress'] = async (req, ctx) => {
+export const indexByAddress: Impl['indexByAddress'] = (req, ctx) => {
   if (!req.address) throw new ConnectError('no address given in request', Code.InvalidArgument);
-  const services = ctx.values.get(servicesCtx);
-  const {
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
-
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
   const addressIndex = getAddressIndexByAddress(fullViewingKey, req.address);
 
   if (!addressIndex) return {};

--- a/packages/services/src/view-service/transaction-info-by-hash.ts
+++ b/packages/services/src/view-service/transaction-info-by-hash.ts
@@ -3,15 +3,17 @@ import { servicesCtx } from '../ctx/prax';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { generateTransactionInfo } from '@penumbra-zone/wasm/src/transaction';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 export const transactionInfoByHash: Impl['transactionInfoByHash'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
-  const {
-    indexedDb,
-    querier,
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
   if (!req.id) throw new ConnectError('Missing transaction ID in request', Code.InvalidArgument);
+
+  const services = ctx.values.get(servicesCtx);
+  const { indexedDb, querier } = await services.getWalletServices();
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
 
   // Check database for transaction first
   // if not in database, query tendermint for public info on the transaction

--- a/packages/services/src/view-service/transaction-info-by-hash.ts
+++ b/packages/services/src/view-service/transaction-info-by-hash.ts
@@ -12,7 +12,7 @@ export const transactionInfoByHash: Impl['transactionInfoByHash'] = async (req, 
   const { indexedDb, querier } = await services.getWalletServices();
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
 
   // Check database for transaction first

--- a/packages/services/src/view-service/transaction-info.test.ts
+++ b/packages/services/src/view-service/transaction-info.test.ts
@@ -10,9 +10,10 @@ import {
   TransactionInfoRequest,
   TransactionInfoResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices, testFullViewingKey, ViewServerMock } from '../test-utils';
-import { Services } from '@penumbra-zone/services-context/src/index';
+import { IndexedDbMock, MockServices, testFullViewingKey } from '../test-utils';
+import { Services } from '@penumbra-zone/services-context';
 import { transactionInfo } from './transaction-info';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 const mockTransactionInfo = vi.hoisted(() => vi.fn());
 vi.mock('@penumbra-zone/wasm/src/transaction', () => ({
@@ -23,7 +24,6 @@ describe('TransactionInfo request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
   let mockIndexedDb: IndexedDbMock;
-  let mockViewServer: ViewServerMock;
   let req: TransactionInfoRequest;
 
   beforeEach(() => {
@@ -39,13 +39,9 @@ describe('TransactionInfo request handler', () => {
       constants: vi.fn(),
     };
 
-    mockViewServer = {
-      fullViewingKey: testFullViewingKey,
-    };
-
     mockServices = {
       getWalletServices: vi.fn(() =>
-        Promise.resolve({ indexedDb: mockIndexedDb, viewServer: mockViewServer }),
+        Promise.resolve({ indexedDb: mockIndexedDb }),
       ) as MockServices['getWalletServices'],
     };
 
@@ -55,7 +51,9 @@ describe('TransactionInfo request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(servicesCtx, mockServices as unknown as Services),
+      contextValues: createContextValues()
+        .set(servicesCtx, mockServices as unknown as Services)
+        .set(fvkCtx, testFullViewingKey),
     });
 
     mockTransactionInfo.mockReturnValue({

--- a/packages/services/src/view-service/transaction-info.ts
+++ b/packages/services/src/view-service/transaction-info.ts
@@ -2,13 +2,16 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { generateTransactionInfo } from '@penumbra-zone/wasm/src/transaction';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 export const transactionInfo: Impl['transactionInfo'] = async function* (req, ctx) {
   const services = ctx.values.get(servicesCtx);
-  const {
-    indexedDb,
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
+  const { indexedDb } = await services.getWalletServices();
+
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
 
   for await (const txRecord of indexedDb.iterateTransactions()) {
     // filter transactions between startHeight and endHeight, inclusive

--- a/packages/services/src/view-service/transaction-info.ts
+++ b/packages/services/src/view-service/transaction-info.ts
@@ -3,6 +3,7 @@ import { servicesCtx } from '../ctx/prax';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { generateTransactionInfo } from '@penumbra-zone/wasm/src/transaction';
 import { fvkCtx } from '../ctx/full-viewing-key';
+import { Code, ConnectError } from '@connectrpc/connect';
 
 export const transactionInfo: Impl['transactionInfo'] = async function* (req, ctx) {
   const services = ctx.values.get(servicesCtx);
@@ -10,7 +11,7 @@ export const transactionInfo: Impl['transactionInfo'] = async function* (req, ct
 
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
 
   for await (const txRecord of indexedDb.iterateTransactions()) {

--- a/packages/services/src/view-service/transaction-planner/index.ts
+++ b/packages/services/src/view-service/transaction-planner/index.ts
@@ -12,7 +12,7 @@ export const transactionPlanner: Impl['transactionPlanner'] = async (req, ctx) =
 
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
 
   assertValidRequest(req);

--- a/packages/services/src/view-service/transaction-planner/index.ts
+++ b/packages/services/src/view-service/transaction-planner/index.ts
@@ -4,13 +4,16 @@ import { planTransaction } from '@penumbra-zone/wasm/src/planner';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { assertSwapAssetsAreNotTheSame } from './assert-swap-assets-are-not-the-same';
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { fvkCtx } from '../../ctx/full-viewing-key';
 
 export const transactionPlanner: Impl['transactionPlanner'] = async (req, ctx) => {
   const services = ctx.values.get(servicesCtx);
-  const {
-    indexedDb,
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
+  const { indexedDb } = await services.getWalletServices();
+
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
 
   assertValidRequest(req);
 

--- a/packages/services/src/view-service/witness-and-build.ts
+++ b/packages/services/src/view-service/witness-and-build.ts
@@ -19,7 +19,7 @@ export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (
   const { indexedDb } = await services.getWalletServices();
   const fullViewingKey = ctx.values.get(fvkCtx);
   if (!fullViewingKey) {
-    throw new Error('Cannot access full viewing key');
+    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
   }
 
   const sct = await indexedDb.getStateCommitmentTree();

--- a/packages/services/src/view-service/witness-and-build.ts
+++ b/packages/services/src/view-service/witness-and-build.ts
@@ -7,6 +7,7 @@ import { getWitness } from '@penumbra-zone/wasm/src/build';
 
 import { Code, ConnectError } from '@connectrpc/connect';
 import { AuthorizationData } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
+import { fvkCtx } from '../ctx/full-viewing-key';
 
 export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (
   { authorizationData, transactionPlan },
@@ -15,10 +16,12 @@ export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (
   const services = ctx.values.get(servicesCtx);
   if (!transactionPlan) throw new ConnectError('No tx plan', Code.InvalidArgument);
 
-  const {
-    indexedDb,
-    viewServer: { fullViewingKey },
-  } = await services.getWalletServices();
+  const { indexedDb } = await services.getWalletServices();
+  const fullViewingKey = ctx.values.get(fvkCtx);
+  if (!fullViewingKey) {
+    throw new Error('Cannot access full viewing key');
+  }
+
   const sct = await indexedDb.getStateCommitmentTree();
 
   const witnessData = getWitness(transactionPlan, sct);

--- a/packages/types/src/servers.ts
+++ b/packages/types/src/servers.ts
@@ -1,10 +1,8 @@
 import { ScanBlockResult } from './state-commitment-tree';
 import { CompactBlock } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/compact_block/v1/compact_block_pb';
 import { MerkleRoot } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
-import { FullViewingKey } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 
 export interface ViewServerInterface {
-  fullViewingKey: FullViewingKey;
   scanBlock(compactBlock: CompactBlock): Promise<boolean>;
   flushUpdates(): ScanBlockResult;
   resetTreeToStored(): Promise<void>;


### PR DESCRIPTION
> currently, method impls that need fvk do something like this
> 
> ```
>   const { fullViewingKey } = (await services.getWalletServices()).viewServer;
> ```
> 
> we should just have a context key that provides fvk to impls, and fvk should not be available from another location.
> 
> relevant to #341


Close #826 