### PR TITLE
Create UI to schedule Dutch auctions

### DIFF
--- a/apps/minifront/public/auction-gradient.svg
+++ b/apps/minifront/public/auction-gradient.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="url(#tealToOrangeGradient)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-gavel">
+  <defs>
+      <linearGradient id="tealToOrangeGradient" x1="0" y1="12" x2="24" y2="12" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#8BE4D9" stop-opacity="0.7"/>
+          <stop offset="0.526042" stop-color="#C8B880" stop-opacity="0.7"/>
+          <stop offset="1" stop-color="#FF902F" stop-opacity="0.6"/>
+      </linearGradient>
+  </defs>
+  <path d="m14.5 12.5-8 8a2.119 2.119 0 1 1-3-3l8-8"/>
+  <path d="m16 16 6-6"/>
+  <path d="m8 8 6-6"/>
+  <path d="m9 7 8 8"/>
+  <path d="m21 11-8-8"/>
+</svg>

--- a/apps/minifront/src/components/dashboard/constants.ts
+++ b/apps/minifront/src/components/dashboard/constants.ts
@@ -1,11 +1,12 @@
 import { DashboardTabMap } from './types';
 import { PagePath } from '../metadata/paths';
 import { EduPanel } from '../shared/edu-panels/content';
+import { Tab } from '../shared/tabs';
 
