### PR TITLE
Process Dutch auction NFT metadata in the block processor

### DIFF
--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -776,8 +776,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -790,8 +790,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2087,8 +2087,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2124,9 +2124,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-auction"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "base64 0.21.7",
+ "bech32",
+ "bitvec",
+ "blake2b_simd 1.0.2",
+ "decaf377 0.5.0",
+ "decaf377-rdsa",
+ "hex",
+ "metrics",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset",
+ "penumbra-dex",
+ "penumbra-keys",
+ "penumbra-num",
+ "penumbra-proof-params",
+ "penumbra-proto",
+ "penumbra-sct",
+ "penumbra-shielded-pool",
+ "penumbra-tct",
+ "penumbra-txhash",
+ "prost",
+ "prost-types",
+ "rand_chacha",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_unit_struct",
+ "serde_with",
+ "sha2 0.10.8",
+ "tap",
+ "tendermint",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-community-pool"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2155,8 +2201,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2187,8 +2233,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2239,8 +2285,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2255,8 +2301,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2278,8 +2324,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2297,8 +2343,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2321,6 +2367,7 @@ dependencies = [
  "once_cell",
  "pbjson-types",
  "penumbra-asset",
+ "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-distributions",
@@ -2349,8 +2396,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2382,8 +2429,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "aes",
  "anyhow",
