### PR TITLE
No shrink pill

### DIFF
--- a/packages/ui/components/ui/tx/view/value-with-address.tsx
+++ b/packages/ui/components/ui/tx/view/value-with-address.tsx
@@ -17,7 +17,7 @@ export const ValueWithAddress = ({
   addressView?: AddressView;
 }) => (
   <div className='flex flex-col justify-between gap-2 sm:flex-row'>
-    {children}
+    <div className='shrink-0'>{children}</div>
 
     {addressView && (
       <div className='flex items-center gap-2 overflow-hidden'>


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/902

Given the addresses is already resizable with the truncate class, this just makes the pill in this view not-resizable.

Before:

<img width="895" alt="Screenshot 2024-04-26 at 12 20 02 PM" src="https://github.com/penumbra-zone/web/assets/16624263/1a6bf943-790a-4517-96d4-a0745c91090f">

After:

<img width="891" alt="Screenshot 2024-04-26 at 12 50 08 PM" src="https://github.com/penumbra-zone/web/assets/16624263/be310964-379a-4ff8-b9e6-e4c0f1a8f4e1">
