### PR TITLE
fix some package details

### DIFF
--- a/.changeset/flat-pillows-hear.md
+++ b/.changeset/flat-pillows-hear.md
@@ -1,4 +1,6 @@
 ---
+'@penumbra-zone/getters': patch
+'@penumbra-zone/protobuf': patch
 '@penumbra-zone/wasm': patch
 ---
 

--- a/.changeset/flat-pillows-hear.md
+++ b/.changeset/flat-pillows-hear.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': patch
+---
+
+readme update recommending bsr

--- a/.changeset/fresh-bugs-pretend.md
+++ b/.changeset/fresh-bugs-pretend.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/getters': major
+---
+
+remove /src/ segment of import path

--- a/.changeset/yellow-walls-drum.md
+++ b/.changeset/yellow-walls-drum.md
@@ -1,0 +1,8 @@
+---
+'@penumbra-zone/perspective': major
+'@penumbra-zone/protobuf': major
+'@penumbra-zone/types': major
+'@penumbra-zone/getters': major
+---
+
+externalize dependencies

--- a/packages/bech32m/package.json
+++ b/packages/bech32m/package.json
@@ -10,14 +10,14 @@
     "lint": "eslint src",
     "test": "vitest run"
   },
+  "files": [
+    "./dist"
+  ],
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*.ts"
   },
   "publishConfig": {
-    "files": [
-      "./dist"
-    ],
     "exports": {
       ".": {
         "import": "./dist/index.js",

--- a/packages/getters/README.md
+++ b/packages/getters/README.md
@@ -1,5 +1,11 @@
 # Getters
 
+**To use this package, you need to [enable the Buf Schema Registry](https://buf.build/docs/bsr/generated-sdks/npm)**
+
+```sh
+echo "@buf:registry=https://buf.build/gen/npm/v1/" >> .npmrc
+```
+
 Getters were designed to solve a common pain point when working with deserialized Protobuf messages: accessing deeply nested, often optional properties.
 
 For example, let's say you have an `AddressView`, and you want to render an `AddressIndex`. You'd need render it conditionally, like so:

--- a/packages/getters/package.json
+++ b/packages/getters/package.json
@@ -10,13 +10,13 @@
     "lint": "eslint src",
     "test": "vitest run"
   },
+  "files": [
+    "dist"
+  ],
   "exports": {
     "./*": "./src/*.ts"
   },
   "publishConfig": {
-    "files": [
-      "dist"
-    ],
     "exports": {
       "./*": "./dist/*.js"
     }

--- a/packages/getters/package.json
+++ b/packages/getters/package.json
@@ -18,7 +18,7 @@
       "dist"
     ],
     "exports": {
-      "./src/*": "./dist/*.js"
+      "./*": "./dist/*.js"
     }
   },
   "dependencies": {

--- a/packages/getters/vite.config.ts
+++ b/packages/getters/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { externalizeDeps } from 'vite-plugin-externalize-deps';
 
 export default defineConfig({
   build: {
@@ -30,5 +31,5 @@ export default defineConfig({
       formats: ['es'],
     },
   },
-  plugins: [dts({ rollupTypes: true })],
+  plugins: [dts({ rollupTypes: true }), externalizeDeps()],
 });

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -10,13 +10,10 @@
     "lint": "eslint plan transaction translators",
     "test": "vitest run"
   },
-  "exports": {
-    "./*": "./*.ts"
-  },
+  "files": [
+    "./dist"
+  ],
   "publishConfig": {
-    "files": [
-      "./dist"
-    ],
     "exports": {
       "./plan/*": "./dist/plan/*.js",
       "./transaction/*": "./dist/transaction/*.js",

--- a/packages/perspective/vite.config.ts
+++ b/packages/perspective/vite.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { externalizeDeps } from 'vite-plugin-externalize-deps';
 
-// eslint-disable-next-line import/no-relative-packages
-import workspaceRoot from '../../package.json';
-
 export default defineConfig({
   build: {
     lib: {
@@ -24,13 +21,5 @@ export default defineConfig({
       formats: ['es'],
     },
   },
-  plugins: [
-    dts({ rollupTypes: true }),
-    externalizeDeps({
-      include: Object.keys({
-        ...workspaceRoot.dependencies,
-        ...workspaceRoot.devDependencies,
-      }),
-    }),
-  ],
+  plugins: [dts({ rollupTypes: true }), externalizeDeps()],
 });

--- a/packages/protobuf/README.md
+++ b/packages/protobuf/README.md
@@ -1,5 +1,11 @@
 # `@penumbra-zone/protobuf`
 
+**To use this package, you need to [enable the Buf Schema Registry](https://buf.build/docs/bsr/generated-sdks/npm)**
+
+```sh
+echo "@buf:registry=https://buf.build/gen/npm/v1/" >> .npmrc
+```
+
 This package exports a `typeRegistry` (and inclusive `jsonOptions`) for use with
 `@bufbuild` and `@connectrpc` tooling, particularly
 `@penumbra-zone/transport-dom`.

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -21,12 +21,6 @@
       }
     }
   },
-  "bundleDependencies": [
-    "@buf/cosmos_ibc.bufbuild_es",
-    "@buf/cosmos_ibc.connectrpc_es",
-    "@buf/penumbra-zone_penumbra.bufbuild_es",
-    "@buf/penumbra-zone_penumbra.connectrpc_es"
-  ],
   "devDependencies": {
     "@bufbuild/protobuf": "^1.9.0",
     "@connectrpc/connect": "^1.4.0"

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "main": "index.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "tailwindcss": "^3.4.3",
     "tailwindcss-animate": "^1.0.7"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -2,8 +2,5 @@
   "name": "tsconfig",
   "version": "1.0.0",
   "private": true,
-  "license": "(MIT OR Apache-2.0)",
-  "publishConfig": {
-    "access": "public"
-  }
+  "license": "(MIT OR Apache-2.0)"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,14 +9,14 @@
     "lint": "eslint src",
     "test": "vitest run"
   },
+  "files": [
+    "dist"
+  ],
   "exports": {
     "./*": "./src/*.ts",
     "./internal-msg/*": "./src/internal-msg/*.ts"
   },
   "publishConfig": {
-    "files": [
-      "dist"
-    ],
     "exports": {
       "./*": "./dist/*.js",
       "./internal-msg/*": "./dist/internal-msg/*.js"

--- a/packages/types/vite.config.ts
+++ b/packages/types/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { externalizeDeps } from 'vite-plugin-externalize-deps';
 
 export default defineConfig({
   build: {
@@ -31,5 +32,5 @@ export default defineConfig({
       formats: ['es'],
     },
   },
-  plugins: [dts({ rollupTypes: true })],
+  plugins: [dts({ rollupTypes: true }), externalizeDeps()],
 });

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -1,5 +1,11 @@
 # @penumbra-zone/wasm
 
+**To use this package, you need to [enable the Buf Schema Registry](https://buf.build/docs/bsr/generated-sdks/npm)**
+
+```sh
+echo "@buf:registry=https://buf.build/gen/npm/v1/" >> .npmrc
+```
+
 The Penumbra core repo has a ton of utilities and functions that are critical to
 developing an app that interacts with the Penumbra chain. However, it is written
 in Rust. This package exists to bridge the gap between the Rust environment and


### PR DESCRIPTION
- correctly locates `files` field of package.json
- removes `/src/` segment from imports of published getters
- externalizes dependencies of perspective, types
    - significantly reduces build output
    - now uses peer depends for message types
- remove `bundledDependencies` from protobuf package
    - i think this wasn't actually working anyway, for pnpm reasons?
    - bundledDependencies could not be shared to satisfy peers, which was half the point

added a note about how to enable the BSR to packages that contain readmes.