### PR TITLE
faster dev init, fix wasm clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules
 
 # testing
 coverage
-vite.config.ts.timestamp-*-*.mjs
+vite*.config.ts.timestamp-*-*.mjs
 
 # build output
 .next/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "all-check": "pnpm clean && pnpm install && pnpm compile && pnpm lint && pnpm lint:rust && pnpm build && pnpm test && pnpm test:rust",
     "build": "turbo build",
     "clean": "turbo clean",
-    "clean:vitest-mjs": "find . -type f -name 'vite.config.ts.timestamp-*-*.mjs' -ls -delete",
+    "clean:vitest-mjs": "find . -type f -name 'vite*.config.ts.timestamp-*-*.mjs' -ls -delete",
     "compile": "turbo compile",
     "dev": "turbo dev",
     "format": "turbo format",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "scripts": {
-    "clean": "rm -v wasm/index*",
+    "clean": "rm -fv wasm/index*",
     "clean:rust": "cargo clean --manifest-path ./crate/Cargo.toml",
     "compile": "cd crate && wasm-pack build --no-pack --target bundler --out-name index --out-dir ../wasm",
     "dev": "cargo watch -C ./crate --postpone -- pnpm turbo run compile",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -8,7 +8,7 @@
     "clean:rust": "cargo clean --manifest-path ./crate/Cargo.toml",
     "compile": "cd crate && wasm-pack build --no-pack --target bundler --out-name index --out-dir ../wasm",
     "dev": "cargo watch -C ./crate --postpone -- pnpm turbo run compile",
-    "format": "cd crate && cargo fmt --all",
+    "format:rust": "cd crate && cargo fmt --all",
     "lint": "eslint \"src/*.ts*\"",
     "lint:rust": "cd crate && cargo fmt --all -- --check && cargo clippy -- -D warnings && cargo clippy --tests -- -D warnings",
     "test": "vitest run",

--- a/turbo.json
+++ b/turbo.json
@@ -42,8 +42,7 @@
       "dependsOn": ["format:ts", "format:rust"]
     },
     "format:rust": {
-      "cache": false,
-      "dependsOn": ["compile"]
+      "cache": false
     },
     "format:ts": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -34,7 +34,7 @@
     },
     "dev": {
       "cache": false,
-      "dependsOn": ["build"],
+      "dependsOn": ["^compile"],
       "persistent": true
     },
     "format": {

--- a/turbo.json
+++ b/turbo.json
@@ -39,11 +39,15 @@
     },
     "format": {
       "cache": false,
-      "dependsOn": ["//#format:syncpack", "//#format:prettier", "format:rust"]
+      "dependsOn": ["format:ts", "format:rust"]
     },
     "format:rust": {
-      "dependsOn": ["compile"],
-      "inputs": ["crate/src/**", "crate/Cargo.toml", "crate/Cargo.lock", "crate/tests/**"]
+      "cache": false,
+      "dependsOn": ["compile"]
+    },
+    "format:ts": {
+      "cache": false,
+      "dependsOn": ["//#format:syncpack", "//#format:prettier"]
     },
     "host": {
       "cache": false,


### PR DESCRIPTION
jesse complained about dev startup slowing down so changing dep from build to compile should accelerate it.

i believe the build issues (package exports) present in https://github.com/penumbra-zone/web/commit/4ef2ef7c3874b9bc85a632455cf6456af46f208d that prompted this change are by #995, so there should be no negative effects of this, but watch out for broken HMR or other issues