### PR TITLE
Don't break account label

### DIFF
--- a/packages/ui/components/ui/tx/view/address-view.tsx
+++ b/packages/ui/components/ui/tx/view/address-view.tsx
@@ -32,7 +32,7 @@ export const AddressViewComponent = ({ view, copyable = true }: AddressViewProps
       {accountIndex !== undefined ? (
         <>
           <AddressIcon address={view.addressView.value.address} size={14} />
-          <span className='font-bold'>
+          <span className='font-bold break-keep'>
             {addressIndexLabel}
             {accountIndex}
           </span>


### PR DESCRIPTION
## Before
<img width="315" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/9f663e12-0c03-4869-b749-9e16558b0f3b">


## After 
<img width="327" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/40ee47be-2a82-4195-bafd-9bc30a0dd1bc">

Looks like #885 was mostly outdated, but I at least fixed this issue.

Closes #885