### PR TITLE
remove superfluous compile workflow trigger

### DIFF
--- a/.github/workflows/compile-wasm.yml
+++ b/.github/workflows/compile-wasm.yml
@@ -2,9 +2,6 @@ name: Compile WASM
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   wasm:


### PR DESCRIPTION
currently, 'Compile WASM' is run simultaneously three times on `main` pushes

<img width="1243" alt="Screenshot 2024-05-03 at 09 16 14" src="https://github.com/penumbra-zone/web/assets/134443988/d60148f6-ed99-4ce4-bc25-483f8f0d655e">

(Packages Release and Turbo CI are both running a 'Compile WASM' step)

this PR removes the `main` push trigger. at one point it was necessary, but that is no longer the case.

should also investigate running the publish workflow *after* the 'Turbo CI' workflow, after tests have run, and when it can use the cached builds.