@@ -2426,8 +2473,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2462,8 +2509,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2488,8 +2535,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2515,8 +2562,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2546,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2565,6 +2612,7 @@ dependencies = [
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
+ "futures",
  "hex",
  "ibc-types",
  "im",
@@ -2593,8 +2641,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2635,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2663,8 +2711,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2686,6 +2734,7 @@ dependencies = [
  "once_cell",
  "pbjson-types",
  "penumbra-asset",
+ "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-fee",
@@ -2713,8 +2762,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.73.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.73.0#6e88f8313428c7efc1713d8e2884f74b474fd497"
+version = "0.71.0"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=c52969b5e#c52969b5ef6e2af83cad9b1670369ba8ae0fcde9"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -2736,6 +2785,7 @@ dependencies = [
  "hex",
  "indexed_db_futures",
  "penumbra-asset",
+ "penumbra-auction",
  "penumbra-compact-block",
  "penumbra-dex",
  "penumbra-fee",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,19 +15,22 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-fee", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.73.0", package = "penumbra-transaction", default-features = false }
+# TODO: Use `tag` instead of `rev` once auctions land in a tagged release of
+# core.
+penumbra-auction         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-auction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-fee", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "c52969b5e", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.80"
 ark-ff                   = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/src/auction.rs
+++ b/packages/wasm/crate/src/auction.rs
@@ -1,0 +1,70 @@
+use crate::{error::WasmResult, metadata::customize_symbol_inner, utils};
+use penumbra_asset::asset::Metadata;
+use penumbra_auction::auction::{dutch::DutchAuctionDescription, AuctionId, AuctionNft};
+use penumbra_proto::DomainType;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// Given a `Uint8Array` encoding of a `DutchAuctionDescription`, returns that
+/// auction's ID.
+#[wasm_bindgen]
+pub fn get_auction_id(description: &[u8]) -> WasmResult<Vec<u8>> {
+    utils::set_panic_hook();
+    let description = DutchAuctionDescription::decode(description)?;
+    Ok(description.id().encode_to_vec())
+}
+
+/// Given a `Uint8Array` encoding of an `AuctionId` (along with a sequence
+/// number), returns the metadata for the auction NFT describing that auction
+/// and its current sequence number.
+#[wasm_bindgen]
+pub fn get_auction_nft_metadata(auction_id: &[u8], seq: u64) -> WasmResult<Vec<u8>> {
+    utils::set_panic_hook();
+    let auction_id = AuctionId::decode(auction_id)?;
+    let nft = AuctionNft::new(auction_id, seq);
+    let metadata_proto = customize_symbol_inner(nft.metadata.to_proto())?;
+    let metadata_domain_type = Metadata::try_from(metadata_proto)?;
+
+    Ok(metadata_domain_type.encode_to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ff::Zero;
+    use decaf377::Fq;
+    use penumbra_asset::{
+        asset::{Id, Metadata},
+        Value,
+    };
+    use penumbra_auction::auction::dutch::DutchAuctionDescription;
+    use penumbra_num::Amount;
+    use penumbra_proto::DomainType;
+
+    use crate::auction::get_auction_id;
+
+    use super::get_auction_nft_metadata;
+
+    #[test]
+    fn it_gets_correct_id_and_metadata() {
+        let description = DutchAuctionDescription {
+            start_height: 0,
+            end_height: 100,
+            input: Value {
+                amount: Amount::default(),
+                asset_id: Id(Fq::zero()),
+            },
+            min_output: Amount::default(),
+            max_output: Amount::default(),
+            nonce: [0; 32],
+            output_id: Id(Fq::zero()),
+            step_count: 100u64,
+        };
+
+        let auction_id_bytes = get_auction_id(&description.encode_to_vec()).unwrap();
+        let result_bytes = get_auction_nft_metadata(&auction_id_bytes, 1234).unwrap();
+        let result = Metadata::decode::<&[u8]>(&result_bytes).unwrap();
+        let result_proto = result.to_proto();
+
+        assert!(result_proto.symbol.starts_with("auction("));
+        assert!(result_proto.display.starts_with("auctionnft_1234_pauctid1"));
+    }
+}

--- a/packages/wasm/crate/src/dex.rs
+++ b/packages/wasm/crate/src/dex.rs
@@ -22,7 +22,7 @@ pub fn compute_position_id(position: &[u8]) -> WasmResult<Vec<u8>> {
 /// Arguments:
 ///     position_value: `lp::position::Position`
 ///     position_state: `lp::position::State`
-/// Returns: `Uint8Array representing a DenomMetadata`
+/// Returns: `Uint8Array` representing a `Metadata`
 #[wasm_bindgen]
 pub fn get_lpnft_asset(position_id: &[u8], position_state: &[u8]) -> WasmResult<Vec<u8>> {
     utils::set_panic_hook();

--- a/packages/wasm/crate/src/lib.rs
+++ b/packages/wasm/crate/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate core;
 
+pub mod auction;
 pub mod build;
 pub mod dex;
 pub mod error;

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -101,7 +101,7 @@ impl ActionList {
         for value in self.balance().provided() {
             self.change_outputs.insert(
                 value.asset_id,
-                OutputPlan::new(&mut OsRng, value, change_address),
+                OutputPlan::new(&mut OsRng, value, change_address.clone()),
             );
         }
     }
@@ -440,7 +440,7 @@ pub async fn plan_transaction(
         actions.push(SpendPlan::new(&mut OsRng, note.note, note.position).into());
 
         // Recompute the change outputs, without accounting for fees.
-        actions.refresh_change(change_address);
+        actions.refresh_change(change_address.clone());
         // Now re-estimate the fee of the updated transaction and adjust the change if possible.
         let fee = actions.fee_estimate(&gas_prices, &fee_tier);
         actions.adjust_change_for_fee(fee);

--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -297,24 +297,20 @@ pub async fn transaction_info_inner(
         };
         match action_view {
             ActionView::Spend(SpendView::Visible { note, .. }) => {
-                let address = note.address();
-                let address_view = fvk.view_address(address.clone());
-                address_views.insert(address, address_view);
+                address_views.insert(note.address(), fvk.view_address(note.address()));
                 asset_ids.insert(note.asset_id());
             }
             ActionView::Output(OutputView::Visible { note, .. }) => {
-                let address = note.address();
-                let address_view = fvk.view_address(address.clone());
-                address_views.insert(address, address_view.clone());
+                address_views.insert(note.address(), fvk.view_address(note.address()));
                 asset_ids.insert(note.asset_id());
 
                 // Also add an AddressView for the return address in the memo.
                 let memo = tx.decrypt_memo(&fvk)?;
-                address_views.insert(memo.return_address(), address_view);
+                address_views.insert(memo.return_address(), fvk.view_address(note.address()));
             }
             ActionView::Swap(SwapView::Visible { swap_plaintext, .. }) => {
                 let address = swap_plaintext.claim_address.clone();
-                let address_view = fvk.view_address(address.clone());
+                let address_view = fvk.view_address(swap_plaintext.claim_address.clone());
                 address_views.insert(address, address_view);
                 asset_ids.insert(swap_plaintext.trading_pair.asset_1());
                 asset_ids.insert(swap_plaintext.trading_pair.asset_2());
@@ -323,9 +319,7 @@ pub async fn transaction_info_inner(
                 output_1, output_2, ..
             }) => {
                 // Both will be sent to the same address so this only needs to be added once
-                let address = output_1.address();
-                let address_view = fvk.view_address(address.clone());
-                address_views.insert(address, address_view);
+                address_views.insert(output_1.address(), fvk.view_address(output_1.address()));
                 asset_ids.insert(output_1.asset_id());
                 asset_ids.insert(output_2.asset_id());
             }

--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -298,21 +298,24 @@ pub async fn transaction_info_inner(
         match action_view {
             ActionView::Spend(SpendView::Visible { note, .. }) => {
                 let address = note.address();
-                address_views.insert(address, fvk.view_address(address));
+                let address_view = fvk.view_address(address.clone());
+                address_views.insert(address, address_view);
                 asset_ids.insert(note.asset_id());
             }
             ActionView::Output(OutputView::Visible { note, .. }) => {
                 let address = note.address();
-                address_views.insert(address, fvk.view_address(address));
+                let address_view = fvk.view_address(address.clone());
+                address_views.insert(address, address_view.clone());
                 asset_ids.insert(note.asset_id());
 
                 // Also add an AddressView for the return address in the memo.
                 let memo = tx.decrypt_memo(&fvk)?;
-                address_views.insert(memo.return_address(), fvk.view_address(address));
+                address_views.insert(memo.return_address(), address_view);
             }
             ActionView::Swap(SwapView::Visible { swap_plaintext, .. }) => {
-                let address = swap_plaintext.claim_address;
-                address_views.insert(address, fvk.view_address(address));
+                let address = swap_plaintext.claim_address.clone();
+                let address_view = fvk.view_address(address.clone());
+                address_views.insert(address, address_view);
                 asset_ids.insert(swap_plaintext.trading_pair.asset_1());
                 asset_ids.insert(swap_plaintext.trading_pair.asset_2());
             }
@@ -321,13 +324,15 @@ pub async fn transaction_info_inner(
             }) => {
                 // Both will be sent to the same address so this only needs to be added once
                 let address = output_1.address();
-                address_views.insert(address, fvk.view_address(address));
+                let address_view = fvk.view_address(address.clone());
+                address_views.insert(address, address_view);
                 asset_ids.insert(output_1.asset_id());
                 asset_ids.insert(output_2.asset_id());
             }
             ActionView::DelegatorVote(DelegatorVoteView::Visible { note, .. }) => {
                 let address = note.address();
-                address_views.insert(address, fvk.view_address(address));
+                let address_view = fvk.view_address(address.clone());
+                address_views.insert(address, address_view);
                 asset_ids.insert(note.asset_id());
             }
             _ => {}

--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -297,21 +297,30 @@ pub async fn transaction_info_inner(
         };
         match action_view {
             ActionView::Spend(SpendView::Visible { note, .. }) => {
-                address_views.insert(note.address(), fvk.view_address(note.address()));
+                address_views.insert(
+                    note.address().encode_to_vec(),
+                    fvk.view_address(note.address()),
+                );
                 asset_ids.insert(note.asset_id());
             }
             ActionView::Output(OutputView::Visible { note, .. }) => {
-                address_views.insert(note.address(), fvk.view_address(note.address()));
+                address_views.insert(
+                    note.address().encode_to_vec(),
+                    fvk.view_address(note.address()),
+                );
                 asset_ids.insert(note.asset_id());
 
                 // Also add an AddressView for the return address in the memo.
                 let memo = tx.decrypt_memo(&fvk)?;
-                address_views.insert(memo.return_address(), fvk.view_address(note.address()));
+                address_views.insert(
+                    memo.return_address().encode_to_vec(),
+                    fvk.view_address(note.address()),
+                );
             }
             ActionView::Swap(SwapView::Visible { swap_plaintext, .. }) => {
                 let address = swap_plaintext.claim_address.clone();
                 let address_view = fvk.view_address(swap_plaintext.claim_address.clone());
-                address_views.insert(address, address_view);
+                address_views.insert(address.encode_to_vec(), address_view);
                 asset_ids.insert(swap_plaintext.trading_pair.asset_1());
                 asset_ids.insert(swap_plaintext.trading_pair.asset_2());
             }
@@ -319,14 +328,17 @@ pub async fn transaction_info_inner(
                 output_1, output_2, ..
             }) => {
                 // Both will be sent to the same address so this only needs to be added once
-                address_views.insert(output_1.address(), fvk.view_address(output_1.address()));
+                address_views.insert(
+                    output_1.address().encode_to_vec(),
+                    fvk.view_address(output_1.address()),
+                );
                 asset_ids.insert(output_1.asset_id());
                 asset_ids.insert(output_2.asset_id());
             }
             ActionView::DelegatorVote(DelegatorVoteView::Visible { note, .. }) => {
                 let address = note.address();
                 let address_view = fvk.view_address(address.clone());
-                address_views.insert(address, address_view);
+                address_views.insert(address.encode_to_vec(), address_view);
                 asset_ids.insert(note.asset_id());
             }
             _ => {}

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -115,6 +115,7 @@ mod tests {
             fixed_candidates: Vec::new(),
             is_enabled: true,
             max_hops: 5u32,
+            max_positions_per_pair: 0,
         };
 
         let app_params = AppParameters {
@@ -129,6 +130,7 @@ mod tests {
             distributions_params: None,
             funding_params: None,
             shielded_pool_params: None,
+            auction_params: None,
         };
 
         let fmd_params = FmdParameters {
@@ -412,6 +414,9 @@ mod tests {
             position_closes: vec![],
             position_withdraws: vec![],
             fee_mode: None,
+            dutch_auction_schedule_actions: vec![],
+            dutch_auction_end_actions: vec![],
+            dutch_auction_withdraw_actions: vec![],
         };
 
         // Viewing key to reveal asset balances and transactions.

--- a/packages/wasm/src/auction.ts
+++ b/packages/wasm/src/auction.ts
@@ -1,0 +1,16 @@
+import {
+  AuctionId,
+  DutchAuctionDescription,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { get_auction_id, get_auction_nft_metadata } from '../wasm';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+export const getAuctionId = (dutchAuctionDescription: DutchAuctionDescription): AuctionId => {
+  const result = get_auction_id(dutchAuctionDescription.toBinary());
+  return AuctionId.fromBinary(result);
+};
+
+export const getAuctionNftMetadata = (auctionId: AuctionId, seq: bigint): Metadata => {
+  const result = get_auction_nft_metadata(auctionId.toBinary(), seq);
+  return Metadata.fromBinary(result);
+};


### PR DESCRIPTION
As part of #942, I've made a massive branch with a ton of changes to the Dutch auction UI. To make the review process more manageable, I'm breaking the changes into smaller atomic PRs.

This PR modifies the block processor to identify Dutch auctions, and save their NFTs' metadata to the database when it encounters them. Future PRs will build on top of this.