### PR TITLE
`ViewService#auctions` RPC method and basic auctions UI

### DIFF
--- a/apps/extension/.env.testnet
+++ b/apps/extension/.env.testnet
@@ -1,4 +1,4 @@
 CHAIN_ID=penumbra-testnet-deimos-6
-IDB_VERSION=35
+IDB_VERSION=36
 MINIFRONT_URL=https://app.testnet.penumbra.zone
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -1,0 +1,14 @@
+import { useStore } from '../../../state';
+
+export const Auctions = () => {
+  const auctions = useStore(state => state.dutchAuction.auctions);
+  return (
+    <div className='flex flex-col gap-2'>
+      {!auctions.length && <>No auctions</>}
+      {!!auctions.length &&
+        auctions.map(auction => (
+          <div key={auction.description?.nonce}>{auction.description?.startHeight.toString()}</div>
+        ))}
+    </div>
+  );
+};

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -25,8 +25,6 @@ const auctionsSelector = (state: AllSlices) => ({
 export const Auctions = () => {
   const { auctions, metadataByAssetId } = useStoreShallow(auctionsSelector);
 
-  if (!auctions.length) return null;
-
   return (
     <>
       <p className='mb-2 bg-text-linear bg-clip-text font-headline text-xl font-semibold leading-[30px] text-transparent md:text-2xl md:font-bold md:leading-9'>
@@ -34,6 +32,8 @@ export const Auctions = () => {
       </p>
 
       <div className='flex flex-col gap-2'>
+        {!auctions.length && "You don't currently have any auctions running."}
+
         {auctions.map(auction => (
           <ViewBox
             key={auction.description?.nonce.toString()}

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -1,6 +1,12 @@
 import { ViewBox } from '@penumbra-zone/ui/components/ui/tx/view/viewbox';
 import { useStore } from '../../../state';
 import { DutchAuctionComponent } from '@penumbra-zone/ui/components/ui/dutch-auction-component';
+import {
+  AssetId,
+  Metadata,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+const getMetadata = (penumbraAssetId?: AssetId) => new Metadata({ penumbraAssetId });
 
 export const Auctions = () => {
   const auctions = useStore(state => state.dutchAuction.auctions);
@@ -13,7 +19,13 @@ export const Auctions = () => {
           <ViewBox
             key={auction.description?.nonce.toString()}
             label='Dutch Auction'
-            visibleContent={<DutchAuctionComponent dutchAuction={auction} />}
+            visibleContent={
+              <DutchAuctionComponent
+                dutchAuction={auction}
+                inputMetadata={getMetadata(auction.description?.input?.assetId)}
+                outputMetadata={getMetadata(auction.description?.outputId)}
+              />
+            }
           />
         ))}
     </div>

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -1,15 +1,20 @@
+import { ViewBox } from '@penumbra-zone/ui/components/ui/tx/view/viewbox';
 import { useStore } from '../../../state';
+import { DutchAuctionComponent } from '@penumbra-zone/ui/components/ui/dutch-auction-component';
 
 export const Auctions = () => {
   const auctions = useStore(state => state.dutchAuction.auctions);
   return (
     <div className='flex flex-col gap-2'>
       {!auctions.length && <>No auctions</>}
+
       {!!auctions.length &&
         auctions.map(auction => (
-          <div key={auction.description?.nonce.toString()}>
-            {auction.description?.startHeight.toString()}
-          </div>
+          <ViewBox
+            key={auction.description?.nonce.toString()}
+            label='Dutch Auction'
+            visibleContent={<DutchAuctionComponent dutchAuction={auction} />}
+          />
         ))}
     </div>
   );

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -7,7 +7,7 @@ export const Auctions = () => {
       {!auctions.length && <>No auctions</>}
       {!!auctions.length &&
         auctions.map(auction => (
-          <div key={auction.description?.nonce}>{auction.description?.startHeight.toString()}</div>
+          <div key={auction.nonce.toString()}>{auction.startHeight.toString()}</div>
         ))}
     </div>
   );

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -7,7 +7,9 @@ export const Auctions = () => {
       {!auctions.length && <>No auctions</>}
       {!!auctions.length &&
         auctions.map(auction => (
-          <div key={auction.nonce.toString()}>{auction.startHeight.toString()}</div>
+          <div key={auction.description?.nonce.toString()}>
+            {auction.description?.startHeight.toString()}
+          </div>
         ))}
     </div>
   );

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -25,12 +25,16 @@ const auctionsSelector = (state: AllSlices) => ({
 export const Auctions = () => {
   const { auctions, metadataByAssetId } = useStoreShallow(auctionsSelector);
 
-  return (
-    <div className='flex flex-col gap-2'>
-      {!auctions.length && <>No auctions</>}
+  if (!auctions.length) return null;
 
-      {!!auctions.length &&
-        auctions.map(auction => (
+  return (
+    <>
+      <p className='mb-2 bg-text-linear bg-clip-text font-headline text-xl font-semibold leading-[30px] text-transparent md:text-2xl md:font-bold md:leading-9'>
+        My auctions
+      </p>
+
+      <div className='flex flex-col gap-2'>
+        {auctions.map(auction => (
           <ViewBox
             key={auction.description?.nonce.toString()}
             label='Dutch Auction'
@@ -43,6 +47,7 @@ export const Auctions = () => {
             }
           />
         ))}
-    </div>
+      </div>
+    </>
   );
 };

--- a/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
+++ b/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
@@ -6,6 +6,9 @@ import { getAllAssets } from '../../../fetchers/assets';
 export const DutchAuctionLoader = async () => {
   await throwIfPraxNotConnectedTimeout();
 
+  // Load into state, but don't block rendering.
+  void useStore.getState().dutchAuction.loadAuctions();
+
   const [assets, balancesResponses] = await Promise.all([
     getAllAssets(),
     getSwappableBalancesResponses(),

--- a/apps/minifront/src/components/swap/dutch-auction/index.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/index.tsx
@@ -7,7 +7,7 @@ import { Auctions } from './auctions';
 export const DutchAuction = () => {
   return (
     <div className='grid gap-6 md:grid-cols-2 md:gap-4 xl:grid-cols-3 xl:gap-5'>
-      <Card className='order-1 md:order-3 xl:order-1'>
+      <Card className='order-1 p-5 md:order-3 md:p-4 xl:order-1 xl:p-5'>
         <Auctions />
       </Card>
 

--- a/apps/minifront/src/components/swap/dutch-auction/index.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/index.tsx
@@ -2,11 +2,14 @@ import { Card } from '@penumbra-zone/ui/components/ui/card';
 import { EduPanel } from '../../shared/edu-panels/content';
 import { EduInfoCard } from '../../shared/edu-panels/edu-info-card';
 import { DutchAuctionForm } from './dutch-auction-form';
+import { Auctions } from './auctions';
 
 export const DutchAuction = () => {
   return (
     <div className='grid gap-6 md:grid-cols-2 md:gap-4 xl:grid-cols-3 xl:gap-5'>
-      <div className='hidden xl:block'></div>
+      <Card className='order-1 md:order-3 xl:order-1'>
+        <Auctions />
+      </Card>
 
       <Card gradient className='order-3 row-span-2 flex-1 p-5 md:order-1 md:p-4 xl:p-5'>
         <DutchAuctionForm />

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -4,7 +4,7 @@ import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { planBuildBroadcast } from '../helpers';
 import { assembleRequest } from './assemble-request';
 import { DurationOption } from './constants';
-import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { viewClient } from '../../clients';
 
 export interface DutchAuctionSlice {
@@ -24,7 +24,7 @@ export interface DutchAuctionSlice {
   setMaxOutput: (maxOutput: string) => void;
   onSubmit: () => Promise<void>;
   txInProgress: boolean;
-  auctions: DutchAuction[];
+  auctions: DutchAuctionDescription[];
   loadAuctions: () => Promise<void>;
 }
 
@@ -100,7 +100,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
   loadAuctions: async () => {
     for await (const response of viewClient.auctions({})) {
       if (!response.auction) continue;
-      const auction = DutchAuction.fromBinary(response.auction.value);
+      const auction = DutchAuctionDescription.fromBinary(response.auction.value);
       const auctions = [...get().dutchAuction.auctions, auction];
 
       set(state => {

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -104,6 +104,10 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
 
   auctions: [],
   loadAuctions: async () => {
+    set(state => {
+      state.dutchAuction.auctions = [];
+    });
+
     for await (const response of viewClient.auctions({})) {
       if (!response.auction) continue;
       const auction = DutchAuction.fromBinary(response.auction.value);

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -4,7 +4,7 @@ import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { planBuildBroadcast } from '../helpers';
 import { assembleRequest } from './assemble-request';
 import { DurationOption } from './constants';
-import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { viewClient } from '../../clients';
 
 export interface DutchAuctionSlice {
@@ -24,7 +24,7 @@ export interface DutchAuctionSlice {
   setMaxOutput: (maxOutput: string) => void;
   onSubmit: () => Promise<void>;
   txInProgress: boolean;
-  auctions: DutchAuctionDescription[];
+  auctions: DutchAuction[];
   loadAuctions: () => Promise<void>;
 }
 
@@ -100,7 +100,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
   loadAuctions: async () => {
     for await (const response of viewClient.auctions({})) {
       if (!response.auction) continue;
-      const auction = DutchAuctionDescription.fromBinary(response.auction.value);
+      const auction = DutchAuction.fromBinary(response.auction.value);
       const auctions = [...get().dutchAuction.auctions, auction];
 
       set(state => {

--- a/packages/bech32m/src/format/convert.ts
+++ b/packages/bech32m/src/format/convert.ts
@@ -16,7 +16,7 @@ export const fromBech32m = <P extends Prefix>(
   prefix: Prefix = b32mStr.slice(0, b32mStr.lastIndexOf('1')) as P,
 ): Uint8Array => {
   const p = b32mStr.slice(0, b32mStr.lastIndexOf('1'));
-  if (p !== prefix) throw new TypeError('Unexpected prefix');
+  if (p !== prefix) throw new TypeError(`Unexpected prefix: expected ${prefix}, got ${p}`);
   return from(b32mStr, p, StringLength[p], ByteLength[p]);
 };
 
@@ -47,7 +47,10 @@ const from = (
   expectLength: number,
   expectBytes: number,
 ): Uint8Array => {
-  if (bStr.length !== expectLength) throw new TypeError('Invalid string length');
+  if (bStr.length !== expectLength) {
+    throw new TypeError(`Invalid string length: expected ${expectLength}, got ${bStr.length}`);
+  }
+
   const { prefix, words } = bech32m.decode(bStr, expectLength);
   if (prefix !== expectPrefix) throw new TypeError('Wrong prefix');
   const bytes = new Uint8Array(bech32m.fromWords(words));
@@ -71,7 +74,9 @@ const to = <P extends string>(
   expectLength: number,
   expectBytes: number,
 ): `${P}1${string}` => {
-  if (bData.length !== expectBytes) throw new TypeError('Invalid data length');
+  if (bData.length !== expectBytes) {
+    throw new TypeError(`Invalid data length: expected ${expectBytes}, got ${bData.length}`);
+  }
   const bStr = bech32m.encode(prefix, bech32m.toWords(bData), expectLength);
   if (bStr.length !== expectLength) throw new TypeError('Unexpected string length');
   return bStr as `${P}1${string}`;

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -22,6 +22,8 @@ import { QueryService as SctService } from '@buf/penumbra-zone_penumbra.connectr
 import { QueryService as ShieldedPoolService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/shielded_pool/v1/shielded_pool_connect';
 import { QueryService as StakeService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/stake/v1/stake_connect';
 
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+
 /**
  * This type registry is for JSON serialization of protobuf messages.
  *
@@ -52,6 +54,9 @@ export const typeRegistry: IMessageTypeRegistry = createRegistry(
   SctService,
   ShieldedPoolService,
   StakeService,
+
+  // Types not explicitly referenced by any above services should be added here.
+  DutchAuction,
 );
 
 /**

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -3,8 +3,6 @@ import { IMessageTypeRegistry, createRegistry } from '@bufbuild/protobuf';
 import { CustodyService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/custody/v1/custody_connect';
 import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
 
-import { ClientState } from '@buf/cosmos_ibc.bufbuild_es/ibc/lightclients/tendermint/v1/tendermint_pb';
-
 import { TendermintProxyService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/util/tendermint_proxy/v1/tendermint_proxy_connect';
 
 import { Query as IbcChannelService } from '@buf/cosmos_ibc.connectrpc_es/ibc/core/channel/v1/query_connect';
@@ -22,6 +20,7 @@ import { QueryService as SctService } from '@buf/penumbra-zone_penumbra.connectr
 import { QueryService as ShieldedPoolService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/shielded_pool/v1/shielded_pool_connect';
 import { QueryService as StakeService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/stake/v1/stake_connect';
 
+import { ClientState } from '@buf/cosmos_ibc.bufbuild_es/ibc/lightclients/tendermint/v1/tendermint_pb';
 import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 /**
@@ -38,8 +37,6 @@ import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/c
 export const typeRegistry: IMessageTypeRegistry = createRegistry(
   CustodyService,
   ViewService,
-
-  ClientState,
 
   TendermintProxyService,
 
@@ -58,6 +55,7 @@ export const typeRegistry: IMessageTypeRegistry = createRegistry(
   // Types not explicitly referenced by any above services should be added here.
   // Otherwise, it will not be possible to serialize/deserialize these types if,
   // e.g., they're used in an `Any` protobuf.
+  ClientState,
   DutchAuction,
 );
 

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -22,7 +22,7 @@ import { QueryService as SctService } from '@buf/penumbra-zone_penumbra.connectr
 import { QueryService as ShieldedPoolService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/shielded_pool/v1/shielded_pool_connect';
 import { QueryService as StakeService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/stake/v1/stake_connect';
 
-import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 /**
  * This type registry is for JSON serialization of protobuf messages.
@@ -56,7 +56,9 @@ export const typeRegistry: IMessageTypeRegistry = createRegistry(
   StakeService,
 
   // Types not explicitly referenced by any above services should be added here.
-  DutchAuctionDescription,
+  // Otherwise, it will not be possible to serialize/deserialize these types if,
+  // e.g., they're used in an `Any` protobuf.
+  DutchAuction,
 );
 
 /**

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -22,7 +22,7 @@ import { QueryService as SctService } from '@buf/penumbra-zone_penumbra.connectr
 import { QueryService as ShieldedPoolService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/shielded_pool/v1/shielded_pool_connect';
 import { QueryService as StakeService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/stake/v1/stake_connect';
 
-import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 /**
  * This type registry is for JSON serialization of protobuf messages.
@@ -56,7 +56,7 @@ export const typeRegistry: IMessageTypeRegistry = createRegistry(
   StakeService,
 
   // Types not explicitly referenced by any above services should be added here.
-  DutchAuction,
+  DutchAuctionDescription,
 );
 
 /**

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -41,10 +41,7 @@ import { toDecimalExchangeRate } from '@penumbra-zone/types/amount';
 import { ValidatorInfoResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 import { getAuctionId, getAuctionNftMetadata } from '@penumbra-zone/wasm/auction';
-import {
-  AuctionId,
-  DutchAuction,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { auctionIdFromBech32 } from '@penumbra-zone/bech32m/pauctid';
 import { ScanBlockResult } from '@penumbra-zone/types/state-commitment-tree';
 
@@ -405,7 +402,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       await Promise.all([
         this.indexedDb.saveAssetsMetadata(metadata),
         this.indexedDb.upsertAuction(auctionId, {
-          auction: new DutchAuction({ description: action.value.description }),
+          auction: action.value.description,
         }),
       ]);
     } else if (action.case === 'actionDutchAuctionEnd' && action.value.auctionId) {

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -405,7 +405,6 @@ export class BlockProcessor implements BlockProcessorInterface {
      * @todo Handle `actionDutchAuctionWithdraw`, and figure out how to
      * determine the sequence number if there have been multiple withdrawals.
      */
-    return undefined;
   }
 
   /**

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -234,7 +234,6 @@ export class BlockProcessor implements BlockProcessorInterface {
 
         for (const spendableNoteRecord of flush.newNotes) {
           recordsByCommitment.set(spendableNoteRecord.noteCommitment!, spendableNoteRecord);
-          // spendableNoteRecord.note?.value?.assetId
         }
         for (const swapRecord of flush.newSwaps)
           recordsByCommitment.set(swapRecord.swapCommitment!, swapRecord);

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -231,8 +231,10 @@ export class BlockProcessor implements BlockProcessorInterface {
         // - update idb
         await this.identifyNewAssets(flush.newNotes);
 
-        for (const spendableNoteRecord of flush.newNotes)
+        for (const spendableNoteRecord of flush.newNotes) {
           recordsByCommitment.set(spendableNoteRecord.noteCommitment!, spendableNoteRecord);
+          // spendableNoteRecord.note?.value?.assetId
+        }
         for (const swapRecord of flush.newSwaps)
           recordsByCommitment.set(swapRecord.swapCommitment!, swapRecord);
       }
@@ -403,6 +405,7 @@ export class BlockProcessor implements BlockProcessorInterface {
      * @todo Handle `actionDutchAuctionWithdraw`, and figure out how to
      * determine the sequence number if there have been multiple withdrawals.
      */
+    return undefined;
   }
 
   /**

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -235,9 +235,8 @@ export class BlockProcessor implements BlockProcessorInterface {
         // - update idb
         await this.identifyNewAssets(flush.newNotes);
 
-        for (const spendableNoteRecord of flush.newNotes) {
+        for (const spendableNoteRecord of flush.newNotes)
           recordsByCommitment.set(spendableNoteRecord.noteCommitment!, spendableNoteRecord);
-        }
         for (const swapRecord of flush.newSwaps)
           recordsByCommitment.set(swapRecord.swapCommitment!, swapRecord);
       }

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -26,6 +26,7 @@ export interface IndexedDbMock {
   getEpochByHeight?: Mock;
   saveAssetsMetadata?: Mock;
   getPricesForAsset?: Mock;
+  iterateAuctions?: () => Partial<AsyncIterable<Mock>>;
 }
 export interface TendermintMock {
   broadcastTx?: Mock;

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -26,7 +26,7 @@ export interface IndexedDbMock {
   getEpochByHeight?: Mock;
   saveAssetsMetadata?: Mock;
   getPricesForAsset?: Mock;
-  iterateAuctions?: () => Partial<AsyncIterable<Mock>>;
+  getAuction?: Mock;
 }
 export interface TendermintMock {
   broadcastTx?: Mock;

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import {
   AuctionId,
-  DutchAuction,
+  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
 import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
@@ -21,53 +21,29 @@ import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbr
 
 const AUCTION_ID_1 = new AuctionId({ inner: new Uint8Array(Array(32).fill(1)) });
 const BECH32M_AUCTION_ID_1 = bech32mAuctionId(AUCTION_ID_1);
-const MOCK_AUCTION_1 = new DutchAuction({
-  description: {
-    startHeight: 0n,
-    endHeight: 120n,
-  },
-  state: {
-    seq: 0n,
-    nextTrigger: 1n,
-  },
+const MOCK_AUCTION_1 = new DutchAuctionDescription({
+  startHeight: 0n,
+  endHeight: 120n,
 });
 
 const AUCTION_ID_2 = new AuctionId({ inner: new Uint8Array(Array(32).fill(2)) });
 const BECH32M_AUCTION_ID_2 = bech32mAuctionId(AUCTION_ID_2);
-const MOCK_AUCTION_2 = new DutchAuction({
-  description: {
-    startHeight: 120n,
-    endHeight: 240n,
-  },
-  state: {
-    seq: 1n,
-    nextTrigger: 121n,
-  },
+const MOCK_AUCTION_2 = new DutchAuctionDescription({
+  startHeight: 120n,
+  endHeight: 240n,
 });
 
 const AUCTION_ID_3 = new AuctionId({ inner: new Uint8Array(Array(32).fill(3)) });
 const BECH32M_AUCTION_ID_3 = bech32mAuctionId(AUCTION_ID_3);
-const MOCK_AUCTION_3 = new DutchAuction({
-  description: {
-    startHeight: 240n,
-    endHeight: 360n,
-  },
-  state: {
-    seq: 2n,
-    nextTrigger: 241n,
-  },
+const MOCK_AUCTION_3 = new DutchAuctionDescription({
+  startHeight: 240n,
+  endHeight: 360n,
 });
 
 const AUCTION_ID_4 = new AuctionId({ inner: new Uint8Array(Array(32).fill(4)) });
-const MOCK_AUCTION_4 = new DutchAuction({
-  description: {
-    startHeight: 360n,
-    endHeight: 480n,
-  },
-  state: {
-    seq: 3n,
-    nextTrigger: 361n,
-  },
+const MOCK_AUCTION_4 = new DutchAuctionDescription({
+  startHeight: 360n,
+  endHeight: 480n,
 });
 
 const MOCK_SPENDABLE_NOTE_RECORD = new SpendableNoteRecord({
@@ -190,7 +166,7 @@ describe('Auctions request handler', () => {
       new AuctionsResponse({
         id: AUCTION_ID_1,
         auction: {
-          typeUrl: DutchAuction.typeName,
+          typeUrl: DutchAuctionDescription.typeName,
           value: TEST_DATA[0]!.value.auction.toBinary(),
         },
         noteRecord: MOCK_SPENDABLE_NOTE_RECORD,
@@ -198,22 +174,8 @@ describe('Auctions request handler', () => {
     );
   });
 
-  it('returns only active auctions by default', async () => {
-    const req = new AuctionsRequest();
-    const result = await Array.fromAsync(auctions(req, mockCtx));
-
-    expect(result.length).toBe(1);
-  });
-
-  it('includes inactive auctions when requested', async () => {
-    const req = new AuctionsRequest({ includeInactive: true });
-    const result = await Array.fromAsync(auctions(req, mockCtx));
-
-    expect(result.length).toBe(3);
-  });
-
   it('excludes auctions not controlled by the current user', async () => {
-    const req = new AuctionsRequest({ includeInactive: true });
+    const req = new AuctionsRequest();
     const results = await Array.fromAsync(auctions(req, mockCtx));
 
     results.forEach(result => {

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -1,0 +1,138 @@
+import Array from '@penumbra-zone/polyfills/Array.fromAsync';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { auctions } from './auctions';
+import {
+  AuctionsRequest,
+  AuctionsResponse,
+  BalancesResponse,
+  SpendableNoteRecord,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
+import { ViewService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/view/v1/view_connect';
+import { ServicesInterface } from '@penumbra-zone/types/services';
+import { HandlerContext, createContextValues, createHandlerContext } from '@connectrpc/connect';
+import { servicesCtx } from '../ctx/prax';
+import { IndexedDbMock, MockServices } from '../test-utils';
+import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
+
+const AUCTION_ID = new AuctionId({ inner: new Uint8Array(Array(32).fill(0)) });
+const BECH32M_AUCTION_ID = bech32mAuctionId(AUCTION_ID);
+
+const MOCK_AUCTION = new DutchAuction({
+  description: {
+    startHeight: 0n,
+    endHeight: 120n,
+  },
+  state: {
+    seq: 0n,
+    nextTrigger: 1n,
+  },
+});
+
+const MOCK_SPENDABLE_NOTE_RECORD = new SpendableNoteRecord({
+  heightCreated: 1234n,
+});
+
+vi.mock('./balances', () => ({
+  *balances() {
+    yield new BalancesResponse({
+      balanceView: {
+        valueView: {
+          case: 'knownAssetId',
+          value: {
+            amount: { hi: 0n, lo: 1n },
+            metadata: {
+              base: `auctionnft_0_${BECH32M_AUCTION_ID}`,
+              display: `auctionnft_0_${BECH32M_AUCTION_ID}`,
+              denomUnits: [{ denom: `auctionnft_0_${BECH32M_AUCTION_ID}`, exponent: 0 }],
+              penumbraAssetId: { inner: new Uint8Array([0, 1, 2, 3]) },
+              symbol: 'auction(abcd1234...)',
+            },
+          },
+        },
+      },
+    });
+  },
+}));
+
+const testData = [
+  {
+    id: AUCTION_ID,
+    value: {
+      auction: MOCK_AUCTION,
+      noteCommitment: new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) }),
+    },
+  },
+];
+
+describe('Auctions request handler', () => {
+  let mockServices: MockServices;
+  let mockCtx: HandlerContext;
+  let mockIndexedDb: IndexedDbMock;
+  let req: AuctionsRequest;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    const mockIterateAuctions = {
+      next: vi.fn(),
+      [Symbol.asyncIterator]: () => mockIterateAuctions,
+    };
+
+    mockIndexedDb = {
+      iterateAuctions: () => mockIterateAuctions,
+      getSpendableNoteByCommitment: vi.fn().mockResolvedValue(MOCK_SPENDABLE_NOTE_RECORD),
+    };
+
+    mockServices = {
+      getWalletServices: vi.fn(() =>
+        Promise.resolve({
+          indexedDb: mockIndexedDb,
+        }),
+      ) as MockServices['getWalletServices'],
+    };
+
+    mockCtx = createHandlerContext({
+      service: ViewService,
+      method: ViewService.methods.auctions,
+      protocolName: 'mock',
+      requestMethod: 'MOCK',
+      url: '/mock',
+      contextValues: createContextValues().set(
+        servicesCtx,
+        mockServices as unknown as ServicesInterface,
+      ),
+    });
+
+    for (const record of testData) {
+      mockIterateAuctions.next.mockResolvedValueOnce({
+        value: record,
+      });
+    }
+    mockIterateAuctions.next.mockResolvedValueOnce({
+      done: true,
+    });
+
+    req = new AuctionsRequest();
+  });
+
+  it('returns auctions', async () => {
+    const result = await Array.fromAsync(auctions(req, mockCtx));
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual(
+      new AuctionsResponse({
+        id: AUCTION_ID,
+        auction: {
+          typeUrl: DutchAuction.typeName,
+          value: testData[0]!.value.auction.toBinary(),
+        },
+        noteRecord: MOCK_SPENDABLE_NOTE_RECORD,
+      }),
+    );
+  });
+});

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -112,7 +112,6 @@ const TEST_DATA = [
 ];
 
 describe('Auctions request handler', () => {
-  let mockServices: MockServices;
   let mockCtx: HandlerContext;
   let mockIndexedDb: IndexedDbMock;
 
@@ -126,13 +125,14 @@ describe('Auctions request handler', () => {
       getSpendableNoteByCommitment: vi.fn().mockResolvedValue(MOCK_SPENDABLE_NOTE_RECORD),
     };
 
-    mockServices = {
-      getWalletServices: vi.fn(() =>
-        Promise.resolve({
-          indexedDb: mockIndexedDb,
-        }),
-      ) as MockServices['getWalletServices'],
-    };
+    const mockServices = () =>
+      Promise.resolve({
+        getWalletServices: vi.fn(() =>
+          Promise.resolve({
+            indexedDb: mockIndexedDb,
+          }),
+        ) as MockServices['getWalletServices'],
+      } as unknown as ServicesInterface);
 
     mockCtx = createHandlerContext({
       service: ViewService,
@@ -140,10 +140,7 @@ describe('Auctions request handler', () => {
       protocolName: 'mock',
       requestMethod: 'MOCK',
       url: '/mock',
-      contextValues: createContextValues().set(
-        servicesCtx,
-        mockServices as unknown as ServicesInterface,
-      ),
+      contextValues: createContextValues().set(servicesCtx, mockServices),
     });
   });
 

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -119,13 +119,10 @@ describe('Auctions request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateAuctions = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateAuctions,
-    };
-
     mockIndexedDb = {
-      iterateAuctions: () => mockIterateAuctions,
+      getAuction: vi.fn((auctionId: AuctionId) =>
+        Promise.resolve(TEST_DATA.find(({ id }) => id.equals(auctionId))?.value),
+      ),
       getSpendableNoteByCommitment: vi.fn().mockResolvedValue(MOCK_SPENDABLE_NOTE_RECORD),
     };
 
@@ -148,15 +145,6 @@ describe('Auctions request handler', () => {
         mockServices as unknown as ServicesInterface,
       ),
     });
-
-    for (const record of TEST_DATA) {
-      mockIterateAuctions.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIterateAuctions.next.mockResolvedValueOnce({
-      done: true,
-    });
   });
 
   it('returns auctions', async () => {
@@ -168,7 +156,7 @@ describe('Auctions request handler', () => {
         id: AUCTION_ID_1,
         auction: {
           typeUrl: DutchAuction.typeName,
-          value: new DutchAuction({ description: TEST_DATA[0]!.value.auction }).toBinary(),
+          value: new DutchAuction({ description: MOCK_AUCTION_1 }).toBinary(),
         },
         noteRecord: MOCK_SPENDABLE_NOTE_RECORD,
       }),

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import {
   AuctionId,
+  DutchAuction,
   DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
@@ -166,8 +167,8 @@ describe('Auctions request handler', () => {
       new AuctionsResponse({
         id: AUCTION_ID_1,
         auction: {
-          typeUrl: DutchAuctionDescription.typeName,
-          value: TEST_DATA[0]!.value.auction.toBinary(),
+          typeUrl: DutchAuction.typeName,
+          value: new DutchAuction({ description: TEST_DATA[0]!.value.auction }).toBinary(),
         },
         noteRecord: MOCK_SPENDABLE_NOTE_RECORD,
       }),

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -53,7 +53,7 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
     throw new ConnectError('`includeInactive` not yet implemented', Code.Unimplemented);
   }
 
-  const services = ctx.values.get(servicesCtx);
+  const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   for await (const auctionId of iterateAuctionsThisUserControls(ctx, accountFilter)) {

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -1,0 +1,6 @@
+import { AuctionsResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { Impl } from '.';
+
+export const auctions: Impl['auctions'] = async function* (req, ctx) {
+  yield new AuctionsResponse();
+};

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -1,6 +1,63 @@
-import { AuctionsResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import {
+  AuctionsResponse,
+  BalancesRequest,
+  BalancesResponse,
+  SpendableNoteRecord,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Impl } from '.';
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { balances } from './balances';
+import { getDisplayDenomFromView } from '@penumbra-zone/getters/value-view';
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { assetPatterns } from '@penumbra-zone/constants/assets';
+import { PartialMessage } from '@bufbuild/protobuf';
+import { servicesCtx } from '../ctx/prax';
+import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
+
+const getBech32mAuctionId = (
+  balancesResponse: PartialMessage<BalancesResponse>,
+): string | undefined => {
+  if (!balancesResponse.balanceView) return;
+
+  const captureGroups = assetPatterns.auctionNft.capture(
+    getDisplayDenomFromView(new ValueView(balancesResponse.balanceView)),
+  );
+
+  if (!captureGroups) return;
+
+  return captureGroups.auctionId;
+};
 
 export const auctions: Impl['auctions'] = async function* (req, ctx) {
-  yield new AuctionsResponse();
+  const { includeInactive, queryLatestState, accountFilter } = req;
+
+  const bech32mAuctionIds = new Set<string>();
+  for await (const balancesResponse of balances(new BalancesRequest({ accountFilter }), ctx)) {
+    const auctionId = getBech32mAuctionId(balancesResponse);
+    if (!auctionId) continue;
+
+    bech32mAuctionIds.add(auctionId);
+  }
+
+  if (!bech32mAuctionIds.size) return;
+
+  const services = ctx.values.get(servicesCtx);
+  const { indexedDb } = await services.getWalletServices();
+
+  for await (const { id, value } of indexedDb.iterateAuctions()) {
+    if (!bech32mAuctionIds.has(bech32mAuctionId(id))) continue;
+    let noteRecord: SpendableNoteRecord | undefined;
+    if (value.noteCommitment) {
+      noteRecord = await indexedDb.getSpendableNoteByCommitment(value.noteCommitment);
+    }
+
+    yield new AuctionsResponse({
+      id,
+      auction: {
+        typeUrl: DutchAuction.typeName,
+        value: value.auction?.toBinary(),
+      },
+      noteRecord,
+    });
+  }
 };

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -5,12 +5,12 @@ import {
   SpendableNoteRecord,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Impl } from '.';
-import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { balances } from './balances';
 import { getDisplayDenomFromView } from '@penumbra-zone/getters/value-view';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { assetPatterns } from '@penumbra-zone/constants/assets';
-import { PartialMessage } from '@bufbuild/protobuf';
+import { Any, PartialMessage } from '@bufbuild/protobuf';
 import { servicesCtx } from '../ctx/prax';
 import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
 import { Code, ConnectError } from '@connectrpc/connect';
@@ -63,12 +63,17 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
       noteRecord = await indexedDb.getSpendableNoteByCommitment(value.noteCommitment);
     }
 
+    const auction = new Any({
+      typeUrl: DutchAuction.typeName,
+      value: new DutchAuction({
+        description: value.auction,
+        /** @todo include state if `queryLatestState` is `true` */
+      }).toBinary(),
+    });
+
     yield new AuctionsResponse({
       id,
-      auction: {
-        typeUrl: DutchAuctionDescription.typeName,
-        value: value.auction?.toBinary(),
-      },
+      auction,
       noteRecord,
     });
   }

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -13,7 +13,8 @@ import { assetPatterns } from '@penumbra-zone/constants/assets';
 import { Any, PartialMessage } from '@bufbuild/protobuf';
 import { servicesCtx } from '../ctx/prax';
 import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
-import { Code, ConnectError } from '@connectrpc/connect';
+import { Code, ConnectError, HandlerContext } from '@connectrpc/connect';
+import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 
 const getBech32mAuctionId = (
   balancesResponse: PartialMessage<BalancesResponse>,
@@ -29,32 +30,37 @@ const getBech32mAuctionId = (
   return captureGroups.auctionId;
 };
 
+const getAuctionsThisUserControls = async (ctx: HandlerContext, accountFilter?: AddressIndex) => {
+  const auctionsThisUserControls = new Set<string>();
+
+  for await (const balancesResponse of balances(new BalancesRequest({ accountFilter }), ctx)) {
+    const auctionId = getBech32mAuctionId(balancesResponse);
+    if (!auctionId) continue;
+
+    auctionsThisUserControls.add(auctionId);
+  }
+
+  return auctionsThisUserControls;
+};
+
 export const auctions: Impl['auctions'] = async function* (req, ctx) {
   const { includeInactive, queryLatestState, accountFilter } = req;
 
   if (queryLatestState) {
     throw new ConnectError('`queryLatestState` not yet implemented', Code.Unimplemented);
   }
-
   if (includeInactive) {
     throw new ConnectError('`includeInactive` not yet implemented', Code.Unimplemented);
   }
 
-  const bech32mAuctionIds = new Set<string>();
-  for await (const balancesResponse of balances(new BalancesRequest({ accountFilter }), ctx)) {
-    const auctionId = getBech32mAuctionId(balancesResponse);
-    if (!auctionId) continue;
-
-    bech32mAuctionIds.add(auctionId);
-  }
-
-  if (!bech32mAuctionIds.size) return;
+  const auctionsThisUserControls = await getAuctionsThisUserControls(ctx, accountFilter);
+  if (!auctionsThisUserControls.size) return;
 
   const services = ctx.values.get(servicesCtx);
   const { indexedDb } = await services.getWalletServices();
 
   for await (const { id, value } of indexedDb.iterateAuctions()) {
-    if (!bech32mAuctionIds.has(bech32mAuctionId(id))) continue;
+    if (!auctionsThisUserControls.has(bech32mAuctionId(id))) continue;
 
     /** @todo: if (req.includeInactive && auctionIsInactive()) continue; */
 

--- a/packages/services/src/view-service/index.ts
+++ b/packages/services/src/view-service/index.ts
@@ -5,6 +5,7 @@ import { addressByIndex } from './address-by-index';
 import { appParameters } from './app-parameters';
 import { assetMetadataById } from './asset-metadata-by-id';
 import { assets } from './assets';
+import { auctions } from './auctions';
 import { authorizeAndBuild } from './authorize-and-build';
 import { balances } from './balances';
 import { broadcastTransaction } from './broadcast-transaction';
@@ -32,11 +33,12 @@ import { witnessAndBuild } from './witness-and-build';
 
 export type Impl = ServiceImpl<typeof ViewService>;
 
-export const viewImpl: Omit<Impl, 'auctions'> = {
+export const viewImpl: Impl = {
   addressByIndex,
   appParameters,
   assetMetadataById,
   assets,
+  auctions,
   authorizeAndBuild,
   balances,
   broadcastTransaction,

--- a/packages/storage/src/chrome/test-utils/tests-setup.js
+++ b/packages/storage/src/chrome/test-utils/tests-setup.js
@@ -23,8 +23,3 @@ globalThis.chrome = {
 
 globalThis.DEFAULT_GRPC_URL = 'https://rpc.example.com/';
 globalThis.MINIFRONT_URL = 'https://app.example.com';
-globalThis.process = {
-  env: {
-    NODE_ENV: 'test',
-  },
-};

--- a/packages/storage/src/chrome/test-utils/tests-setup.js
+++ b/packages/storage/src/chrome/test-utils/tests-setup.js
@@ -23,3 +23,8 @@ globalThis.chrome = {
 
 globalThis.DEFAULT_GRPC_URL = 'https://rpc.example.com/';
 globalThis.MINIFRONT_URL = 'https://app.example.com';
+globalThis.process = {
+  env: {
+    NODE_ENV: 'test',
+  },
+};

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -59,7 +59,7 @@ import type {
 import { sctPosition } from '@penumbra-zone/wasm/tree';
 import {
   AuctionId,
-  DutchAuction,
+  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 interface IndexedDbProps {
@@ -676,16 +676,18 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   // As more auction types are created, add them to T as a union type.
-  async upsertAuction<T extends DutchAuction>(
+  async upsertAuction<T extends DutchAuctionDescription>(
     auctionId: AuctionId,
-    auction: T,
-    noteCommitment: StateCommitment,
+    value: {
+      auction?: T;
+      noteCommitment?: StateCommitment;
+    },
   ): Promise<void> {
     await this.u.update({
       table: 'AUCTIONS',
       value: {
-        auction: auction.toJson() as Jsonified<T>,
-        noteCommitment: noteCommitment.toJson() as Jsonified<StateCommitment>,
+        auction: value.auction?.toJson() as Jsonified<T>,
+        noteCommitment: value.noteCommitment?.toJson() as Jsonified<StateCommitment>,
       },
       key: uint8ArrayToBase64(auctionId.inner),
     });

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -59,7 +59,7 @@ import type {
 import { sctPosition } from '@penumbra-zone/wasm/tree';
 import {
   AuctionId,
-  DutchAuctionDescription,
+  DutchAuction,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 interface IndexedDbProps {
@@ -676,7 +676,7 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   // As more auction types are created, add them to T as a union type.
-  async upsertAuction<T extends DutchAuctionDescription>(
+  async upsertAuction<T extends DutchAuction>(
     auctionId: AuctionId,
     value: {
       auction?: T;

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -115,6 +115,7 @@ export class IndexedDb implements IndexedDbInterface {
         db.createObjectStore('PRICES', {
           keyPath: ['pricedAsset.inner', 'numeraire.inner'],
         }).createIndex('pricedAsset', 'pricedAsset.inner');
+        db.createObjectStore('AUCTIONS');
       },
     });
     const constants = {

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -692,4 +692,8 @@ export class IndexedDb implements IndexedDbInterface {
       key: uint8ArrayToBase64(auctionId.inner),
     });
   }
+
+  async *iterateAuctions() {
+    const results = this.db.transaction('AUCTIONS', 'readonly').store;
+  }
 }

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -57,6 +57,10 @@ import type {
   StateCommitmentTree,
 } from '@penumbra-zone/types/state-commitment-tree';
 import { sctPosition } from '@penumbra-zone/wasm/tree';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 interface IndexedDbProps {
   dbVersion: number; // Incremented during schema changes
@@ -669,5 +673,21 @@ export class IndexedDb implements IndexedDbInterface {
 
       txs.add({ table: 'SWAPS', value: n.toJson() as Jsonified<SwapRecord> });
     }
+  }
+
+  // As more auction types are created, add them to T as a union type.
+  async upsertAuction<T extends DutchAuction>(
+    auctionId: AuctionId,
+    auction: T,
+    noteCommitment: StateCommitment,
+  ): Promise<void> {
+    await this.u.update({
+      table: 'AUCTIONS',
+      value: {
+        auction: auction.toJson() as Jsonified<T>,
+        noteCommitment: noteCommitment.toJson() as Jsonified<StateCommitment>,
+      },
+      key: uint8ArrayToBase64(auctionId.inner),
+    });
   }
 }

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -59,7 +59,7 @@ import type {
 import { sctPosition } from '@penumbra-zone/wasm/tree';
 import {
   AuctionId,
-  DutchAuction,
+  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 interface IndexedDbProps {
@@ -676,7 +676,7 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   // As more auction types are created, add them to T as a union type.
-  async upsertAuction<T extends DutchAuction>(
+  async upsertAuction<T extends DutchAuctionDescription>(
     auctionId: AuctionId,
     value: {
       auction?: T;
@@ -710,7 +710,7 @@ export class IndexedDb implements IndexedDbInterface {
             id: new AuctionId({ inner: base64ToUint8Array(cursor.key) }),
             value: {
               auction: cursor.value.auction
-                ? DutchAuction.fromJson(cursor.value.auction)
+                ? DutchAuctionDescription.fromJson(cursor.value.auction)
                 : undefined,
               noteCommitment: cursor.value.noteCommitment
                 ? StateCommitment.fromJson(cursor.value.noteCommitment)

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -50,7 +50,7 @@ import {
 import type { IdbUpdate, PenumbraDb } from '@penumbra-zone/types/indexed-db';
 import {
   AuctionId,
-  DutchAuction,
+  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import Array from '@penumbra-zone/polyfills/Array.fromAsync';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
@@ -638,7 +638,7 @@ describe('IndexedDb', () => {
 
     it('inserts an auction', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
-      const auction = new DutchAuction({ description: { startHeight: 1234n } });
+      const auction = new DutchAuctionDescription({ startHeight: 1234n });
       await db.upsertAuction(auctionId, { auction });
 
       const auctions = await Array.fromAsync(db.iterateAuctions());
@@ -668,7 +668,7 @@ describe('IndexedDb', () => {
 
     it('inserts both an auction and a note commitment', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
-      const auction = new DutchAuction({ description: { startHeight: 1234n } });
+      const auction = new DutchAuctionDescription({ startHeight: 1234n });
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { auction, noteCommitment });
 
@@ -685,7 +685,7 @@ describe('IndexedDb', () => {
 
     it('inserts an auction and then updates with a note commitment when given the same auction ID', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
-      const auction = new DutchAuction({ description: { startHeight: 1234n } });
+      const auction = new DutchAuctionDescription({ startHeight: 1234n });
       await db.upsertAuction(auctionId, { auction });
 
       let auctions = await Array.fromAsync(db.iterateAuctions());
@@ -714,7 +714,7 @@ describe('IndexedDb', () => {
       let auctions = await Array.fromAsync(db.iterateAuctions());
       expect(auctions.length).toBe(1);
 
-      const auction = new DutchAuction({ description: { startHeight: 1234n } });
+      const auction = new DutchAuctionDescription({ startHeight: 1234n });
       await db.upsertAuction(auctionId, { auction });
 
       auctions = await Array.fromAsync(db.iterateAuctions());

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -641,13 +641,9 @@ describe('IndexedDb', () => {
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
       await db.upsertAuction(auctionId, { auction });
 
-      const auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
-      expect(auctions[0]).toEqual({
-        id: auctionId,
-        value: {
-          auction,
-        },
+      const fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toEqual({
+        auction,
       });
     });
 
@@ -656,13 +652,9 @@ describe('IndexedDb', () => {
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { noteCommitment });
 
-      const auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
-      expect(auctions[0]).toEqual({
-        id: auctionId,
-        value: {
-          noteCommitment,
-        },
+      const fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toEqual({
+        noteCommitment,
       });
     });
 
@@ -672,14 +664,10 @@ describe('IndexedDb', () => {
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { auction, noteCommitment });
 
-      const auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
-      expect(auctions[0]).toEqual({
-        id: auctionId,
-        value: {
-          auction,
-          noteCommitment,
-        },
+      const fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toEqual({
+        auction,
+        noteCommitment,
       });
     });
 
@@ -688,21 +676,18 @@ describe('IndexedDb', () => {
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
       await db.upsertAuction(auctionId, { auction });
 
-      let auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
+      let fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toBeTruthy();
 
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { noteCommitment });
 
-      auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
+      fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toBeTruthy();
 
-      expect(auctions[0]).toEqual({
-        id: auctionId,
-        value: {
-          auction,
-          noteCommitment,
-        },
+      expect(fetchedAuction).toEqual({
+        auction,
+        noteCommitment,
       });
     });
 
@@ -711,21 +696,18 @@ describe('IndexedDb', () => {
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { noteCommitment });
 
-      let auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
+      let fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toBeTruthy();
 
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
       await db.upsertAuction(auctionId, { auction });
 
-      auctions = await Array.fromAsync(db.iterateAuctions());
-      expect(auctions.length).toBe(1);
+      fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toBeTruthy();
 
-      expect(auctions[0]).toEqual({
-        id: auctionId,
-        value: {
-          auction,
-          noteCommitment,
-        },
+      expect(fetchedAuction).toEqual({
+        auction,
+        noteCommitment,
       });
     });
   });

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -52,7 +52,6 @@ import {
   AuctionId,
   DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
-import Array from '@penumbra-zone/polyfills/Array.fromAsync';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
 
 describe('IndexedDb', () => {

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -48,6 +48,10 @@ import {
   Metadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import type { IdbUpdate, PenumbraDb } from '@penumbra-zone/types/indexed-db';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 describe('IndexedDb', () => {
   // uses different wallet ids so no collisions take place
@@ -620,6 +624,22 @@ describe('IndexedDb', () => {
           asOfHeight: 50n,
         }),
       ]);
+    });
+  });
+
+  describe('upsertAuction()', () => {
+    let db: IndexedDb;
+
+    beforeEach(async () => {
+      db = await IndexedDb.initialize({ ...generateInitialProps() });
+    });
+
+    it('inserts an auction', async () => {
+      const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
+      const auction = new DutchAuction();
+      await db.upsertAuction(auctionId, { auction });
+
+      // const auctions = Array.from
     });
   });
 });

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -41,6 +41,7 @@ import {
   TransactionInfo,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import type { Jsonified } from './jsonified';
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
   table: StoreName;
@@ -189,6 +190,14 @@ export interface PenumbraDb extends DBSchema {
       pricedAsset: Jsonified<Required<EstimatedPrice>['pricedAsset']['inner']>;
     };
   };
+  AUCTIONS: {
+    key: string; // base64 AuctionId
+    value: {
+      noteCommitment: Jsonified<StateCommitment>;
+      // add more types to `auction` as more auction types are created
+      auction: Jsonified<DutchAuction>;
+    };
+  };
 }
 
 // need to store PositionId and Position in the same table
@@ -209,6 +218,7 @@ export interface IdbConstants {
 
 export const IDB_TABLES: Tables = {
   assets: 'ASSETS',
+  auctions: 'AUCTIONS',
   notes: 'NOTES',
   spendable_notes: 'SPENDABLE_NOTES',
   swaps: 'SWAPS',

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -41,7 +41,10 @@ import {
   TransactionInfo,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import type { Jsonified } from './jsonified';
-import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
   table: StoreName;
@@ -101,6 +104,11 @@ export interface IndexedDbInterface {
     height: bigint,
   ): Promise<void>;
   getPricesForAsset(assetMetadata: Metadata, latestBlockHeight: bigint): Promise<EstimatedPrice[]>;
+  upsertAuction<T extends DutchAuction>(
+    auctionId: AuctionId,
+    auction: T,
+    noteCommitment: StateCommitment,
+  ): Promise<void>;
 }
 
 export interface PenumbraDb extends DBSchema {

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -213,9 +213,9 @@ export interface PenumbraDb extends DBSchema {
   AUCTIONS: {
     key: string; // base64 AuctionId
     value: {
-      noteCommitment: Jsonified<StateCommitment>;
+      noteCommitment?: Jsonified<StateCommitment>;
       // add more types to `auction` as more auction types are created
-      auction: Jsonified<DutchAuction>;
+      auction?: Jsonified<DutchAuction>;
     };
   };
 }

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -114,17 +114,11 @@ export interface IndexedDbInterface {
     },
   ): Promise<void>;
 
-  iterateAuctions(): AsyncGenerator<
-    {
-      id: AuctionId;
-      value: {
-        // Add more auction union types as they are created
-        auction?: DutchAuctionDescription;
-        noteCommitment?: StateCommitment;
-      };
-    },
-    void
-  >;
+  getAuction(auctionId: AuctionId): Promise<{
+    // Add more auction union types as they are created
+    auction?: DutchAuctionDescription;
+    noteCommitment?: StateCommitment;
+  }>;
 }
 
 export interface PenumbraDb extends DBSchema {

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -44,7 +44,6 @@ import type { Jsonified } from './jsonified';
 import {
   AuctionId,
   DutchAuction,
-  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
@@ -105,13 +104,23 @@ export interface IndexedDbInterface {
     height: bigint,
   ): Promise<void>;
   getPricesForAsset(assetMetadata: Metadata, latestBlockHeight: bigint): Promise<EstimatedPrice[]>;
-  upsertAuction<T extends DutchAuctionDescription>(
+  upsertAuction<T extends DutchAuction>(
     auctionId: AuctionId,
     value: {
       auction?: T;
       noteCommitment?: StateCommitment;
     },
   ): Promise<void>;
+  iterateAuctions(): AsyncGenerator<
+    {
+      id: AuctionId;
+      value: {
+        auction?: DutchAuction;
+        noteCommitment?: StateCommitment;
+      };
+    },
+    void
+  >;
 }
 
 export interface PenumbraDb extends DBSchema {
@@ -206,7 +215,7 @@ export interface PenumbraDb extends DBSchema {
     value: {
       noteCommitment: Jsonified<StateCommitment>;
       // add more types to `auction` as more auction types are created
-      auction: Jsonified<DutchAuctionDescription>;
+      auction: Jsonified<DutchAuction>;
     };
   };
 }

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -44,6 +44,7 @@ import type { Jsonified } from './jsonified';
 import {
   AuctionId,
   DutchAuction,
+  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
@@ -104,10 +105,12 @@ export interface IndexedDbInterface {
     height: bigint,
   ): Promise<void>;
   getPricesForAsset(assetMetadata: Metadata, latestBlockHeight: bigint): Promise<EstimatedPrice[]>;
-  upsertAuction<T extends DutchAuction>(
+  upsertAuction<T extends DutchAuctionDescription>(
     auctionId: AuctionId,
-    auction: T,
-    noteCommitment: StateCommitment,
+    value: {
+      auction?: T;
+      noteCommitment?: StateCommitment;
+    },
   ): Promise<void>;
 }
 
@@ -203,7 +206,7 @@ export interface PenumbraDb extends DBSchema {
     value: {
       noteCommitment: Jsonified<StateCommitment>;
       // add more types to `auction` as more auction types are created
-      auction: Jsonified<DutchAuction>;
+      auction: Jsonified<DutchAuctionDescription>;
     };
   };
 }

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -43,7 +43,7 @@ import {
 import type { Jsonified } from './jsonified';
 import {
   AuctionId,
-  DutchAuction,
+  DutchAuctionDescription,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
@@ -104,18 +104,22 @@ export interface IndexedDbInterface {
     height: bigint,
   ): Promise<void>;
   getPricesForAsset(assetMetadata: Metadata, latestBlockHeight: bigint): Promise<EstimatedPrice[]>;
-  upsertAuction<T extends DutchAuction>(
+
+  // Add more auction union types as they are created
+  upsertAuction<T extends DutchAuctionDescription>(
     auctionId: AuctionId,
     value: {
       auction?: T;
       noteCommitment?: StateCommitment;
     },
   ): Promise<void>;
+
   iterateAuctions(): AsyncGenerator<
     {
       id: AuctionId;
       value: {
-        auction?: DutchAuction;
+        // Add more auction union types as they are created
+        auction?: DutchAuctionDescription;
         noteCommitment?: StateCommitment;
       };
     },
@@ -214,8 +218,8 @@ export interface PenumbraDb extends DBSchema {
     key: string; // base64 AuctionId
     value: {
       noteCommitment?: Jsonified<StateCommitment>;
-      // add more types to `auction` as more auction types are created
-      auction?: Jsonified<DutchAuction>;
+      // Add more types to `auction` as more auction types are created
+      auction?: Jsonified<DutchAuctionDescription>;
     };
   };
 }

--- a/packages/ui/components/ui/dutch-auction-component.tsx
+++ b/packages/ui/components/ui/dutch-auction-component.tsx
@@ -1,0 +1,64 @@
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { ActionDetails } from './tx/view/action-details';
+import { ValueViewComponent } from './tx/view/value';
+import {
+  Metadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+
+const getValueView = (amount?: Amount, metadata?: Metadata) =>
+  new ValueView({
+    valueView: {
+      case: 'knownAssetId',
+      value: {
+        amount,
+        metadata,
+      },
+    },
+  });
+
+export const DutchAuctionComponent = ({
+  dutchAuction,
+  inputMetadata,
+  outputMetadata,
+}: {
+  dutchAuction: DutchAuction;
+  inputMetadata?: Metadata;
+  outputMetadata?: Metadata;
+}) => {
+  const { description } = dutchAuction;
+  if (!description) return null;
+
+  const input = getValueView(description.input?.amount, inputMetadata);
+  const maxOutput = getValueView(description.maxOutput, outputMetadata);
+  const minOutput = getValueView(description.minOutput, outputMetadata);
+
+  return (
+    <ActionDetails>
+      <ActionDetails.Row label='Input'>
+        <ValueViewComponent view={input} />
+      </ActionDetails.Row>
+
+      <ActionDetails.Row label='Output'>
+        <div className='flex flex-col items-end gap-2 sm:flex-row'>
+          <div className='flex items-center gap-2'>
+            <span className='text-nowrap text-muted-foreground'>Max:</span>
+            <ValueViewComponent view={maxOutput} />
+          </div>
+          <div className='flex items-center gap-2'>
+            <span className='text-nowrap text-muted-foreground'>Min:</span>
+            <ValueViewComponent view={minOutput} />
+          </div>
+        </div>
+      </ActionDetails.Row>
+
+      <ActionDetails.Row label='Duration'>
+        <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
+        {description.startHeight.toString()}
+        <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
+        {description.endHeight.toString()}
+      </ActionDetails.Row>
+    </ActionDetails>
+  );
+};

--- a/packages/ui/components/ui/dutch-auction-component.tsx
+++ b/packages/ui/components/ui/dutch-auction-component.tsx
@@ -41,7 +41,7 @@ export const DutchAuctionComponent = ({
       </ActionDetails.Row>
 
       <ActionDetails.Row label='Output'>
-        <div className='flex flex-col items-end gap-2 sm:flex-row'>
+        <div className='flex flex-wrap justify-end gap-2'>
           <div className='flex items-center gap-2'>
             <span className='text-nowrap text-muted-foreground'>Max:</span>
             <ValueViewComponent view={maxOutput} />

--- a/packages/ui/components/ui/tx/view/action-dutch-auction-schedule-view.tsx
+++ b/packages/ui/components/ui/tx/view/action-dutch-auction-schedule-view.tsx
@@ -1,62 +1,24 @@
-import { ActionDutchAuctionScheduleView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
-import { ViewBox } from './viewbox';
-import { ActionDetails } from './action-details';
 import {
-  Metadata,
-  ValueView,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { ValueViewComponent } from './value';
-import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
-
-const getValueView = (amount?: Amount, metadata?: Metadata) =>
-  new ValueView({
-    valueView: {
-      case: 'knownAssetId',
-      value: {
-        amount,
-        metadata,
-      },
-    },
-  });
+  ActionDutchAuctionScheduleView,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { DutchAuctionComponent } from '../../dutch-auction-component';
+import { ViewBox } from './viewbox';
 
 export const ActionDutchAuctionScheduleViewComponent = ({
   value,
 }: {
   value: ActionDutchAuctionScheduleView;
 }) => {
-  const input = getValueView(value.action?.description?.input?.amount, value.inputMetadata);
-  const maxOutput = getValueView(value.action?.description?.maxOutput, value.outputMetadata);
-  const minOutput = getValueView(value.action?.description?.minOutput, value.outputMetadata);
-
   return (
     <ViewBox
       label='Schedule a Dutch Auction'
       visibleContent={
-        <ActionDetails>
-          <ActionDetails.Row label='Input'>
-            <ValueViewComponent view={input} />
-          </ActionDetails.Row>
-
-          <ActionDetails.Row label='Output'>
-            <div className='flex flex-col items-end gap-2 sm:flex-row'>
-              <div className='flex items-center gap-2'>
-                <span className='text-nowrap text-muted-foreground'>Max:</span>
-                <ValueViewComponent view={maxOutput} />
-              </div>
-              <div className='flex items-center gap-2'>
-                <span className='text-nowrap text-muted-foreground'>Min:</span>
-                <ValueViewComponent view={minOutput} />
-              </div>
-            </div>
-          </ActionDetails.Row>
-
-          <ActionDetails.Row label='Duration'>
-            <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
-            {value.action?.description?.startHeight.toString()}
-            <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
-            {value.action?.description?.endHeight.toString()}
-          </ActionDetails.Row>
-        </ActionDetails>
+        <DutchAuctionComponent
+          dutchAuction={new DutchAuction({ description: value.action?.description })}
+          inputMetadata={value.inputMetadata}
+          outputMetadata={value.outputMetadata}
+        />
       }
     />
   );

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -84,6 +84,7 @@ mod tests {
             epochs: String,
             transactions: String,
             full_sync_height: String,
+            auctions: String,
         }
 
         // Define `IndexDB` table parameters and constants.
@@ -98,6 +99,7 @@ mod tests {
             epochs: "EPOCHS".to_string(),
             transactions: "TRANSACTIONS".to_string(),
             full_sync_height: "FULL_SYNC_HEIGHT".to_string(),
+            auctions: "AUCTIONS".to_string(),
         };
 
         let constants: IndexedDbConstants = IndexedDbConstants {


### PR DESCRIPTION
![image](https://github.com/penumbra-zone/web/assets/1121544/ca75c88c-003e-4d7f-b8f9-74a993b6aae7)

This PR does two things: 1) implements `ViewService#auctions`, and 2) creates a basic UI for viewing your existing auctions (basically as a proof of concept that the RPC method works).

## In this PR
- Create a basic UI for rendering the user's auctions. This will grow over time as we add features to it, like ending/withdrawing from auctions.
- Implement part of the `ViewService#auctions` RPC method (except `queryLatestState` and `includeInactive` — see below).
- Create an `AUCTIONS` IndexedDB table to store `DutchAuctionDescription`s and their corresponding NFTs' `noteCommitment`s, keyed by `AuctionId`.
- Update the block processor to save auction data to the database when it encounters that data.
- Extract a `<DutchAuctionComponent />` that's shared by `<ActionDutchAuctionScheduleViewComponent />` and `<Auctions />` (the latter renders the auctions list on the new auction page).

## Not in this PR
- We can't yet get the latest auction state from the fullnode (via `queryLatestState`) because of Issues™ — that'll come in a later PR.
- I'll add `includeInactive` support (and the corresponding `auctionState` seq number in the database) in a follow-up PR.

Relates to #980 and #1018 (but closes neither, since there's more work to be done)