-export const dashboardTabs = [
-  { title: 'Assets', href: PagePath.DASHBOARD, active: true },
-  { title: 'Transactions', href: PagePath.TRANSACTIONS, active: true },
-  { title: 'NFTs', href: PagePath.NFTS, active: false },
+export const dashboardTabs: Tab[] = [
+  { title: 'Assets', href: PagePath.DASHBOARD, enabled: true },
+  { title: 'Transactions', href: PagePath.TRANSACTIONS, enabled: true },
+  { title: 'NFTs', href: PagePath.NFTS, enabled: false },
 ];
 
 export const dashboardTabsHelper: DashboardTabMap = {

--- a/apps/minifront/src/components/header/constants.tsx
+++ b/apps/minifront/src/components/header/constants.tsx
@@ -29,6 +29,7 @@ export const headerLinks: HeaderLink[] = [
     href: PagePath.SWAP,
     label: 'Swap',
     active: true,
+    subLinks: [PagePath.SWAP_AUCTION],
     mobileIcon: <SwapIcon />,
   },
   {

--- a/apps/minifront/src/components/metadata/content.ts
+++ b/apps/minifront/src/components/metadata/content.ts
@@ -39,6 +39,10 @@ export const metadata: Record<PagePath, PageMetadata> = {
     title: 'Penumbra | Swap',
     description: eduPanelContent[EduPanel.TEMP_FILLER],
   },
+  [PagePath.SWAP_AUCTION]: {
+    title: 'Penumbra | Auction',
+    description: eduPanelContent[EduPanel.TEMP_FILLER],
+  },
   [PagePath.STAKING]: {
     title: 'Penumbra | Staking',
     description: eduPanelContent[EduPanel.TEMP_FILLER],

--- a/apps/minifront/src/components/metadata/content.ts
+++ b/apps/minifront/src/components/metadata/content.ts
@@ -37,15 +37,15 @@ export const metadata: Record<PagePath, PageMetadata> = {
   },
   [PagePath.SWAP]: {
     title: 'Penumbra | Swap',
-    description: eduPanelContent[EduPanel.TEMP_FILLER],
+    description: eduPanelContent[EduPanel.SWAP],
   },
   [PagePath.SWAP_AUCTION]: {
     title: 'Penumbra | Auction',
-    description: eduPanelContent[EduPanel.TEMP_FILLER],
+    description: eduPanelContent[EduPanel.SWAP_AUCTION],
   },
   [PagePath.STAKING]: {
     title: 'Penumbra | Staking',
-    description: eduPanelContent[EduPanel.TEMP_FILLER],
+    description: eduPanelContent[EduPanel.STAKING],
   },
   [PagePath.TRANSACTION_DETAILS]: {
     title: 'Penumbra | Transaction',

--- a/apps/minifront/src/components/metadata/paths.ts
+++ b/apps/minifront/src/components/metadata/paths.ts
@@ -1,6 +1,7 @@
 export enum PagePath {
   INDEX = '/',
   SWAP = '/swap',
+  SWAP_AUCTION = '/swap/auction',
   SEND = '/send',
   STAKING = '/staking',
   RECEIVE = '/send/receive',

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -10,10 +10,13 @@ import { SendAssetBalanceLoader, SendForm } from './send/send-form';
 import { Receive } from './send/receive';
 import { ErrorBoundary } from './shared/error-boundary';
 import { SwapLayout } from './swap/layout';
-import { SwapLoader } from './swap/swap-loader';
+import { SwapLoader } from './swap/swap/swap-loader';
 import { StakingLayout, StakingLoader } from './staking/layout';
 import { IbcLoader } from './ibc/ibc-loader';
 import { IbcLayout } from './ibc/layout';
+import { Swap } from './swap/swap';
+import { DutchAuction } from './swap/dutch-auction';
+import { DutchAuctionLoader } from './swap/dutch-auction/dutch-auction-loader';
 
 export const rootRouter = createHashRouter([
   {
@@ -57,8 +60,19 @@ export const rootRouter = createHashRouter([
       },
       {
         path: PagePath.SWAP,
-        loader: SwapLoader,
         element: <SwapLayout />,
+        children: [
+          {
+            index: true,
+            loader: SwapLoader,
+            element: <Swap />,
+          },
+          {
+            path: PagePath.SWAP_AUCTION,
+            loader: DutchAuctionLoader,
+            element: <DutchAuction />,
+          },
+        ],
       },
       {
         path: PagePath.TRANSACTION_DETAILS,

--- a/apps/minifront/src/components/send/constants.ts
+++ b/apps/minifront/src/components/send/constants.ts
@@ -16,6 +16,6 @@ export const sendTabsHelper: SendTabMap = {
 };
 
 export const sendTabs = [
-  { title: 'Send', href: PagePath.SEND, active: true },
-  { title: 'Receive', href: PagePath.RECEIVE, active: true },
+  { title: 'Send', href: PagePath.SEND, enabled: true },
+  { title: 'Receive', href: PagePath.RECEIVE, enabled: true },
 ];

--- a/apps/minifront/src/components/shared/asset-selector.tsx
+++ b/apps/minifront/src/components/shared/asset-selector.tsx
@@ -14,10 +14,9 @@ import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/valu
 import { useEffect, useMemo, useState } from 'react';
 import { IconInput } from '@penumbra-zone/ui/components/ui/icon-input';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
-import { SwapLoaderResponse } from '../swap/swap-loader';
-import { useLoaderData } from 'react-router-dom';
 
 interface AssetSelectorProps {
+  assets: Metadata[];
   value?: Metadata;
   onChange: (metadata: Metadata) => void;
   /**
@@ -46,8 +45,7 @@ const switchAssetIfNecessary = ({
   }
 };
 
-const useFilteredAssets = ({ value, onChange, filter }: AssetSelectorProps) => {
-  const { assets } = useLoaderData() as SwapLoaderResponse;
+const useFilteredAssets = ({ assets, value, onChange, filter }: AssetSelectorProps) => {
   const sortedAssets = useMemo(
     () =>
       [...assets].sort((a, b) =>
@@ -66,7 +64,7 @@ const useFilteredAssets = ({ value, onChange, filter }: AssetSelectorProps) => {
     [filter, value, filteredAssets, onChange],
   );
 
-  return { assets: filteredAssets, search, setSearch };
+  return { filteredAssets, search, setSearch };
 };
 
 const bySearch = (search: string) => (asset: Metadata) =>
@@ -80,8 +78,13 @@ const bySearch = (search: string) => (asset: Metadata) =>
  * For an asset selector that picks from the user's balances, use
  * `<BalanceSelector />`.
  */
-export const AssetSelector = ({ onChange, value, filter }: AssetSelectorProps) => {
-  const { assets, search, setSearch } = useFilteredAssets({ value, onChange, filter });
+export const AssetSelector = ({ assets, onChange, value, filter }: AssetSelectorProps) => {
+  const { filteredAssets, search, setSearch } = useFilteredAssets({
+    assets,
+    value,
+    onChange,
+    filter,
+  });
 
   /**
    * @todo: Refactor to not use `ValueViewComponent`, since it's not intended to
@@ -109,7 +112,7 @@ export const AssetSelector = ({ onChange, value, filter }: AssetSelectorProps) =
               onChange={setSearch}
               placeholder='Search assets...'
             />
-            {assets.map(metadata => (
+            {filteredAssets.map(metadata => (
               <div key={metadata.display} className='flex flex-col'>
                 <DialogClose>
                   <div

--- a/apps/minifront/src/components/shared/edu-panels/content.tsx
+++ b/apps/minifront/src/components/shared/edu-panels/content.tsx
@@ -6,6 +6,7 @@ export enum EduPanel {
   RECEIVING_FUNDS,
   IBC_WITHDRAW,
   SWAP,
+  SWAP_AUCTION,
   STAKING,
   TEMP_FILLER,
 }
@@ -25,6 +26,8 @@ export const eduPanelContent: Record<EduPanel, string> = {
     'IBC to a connected chain. Note that if the chain is a transparent chain, the transaction will be visible to others.',
   [EduPanel.SWAP]:
     'Shielded swaps between any kind of cryptoasset, with sealed-bid, batch pricing and no frontrunning. Only the batch totals are revealed, providing long-term privacy. Penumbra has no MEV, because transactions do not leak data about user activity.',
+  [EduPanel.SWAP_AUCTION]:
+    "Offer a specific quantity of cryptocurrency at decreasing prices until all the tokens are sold. Buyers can place bids at the price they're willing to pay, with the auction concluding when all tokens are sold or when the auction time expires. This mechanism allows for price discovery based on market demand, with participants potentially acquiring tokens at prices lower than initially offered.",
   [EduPanel.STAKING]:
     'Explore the available validator nodes and their associated rewards, performance metrics, and staking requirements. Select the validator you wish to delegate your tokens to, based on factors like uptime, reputation, and expected returns. Stay informed about validator performance updates, rewards distribution, and any network upgrades to ensure a seamless staking experience.',
   [EduPanel.TEMP_FILLER]:

--- a/apps/minifront/src/components/shared/tabs.tsx
+++ b/apps/minifront/src/components/shared/tabs.tsx
@@ -3,8 +3,14 @@ import { cn } from '@penumbra-zone/ui/lib/utils';
 import { PagePath } from '../metadata/paths';
 import { useNavigate } from 'react-router-dom';
 
+export interface Tab {
+  title: string;
+  enabled: boolean;
+  href: PagePath;
+}
+
 interface TabsProps {
-  tabs: { title: string; active: boolean; href: PagePath }[];
+  tabs: Tab[];
   activeTab: PagePath;
   className?: string;
 }
@@ -21,7 +27,7 @@ export const Tabs = ({ tabs, activeTab, className }: TabsProps) => {
     >
       {tabs.map(
         tab =>
-          tab.active && (
+          tab.enabled && (
             <Button
               className={cn(
                 'w-full transition-all',

--- a/apps/minifront/src/components/swap/dutch-auction/duration-slider.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/duration-slider.tsx
@@ -1,0 +1,32 @@
+import { Slider } from '@penumbra-zone/ui/components/ui/slider';
+import { DURATION_OPTIONS } from '../../../state/dutch-auction/constants';
+import { useStoreShallow } from '../../../utils/use-store-shallow';
+import { AllSlices } from '../../../state';
+
+const durationSliderSelector = (state: AllSlices) => ({
+  duration: state.dutchAuction.duration,
+  setDuration: state.dutchAuction.setDuration,
+});
+
+export const DurationSlider = () => {
+  const { duration, setDuration } = useStoreShallow(durationSliderSelector);
+
+  const handleChange = (newValue: number[]) => {
+    const value = newValue[0]!; // We don't use multiple values in the slider
+    const option = DURATION_OPTIONS[value]!;
+
+    setDuration(option);
+  };
+
+  return (
+    <div className='flex flex-col items-center gap-4'>
+      <Slider
+        min={0}
+        max={DURATION_OPTIONS.length - 1}
+        value={[DURATION_OPTIONS.indexOf(duration)]}
+        onValueChange={handleChange}
+      />
+      {duration}
+    </div>
+  );
+};

--- a/apps/minifront/src/components/swap/dutch-auction/dutch-auction-form.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/dutch-auction-form.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@penumbra-zone/ui/components/ui/button';
+import { AllSlices } from '../../../state';
+import { useStoreShallow } from '../../../utils/use-store-shallow';
+import { InputBlock } from '../../shared/input-block';
+import InputToken from '../../shared/input-token';
+import { DurationSlider } from './duration-slider';
+import { Prices } from './prices';
+
+const dutchAuctionFormSelector = (state: AllSlices) => ({
+  balances: state.dutchAuction.balancesResponses,
+  assetIn: state.dutchAuction.assetIn,
+  setAssetIn: state.dutchAuction.setAssetIn,
+  amount: state.dutchAuction.amount,
+  setAmount: state.dutchAuction.setAmount,
+  onSubmit: state.dutchAuction.onSubmit,
+  submitButtonDisabled: state.dutchAuction.txInProgress || !state.dutchAuction.amount,
+});
+
+export const DutchAuctionForm = () => {
+  const { amount, setAmount, assetIn, setAssetIn, balances, onSubmit, submitButtonDisabled } =
+    useStoreShallow(dutchAuctionFormSelector);
+
+  return (
+    <form
+      className='flex flex-col gap-4 xl:gap-3'
+      onSubmit={e => {
+        e.preventDefault();
+        void onSubmit();
+      }}
+    >
+      <InputToken
+        label='Amount to sell'
+        balances={balances}
+        selection={assetIn}
+        setSelection={setAssetIn}
+        value={amount}
+        onChange={e => {
+          if (Number(e.target.value) < 0) return;
+          setAmount(e.target.value);
+        }}
+        placeholder='Enter an amount'
+      />
+
+      <InputBlock label='Duration'>
+        <div className='pt-2'>
+          <DurationSlider />
+        </div>
+      </InputBlock>
+
+      <InputBlock label='Price'>
+        <div className='pt-2'>
+          <Prices />
+        </div>
+      </InputBlock>
+
+      <Button variant='gradient' type='submit' disabled={submitButtonDisabled}>
+        Start auctions
+      </Button>
+    </form>
+  );
+};

--- a/apps/minifront/src/components/swap/dutch-auction/dutch-auction-form.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/dutch-auction-form.tsx
@@ -4,7 +4,7 @@ import { useStoreShallow } from '../../../utils/use-store-shallow';
 import { InputBlock } from '../../shared/input-block';
 import InputToken from '../../shared/input-token';
 import { DurationSlider } from './duration-slider';
-import { Prices } from './prices';
+import { Price } from './price';
 
 const dutchAuctionFormSelector = (state: AllSlices) => ({
   balances: state.dutchAuction.balancesResponses,
@@ -49,7 +49,7 @@ export const DutchAuctionForm = () => {
 
       <InputBlock label='Price'>
         <div className='pt-2'>
-          <Prices />
+          <Price />
         </div>
       </InputBlock>
 

--- a/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
+++ b/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
@@ -1,0 +1,21 @@
+import { throwIfPraxNotConnectedTimeout } from '@penumbra-zone/client';
+import { getSwappableBalancesResponses } from '../helpers';
+import { useStore } from '../../../state';
+import { getAllAssets } from '../../../fetchers/assets';
+
+export const DutchAuctionLoader = async () => {
+  await throwIfPraxNotConnectedTimeout();
+
+  const [assets, balancesResponses] = await Promise.all([
+    getAllAssets(),
+    getSwappableBalancesResponses(),
+  ]);
+  useStore.getState().dutchAuction.setBalancesResponses(balancesResponses);
+
+  if (balancesResponses[0]) {
+    useStore.getState().dutchAuction.setAssetIn(balancesResponses[0]);
+    useStore.getState().dutchAuction.setAssetOut(assets[0]!);
+  }
+
+  return assets;
+};

--- a/apps/minifront/src/components/swap/dutch-auction/index.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/index.tsx
@@ -1,0 +1,23 @@
+import { Card } from '@penumbra-zone/ui/components/ui/card';
+import { EduPanel } from '../../shared/edu-panels/content';
+import { EduInfoCard } from '../../shared/edu-panels/edu-info-card';
+import { DutchAuctionForm } from './dutch-auction-form';
+
+export const DutchAuction = () => {
+  return (
+    <div className='grid gap-6 md:grid-cols-2 md:gap-4 xl:grid-cols-3 xl:gap-5'>
+      <div className='hidden xl:block'></div>
+
+      <Card gradient className='order-3 row-span-2 flex-1 p-5 md:order-1 md:p-4 xl:p-5'>
+        <DutchAuctionForm />
+      </Card>
+
+      <EduInfoCard
+        className='row-span-1 md:order-2'
+        src='./auction-gradient.svg'
+        label='Dutch Auction'
+        content={EduPanel.SWAP_AUCTION}
+      />
+    </div>
+  );
+};

--- a/apps/minifront/src/components/swap/dutch-auction/price.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/price.tsx
@@ -34,7 +34,7 @@ export const Price = () => {
             max={maxOutput}
             onChange={e => setMinOutput(e.target.value)}
             type='number'
-            inputMode='numeric'
+            inputMode='decimal'
           />
         </div>
 

--- a/apps/minifront/src/components/swap/dutch-auction/price.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/price.tsx
@@ -30,7 +30,7 @@ export const Price = () => {
           <Input
             variant='transparent'
             value={minOutput}
-            min={1}
+            min={0}
             max={maxOutput}
             onChange={e => setMinOutput(e.target.value)}
             type='number'

--- a/apps/minifront/src/components/swap/dutch-auction/price.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/price.tsx
@@ -6,7 +6,7 @@ import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
 import { useLoaderData } from 'react-router-dom';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 
-const pricesSelector = (state: AllSlices) => ({
+const priceSelector = (state: AllSlices) => ({
   assetIn: state.dutchAuction.assetIn,
   assetOut: state.dutchAuction.assetOut,
   setAssetOut: state.dutchAuction.setAssetOut,
@@ -16,9 +16,9 @@ const pricesSelector = (state: AllSlices) => ({
   setMaxOutput: state.dutchAuction.setMaxOutput,
 });
 
-export const Prices = () => {
+export const Price = () => {
   const { minOutput, setMinOutput, maxOutput, setMaxOutput, assetIn, assetOut, setAssetOut } =
-    useStoreShallow(pricesSelector);
+    useStoreShallow(priceSelector);
   const assetInId = getAssetIdFromValueView(assetIn?.balanceView);
   const assets = useLoaderData() as Metadata[];
 

--- a/apps/minifront/src/components/swap/dutch-auction/price.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/price.tsx
@@ -24,31 +24,31 @@ export const Price = () => {
 
   return (
     <div className='flex grow items-center gap-4'>
-      <div className='flex items-center gap-2'>
-        <span className='text-muted-foreground'>Min:</span>
-        <Input
-          variant='transparent'
-          value={minOutput}
-          min={1}
-          max={maxOutput}
-          onChange={e => setMinOutput(e.target.value)}
-          type='number'
-          inputMode='numeric'
-          className='grow'
-        />
-      </div>
+      <div className='flex grow flex-col gap-2'>
+        <div className='flex items-center gap-2'>
+          <span className='text-muted-foreground'>Min:</span>
+          <Input
+            variant='transparent'
+            value={minOutput}
+            min={1}
+            max={maxOutput}
+            onChange={e => setMinOutput(e.target.value)}
+            type='number'
+            inputMode='numeric'
+          />
+        </div>
 
-      <div className='flex grow items-center gap-2'>
-        <span className='text-muted-foreground'>Max:</span>
-        <Input
-          variant='transparent'
-          value={maxOutput}
-          min={minOutput}
-          onChange={e => setMaxOutput(e.target.value)}
-          type='number'
-          inputMode='numeric'
-          className='grow text-right'
-        />
+        <div className='flex grow items-center gap-2'>
+          <span className='text-muted-foreground'>Max:</span>
+          <Input
+            variant='transparent'
+            value={maxOutput}
+            min={minOutput}
+            onChange={e => setMaxOutput(e.target.value)}
+            type='number'
+            inputMode='numeric'
+          />
+        </div>
       </div>
 
       <div className='w-min'>

--- a/apps/minifront/src/components/swap/dutch-auction/prices.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/prices.tsx
@@ -1,0 +1,64 @@
+import { AllSlices } from '../../../state';
+import { useStoreShallow } from '../../../utils/use-store-shallow';
+import { Input } from '@penumbra-zone/ui/components/ui/input';
+import { AssetSelector } from '../../shared/asset-selector';
+import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
+import { useLoaderData } from 'react-router-dom';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+const pricesSelector = (state: AllSlices) => ({
+  assetIn: state.dutchAuction.assetIn,
+  assetOut: state.dutchAuction.assetOut,
+  setAssetOut: state.dutchAuction.setAssetOut,
+  minOutput: state.dutchAuction.minOutput,
+  setMinOutput: state.dutchAuction.setMinOutput,
+  maxOutput: state.dutchAuction.maxOutput,
+  setMaxOutput: state.dutchAuction.setMaxOutput,
+});
+
+export const Prices = () => {
+  const { minOutput, setMinOutput, maxOutput, setMaxOutput, assetIn, assetOut, setAssetOut } =
+    useStoreShallow(pricesSelector);
+  const assetInId = getAssetIdFromValueView(assetIn?.balanceView);
+  const assets = useLoaderData() as Metadata[];
+
+  return (
+    <div className='flex grow items-center gap-4'>
+      <div className='flex items-center gap-2'>
+        <span className='text-muted-foreground'>Min:</span>
+        <Input
+          variant='transparent'
+          value={minOutput}
+          min={1}
+          max={maxOutput}
+          onChange={e => setMinOutput(e.target.value)}
+          type='number'
+          inputMode='numeric'
+          className='grow'
+        />
+      </div>
+
+      <div className='flex grow items-center gap-2'>
+        <span className='text-muted-foreground'>Max:</span>
+        <Input
+          variant='transparent'
+          value={maxOutput}
+          min={minOutput}
+          onChange={e => setMaxOutput(e.target.value)}
+          type='number'
+          inputMode='numeric'
+          className='grow text-right'
+        />
+      </div>
+
+      <div className='w-min'>
+        <AssetSelector
+          assets={assets}
+          value={assetOut}
+          onChange={setAssetOut}
+          filter={asset => !asset.penumbraAssetId?.equals(assetInId)}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/minifront/src/components/swap/helpers.ts
+++ b/apps/minifront/src/components/swap/helpers.ts
@@ -1,0 +1,34 @@
+import { assetPatterns } from '@penumbra-zone/constants/assets';
+import { getBalances } from '../../fetchers/balances';
+import {
+  getAmount,
+  getDisplayDenomExponentFromValueView,
+  getDisplayDenomFromView,
+} from '@penumbra-zone/getters/value-view';
+import { fromBaseUnitAmount } from '@penumbra-zone/types/amount';
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+
+const byBalanceDescending = (a: BalancesResponse, b: BalancesResponse) => {
+  const aExponent = getDisplayDenomExponentFromValueView(a.balanceView);
+  const bExponent = getDisplayDenomExponentFromValueView(b.balanceView);
+  const aAmount = fromBaseUnitAmount(getAmount(a.balanceView), aExponent);
+  const bAmount = fromBaseUnitAmount(getAmount(b.balanceView), bExponent);
+
+  return bAmount.comparedTo(aAmount);
+};
+
+const nonSwappableAssetPatterns = [
+  assetPatterns.lpNft,
+  assetPatterns.proposalNft,
+  assetPatterns.votingReceipt,
+];
+
+const isSwappable = (balancesResponse: BalancesResponse) =>
+  nonSwappableAssetPatterns.every(
+    pattern => !pattern.matches(getDisplayDenomFromView(balancesResponse.balanceView)),
+  );
+
+export const getSwappableBalancesResponses = async (): Promise<BalancesResponse[]> => {
+  const balancesResponses = await getBalances();
+  return balancesResponses.filter(isSwappable).sort(byBalanceDescending);
+};

--- a/apps/minifront/src/components/swap/layout.tsx
+++ b/apps/minifront/src/components/swap/layout.tsx
@@ -1,25 +1,32 @@
-import { Card } from '@penumbra-zone/ui/components/ui/card';
-import { EduInfoCard } from '../shared/edu-panels/edu-info-card';
-import { EduPanel } from '../shared/edu-panels/content';
-import { SwapForm } from './swap-form';
-import { UnclaimedSwaps } from './unclaimed-swaps';
 import { RestrictMaxWidth } from '../shared/restrict-max-width';
+import { Tab, Tabs } from '../shared/tabs';
+import { PagePath } from '../metadata/paths';
+import { usePagePath } from '../../fetchers/page-path';
+import { Outlet } from 'react-router-dom';
+
+const TABS: Tab[] = [
+  {
+    title: 'Swap',
+    enabled: true,
+    href: PagePath.SWAP,
+  },
+  {
+    title: 'Auction',
+    enabled: true,
+    href: PagePath.SWAP_AUCTION,
+  },
+];
 
 export const SwapLayout = () => {
+  const pathname = usePagePath<(typeof TABS)[number]['href']>();
+
   return (
     <RestrictMaxWidth>
-      <div className='grid gap-6 md:grid-cols-2 md:gap-4 xl:grid-cols-3 xl:gap-5'>
-        <UnclaimedSwaps />
-        <Card gradient className='order-3 row-span-2 flex-1 p-5 md:order-1 md:p-4 xl:p-5'>
-          <SwapForm />
-        </Card>
-        <EduInfoCard
-          className='row-span-1 md:order-2'
-          src='./swap-icon.svg'
-          label='Shielded Swap'
-          content={EduPanel.SWAP}
-        />
+      <div className='flex justify-center'>
+        <Tabs tabs={TABS} activeTab={pathname} />
       </div>
+
+      <Outlet />
     </RestrictMaxWidth>
   );
 };

--- a/apps/minifront/src/components/swap/layout.tsx
+++ b/apps/minifront/src/components/swap/layout.tsx
@@ -12,7 +12,7 @@ const TABS: Tab[] = [
   },
   {
     title: 'Auction',
-    enabled: true,
+    enabled: false,
     href: PagePath.SWAP_AUCTION,
   },
 ];
@@ -23,7 +23,8 @@ export const SwapLayout = () => {
   return (
     <RestrictMaxWidth>
       <div className='flex justify-center'>
-        <Tabs tabs={TABS} activeTab={pathname} />
+        {/** @todo: Remove this conditional when we launch auctions */}
+        {TABS[1]!.enabled && <Tabs tabs={TABS} activeTab={pathname} />}
       </div>
 
       <Outlet />

--- a/apps/minifront/src/components/swap/swap/asset-out-box.tsx
+++ b/apps/minifront/src/components/swap/swap/asset-out-box.tsx
@@ -1,5 +1,5 @@
-import { useStore } from '../../state';
-import { SimulateSwapResult, swapSelector } from '../../state/swap';
+import { useStore } from '../../../state';
+import { SimulateSwapResult, swapSelector } from '../../../state/swap';
 import {
   Tooltip,
   TooltipContent,
@@ -7,13 +7,13 @@ import {
   TooltipTrigger,
 } from '@penumbra-zone/ui/components/ui/tooltip';
 import { buttonVariants } from '@penumbra-zone/ui/components/ui/button';
-import { AssetSelector } from '../shared/asset-selector';
+import { AssetSelector } from '../../shared/asset-selector';
 import {
   Metadata,
   ValueView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { ValueViewComponent } from '@penumbra-zone/ui/components/ui/tx/view/value';
-import { groupByAsset } from '../../fetchers/balances/by-asset';
+import { groupByAsset } from '../../../fetchers/balances/by-asset';
 import { cn } from '@penumbra-zone/ui/lib/utils';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
@@ -22,6 +22,8 @@ import { formatNumber, isZero } from '@penumbra-zone/types/amount';
 import { getAmount } from '@penumbra-zone/getters/value-view';
 import { WalletIcon } from '@penumbra-zone/ui/components/ui/icons/wallet';
 import { getAssetIdFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import { useLoaderData } from 'react-router-dom';
+import { SwapLoaderResponse } from './swap-loader';
 
 const findMatchingBalance = (
   metadata: Metadata | undefined,
@@ -51,6 +53,7 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
   const { assetIn, assetOut, setAssetOut, simulateSwap, simulateOutLoading, simulateOutResult } =
     useStore(swapSelector);
 
+  const { assets } = useLoaderData() as SwapLoaderResponse;
   const matchingBalance = findMatchingBalance(assetOut, balances);
   const assetInId = getAssetIdFromBalancesResponseOptional(assetIn);
   const filter = assetInId
@@ -72,7 +75,12 @@ export const AssetOutBox = ({ balances }: AssetOutBoxProps) => {
         </div>
         <div className='flex flex-col'>
           <div className='ml-auto w-auto shrink-0'>
-            <AssetSelector value={assetOut} onChange={setAssetOut} filter={filter} />
+            <AssetSelector
+              assets={assets}
+              value={assetOut}
+              onChange={setAssetOut}
+              filter={filter}
+            />
           </div>
           <div className='mt-[6px] flex items-start justify-between'>
             <div />

--- a/apps/minifront/src/components/swap/swap/index.tsx
+++ b/apps/minifront/src/components/swap/swap/index.tsx
@@ -1,0 +1,22 @@
+import { Card } from '@penumbra-zone/ui/components/ui/card';
+import { EduInfoCard } from '../../shared/edu-panels/edu-info-card';
+import { EduPanel } from '../../shared/edu-panels/content';
+import { SwapForm } from './swap-form';
+import { UnclaimedSwaps } from './unclaimed-swaps';
+
+export const Swap = () => {
+  return (
+    <div className='grid gap-6 md:grid-cols-2 md:gap-4 xl:grid-cols-3 xl:gap-5'>
+      <UnclaimedSwaps />
+      <Card gradient className='order-3 row-span-2 flex-1 p-5 md:order-1 md:p-4 xl:p-5'>
+        <SwapForm />
+      </Card>
+      <EduInfoCard
+        className='row-span-1 md:order-2'
+        src='./swap-icon.svg'
+        label='Shielded Swap'
+        content={EduPanel.SWAP}
+      />
+    </div>
+  );
+};

--- a/apps/minifront/src/components/swap/swap/swap-form.tsx
+++ b/apps/minifront/src/components/swap/swap/swap-form.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@penumbra-zone/ui/components/ui/button';
-import InputToken from '../shared/input-token';
+import InputToken from '../../shared/input-token';
 import { useLoaderData } from 'react-router-dom';
-import { useStore } from '../../state';
-import { swapSelector, swapValidationErrors } from '../../state/swap';
+import { useStore } from '../../../state';
+import { swapSelector, swapValidationErrors } from '../../../state/swap';
 import { AssetOutBox } from './asset-out-box';
 import { SwapLoaderResponse } from './swap-loader';
 

--- a/apps/minifront/src/components/swap/swap/unclaimed-swaps.tsx
+++ b/apps/minifront/src/components/swap/swap/unclaimed-swaps.tsx
@@ -3,8 +3,8 @@ import { Card } from '@penumbra-zone/ui/components/ui/card';
 import { useLoaderData, useRevalidator } from 'react-router-dom';
 import { SwapLoaderResponse, UnclaimedSwapsWithMetadata } from './swap-loader';
 import { AssetIcon } from '@penumbra-zone/ui/components/ui/tx/view/asset-icon';
-import { useStore } from '../../state';
-import { unclaimedSwapsSelector } from '../../state/unclaimed-swaps';
+import { useStore } from '../../../state';
+import { unclaimedSwapsSelector } from '../../../state/unclaimed-swaps';
 import { getSwapRecordCommitment } from '@penumbra-zone/getters/swap-record';
 import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
 

--- a/apps/minifront/src/state/dutch-auction/assemble-request.test.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.test.ts
@@ -46,7 +46,7 @@ describe('assembleRequest()', () => {
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
     );
     expect(req.dutchAuctionScheduleActions[0]!.description!.endHeight).toBe(
-      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS.get('10min')!,
+      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS['10min'],
     );
 
     const req2 = await assembleRequest({ ...ARGS, duration: '48h' });
@@ -55,7 +55,7 @@ describe('assembleRequest()', () => {
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
     );
     expect(req2.dutchAuctionScheduleActions[0]!.description!.endHeight).toBe(
-      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS.get('48h')!,
+      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS['48h'],
     );
   });
 

--- a/apps/minifront/src/state/dutch-auction/assemble-request.test.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assembleRequest } from './assemble-request';
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { BLOCKS_PER_MINUTE, DURATION_IN_BLOCKS } from './constants';
+
+const MOCK_START_HEIGHT = vi.hoisted(() => 1234n);
+
+const mockViewClient = vi.hoisted(() => ({
+  status: () => Promise.resolve({ fullSyncHeight: MOCK_START_HEIGHT }),
+}));
+
+vi.mock('../../clients', () => ({
+  viewClient: mockViewClient,
+}));
+
+const metadata = new Metadata({
+  penumbraAssetId: {},
+});
+
+const balancesResponse = new BalancesResponse({
+  balanceView: {
+    valueView: {
+      case: 'knownAssetId',
+      value: {
+        metadata,
+      },
+    },
+  },
+});
+
+const ARGS: Parameters<typeof assembleRequest>[0] = {
+  amount: '123',
+  duration: '10min',
+  minOutput: '1',
+  maxOutput: '1000',
+  assetIn: balancesResponse,
+  assetOut: metadata,
+};
+
+describe('assembleRequest()', () => {
+  it('correctly converts durations to block heights', async () => {
+    const req = await assembleRequest({ ...ARGS, duration: '10min' });
+
+    expect(req.dutchAuctionScheduleActions[0]!.description!.startHeight).toBe(
+      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
+    );
+    expect(req.dutchAuctionScheduleActions[0]!.description!.endHeight).toBe(
+      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS.get('10min')!,
+    );
+
+    const req2 = await assembleRequest({ ...ARGS, duration: '48h' });
+
+    expect(req2.dutchAuctionScheduleActions[0]!.description!.startHeight).toBe(
+      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
+    );
+    expect(req2.dutchAuctionScheduleActions[0]!.description!.endHeight).toBe(
+      MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS.get('48h')!,
+    );
+  });
+});

--- a/apps/minifront/src/state/dutch-auction/assemble-request.test.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.test.ts
@@ -58,4 +58,10 @@ describe('assembleRequest()', () => {
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS.get('48h')!,
     );
   });
+
+  it('uses a step count of 120', async () => {
+    const req = await assembleRequest(ARGS);
+
+    expect(req.dutchAuctionScheduleActions[0]!.description!.stepCount).toBe(120n);
+  });
 });

--- a/apps/minifront/src/state/dutch-auction/assemble-request.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.ts
@@ -32,7 +32,7 @@ export const assembleRequest = async ({
   const { fullSyncHeight } = await viewClient.status({});
 
   const startHeight = getStartHeight(fullSyncHeight);
-  const endHeight = startHeight + DURATION_IN_BLOCKS.get(duration)!;
+  const endHeight = startHeight + DURATION_IN_BLOCKS[duration];
 
   return new TransactionPlannerRequest({
     dutchAuctionScheduleActions: [

--- a/apps/minifront/src/state/dutch-auction/assemble-request.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.ts
@@ -1,7 +1,10 @@
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { BLOCKS_PER_MINUTE, DURATION_IN_BLOCKS, STEP_COUNT } from './constants';
-import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
-import { getAssetId } from '@penumbra-zone/getters/metadata';
+import {
+  getAssetIdFromValueView,
+  getDisplayDenomExponentFromValueView,
+} from '@penumbra-zone/getters/value-view';
+import { getAssetId, getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 import { DutchAuctionSlice } from '.';
 import { viewClient } from '../../clients';
 import { fromString } from '@penumbra-zone/types/amount';
@@ -27,7 +30,9 @@ export const assembleRequest = async ({
 >): Promise<TransactionPlannerRequest> => {
   const assetId = getAssetIdFromValueView(assetIn?.balanceView);
   const outputId = getAssetId(assetOut);
-  const amount = fromString(amountAsString);
+  const assetInExponent = getDisplayDenomExponentFromValueView(assetIn?.balanceView);
+  const assetOutExponent = getDisplayDenomExponent(assetOut);
+  const amount = fromString(amountAsString, assetInExponent);
 
   const { fullSyncHeight } = await viewClient.status({});
 
@@ -46,8 +51,8 @@ export const assembleRequest = async ({
           startHeight,
           endHeight,
           stepCount: STEP_COUNT,
-          minOutput: fromString(minOutput),
-          maxOutput: fromString(maxOutput),
+          minOutput: fromString(minOutput, assetOutExponent),
+          maxOutput: fromString(maxOutput, assetOutExponent),
         },
       },
     ],

--- a/apps/minifront/src/state/dutch-auction/assemble-request.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.ts
@@ -21,7 +21,10 @@ export const assembleRequest = async ({
   minOutput,
   maxOutput,
   duration,
-}: DutchAuctionSlice): Promise<TransactionPlannerRequest> => {
+}: Pick<
+  DutchAuctionSlice,
+  'amount' | 'assetIn' | 'assetOut' | 'minOutput' | 'maxOutput' | 'duration'
+>): Promise<TransactionPlannerRequest> => {
   const assetId = getAssetIdFromValueView(assetIn?.balanceView);
   const outputId = getAssetId(assetOut);
   const amount = fromString(amountAsString);

--- a/apps/minifront/src/state/dutch-auction/assemble-request.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-request.ts
@@ -1,0 +1,52 @@
+import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { BLOCKS_PER_MINUTE, DURATION_IN_BLOCKS, STEP_COUNT } from './constants';
+import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
+import { getAssetId } from '@penumbra-zone/getters/metadata';
+import { DutchAuctionSlice } from '.';
+import { viewClient } from '../../clients';
+import { fromString } from '@penumbra-zone/types/amount';
+
+/**
+ * The start height of an auction must be, at minimum, the current block height.
+ * Since the transaction may take a while to build, and the user may take a
+ * while to approve it, we need to add some buffer time to the start height.
+ * Roughly a minute seems appropriate.
+ */
+const getStartHeight = (fullSyncHeight: bigint) => fullSyncHeight + BLOCKS_PER_MINUTE;
+
+export const assembleRequest = async ({
+  amount: amountAsString,
+  assetIn,
+  assetOut,
+  minOutput,
+  maxOutput,
+  duration,
+}: DutchAuctionSlice): Promise<TransactionPlannerRequest> => {
+  const assetId = getAssetIdFromValueView(assetIn?.balanceView);
+  const outputId = getAssetId(assetOut);
+  const amount = fromString(amountAsString);
+
+  const { fullSyncHeight } = await viewClient.status({});
+
+  const startHeight = getStartHeight(fullSyncHeight);
+  const endHeight = startHeight + DURATION_IN_BLOCKS.get(duration)!;
+
+  return new TransactionPlannerRequest({
+    dutchAuctionScheduleActions: [
+      {
+        description: {
+          input: {
+            amount,
+            assetId,
+          },
+          outputId,
+          startHeight,
+          endHeight,
+          stepCount: STEP_COUNT,
+          minOutput: fromString(minOutput),
+          maxOutput: fromString(maxOutput),
+        },
+      },
+    ],
+  });
+};

--- a/apps/minifront/src/state/dutch-auction/constants.test.ts
+++ b/apps/minifront/src/state/dutch-auction/constants.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { DURATION_IN_BLOCKS, STEP_COUNT } from './constants';
+
+const isCleanlyDivisible = (numerator: bigint, denominator: bigint): boolean =>
+  Number(numerator) % Number(denominator) === 0;
+
+/**
+ * "Why are we testing a constants file?!" Good question!
+ *
+ * Each duration for an auction needs to be cleanly divisible by the step count
+ * so that sub-auctions can be evenly distributed. If an unsuspecting developer
+ * changes some of the constants in `./constants.ts` in the future, there could
+ * be durations that aren't cleanly divisible by the step count. So this test
+ * suite ensures that that case never happens.
+ */
+describe('DURATION_IN_BLOCKS and STEP_COUNT', () => {
+  test('every duration option is cleanly divisible by `STEP_COUNT`', () => {
+    Object.values(DURATION_IN_BLOCKS).forEach(duration => {
+      expect(isCleanlyDivisible(duration, STEP_COUNT)).toBe(true);
+    });
+  });
+});

--- a/apps/minifront/src/state/dutch-auction/constants.ts
+++ b/apps/minifront/src/state/dutch-auction/constants.ts
@@ -14,13 +14,13 @@ const MINUTE_MS = 60_000n;
 export const BLOCKS_PER_MINUTE = MINUTE_MS / APPROX_BLOCK_DURATION_MS;
 const BLOCKS_PER_HOUR = BLOCKS_PER_MINUTE * 60n;
 
-export const DURATION_IN_BLOCKS = new Map<DurationOption, bigint>([
-  ['10min', 10n * BLOCKS_PER_MINUTE],
-  ['30min', 30n * BLOCKS_PER_MINUTE],
-  ['1h', BLOCKS_PER_HOUR],
-  ['2h', 2n * BLOCKS_PER_HOUR],
-  ['6h', 6n * BLOCKS_PER_HOUR],
-  ['12h', 12n * BLOCKS_PER_HOUR],
-  ['24h', 24n * BLOCKS_PER_HOUR],
-  ['48h', 48n * BLOCKS_PER_HOUR],
-]);
+export const DURATION_IN_BLOCKS: Record<DurationOption, bigint> = {
+  '10min': 10n * BLOCKS_PER_MINUTE,
+  '30min': 30n * BLOCKS_PER_MINUTE,
+  '1h': BLOCKS_PER_HOUR,
+  '2h': 2n * BLOCKS_PER_HOUR,
+  '6h': 6n * BLOCKS_PER_HOUR,
+  '12h': 12n * BLOCKS_PER_HOUR,
+  '24h': 24n * BLOCKS_PER_HOUR,
+  '48h': 48n * BLOCKS_PER_HOUR,
+};

--- a/apps/minifront/src/state/dutch-auction/constants.ts
+++ b/apps/minifront/src/state/dutch-auction/constants.ts
@@ -1,0 +1,26 @@
+export const DURATION_OPTIONS = ['10min', '30min', '1h', '2h', '6h', '12h', '24h', '48h'] as const;
+export type DurationOption = (typeof DURATION_OPTIONS)[number];
+
+/**
+ * Blocks are ~5 seconds long (so, 12 blocks/minute), and the minimum duration
+ * for an auction is 10 minutes (so, 120 blocks). All other auction durations
+ * are even multiples of 10 minutes. So we'll set the step count to 120, so that
+ * the sub-auctions can divide evenly into the number of intervening blocks.
+ */
+export const STEP_COUNT = 120n;
+
+const APPROX_BLOCK_DURATION_MS = 5_000n;
+const MINUTE_MS = 60_000n;
+export const BLOCKS_PER_MINUTE = MINUTE_MS / APPROX_BLOCK_DURATION_MS;
+const BLOCKS_PER_HOUR = BLOCKS_PER_MINUTE * 60n;
+
+export const DURATION_IN_BLOCKS = new Map<DurationOption, bigint>([
+  ['10min', 10n * BLOCKS_PER_MINUTE],
+  ['30min', 30n * BLOCKS_PER_MINUTE],
+  ['1h', BLOCKS_PER_HOUR],
+  ['2h', 2n * BLOCKS_PER_HOUR],
+  ['6h', 6n * BLOCKS_PER_HOUR],
+  ['12h', 12n * BLOCKS_PER_HOUR],
+  ['24h', 24n * BLOCKS_PER_HOUR],
+  ['48h', 48n * BLOCKS_PER_HOUR],
+]);

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -1,0 +1,94 @@
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { SliceCreator } from '..';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { planBuildBroadcast } from '../helpers';
+import { assembleRequest } from './assemble-request';
+import { DurationOption } from './constants';
+
+export interface DutchAuctionSlice {
+  balancesResponses: BalancesResponse[];
+  setBalancesResponses: (balancesResponses: BalancesResponse[]) => void;
+  assetIn?: BalancesResponse;
+  setAssetIn: (assetIn: BalancesResponse) => void;
+  assetOut?: Metadata;
+  setAssetOut: (assetOut: Metadata) => void;
+  amount: string;
+  setAmount: (amount: string) => void;
+  duration: DurationOption;
+  setDuration: (duration: DurationOption) => void;
+  minOutput: string;
+  setMinOutput: (minOutput: string) => void;
+  maxOutput: string;
+  setMaxOutput: (maxOutput: string) => void;
+  onSubmit: () => Promise<void>;
+  txInProgress: boolean;
+}
+
+export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (set, get) => ({
+  balancesResponses: [],
+  setBalancesResponses: balancesResponses => {
+    set(state => {
+      state.dutchAuction.balancesResponses = balancesResponses;
+    });
+  },
+
+  assetIn: undefined,
+  setAssetIn: assetIn => {
+    set(state => {
+      state.dutchAuction.assetIn = assetIn;
+    });
+  },
+
+  assetOut: undefined,
+  setAssetOut: assetOut => {
+    set(state => {
+      state.dutchAuction.assetOut = assetOut;
+    });
+  },
+
+  amount: '',
+  setAmount: amount => {
+    set(state => {
+      state.dutchAuction.amount = amount;
+    });
+  },
+
+  duration: '10min',
+  setDuration: duration => {
+    set(state => {
+      state.dutchAuction.duration = duration;
+    });
+  },
+
+  minOutput: '1',
+  setMinOutput: minOutput => {
+    set(state => {
+      state.dutchAuction.minOutput = minOutput;
+    });
+  },
+  maxOutput: '1000',
+  setMaxOutput: maxOutput => {
+    set(state => {
+      state.dutchAuction.maxOutput = maxOutput;
+    });
+  },
+
+  onSubmit: async () => {
+    set(state => {
+      state.dutchAuction.txInProgress = true;
+    });
+
+    try {
+      const req = await assembleRequest(get().dutchAuction);
+      await planBuildBroadcast('dutchAuctionSchedule', req);
+
+      get().dutchAuction.setAmount('');
+    } finally {
+      set(state => {
+        state.dutchAuction.txInProgress = false;
+      });
+    }
+  },
+
+  txInProgress: false,
+});

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -1,6 +1,7 @@
 import { create, StateCreator } from 'zustand';
 import { enableMapSet } from 'immer';
 import { immer } from 'zustand/middleware/immer';
+import { createDutchAuctionSlice, DutchAuctionSlice } from './dutch-auction';
 import { createSwapSlice, SwapSlice } from './swap';
 import { createIbcOutSlice, IbcOutSlice } from './ibc-out';
 import { createSendSlice, SendSlice } from './send';
@@ -19,6 +20,7 @@ enableMapSet();
 export interface AllSlices {
   ibcIn: IbcInSlice;
   ibcOut: IbcOutSlice;
+  dutchAuction: DutchAuctionSlice;
   send: SendSlice;
   staking: StakingSlice;
   swap: SwapSlice;
@@ -37,6 +39,7 @@ export const initializeStore = () => {
   return immer((setState, getState: () => AllSlices, store) => ({
     ibcIn: createIbcInSlice()(setState, getState, store),
     ibcOut: createIbcOutSlice()(setState, getState, store),
+    dutchAuction: createDutchAuctionSlice()(setState, getState, store),
     send: createSendSlice()(setState, getState, store),
     staking: createStakingSlice()(setState, getState, store),
     swap: createSwapSlice()(setState, getState, store),

--- a/packages/constants/src/assets.test.ts
+++ b/packages/constants/src/assets.test.ts
@@ -2,7 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { assetPatterns, RegexMatcher } from './assets';
 
 describe('assetPatterns', () => {
-  describe('lpNftPattern', () => {
+  describe('auctionNft', () => {
+    it('matches when a string is a valid auction NFT', () => {
+      expect(assetPatterns.auctionNft.matches('auctionnft_0_pauctid1abc123')).toBe(true);
+    });
+
+    it('matches when a string contains, but does not begin with, a valid auction NFT', () => {
+      expect(
+        assetPatterns.auctionNft.matches('ibc-transfer/channel-1234/auctionnft_0_pauctid1abc123'),
+      ).toBe(false);
+    });
+
+    it('captures the capture groups correctly', () => {
+      const result = assetPatterns.auctionNft.capture('auctionnft_0_pauctid1abc123');
+      expect(result).toEqual({ auctionId: 'pauctid1abc123', seqNum: '0' });
+    });
+  });
+
+  describe('lpNft', () => {
     it('matches when a string begins with `lpnft_`', () => {
       expect(assetPatterns.lpNft.matches('lpnft_abc123')).toBe(true);
     });
@@ -12,7 +29,7 @@ describe('assetPatterns', () => {
     });
   });
 
-  describe('delegationTokenPattern', () => {
+  describe('delegationToken', () => {
     it('matches when a string is a valid delegation token name', () => {
       expect(assetPatterns.delegationToken.matches('delegation_penumbravalid1abc123')).toBe(true);
     });
@@ -26,7 +43,7 @@ describe('assetPatterns', () => {
     });
   });
 
-  describe('proposalNftPattern', () => {
+  describe('proposalNft', () => {
     it('matches when a string begins with `proposal_`', () => {
       expect(assetPatterns.proposalNft.matches('proposal_abc123')).toBe(true);
     });
@@ -38,7 +55,7 @@ describe('assetPatterns', () => {
     });
   });
 
-  describe('unbondingTokenPattern', () => {
+  describe('unbondingToken', () => {
     it('matches when a string is a valid unbonding token name', () => {
       expect(
         assetPatterns.unbondingToken.matches('unbonding_start_at_1_penumbravalid1abc123'),
@@ -61,7 +78,7 @@ describe('assetPatterns', () => {
     });
   });
 
-  describe('votingReceiptPattern', () => {
+  describe('votingReceipt', () => {
     it('matches when a string begins with `voted_on_`', () => {
       expect(assetPatterns.votingReceipt.matches('voted_on_abc123')).toBe(true);
     });

--- a/packages/constants/src/assets.test.ts
+++ b/packages/constants/src/assets.test.ts
@@ -7,7 +7,7 @@ describe('assetPatterns', () => {
       expect(assetPatterns.auctionNft.matches('auctionnft_0_pauctid1abc123')).toBe(true);
     });
 
-    it('matches when a string contains, but does not begin with, a valid auction NFT', () => {
+    it('does not match when a string contains, but does not begin with, a valid auction NFT', () => {
       expect(
         assetPatterns.auctionNft.matches('ibc-transfer/channel-1234/auctionnft_0_pauctid1abc123'),
       ).toBe(false);

--- a/packages/constants/src/assets.ts
+++ b/packages/constants/src/assets.ts
@@ -5,6 +5,11 @@ export const PRICE_RELEVANCE_THRESHOLDS = {
   default: 200,
 };
 
+export interface AuctionNftCaptureGroups {
+  seqNum: string;
+  auctionId: string;
+}
+
 export interface IbcCaptureGroups {
   channel: string;
   denom: string;
@@ -22,6 +27,7 @@ export interface UnbondingCaptureGroups {
 }
 
 export interface AssetPatterns {
+  auctionNft: RegexMatcher<AuctionNftCaptureGroups>;
   lpNft: RegexMatcher;
   delegationToken: RegexMatcher<DelegationCaptureGroups>;
   proposalNft: RegexMatcher;
@@ -62,6 +68,9 @@ export class RegexMatcher<T = never> {
  * https://github.com/penumbra-zone/penumbra/blob/main/crates/core/asset/src/asset/registry.rs
  */
 export const assetPatterns: AssetPatterns = {
+  auctionNft: new RegexMatcher(
+    /^auctionnft_(?<seqNum>[0-9]+)_(?<auctionId>pauctid1[a-zA-HJ-NP-Z0-9]+)$/,
+  ),
   lpNft: new RegexMatcher(/^lpnft_/),
   delegationToken: new RegexMatcher(
     /^delegation_(?<idKey>penumbravalid1(?<id>[a-zA-HJ-NP-Z0-9]+))$/,

--- a/packages/perspective/plan/view-action-plan.ts
+++ b/packages/perspective/plan/view-action-plan.ts
@@ -250,6 +250,13 @@ export const viewActionPlan =
           },
         });
 
+      case 'actionDutchAuctionSchedule':
+      case 'actionDutchAuctionEnd':
+      case 'actionDutchAuctionWithdraw':
+        return new ActionView({
+          actionView: actionPlan.action,
+        });
+
       case undefined:
         throw new Error('No action case in action plan');
       default:

--- a/packages/perspective/transaction/classification.ts
+++ b/packages/perspective/transaction/classification.ts
@@ -20,4 +20,6 @@ export type TransactionClassification =
   /** The transaction contains an `undelegateClaim` action. */
   | 'undelegateClaim'
   /** The transaction contains an `ics20Withdrawal` action. */
-  | 'ics20Withdrawal';
+  | 'ics20Withdrawal'
+  /** The transaction contains an `actionDutchAuctionSchedule` action. */
+  | 'dutchAuctionSchedule';

--- a/packages/perspective/transaction/classify.test.ts
+++ b/packages/perspective/transaction/classify.test.ts
@@ -317,6 +317,35 @@ describe('classifyTransaction()', () => {
     expect(classifyTransaction(transactionView)).toBe('undelegateClaim');
   });
 
+  it('returns `dutchAuctionSchedule` for transactions with an `actionDutchAuctionSchedule` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [
+          {
+            actionView: {
+              case: 'actionDutchAuctionSchedule',
+              value: {},
+            },
+          },
+          {
+            actionView: {
+              case: 'spend',
+              value: {},
+            },
+          },
+          {
+            actionView: {
+              case: 'output',
+              value: {},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('dutchAuctionSchedule');
+  });
+
   it("returns `unknown` for transactions that don't fit the above categories", () => {
     const transactionView = new TransactionView({
       bodyView: {

--- a/packages/perspective/transaction/classify.ts
+++ b/packages/perspective/transaction/classify.ts
@@ -7,14 +7,15 @@ export const classifyTransaction = (txv?: TransactionView): TransactionClassific
     return 'unknown';
   }
 
-  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'swap')) return 'swap';
-  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'swapClaim')) return 'swapClaim';
-  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'delegate')) return 'delegate';
-  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'undelegate')) return 'undelegate';
-  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'undelegateClaim'))
-    return 'undelegateClaim';
-  if (txv.bodyView?.actionViews.some(a => a.actionView.case === 'ics20Withdrawal'))
-    return 'ics20Withdrawal';
+  const allActionCases = new Set(txv.bodyView?.actionViews.map(a => a.actionView.case));
+
+  if (allActionCases.has('swap')) return 'swap';
+  if (allActionCases.has('swapClaim')) return 'swapClaim';
+  if (allActionCases.has('delegate')) return 'delegate';
+  if (allActionCases.has('undelegate')) return 'undelegate';
+  if (allActionCases.has('undelegateClaim')) return 'undelegateClaim';
+  if (allActionCases.has('ics20Withdrawal')) return 'ics20Withdrawal';
+  if (allActionCases.has('actionDutchAuctionSchedule')) return 'dutchAuctionSchedule';
 
   const hasOpaqueSpend = txv.bodyView?.actionViews.some(
     a => a.actionView.case === 'spend' && a.actionView.value.spendView.case === 'opaque',
@@ -88,6 +89,7 @@ export const TRANSACTION_LABEL_BY_CLASSIFICATION: Record<TransactionClassificati
   undelegate: 'Undelegate',
   undelegateClaim: 'Undelegate Claim',
   ics20Withdrawal: 'Ics20 Withdrawal',
+  dutchAuctionSchedule: 'Dutch Auction Schedule',
 };
 
 export const getTransactionClassificationLabel = (txv?: TransactionView): string =>

--- a/packages/types/src/amount.test.ts
+++ b/packages/types/src/amount.test.ts
@@ -4,6 +4,7 @@ import {
   divideAmounts,
   formatNumber,
   fromBaseUnitAmount,
+  fromString,
   fromValueView,
   isZero,
   joinLoHiAmount,
@@ -251,5 +252,14 @@ describe('formatNumber', () => {
 
   it('formats negative number correctly', () => {
     expect(formatNumber(-123.456, { precision: 2 })).toBe('-123.46');
+  });
+});
+
+describe('fromString', () => {
+  it('converts a string to an amount', () => {
+    const result = fromString('123456');
+    const expected = new Amount({ hi: 0n, lo: 123456n });
+
+    expect(result.equals(expected)).toBe(true);
   });
 });

--- a/packages/types/src/amount.test.ts
+++ b/packages/types/src/amount.test.ts
@@ -262,4 +262,11 @@ describe('fromString', () => {
 
     expect(result.equals(expected)).toBe(true);
   });
+
+  it('handles an exponent', () => {
+    const result = fromString('123.456', 3);
+    const expected = new Amount({ hi: 0n, lo: 123456n });
+
+    expect(result.equals(expected)).toBe(true);
+  });
 });

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -1,5 +1,5 @@
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
-import { fromBaseUnit, joinLoHi, splitLoHi } from './lo-hi';
+import { fromBaseUnit, joinLoHi, splitLoHi, toBaseUnit } from './lo-hi';
 import { BigNumber } from 'bignumber.js';
 import { ValueView_KnownAssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
@@ -23,7 +23,8 @@ export const fromValueView = ({ amount, metadata }: ValueView_KnownAssetId): Big
   return fromBaseUnitAmount(amount, getDisplayDenomExponent(metadata));
 };
 
-export const fromString = (amount: string): Amount => new Amount(splitLoHi(BigInt(amount)));
+export const fromString = (amount: string, exponent = 0): Amount =>
+  new Amount(toBaseUnit(BigNumber(amount), exponent));
 
 export const addAmounts = (a: Amount, b: Amount): Amount => {
   const joined = joinLoHiAmount(a) + joinLoHiAmount(b);

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -23,6 +23,8 @@ export const fromValueView = ({ amount, metadata }: ValueView_KnownAssetId): Big
   return fromBaseUnitAmount(amount, getDisplayDenomExponent(metadata));
 };
 
+export const fromString = (amount: string): Amount => new Amount(splitLoHi(BigInt(amount)));
+
 export const addAmounts = (a: Amount, b: Amount): Amount => {
   const joined = joinLoHiAmount(a) + joinLoHiAmount(b);
   const { lo, hi } = splitLoHi(joined);

--- a/packages/ui/components/ui/slider.tsx
+++ b/packages/ui/components/ui/slider.tsx
@@ -2,10 +2,30 @@
 
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
+/**
+ * Renders a draggable range slider:
+ * |---o-------------|
+ *
+ * @example
+ * ```tsx
+ * <Slider
+ *   min={0}
+ *   max={10}
+ *   step={2}
+ *   value={value}
+ *   onValueChange={onValueChange}
+ * />
+ * ```
+ */
 const Slider = (props: {
   min?: number;
   max?: number;
+  /** The step size to count by */
   step?: number;
+  /**
+   * Note that this is an array. You can pass more than one value to have
+   * multiple draggable points on the slider.
+   */
   value: number[];
   onValueChange: (value: number[]) => void;
 }) => (

--- a/packages/ui/components/ui/slider.tsx
+++ b/packages/ui/components/ui/slider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import * as SliderPrimitive from '@radix-ui/react-slider';
+
+const Slider = (props: {
+  min?: number;
+  max?: number;
+  step?: number;
+  value: number[];
+  onValueChange: (value: number[]) => void;
+}) => (
+  <SliderPrimitive.Root
+    className={'relative flex w-full touch-none select-none items-center'}
+    {...props}
+  >
+    <SliderPrimitive.Track className='relative h-2 w-full grow overflow-hidden rounded-full bg-secondary'>
+      <SliderPrimitive.Range className='absolute h-full bg-secondary' />
+    </SliderPrimitive.Track>
+    {Array(props.value.length)
+      .fill(null)
+      .map((_, index) => (
+        <SliderPrimitive.Thumb
+          key={index}
+          className='block size-5 rounded-full border-2 border-secondary bg-background ring-offset-background transition-colors focus-visible:border-white focus-visible:outline-none focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'
+        />
+      ))}
+  </SliderPrimitive.Root>
+);
+
+export { Slider };

--- a/packages/ui/components/ui/tx/view/action-dutch-auction-schedule.tsx
+++ b/packages/ui/components/ui/tx/view/action-dutch-auction-schedule.tsx
@@ -40,13 +40,13 @@ export const ActionDutchAuctionScheduleComponent = ({
           </ActionDetails.Row>
 
           <ActionDetails.Row label='Output'>
-            <div className='flex flex-col items-center gap-2 sm:flex-row'>
+            <div className='flex flex-col items-end gap-2 sm:flex-row'>
               <div className='flex items-center gap-2'>
-                <span className='text-muted-foreground'>Max:</span>
+                <span className='text-nowrap text-muted-foreground'>Max:</span>
                 <ValueViewComponent view={maxOutput} />
               </div>
               <div className='flex items-center gap-2'>
-                <span className='text-muted-foreground'>Min:</span>
+                <span className='text-nowrap text-muted-foreground'>Min:</span>
                 <ValueViewComponent view={minOutput} />
               </div>
             </div>

--- a/packages/ui/components/ui/tx/view/action-dutch-auction-schedule.tsx
+++ b/packages/ui/components/ui/tx/view/action-dutch-auction-schedule.tsx
@@ -1,0 +1,63 @@
+import { ActionDutchAuctionSchedule } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { ViewBox } from './viewbox';
+import { ActionDetails } from './action-details';
+import {
+  AssetId,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { ValueViewComponent } from './value';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+
+const getValueView = (amount?: Amount, assetId?: AssetId) =>
+  new ValueView({
+    valueView: {
+      case: 'knownAssetId',
+      value: {
+        amount,
+        metadata: {
+          penumbraAssetId: assetId,
+        },
+      },
+    },
+  });
+
+export const ActionDutchAuctionScheduleComponent = ({
+  value,
+}: {
+  value: ActionDutchAuctionSchedule;
+}) => {
+  const input = getValueView(value.description?.input?.amount, value.description?.input?.assetId);
+  const maxOutput = getValueView(value.description?.maxOutput, value.description?.outputId);
+  const minOutput = getValueView(value.description?.minOutput, value.description?.outputId);
+
+  return (
+    <ViewBox
+      label='Schedule a Dutch Auction'
+      visibleContent={
+        <ActionDetails>
+          <ActionDetails.Row label='Input'>
+            <ValueViewComponent view={input} />
+          </ActionDetails.Row>
+
+          <ActionDetails.Row label='Output'>
+            <div className='flex flex-col items-center gap-2 sm:flex-row'>
+              <div className='flex items-center gap-2'>
+                <span className='text-muted-foreground'>Max:</span>
+                <ValueViewComponent view={maxOutput} />
+              </div>
+              <div className='flex items-center gap-2'>
+                <span className='text-muted-foreground'>Min:</span>
+                <ValueViewComponent view={minOutput} />
+              </div>
+            </div>
+          </ActionDetails.Row>
+
+          <ActionDetails.Row label='Duration'>
+            Height {value.description?.startHeight.toString()} to{' '}
+            {value.description?.endHeight.toString()}
+          </ActionDetails.Row>
+        </ActionDetails>
+      }
+    />
+  );
+};

--- a/packages/ui/components/ui/tx/view/action-view.tsx
+++ b/packages/ui/components/ui/tx/view/action-view.tsx
@@ -8,6 +8,7 @@ import { UndelegateClaimComponent } from './undelegate-claim';
 import { Ics20WithdrawalComponent } from './isc20-withdrawal';
 import { UnimplementedView } from './unimplemented-view';
 import { SwapViewComponent } from './swap';
+import { ActionDutchAuctionScheduleComponent } from './action-dutch-auction-schedule';
 
 const CASE_TO_LABEL: Record<string, string> = {
   daoDeposit: 'DAO Deposit',
@@ -66,6 +67,9 @@ export const ActionViewComponent = ({ av: { actionView } }: { av: ActionView }) 
 
     case 'undelegateClaim':
       return <UndelegateClaimComponent value={actionView.value} />;
+
+    case 'actionDutchAuctionSchedule':
+      return <ActionDutchAuctionScheduleComponent value={actionView.value} />;
 
     case 'validatorDefinition':
       return <UnimplementedView label='Validator Definition' />;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-progress": "^1.0.3",
     "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.0.0
         version: 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slider':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.0.2
         version: 1.0.2(@types/react@18.3.1)(react@18.3.1)
@@ -7192,6 +7195,37 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.5.5(@types/react@18.3.1)(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-slider@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-NKs15MJylfzVsCagVSWKhGGLNR1W9qWs+HtgbmjjVUB3B9+lb3PYoXxVju3kOrpf0VKyVCtZp+iTwVoqpa1Chw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /@radix-ui/react-slot@1.0.0(react@18.3.1):


### PR DESCRIPTION
https://github.com/penumbra-zone/web/assets/1121544/5b369620-657f-4dd6-b46d-b66aafbf146f



- Create a form and state slice for creating Dutch auctions
- Create a new `<ActionDutchAuctionScheduleComponent />` to represent the action of scheduling a Dutch auction. It appears in both the transaction approval dialog and in the transaction view for a transaction containing a Dutch Auction Schedule action.
- Create a new `<Slider />` component that allows users to use a slider to choose a value from a numeric range.
- Extract a `<Swap />` component; it's now a router sibling of `<DutchAuction />`
- Rename `active` to `enabled` in the `Tab` interface, so as to differentiate from when `active` means that a tab is _selected_.

## Coming in future PRs
- UI for ending auction(s)
- UI for withdrawing from auctions
- UI for viewing auctions

Closes #944
Closes #978