### PR TITLE
fix transport-dom package

### DIFF
--- a/.changeset/five-baboons-itch.md
+++ b/.changeset/five-baboons-itch.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/transport-dom': major
+---
+
+correctly build transport-dom

--- a/packages/transport-dom/package.json
+++ b/packages/transport-dom/package.json
@@ -5,19 +5,24 @@
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
-    "clean": "rm -rfv dist",
+    "clean": "rm -rfv dist package penumbra-zone-transport-dom-*.tgz",
     "lint": "eslint \"**/*.ts*\"",
+    "prebuild": "$npm_execpath run clean",
+    "prepack": "$npm_execpath run build",
     "test": "vitest run"
   },
+  "files": [
+    "dist"
+  ],
   "exports": {
     "./*": "./src/*.ts"
   },
   "publishConfig": {
-    "files": [
-      "dist"
-    ],
     "exports": {
-      "./src/*": "./dist/*.js"
+      "./*": {
+        "import": "./dist/*.js",
+        "types": "./dist/*.d.ts"
+      }
     }
   },
   "devDependencies": {

--- a/packages/transport-dom/tsconfig.json
+++ b/packages/transport-dom/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "tsconfig/base.json",
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "outDir": "dist",
     "noEmit": true

--- a/packages/transport-dom/vite.config.ts
+++ b/packages/transport-dom/vite.config.ts
@@ -1,5 +1,8 @@
+/// <reference types="vitest" />
+
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { externalizeDeps } from 'vite-plugin-externalize-deps';
 
 export default defineConfig({
   build: {
@@ -16,7 +19,7 @@ export default defineConfig({
       formats: ['es'],
     },
   },
-  plugins: [dts({ rollupTypes: true })],
+  plugins: [dts({ rollupTypes: true }), externalizeDeps({ except: ['@penumbra-zone/polyfills'] })],
   test: {
     include: ['**/*.test.ts'],
     browser: {


### PR DESCRIPTION
- correct `publishConfig` paths
- correct location of `files` field
- `tsconfig.json` excludes build output
- `prepack` script runs build
- `prebuild` script runs clean
- `clean` script removes pack outputs
- vite build reconfigured
  - `vite-plugin-externalize-deps` to actually use dependencies
  - except for `@penumbra-zone/polyfills` which is configured to inline