### PR TITLE
Expose `batch-swap-output-data` getters to package consumers

### DIFF
--- a/packages/getters/vite.config.ts
+++ b/packages/getters/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     lib: {
       entry: {
         'address-view': './src/address-view.ts',
+        'batch-swap-output-data': './src/batch-swap-output-data.ts',
         'delegations-by-address-index-response': './src/delegations-by-address-index-response.ts',
         'funding-stream': './src/funding-stream.ts',
         metadata: './src/metadata.ts',


### PR DESCRIPTION
# Summary

It looks like the getters defined for `BatchSwapOutputData` are exported but never exposed in `vite.config.ts` for downstream users to access. This PR is a one line change to `vite.config.ts` that changes that.