### PR TITLE
Insert missing asset IDs for ActionDutchAuctionSchedule

### DIFF
--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 
 use anyhow::anyhow;
+use penumbra_auction::auction::dutch::actions::view::ActionDutchAuctionScheduleView;
 use penumbra_dex::BatchSwapOutputData;
 use penumbra_keys::keys::SpendKey;
 use penumbra_keys::FullViewingKey;
@@ -340,6 +341,13 @@ pub async fn transaction_info_inner(
                 let address_view = fvk.view_address(address.clone());
                 address_views.insert(address.encode_to_vec(), address_view);
                 asset_ids.insert(note.asset_id());
+            }
+            ActionView::ActionDutchAuctionSchedule(ActionDutchAuctionScheduleView {
+                action,
+                ..
+            }) => {
+                asset_ids.insert(action.description.output_id);
+                asset_ids.insert(action.description.input.asset_id);
             }
             _ => {}
         }


### PR DESCRIPTION
## Before
![image](https://github.com/penumbra-zone/web/assets/1121544/489cbc5b-439a-4460-b583-a25d472c6656)

(Note that the input metadata was present because the TXP had been filled with that metadata when processing the "Spend" action. However, we don't want to rely on that.)

## After
![image](https://github.com/penumbra-zone/web/assets/1121544/d822a43d-e7fb-4d45-ab34-9297ff510021)

## Punting to future PRs
- Add the same handling for `*Withdraw`/`*End` actions. Punting for now since that flow isn't yet supported on web.