### PR TITLE
don't block services init on storage key presence

### DIFF
--- a/apps/extension/src/ctx/full-viewing-key.ts
+++ b/apps/extension/src/ctx/full-viewing-key.ts
@@ -1,0 +1,10 @@
+import { FullViewingKey } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { localExtStorage } from '@penumbra-zone/storage/chrome/local';
+
+export const getFullViewingKey = async () => {
+  const wallet0 = (await localExtStorage.get('wallets'))[0];
+  if (!wallet0) throw new ConnectError('No wallet available', Code.FailedPrecondition);
+
+  return FullViewingKey.fromJsonString(wallet0.fullViewingKey);
+};

--- a/apps/extension/src/get-rpc-impls.ts
+++ b/apps/extension/src/get-rpc-impls.ts
@@ -23,14 +23,12 @@ import { sctImpl } from '@penumbra-zone/services/sct-service';
 import { stakingImpl } from '@penumbra-zone/services/staking-service';
 import { viewImpl } from '@penumbra-zone/services/view-service';
 
-import { localExtStorage } from '@penumbra-zone/storage/chrome/local';
 import { ServiceType } from '@bufbuild/protobuf';
 
-export const getRpcImpls = async () => {
-  const grpcEndpoint = await localExtStorage.get('grpcEndpoint');
-  if (!grpcEndpoint) throw new Error('gRPC endpoint not set yet');
+type RpcImplTuple<T extends ServiceType> = [T, Partial<ServiceImpl<T>>];
 
-  type RpcImplTuple<T extends ServiceType> = [T, Partial<ServiceImpl<T>>];
+export const getRpcImpls = (baseUrl: string) => {
+  const webTransport = createGrpcWebTransport({ baseUrl });
 
   const penumbraProxies: RpcImplTuple<ServiceType>[] = [
     AppService,
@@ -49,7 +47,7 @@ export const getRpcImpls = async () => {
         serviceType,
         createProxyImpl(
           serviceType,
-          createPromiseClient(serviceType, createGrpcWebTransport({ baseUrl: grpcEndpoint })),
+          createPromiseClient(serviceType, webTransport),
           noContextHandler,
         ),
       ] as const,

--- a/apps/extension/src/storage/onboard.ts
+++ b/apps/extension/src/storage/onboard.ts
@@ -1,0 +1,50 @@
+import { localExtStorage } from '@penumbra-zone/storage/chrome/local';
+import { WalletJson } from '@penumbra-zone/types/wallet';
+
+/**
+ * When a user first onboards with the extension, they won't have chosen a gRPC
+ * endpoint yet. So we'll wait until they've chosen one to start trying to make
+ * requests against it.
+ */
+export const onboardGrpcEndpoint = async (): Promise<string> => {
+  const grpcEndpoint = await localExtStorage.get('grpcEndpoint');
+  if (grpcEndpoint) return grpcEndpoint;
+
+  return new Promise(resolve => {
+    const storageListener = (changes: Record<string, { newValue?: unknown }>) => {
+      const newValue = changes['grpcEndpoint']?.newValue;
+      if (newValue && typeof newValue === 'string') {
+        resolve(newValue);
+        localExtStorage.removeListener(storageListener);
+      }
+    };
+    localExtStorage.addListener(storageListener);
+  });
+};
+
+export const onboardWallet = async (): Promise<WalletJson> => {
+  const wallets = await localExtStorage.get('wallets');
+  if (wallets[0]) return wallets[0];
+
+  return new Promise(resolve => {
+    const storageListener = (changes: Record<string, { newValue?: unknown }>) => {
+      const newValue: unknown = changes['wallets']?.newValue;
+      if (Array.isArray(newValue) && newValue[0]) {
+        resolve(newValue[0] as WalletJson);
+        localExtStorage.removeListener(storageListener);
+      }
+    };
+    localExtStorage.addListener(storageListener);
+  });
+};
+
+/**
+ This fixes an issue where some users do not have 'grpcEndpoint' set after they have finished onboarding
+ */
+export const fixEmptyGrpcEndpointAfterOnboarding = async () => {
+  //TODO change to mainnet default RPC
+  const DEFAULT_GRPC_URL = 'https://grpc.testnet.penumbra.zone';
+  const grpcEndpoint = await localExtStorage.get('grpcEndpoint');
+  const wallets = await localExtStorage.get('wallets');
+  if (!grpcEndpoint && wallets[0]) await localExtStorage.set('grpcEndpoint', DEFAULT_GRPC_URL);
+};

--- a/packages/services/src/ctx/custody-client.ts
+++ b/packages/services/src/ctx/custody-client.ts
@@ -1,5 +1,5 @@
 import { ContextKey, createContextKey, PromiseClient } from '@connectrpc/connect';
 import type { CustodyService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/custody/v1/custody_connect';
 
-export const custodyCtx: ContextKey<PromiseClient<typeof CustodyService> | undefined> =
+export const custodyClientCtx: ContextKey<PromiseClient<typeof CustodyService> | undefined> =
   createContextKey(undefined);

--- a/packages/services/src/ctx/full-viewing-key.ts
+++ b/packages/services/src/ctx/full-viewing-key.ts
@@ -1,4 +1,6 @@
-import { createContextKey } from '@connectrpc/connect';
+import { Code, ConnectError, createContextKey } from '@connectrpc/connect';
 import { FullViewingKey } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 
-export const fvkCtx = createContextKey<FullViewingKey | undefined>(undefined);
+export const fvkCtx = createContextKey<() => Promise<FullViewingKey>>(() =>
+  Promise.reject(new ConnectError('No full viewing key available', Code.FailedPrecondition)),
+);

--- a/packages/services/src/ctx/prax.ts
+++ b/packages/services/src/ctx/prax.ts
@@ -3,11 +3,13 @@
  *  portable service implementations, should eventually be refactored.
  */
 
-import { createContextKey } from '@connectrpc/connect';
+import { Code, ConnectError, createContextKey } from '@connectrpc/connect';
 import { localExtStorage } from '@penumbra-zone/storage/chrome/local';
 import { sessionExtStorage } from '@penumbra-zone/storage/chrome/session';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
-export const servicesCtx = createContextKey<ServicesInterface>({} as ServicesInterface);
+export const servicesCtx = createContextKey<() => Promise<ServicesInterface>>(() =>
+  Promise.reject(new ConnectError('No prax services interface available', Code.FailedPrecondition)),
+);
 export const extLocalCtx = createContextKey(localExtStorage);
 export const extSessionCtx = createContextKey(sessionExtStorage);

--- a/packages/services/src/custody-service/authorize/index.test.ts
+++ b/packages/services/src/custody-service/authorize/index.test.ts
@@ -99,8 +99,8 @@ describe('Authorize request handler', () => {
         .set(extLocalCtx, mockExtLocalCtx as unknown)
         .set(approverCtx, mockApproverCtx as unknown)
         .set(extSessionCtx, mockExtSessionCtx as unknown)
-        .set(servicesCtx, mockServices as unknown as ServicesInterface)
-        .set(fvkCtx, testFullViewingKey),
+        .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
+        .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
 
     for (const record of testAssetsMetadata) {

--- a/packages/services/src/sct-service/epoch-by-height.test.ts
+++ b/packages/services/src/sct-service/epoch-by-height.test.ts
@@ -32,9 +32,8 @@ describe('EpochByHeight request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/sct-service/epoch-by-height.ts
+++ b/packages/services/src/sct-service/epoch-by-height.ts
@@ -5,7 +5,7 @@ import { servicesCtx } from '../ctx/prax';
 export const epochByHeight: Impl['epochByHeight'] = async (req, ctx) => {
   const { height } = req;
 
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   const epoch = await indexedDb.getEpochByHeight(height);

--- a/packages/services/src/staking-service/validator-info.test.ts
+++ b/packages/services/src/staking-service/validator-info.test.ts
@@ -58,9 +58,8 @@ describe('ValidatorInfo request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/staking-service/validator-info.ts
+++ b/packages/services/src/staking-service/validator-info.ts
@@ -7,7 +7,7 @@ import {
 import { getStateEnumFromValidatorInfo } from '@penumbra-zone/getters/validator-info';
 
 export const validatorInfo: Impl['validatorInfo'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   for await (const validatorInfo of indexedDb.iterateValidatorInfos()) {

--- a/packages/services/src/staking-service/validator-penalty.test.ts
+++ b/packages/services/src/staking-service/validator-penalty.test.ts
@@ -35,9 +35,8 @@ describe('ValidatorPenalty request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/staking-service/validator-penalty.ts
+++ b/packages/services/src/staking-service/validator-penalty.ts
@@ -2,6 +2,6 @@ import { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const validatorPenalty: Impl['validatorPenalty'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   return services.querier.staking.validatorPenalty(req);
 };

--- a/packages/services/src/view-service/address-by-index.test.ts
+++ b/packages/services/src/view-service/address-by-index.test.ts
@@ -20,7 +20,7 @@ describe('AddressByIndex request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(fvkCtx, testFullViewingKey),
+      contextValues: createContextValues().set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
   });
 

--- a/packages/services/src/view-service/address-by-index.ts
+++ b/packages/services/src/view-service/address-by-index.ts
@@ -2,14 +2,9 @@ import type { Impl } from '.';
 
 import { getAddressByIndex } from '@penumbra-zone/wasm/keys';
 import { fvkCtx } from '../ctx/full-viewing-key';
-import { Code, ConnectError } from '@connectrpc/connect';
 
-export const addressByIndex: Impl['addressByIndex'] = (req, ctx) => {
-  const fullViewingKey = ctx.values.get(fvkCtx);
-  if (!fullViewingKey) {
-    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
-  }
-  const address = getAddressByIndex(fullViewingKey, req.addressIndex?.account ?? 0);
-
+export const addressByIndex: Impl['addressByIndex'] = async (req, ctx) => {
+  const fvk = ctx.values.get(fvkCtx);
+  const address = getAddressByIndex(await fvk(), req.addressIndex?.account ?? 0);
   return { address };
 };

--- a/packages/services/src/view-service/app-parameters.test.ts
+++ b/packages/services/src/view-service/app-parameters.test.ts
@@ -46,9 +46,8 @@ describe('AppParameters request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/view-service/app-parameters.ts
+++ b/packages/services/src/view-service/app-parameters.ts
@@ -3,7 +3,7 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const appParameters: Impl['appParameters'] = async (_, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   const subscription = indexedDb.subscribe('APP_PARAMETERS');

--- a/packages/services/src/view-service/asset-metadata-by-id.test.ts
+++ b/packages/services/src/view-service/asset-metadata-by-id.test.ts
@@ -47,9 +47,8 @@ describe('AssetMetadataById request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/asset-metadata-by-id.ts
+++ b/packages/services/src/view-service/asset-metadata-by-id.ts
@@ -9,7 +9,7 @@ export const assetMetadataById: Impl['assetMetadataById'] = async ({ assetId }, 
       'Either `inner`, `altBaseDenom`, or `altBech32m` must be set on the asset ID passed in the `assetMetadataById` request',
     );
 
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb, querier } = await services.getWalletServices();
 
   const localMetadata = await indexedDb.getAssetsMetadata(assetId);

--- a/packages/services/src/view-service/assets.test.ts
+++ b/packages/services/src/view-service/assets.test.ts
@@ -43,9 +43,8 @@ describe('Assets request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/assets.ts
+++ b/packages/services/src/view-service/assets.ts
@@ -3,7 +3,7 @@ import { servicesCtx } from '../ctx/prax';
 import { assetPatterns, RegexMatcher } from '@penumbra-zone/constants/assets';
 
 export const assets: Impl['assets'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   const {

--- a/packages/services/src/view-service/authorize-and-build.ts
+++ b/packages/services/src/view-service/authorize-and-build.ts
@@ -10,14 +10,11 @@ export const authorizeAndBuild: Impl['authorizeAndBuild'] = async function* (
   { transactionPlan },
   ctx,
 ) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   if (!transactionPlan) throw new ConnectError('No tx plan in request', Code.InvalidArgument);
 
   const { indexedDb } = await services.getWalletServices();
-  const fullViewingKey = ctx.values.get(fvkCtx);
-  if (!fullViewingKey) {
-    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
-  }
+  const fvk = ctx.values.get(fvkCtx);
 
   const sct = await indexedDb.getStateCommitmentTree();
   const witnessData = getWitness(transactionPlan, sct);
@@ -26,6 +23,6 @@ export const authorizeAndBuild: Impl['authorizeAndBuild'] = async function* (
     transactionPlan,
     witnessData,
     custodyAuthorize(ctx, transactionPlan),
-    fullViewingKey,
+    await fvk(),
   );
 };

--- a/packages/services/src/view-service/balances.test.ts
+++ b/packages/services/src/view-service/balances.test.ts
@@ -92,8 +92,8 @@ describe('Balances request handler', () => {
       requestMethod: 'MOCK',
       url: '/mock',
       contextValues: createContextValues()
-        .set(servicesCtx, mockServices as unknown as ServicesInterface)
-        .set(fvkCtx, testFullViewingKey),
+        .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
+        .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
 
     for (const record of testData) {

--- a/packages/services/src/view-service/balances.ts
+++ b/packages/services/src/view-service/balances.ts
@@ -33,7 +33,7 @@ import { Stringified } from '@penumbra-zone/types/jsonified';
 
 // Handles aggregating amounts and filtering by account number/asset id
 export const balances: Impl['balances'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb, querier } = await services.getWalletServices();
 
   // latestBlockHeight is needed to calculate the threshold of price relevance,

--- a/packages/services/src/view-service/broadcast-transaction.test.ts
+++ b/packages/services/src/view-service/broadcast-transaction.test.ts
@@ -62,9 +62,8 @@ describe('BroadcastTransaction request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/broadcast-transaction.ts
+++ b/packages/services/src/view-service/broadcast-transaction.ts
@@ -7,7 +7,7 @@ import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbr
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 
 export const broadcastTransaction: Impl['broadcastTransaction'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { tendermint } = services.querier;
   const { indexedDb } = await services.getWalletServices();
   if (!req.transaction)

--- a/packages/services/src/view-service/ephemeral-address.test.ts
+++ b/packages/services/src/view-service/ephemeral-address.test.ts
@@ -20,7 +20,7 @@ describe('EphemeralAddress request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(fvkCtx, testFullViewingKey),
+      contextValues: createContextValues().set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
   });
 
@@ -32,8 +32,8 @@ describe('EphemeralAddress request handler', () => {
     expect(ephemeralAddressResponse.address).toBeInstanceOf(Address);
   });
 
-  test('should get an error if addressIndex is missing', () => {
-    expect(() => ephemeralAddress(new EphemeralAddressRequest(), mockCtx)).toThrowError(
+  test('should get an error if addressIndex is missing', async () => {
+    await expect(ephemeralAddress(new EphemeralAddressRequest(), mockCtx)).rejects.toThrow(
       'Missing address index',
     );
   });

--- a/packages/services/src/view-service/ephemeral-address.ts
+++ b/packages/services/src/view-service/ephemeral-address.ts
@@ -2,17 +2,13 @@ import type { Impl } from '.';
 
 import { getEphemeralByIndex } from '@penumbra-zone/wasm/keys';
 import { fvkCtx } from '../ctx/full-viewing-key';
-import { Code, ConnectError } from '@connectrpc/connect';
 
-export const ephemeralAddress: Impl['ephemeralAddress'] = (req, ctx) => {
+export const ephemeralAddress: Impl['ephemeralAddress'] = async (req, ctx) => {
   if (!req.addressIndex) {
     throw new Error('Missing address index');
   }
-  const fullViewingKey = ctx.values.get(fvkCtx);
-  if (!fullViewingKey) {
-    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
-  }
-  const address = getEphemeralByIndex(fullViewingKey, req.addressIndex.account);
+  const fvk = ctx.values.get(fvkCtx);
+  const address = getEphemeralByIndex(await fvk(), req.addressIndex.account);
 
   return { address };
 };

--- a/packages/services/src/view-service/fmd-parameters.test.ts
+++ b/packages/services/src/view-service/fmd-parameters.test.ts
@@ -33,9 +33,8 @@ describe('FmdParameters request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/view-service/fmd-parameters.ts
+++ b/packages/services/src/view-service/fmd-parameters.ts
@@ -4,7 +4,7 @@ import { servicesCtx } from '../ctx/prax';
 import { Code, ConnectError } from '@connectrpc/connect';
 
 export const fMDParameters: Impl['fMDParameters'] = async (_, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   const parameters = await indexedDb.getFmdParams();
   if (!parameters) throw new ConnectError('No FMD parameters', Code.FailedPrecondition);

--- a/packages/services/src/view-service/gas-prices.test.ts
+++ b/packages/services/src/view-service/gas-prices.test.ts
@@ -33,9 +33,8 @@ describe('GasPrices request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/view-service/gas-prices.ts
+++ b/packages/services/src/view-service/gas-prices.ts
@@ -21,7 +21,7 @@ import { Code, ConnectError } from '@connectrpc/connect';
  * as the blocks are scanned. This way, it can be readily accessed when needed.
  */
 export const gasPrices: Impl['gasPrices'] = async (_, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   const gasPrices = await indexedDb.getGasPrices();
   if (!gasPrices) throw new ConnectError('Gas prices is not available', Code.NotFound);

--- a/packages/services/src/view-service/index-by-address.test.ts
+++ b/packages/services/src/view-service/index-by-address.test.ts
@@ -23,7 +23,7 @@ describe('IndexByAddress request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(fvkCtx, testFullViewingKey),
+      contextValues: createContextValues().set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
 
     testAddress = getAddressByIndex(testFullViewingKey, 0);

--- a/packages/services/src/view-service/index-by-address.ts
+++ b/packages/services/src/view-service/index-by-address.ts
@@ -5,13 +5,10 @@ import { getAddressIndexByAddress } from '@penumbra-zone/wasm/address';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { fvkCtx } from '../ctx/full-viewing-key';
 
-export const indexByAddress: Impl['indexByAddress'] = (req, ctx) => {
+export const indexByAddress: Impl['indexByAddress'] = async (req, ctx) => {
   if (!req.address) throw new ConnectError('no address given in request', Code.InvalidArgument);
-  const fullViewingKey = ctx.values.get(fvkCtx);
-  if (!fullViewingKey) {
-    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
-  }
-  const addressIndex = getAddressIndexByAddress(fullViewingKey, req.address);
+  const fvk = ctx.values.get(fvkCtx);
+  const addressIndex = getAddressIndexByAddress(await fvk(), req.address);
 
   if (!addressIndex) return {};
 

--- a/packages/services/src/view-service/note-by-commitment.test.ts
+++ b/packages/services/src/view-service/note-by-commitment.test.ts
@@ -43,9 +43,8 @@ describe('NoteByCommitment request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/note-by-commitment.ts
+++ b/packages/services/src/view-service/note-by-commitment.ts
@@ -6,7 +6,7 @@ import { SpendableNoteRecord } from '@buf/penumbra-zone_penumbra.bufbuild_es/pen
 import { Code, ConnectError } from '@connectrpc/connect';
 
 export const noteByCommitment: Impl['noteByCommitment'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   if (!req.noteCommitment)
     throw new ConnectError('Missing note commitment in request', Code.InvalidArgument);

--- a/packages/services/src/view-service/notes-for-voting.test.ts
+++ b/packages/services/src/view-service/notes-for-voting.test.ts
@@ -32,9 +32,8 @@ describe('NotesForVoting request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/view-service/notes-for-voting.ts
+++ b/packages/services/src/view-service/notes-for-voting.ts
@@ -2,7 +2,7 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const notesForVoting: Impl['notesForVoting'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   const votingNotes = await indexedDb.getNotesForVoting(req.addressIndex, req.votableAtHeight);
 

--- a/packages/services/src/view-service/notes.test.ts
+++ b/packages/services/src/view-service/notes.test.ts
@@ -46,9 +46,8 @@ describe('Notes request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/notes.ts
+++ b/packages/services/src/view-service/notes.ts
@@ -5,7 +5,7 @@ import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/nu
 import { addAmounts, joinLoHiAmount } from '@penumbra-zone/types/amount';
 
 export const notes: Impl['notes'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   const { assetId, addressIndex, includeSpent, amountToSpend } = req;

--- a/packages/services/src/view-service/nullifier-status.test.ts
+++ b/packages/services/src/view-service/nullifier-status.test.ts
@@ -60,9 +60,8 @@ describe('nullifierStatus', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/view-service/nullifier-status.ts
+++ b/packages/services/src/view-service/nullifier-status.ts
@@ -19,7 +19,7 @@ export const nullifierStatus: Impl['nullifierStatus'] = async (req, ctx) => {
   const { nullifier } = req;
   if (!nullifier) throw new ConnectError('No nullifier passed', Code.InvalidArgument);
 
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   // grab subscription to table updates before checking the tables.  this avoids

--- a/packages/services/src/view-service/owned-position-ids.test.ts
+++ b/packages/services/src/view-service/owned-position-ids.test.ts
@@ -44,9 +44,8 @@ describe('OwnedPositionIds request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/owned-position-ids.ts
+++ b/packages/services/src/view-service/owned-position-ids.ts
@@ -2,7 +2,7 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const ownedPositionIds: Impl['ownedPositionIds'] = async function* (req, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
 
   const { indexedDb } = await services.getWalletServices();
 

--- a/packages/services/src/view-service/status-stream.test.ts
+++ b/packages/services/src/view-service/status-stream.test.ts
@@ -50,9 +50,8 @@ describe('Status stream request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/status-stream.ts
+++ b/packages/services/src/view-service/status-stream.ts
@@ -2,7 +2,7 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const statusStream: Impl['statusStream'] = async function* (_, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   const latestBlockHeight = await services.querier.tendermint.latestBlockHeight();
 

--- a/packages/services/src/view-service/status.test.ts
+++ b/packages/services/src/view-service/status.test.ts
@@ -42,9 +42,8 @@ describe('Status request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
   });

--- a/packages/services/src/view-service/status.ts
+++ b/packages/services/src/view-service/status.ts
@@ -2,7 +2,7 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const status: Impl['status'] = async (_, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   const latestBlockHeight = await services.querier.tendermint.latestBlockHeight();
   const fullSyncHeight = await indexedDb.getFullSyncHeight();

--- a/packages/services/src/view-service/swap-by-commitment.test.ts
+++ b/packages/services/src/view-service/swap-by-commitment.test.ts
@@ -43,9 +43,8 @@ describe('SwapByCommitment request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/swap-by-commitment.ts
+++ b/packages/services/src/view-service/swap-by-commitment.ts
@@ -6,7 +6,7 @@ import { SwapRecord } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/vie
 import { Code, ConnectError } from '@connectrpc/connect';
 
 export const swapByCommitment: Impl['swapByCommitment'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
   const { swapCommitment } = req;
   if (!swapCommitment)

--- a/packages/services/src/view-service/transaction-info-by-hash.test.ts
+++ b/packages/services/src/view-service/transaction-info-by-hash.test.ts
@@ -54,8 +54,8 @@ describe('TransactionInfoByHash request handler', () => {
       requestMethod: 'MOCK',
       url: '/mock',
       contextValues: createContextValues()
-        .set(servicesCtx, mockServices as unknown as ServicesInterface)
-        .set(fvkCtx, testFullViewingKey),
+        .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
+        .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
     mockTransactionInfo.mockReturnValueOnce({
       txp: transactionPerspective,

--- a/packages/services/src/view-service/transaction-info.test.ts
+++ b/packages/services/src/view-service/transaction-info.test.ts
@@ -52,8 +52,8 @@ describe('TransactionInfo request handler', () => {
       requestMethod: 'MOCK',
       url: '/mock',
       contextValues: createContextValues()
-        .set(servicesCtx, mockServices as unknown as ServicesInterface)
-        .set(fvkCtx, testFullViewingKey),
+        .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
+        .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
 
     mockTransactionInfo.mockReturnValue({

--- a/packages/services/src/view-service/transaction-planner/index.test.ts
+++ b/packages/services/src/view-service/transaction-planner/index.test.ts
@@ -47,8 +47,8 @@ describe('TransactionPlanner request handler', () => {
       requestMethod: 'MOCK',
       url: '/mock',
       contextValues: createContextValues()
-        .set(servicesCtx, mockServices as unknown as ServicesInterface)
-        .set(fvkCtx, testFullViewingKey),
+        .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
+        .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
 
     req = new TransactionPlannerRequest({});

--- a/packages/services/src/view-service/transaction-planner/index.ts
+++ b/packages/services/src/view-service/transaction-planner/index.ts
@@ -7,13 +7,10 @@ import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_
 import { fvkCtx } from '../../ctx/full-viewing-key';
 
 export const transactionPlanner: Impl['transactionPlanner'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
-  const fullViewingKey = ctx.values.get(fvkCtx);
-  if (!fullViewingKey) {
-    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
-  }
+  const fvk = ctx.values.get(fvkCtx);
 
   assertValidRequest(req);
 
@@ -27,7 +24,7 @@ export const transactionPlanner: Impl['transactionPlanner'] = async (req, ctx) =
 
   const idbConstants = indexedDb.constants();
 
-  const plan = await planTransaction(idbConstants, req, fullViewingKey);
+  const plan = await planTransaction(idbConstants, req, await fvk());
   return { plan };
 };
 

--- a/packages/services/src/view-service/unclaimed-swaps.test.ts
+++ b/packages/services/src/view-service/unclaimed-swaps.test.ts
@@ -44,9 +44,8 @@ describe('UnclaimedSwaps request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
 

--- a/packages/services/src/view-service/unclaimed-swaps.ts
+++ b/packages/services/src/view-service/unclaimed-swaps.ts
@@ -2,7 +2,7 @@ import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 
 export const unclaimedSwaps: Impl['unclaimedSwaps'] = async function* (_, ctx) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
 
   const { indexedDb } = await services.getWalletServices();
 

--- a/packages/services/src/view-service/util/custody-authorize.ts
+++ b/packages/services/src/view-service/util/custody-authorize.ts
@@ -3,13 +3,13 @@ import {
   TransactionPlan,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { HandlerContext, ConnectError, Code } from '@connectrpc/connect';
-import { custodyCtx } from '../../ctx/custody';
+import { custodyClientCtx } from '../../ctx/custody-client';
 
 export const custodyAuthorize = async (
   ctx: HandlerContext,
   plan: TransactionPlan,
 ): Promise<AuthorizationData> => {
-  const custodyClient = ctx.values.get(custodyCtx);
+  const custodyClient = ctx.values.get(custodyClientCtx);
   if (!custodyClient)
     throw new ConnectError('Cannot access custody service', Code.FailedPrecondition);
   const { data } = await custodyClient.authorize({ plan });

--- a/packages/services/src/view-service/witness-and-build.ts
+++ b/packages/services/src/view-service/witness-and-build.ts
@@ -13,14 +13,11 @@ export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (
   { authorizationData, transactionPlan },
   ctx,
 ) {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   if (!transactionPlan) throw new ConnectError('No tx plan', Code.InvalidArgument);
 
   const { indexedDb } = await services.getWalletServices();
-  const fullViewingKey = ctx.values.get(fvkCtx);
-  if (!fullViewingKey) {
-    throw new ConnectError('Cannot access full viewing key', Code.Unauthenticated);
-  }
+  const fvk = ctx.values.get(fvkCtx);
 
   const sct = await indexedDb.getStateCommitmentTree();
 
@@ -30,6 +27,6 @@ export const witnessAndBuild: Impl['witnessAndBuild'] = async function* (
     transactionPlan,
     witnessData,
     Promise.resolve(authorizationData ?? new AuthorizationData()),
-    fullViewingKey,
+    await fvk(),
   );
 };

--- a/packages/services/src/view-service/witness.test.ts
+++ b/packages/services/src/view-service/witness.test.ts
@@ -37,9 +37,8 @@ describe('Witness request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
     });
     req = new WitnessRequest({

--- a/packages/services/src/view-service/witness.ts
+++ b/packages/services/src/view-service/witness.ts
@@ -6,7 +6,7 @@ import { getWitness } from '@penumbra-zone/wasm/build';
 import { Code, ConnectError } from '@connectrpc/connect';
 
 export const witness: Impl['witness'] = async (req, ctx) => {
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
 
   if (!req.transactionPlan) throw new ConnectError('No tx plan in request', Code.InvalidArgument);
 


### PR DESCRIPTION
servicesCtx and fvkCtx beocme promises, so services init no longer blocks on storage key presence - a function is provided via context to query storage at runtime.

this is part of improving handler context #924 and makes initialization asynchronous and much more robust, which has benefits used in #998 to allow services to run entirely without network connection.