### PR TITLE
don't assert key

### DIFF
--- a/apps/extension/src/wasm-build-action.ts
+++ b/apps/extension/src/wasm-build-action.ts
@@ -66,7 +66,7 @@ async function executeWorker(
     witness,
     fullViewingKey,
     actionPlanIndex,
-    keyFileNames[actionType]!.href,
+    keyFileNames[actionType]?.href,
   );
 
   return action.toJson();


### PR DESCRIPTION
fixes undefined access (caller might not provide key url)