### PR TITLE
wasm clean script, all-check clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "penumbra-zone/web.git",
   "packageManager": "pnpm@8.6.11",
   "scripts": {
-    "all-check": "pnpm install && pnpm compile && pnpm format-check && pnpm lint && pnpm test && pnpm build && pnpm format-check:rust && pnpm lint:rust && pnpm test:rust",
+    "all-check": "pnpm clean && pnpm install && pnpm compile && pnpm format-check && pnpm lint && pnpm test && pnpm build && pnpm format-check:rust && pnpm lint:rust && pnpm test:rust",
     "build": "turbo run build",
     "changeset": "changeset",
     "changeset:publish": "changeset publish",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "scripts": {
-    "clean": "rm -rfv dist wasm ; cargo clean --manifest-path ./crate/Cargo.toml",
+    "clean": "rm -rfv wasm/*.{js,ts,wasm} ; cargo clean --manifest-path ./crate/Cargo.toml",
     "compile": "cd crate ; wasm-pack build --no-pack --target bundler --out-name index --out-dir ../wasm",
     "dev": "cargo watch -C ./crate --postpone -- pnpm turbo run compile",
     "lint": "eslint \"src/*.ts*\"",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -4,7 +4,8 @@
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "scripts": {
-    "clean": "rm -rfv wasm/*.{js,ts,wasm} ; cargo clean --manifest-path ./crate/Cargo.toml",
+    "clean": "rm -v wasm/index*",
+    "clean:rust": "cargo clean --manifest-path ./crate/Cargo.toml",
     "compile": "cd crate ; wasm-pack build --no-pack --target bundler --out-name index --out-dir ../wasm",
     "dev": "cargo watch -C ./crate --postpone -- pnpm turbo run compile",
     "lint": "eslint \"src/*.ts*\"",


### PR DESCRIPTION
correcting the clean script in wasm pkg to maintain the `.npmignore` file which should not be deleted

moved the existing `cargo clean` part to its own script `clean:rust` which must be called more deliberately. i think this is better because `cargo clean` is a bit more destructive than our other clean scripts, as it removes things like downloaded dependencies and dependency build outputs - so avoiding a `cargo clean` greatly accelerates recompile.

and now that clean doesn't force a full recompile, i also added clean to all-check which is nice for wiping those annoying mjs temp files