### PR TITLE
Handle `includeInactive` in `ViewService#auctions`

### DIFF
--- a/apps/extension/.env.testnet
+++ b/apps/extension/.env.testnet
@@ -1,4 +1,4 @@
 CHAIN_ID=penumbra-testnet-deimos-7
-IDB_VERSION=37
+IDB_VERSION=38
 MINIFRONT_URL=https://app.testnet.penumbra.zone
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/apps/extension/.env.testnet
+++ b/apps/extension/.env.testnet
@@ -1,4 +1,4 @@
 CHAIN_ID=penumbra-testnet-deimos-7
-IDB_VERSION=38
+IDB_VERSION=39
 MINIFRONT_URL=https://app.testnet.penumbra.zone
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -18,12 +18,13 @@ const getMetadata = (metadataByAssetId: Record<string, Metadata>, assetId?: Asse
 };
 
 const auctionsSelector = (state: AllSlices) => ({
-  auctions: state.dutchAuction.auctions,
+  auctionInfos: state.dutchAuction.auctionInfos,
   metadataByAssetId: state.dutchAuction.metadataByAssetId,
+  endAuction: state.dutchAuction.endAuction,
 });
 
 export const Auctions = () => {
-  const { auctions, metadataByAssetId } = useStoreShallow(auctionsSelector);
+  const { auctionInfos, metadataByAssetId, endAuction } = useStoreShallow(auctionsSelector);
 
   return (
     <>
@@ -32,17 +33,25 @@ export const Auctions = () => {
       </p>
 
       <div className='flex flex-col gap-2'>
-        {!auctions.length && "You don't currently have any auctions running."}
+        {!auctionInfos.length && "You don't currently have any auctions running."}
 
-        {auctions.map(auction => (
+        {auctionInfos.map(auctionInfo => (
           <ViewBox
-            key={auction.description?.nonce.toString()}
+            key={auctionInfo.auction.description?.nonce.toString()}
             label='Dutch Auction'
             visibleContent={
               <DutchAuctionComponent
-                dutchAuction={auction}
-                inputMetadata={getMetadata(metadataByAssetId, auction.description?.input?.assetId)}
-                outputMetadata={getMetadata(metadataByAssetId, auction.description?.outputId)}
+                dutchAuction={auctionInfo.auction}
+                inputMetadata={getMetadata(
+                  metadataByAssetId,
+                  auctionInfo.auction.description?.input?.assetId,
+                )}
+                outputMetadata={getMetadata(
+                  metadataByAssetId,
+                  auctionInfo.auction.description?.outputId,
+                )}
+                showEndButton
+                onClickEndButton={() => void endAuction(auctionInfo.id)}
               />
             }
           />

--- a/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
+++ b/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
@@ -7,7 +7,7 @@ export const DutchAuctionLoader = async () => {
   await throwIfPraxNotConnectedTimeout();
 
   // Load into state, but don't block rendering.
-  void useStore.getState().dutchAuction.loadAuctions();
+  void useStore.getState().dutchAuction.loadAuctionInfos();
 
   const [assets, balancesResponses] = await Promise.all([
     getAllAssets(),

--- a/apps/minifront/src/state/dutch-auction/assemble-schedule-request.test.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-schedule-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assembleRequest } from './assemble-request';
+import { assembleScheduleRequest } from './assemble-schedule-request';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { BLOCKS_PER_MINUTE, DURATION_IN_BLOCKS } from './constants';
@@ -42,7 +42,7 @@ const balancesResponse = new BalancesResponse({
   },
 });
 
-const ARGS: Parameters<typeof assembleRequest>[0] = {
+const ARGS: Parameters<typeof assembleScheduleRequest>[0] = {
   amount: '123',
   duration: '10min',
   minOutput: '1',
@@ -51,9 +51,9 @@ const ARGS: Parameters<typeof assembleRequest>[0] = {
   assetOut: metadata,
 };
 
-describe('assembleRequest()', () => {
+describe('assembleScheduleRequest()', () => {
   it('correctly converts durations to block heights', async () => {
-    const req = await assembleRequest({ ...ARGS, duration: '10min' });
+    const req = await assembleScheduleRequest({ ...ARGS, duration: '10min' });
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.startHeight).toBe(
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
@@ -62,7 +62,7 @@ describe('assembleRequest()', () => {
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS['10min'],
     );
 
-    const req2 = await assembleRequest({ ...ARGS, duration: '48h' });
+    const req2 = await assembleScheduleRequest({ ...ARGS, duration: '48h' });
 
     expect(req2.dutchAuctionScheduleActions[0]!.description!.startHeight).toBe(
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
@@ -73,13 +73,13 @@ describe('assembleRequest()', () => {
   });
 
   it('uses a step count of 120', async () => {
-    const req = await assembleRequest(ARGS);
+    const req = await assembleScheduleRequest(ARGS);
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.stepCount).toBe(120n);
   });
 
   it('correctly parses the input based on the display denom exponent', async () => {
-    const req = await assembleRequest(ARGS);
+    const req = await assembleScheduleRequest(ARGS);
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.input?.amount).toEqual(
       new Amount({ hi: 0n, lo: 123_000_000n }),
@@ -87,7 +87,7 @@ describe('assembleRequest()', () => {
   });
 
   it('correctly parses the min/max outputs based on the display denom exponent', async () => {
-    const req = await assembleRequest(ARGS);
+    const req = await assembleScheduleRequest(ARGS);
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.minOutput).toEqual(
       new Amount({ hi: 0n, lo: 1_000_000n }),

--- a/apps/minifront/src/state/dutch-auction/assemble-schedule-request.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-schedule-request.ts
@@ -17,7 +17,7 @@ import { fromString } from '@penumbra-zone/types/amount';
  */
 const getStartHeight = (fullSyncHeight: bigint) => fullSyncHeight + BLOCKS_PER_MINUTE;
 
-export const assembleRequest = async ({
+export const assembleScheduleRequest = async ({
   amount: amountAsString,
   assetIn,
   assetOut,

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -1,15 +1,26 @@
-import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import {
+  BalancesResponse,
+  TransactionPlannerRequest,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { SliceCreator } from '..';
 import {
   AssetId,
   Metadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { planBuildBroadcast } from '../helpers';
-import { assembleRequest } from './assemble-request';
+import { assembleScheduleRequest } from './assemble-schedule-request';
 import { DurationOption } from './constants';
-import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { viewClient } from '../../clients';
 import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
+
+interface AuctionInfo {
+  id: AuctionId;
+  auction: DutchAuction;
+}
 
 export interface DutchAuctionSlice {
   balancesResponses: BalancesResponse[];
@@ -28,10 +39,11 @@ export interface DutchAuctionSlice {
   setMaxOutput: (maxOutput: string) => void;
   onSubmit: () => Promise<void>;
   txInProgress: boolean;
-  auctions: DutchAuction[];
-  loadAuctions: () => Promise<void>;
+  auctionInfos: AuctionInfo[];
+  loadAuctionInfos: () => Promise<void>;
   loadMetadata: (assetId?: AssetId) => Promise<void>;
   metadataByAssetId: Record<string, Metadata>;
+  endAuction: (auctionId: AuctionId) => Promise<void>;
 }
 
 export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (set, get) => ({
@@ -89,10 +101,11 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     });
 
     try {
-      const req = await assembleRequest(get().dutchAuction);
+      const req = await assembleScheduleRequest(get().dutchAuction);
       await planBuildBroadcast('dutchAuctionSchedule', req);
 
       get().dutchAuction.setAmount('');
+      void get().dutchAuction.loadAuctionInfos();
     } finally {
       set(state => {
         state.dutchAuction.txInProgress = false;
@@ -102,22 +115,22 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
 
   txInProgress: false,
 
-  auctions: [],
-  loadAuctions: async () => {
+  auctionInfos: [],
+  loadAuctionInfos: async () => {
     set(state => {
-      state.dutchAuction.auctions = [];
+      state.dutchAuction.auctionInfos = [];
     });
 
     for await (const response of viewClient.auctions({})) {
-      if (!response.auction) continue;
+      if (!response.auction || !response.id) continue;
       const auction = DutchAuction.fromBinary(response.auction.value);
-      const auctions = [...get().dutchAuction.auctions, auction];
+      const auctions = [...get().dutchAuction.auctionInfos, { id: response.id, auction }];
 
       void get().dutchAuction.loadMetadata(auction.description?.input?.assetId);
       void get().dutchAuction.loadMetadata(auction.description?.outputId);
 
       set(state => {
-        state.dutchAuction.auctions = auctions;
+        state.dutchAuction.auctionInfos = auctions;
       });
     }
   },
@@ -135,4 +148,20 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
   },
 
   metadataByAssetId: {},
+
+  endAuction: async auctionId => {
+    set(state => {
+      state.dutchAuction.txInProgress = true;
+    });
+
+    try {
+      const req = new TransactionPlannerRequest({ dutchAuctionEndActions: [{ auctionId }] });
+      await planBuildBroadcast('dutchAuctionEnd', req);
+      void get().dutchAuction.loadAuctionInfos();
+    } finally {
+      set(state => {
+        state.dutchAuction.txInProgress = false;
+      });
+    }
+  },
 });

--- a/packages/perspective/transaction/classification.ts
+++ b/packages/perspective/transaction/classification.ts
@@ -22,4 +22,8 @@ export type TransactionClassification =
   /** The transaction contains an `ics20Withdrawal` action. */
   | 'ics20Withdrawal'
   /** The transaction contains an `actionDutchAuctionSchedule` action. */
-  | 'dutchAuctionSchedule';
+  | 'dutchAuctionSchedule'
+  /** The transaction contains an `actionDutchAuctionEnd` action. */
+  | 'dutchAuctionEnd'
+  /** The transaction contains an `actionDutchAuctionWithdraw` action. */
+  | 'dutchAuctionWithdraw';

--- a/packages/perspective/transaction/classify.test.ts
+++ b/packages/perspective/transaction/classify.test.ts
@@ -320,30 +320,31 @@ describe('classifyTransaction()', () => {
   it('returns `dutchAuctionSchedule` for transactions with an `actionDutchAuctionSchedule` action', () => {
     const transactionView = new TransactionView({
       bodyView: {
-        actionViews: [
-          {
-            actionView: {
-              case: 'actionDutchAuctionSchedule',
-              value: {},
-            },
-          },
-          {
-            actionView: {
-              case: 'spend',
-              value: {},
-            },
-          },
-          {
-            actionView: {
-              case: 'output',
-              value: {},
-            },
-          },
-        ],
+        actionViews: [{ actionView: { case: 'actionDutchAuctionSchedule', value: {} } }],
       },
     });
 
     expect(classifyTransaction(transactionView)).toBe('dutchAuctionSchedule');
+  });
+
+  it('returns `dutchAuctionEnd` for transactions with an `actionDutchAuctionEnd` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [{ actionView: { case: 'actionDutchAuctionEnd', value: {} } }],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('dutchAuctionEnd');
+  });
+
+  it('returns `dutchAuctionWithdraw` for transactions with an `actionDutchAuctionWithdraw` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [{ actionView: { case: 'actionDutchAuctionWithdraw', value: {} } }],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('dutchAuctionWithdraw');
   });
 
   it("returns `unknown` for transactions that don't fit the above categories", () => {

--- a/packages/perspective/transaction/classify.ts
+++ b/packages/perspective/transaction/classify.ts
@@ -16,6 +16,8 @@ export const classifyTransaction = (txv?: TransactionView): TransactionClassific
   if (allActionCases.has('undelegateClaim')) return 'undelegateClaim';
   if (allActionCases.has('ics20Withdrawal')) return 'ics20Withdrawal';
   if (allActionCases.has('actionDutchAuctionSchedule')) return 'dutchAuctionSchedule';
+  if (allActionCases.has('actionDutchAuctionEnd')) return 'dutchAuctionEnd';
+  if (allActionCases.has('actionDutchAuctionWithdraw')) return 'dutchAuctionWithdraw';
 
   const hasOpaqueSpend = txv.bodyView?.actionViews.some(
     a => a.actionView.case === 'spend' && a.actionView.value.spendView.case === 'opaque',
@@ -90,6 +92,8 @@ export const TRANSACTION_LABEL_BY_CLASSIFICATION: Record<TransactionClassificati
   undelegateClaim: 'Undelegate Claim',
   ics20Withdrawal: 'Ics20 Withdrawal',
   dutchAuctionSchedule: 'Dutch Auction Schedule',
+  dutchAuctionEnd: 'Dutch Auction End',
+  dutchAuctionWithdraw: 'Dutch Auction Withdraw',
 };
 
 export const getTransactionClassificationLabel = (txv?: TransactionView): string =>

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -419,24 +419,29 @@ export class BlockProcessor implements BlockProcessorInterface {
   private async identifyAuctionNfts(action: Action['action']) {
     if (action.case === 'actionDutchAuctionSchedule' && action.value.description) {
       const auctionId = getAuctionId(action.value.description);
-      const metadata = getAuctionNftMetadata(
-        auctionId,
-        // Always a sequence number of 0 when starting a Dutch auction
-        0n,
-      );
+
+      // Always a sequence number of 0 when starting a Dutch auction
+      const seqNum = 0n;
+
+      const metadata = getAuctionNftMetadata(auctionId, seqNum);
+
       await Promise.all([
         this.indexedDb.saveAssetsMetadata(metadata),
         this.indexedDb.upsertAuction(auctionId, {
           auction: action.value.description,
+          seqNum,
         }),
       ]);
     } else if (action.case === 'actionDutchAuctionEnd' && action.value.auctionId) {
-      const metadata = getAuctionNftMetadata(
-        action.value.auctionId,
-        // Always a sequence number of 1 when ending a Dutch auction
-        1n,
-      );
-      await this.indexedDb.saveAssetsMetadata(metadata);
+      // Always a sequence number of 1 when ending a Dutch auction
+      const seqNum = 1n;
+
+      const metadata = getAuctionNftMetadata(action.value.auctionId, seqNum);
+
+      await Promise.all([
+        this.indexedDb.saveAssetsMetadata(metadata),
+        this.indexedDb.upsertAuction(action.value.auctionId, { seqNum }),
+      ]);
     }
     /**
      * @todo Handle `actionDutchAuctionWithdraw`, and figure out how to

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -442,11 +442,19 @@ export class BlockProcessor implements BlockProcessorInterface {
         this.indexedDb.saveAssetsMetadata(metadata),
         this.indexedDb.upsertAuction(action.value.auctionId, { seqNum }),
       ]);
+    } else if (action.case === 'actionDutchAuctionWithdraw') {
+      const auctionId = action.value.auctionId;
+      if (!auctionId) return;
+
+      const metadata = getAuctionNftMetadata(auctionId, action.value.seq);
+
+      await Promise.all([
+        this.indexedDb.saveAssetsMetadata(metadata),
+        this.indexedDb.upsertAuction(auctionId, {
+          seqNum: action.value.seq,
+        }),
+      ]);
     }
-    /**
-     * @todo Handle `actionDutchAuctionWithdraw`, and figure out how to
-     * determine the sequence number if there have been multiple withdrawals.
-     */
   }
 
   /**

--- a/packages/query/src/queriers/auction.ts
+++ b/packages/query/src/queriers/auction.ts
@@ -1,0 +1,31 @@
+import { AuctionQuerierInterface } from '@penumbra-zone/types/querier';
+import { QueryService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/auction/v1alpha1/auction_connect';
+import { PromiseClient } from '@connectrpc/connect';
+import { createClient } from './utils';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { typeUrlMatchesTypeName } from '@penumbra-zone/types/protobuf';
+
+export class AuctionQuerier implements AuctionQuerierInterface {
+  private readonly client: PromiseClient<typeof QueryService>;
+
+  constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
+    this.client = createClient(grpcEndpoint, QueryService);
+  }
+
+  async auctionStateById(id: AuctionId): Promise<
+    // Add more auction types to this union type as they are created.
+    DutchAuction | undefined
+  > {
+    const result = await this.client.auctionStateById({ id });
+
+    // As more auction types are created, handle them here.
+    if (typeUrlMatchesTypeName(result.auction?.typeUrl, DutchAuction.typeName)) {
+      return DutchAuction.fromBinary(result.auction.value);
+    }
+
+    return undefined;
+  }
+}

--- a/packages/query/src/root-querier.ts
+++ b/packages/query/src/root-querier.ts
@@ -6,6 +6,7 @@ import { IbcClientQuerier } from './queriers/ibc-client';
 import { CnidariumQuerier } from './queriers/cnidarium';
 import { StakingQuerier } from './queriers/staking';
 import type { RootQuerierInterface } from '@penumbra-zone/types/querier';
+import { AuctionQuerier } from './queriers/auction';
 
 // Given the amount of query services, this root querier aggregates them all
 // to make it easier for consumers
@@ -17,6 +18,7 @@ export class RootQuerier implements RootQuerierInterface {
   readonly ibcClient: IbcClientQuerier;
   readonly staking: StakingQuerier;
   readonly cnidarium: CnidariumQuerier;
+  readonly auction: AuctionQuerier;
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.app = new AppQuerier({ grpcEndpoint });
@@ -26,5 +28,6 @@ export class RootQuerier implements RootQuerierInterface {
     this.ibcClient = new IbcClientQuerier({ grpcEndpoint });
     this.staking = new StakingQuerier({ grpcEndpoint });
     this.cnidarium = new CnidariumQuerier({ grpcEndpoint });
+    this.auction = new AuctionQuerier({ grpcEndpoint });
   }
 }

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -28,6 +28,11 @@ export interface IndexedDbMock {
   getPricesForAsset?: Mock;
   getAuction?: Mock;
 }
+
+export interface AuctionMock {
+  auctionStateById: Mock;
+}
+
 export interface TendermintMock {
   broadcastTx?: Mock;
   getTransaction?: Mock;
@@ -42,7 +47,8 @@ export interface ViewServerMock {
   fullViewingKey?: FullViewingKey;
 }
 
-interface MockQuerier {
+export interface MockQuerier {
+  auction?: AuctionMock;
   tendermint?: TendermintMock;
   shieldedPool?: ShieldedPoolMock;
   staking?: StakingMock;

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -86,6 +86,7 @@ const TEST_DATA = [
     value: {
       auction: MOCK_AUCTION_1,
       noteCommitment: new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) }),
+      seqNum: 0n,
     },
   },
   {
@@ -93,6 +94,7 @@ const TEST_DATA = [
     value: {
       auction: MOCK_AUCTION_2,
       noteCommitment: new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) }),
+      seqNum: 1n,
     },
   },
   {
@@ -100,6 +102,7 @@ const TEST_DATA = [
     value: {
       auction: MOCK_AUCTION_3,
       noteCommitment: new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) }),
+      seqNum: 2n,
     },
   },
   {
@@ -107,6 +110,7 @@ const TEST_DATA = [
     value: {
       auction: MOCK_AUCTION_4,
       noteCommitment: new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) }),
+      seqNum: 0n,
     },
   },
 ];
@@ -146,9 +150,9 @@ describe('Auctions request handler', () => {
 
   it('returns auctions', async () => {
     const req = new AuctionsRequest();
-    const result = await Array.fromAsync(auctions(req, mockCtx));
+    const results = await Array.fromAsync(auctions(req, mockCtx));
 
-    expect(result[0]).toEqual(
+    expect(results[0]).toEqual(
       new AuctionsResponse({
         id: AUCTION_ID_1,
         auction: {
@@ -173,5 +177,21 @@ describe('Auctions request handler', () => {
         }),
       );
     });
+  });
+
+  it('excludes inactive auctions by default', async () => {
+    const req = new AuctionsRequest();
+    const results = await Array.fromAsync(auctions(req, mockCtx));
+
+    expect(results.some(result => new AuctionId(result.id).equals(AUCTION_ID_2))).toBe(false);
+    expect(results.some(result => new AuctionId(result.id).equals(AUCTION_ID_3))).toBe(false);
+  });
+
+  it('includes inactive auctions if `includeInactive` is `true`', async () => {
+    const req = new AuctionsRequest({ includeInactive: true });
+    const results = await Array.fromAsync(auctions(req, mockCtx));
+
+    expect(results.some(result => new AuctionId(result.id).equals(AUCTION_ID_2))).toBe(true);
+    expect(results.some(result => new AuctionId(result.id).equals(AUCTION_ID_3))).toBe(true);
   });
 });

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -8,6 +8,7 @@ import { Impl } from '.';
 import {
   AuctionId,
   DutchAuction,
+  DutchAuctionState,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { balances } from './balances';
 import { getDisplayDenomFromView } from '@penumbra-zone/getters/value-view';
@@ -16,7 +17,7 @@ import { assetPatterns } from '@penumbra-zone/constants/assets';
 import { Any, PartialMessage } from '@bufbuild/protobuf';
 import { servicesCtx } from '../ctx/prax';
 import { auctionIdFromBech32 } from '@penumbra-zone/bech32m/pauctid';
-import { Code, ConnectError, HandlerContext } from '@connectrpc/connect';
+import { HandlerContext } from '@connectrpc/connect';
 import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 
 const getBech32mAuctionId = (
@@ -48,12 +49,8 @@ const iterateAuctionsThisUserControls = async function* (
 export const auctions: Impl['auctions'] = async function* (req, ctx) {
   const { includeInactive, queryLatestState, accountFilter } = req;
 
-  if (queryLatestState) {
-    throw new ConnectError('`queryLatestState` not yet implemented', Code.Unimplemented);
-  }
-
   const services = await ctx.values.get(servicesCtx)();
-  const { indexedDb } = await services.getWalletServices();
+  const { indexedDb, querier } = await services.getWalletServices();
 
   for await (const auctionId of iterateAuctionsThisUserControls(ctx, accountFilter)) {
     const id = new AuctionId(auctionIdFromBech32(auctionId));
@@ -65,14 +62,16 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
       noteRecord = await indexedDb.getSpendableNoteByCommitment(value.noteCommitment);
     }
 
-    let auction: Any | undefined;
+    let state: DutchAuctionState | undefined;
+    if (queryLatestState) state = (await querier.auction.auctionStateById(id))?.state;
 
-    if (value.auction) {
+    let auction: Any | undefined;
+    if (!!value.auction || state) {
       auction = new Any({
         typeUrl: DutchAuction.typeName,
         value: new DutchAuction({
           description: value.auction,
-          /** @todo include state if `queryLatestState` is `true` */
+          state,
         }).toBinary(),
       });
     }

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -49,17 +49,14 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
   if (queryLatestState) {
     throw new ConnectError('`queryLatestState` not yet implemented', Code.Unimplemented);
   }
-  if (includeInactive) {
-    throw new ConnectError('`includeInactive` not yet implemented', Code.Unimplemented);
-  }
 
   const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
   for await (const auctionId of iterateAuctionsThisUserControls(ctx, accountFilter)) {
-    /** @todo: if (req.includeInactive && auctionIsInactive()) continue; */
     const id = new AuctionId(auctionIdFromBech32(auctionId));
     const value = await indexedDb.getAuction(id);
+    if (!includeInactive && value.seqNum) continue;
 
     let noteRecord: SpendableNoteRecord | undefined;
     if (value.noteCommitment) {

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -33,6 +33,8 @@ const getBech32mAuctionId = (
   return captureGroups.auctionId;
 };
 
+const isInactive = (seqNum?: bigint) => (seqNum === undefined ? false : seqNum > 0n);
+
 const iterateAuctionsThisUserControls = async function* (
   ctx: HandlerContext,
   accountFilter?: AddressIndex,
@@ -56,7 +58,7 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
   for await (const auctionId of iterateAuctionsThisUserControls(ctx, accountFilter)) {
     const id = new AuctionId(auctionIdFromBech32(auctionId));
     const value = await indexedDb.getAuction(id);
-    if (!includeInactive && value.seqNum) continue;
+    if (!includeInactive && isInactive(value.seqNum)) continue;
 
     let noteRecord: SpendableNoteRecord | undefined;
     if (value.noteCommitment) {

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -691,6 +691,7 @@ export class IndexedDb implements IndexedDbInterface {
     value: {
       auction?: T;
       noteCommitment?: StateCommitment;
+      state?: bigint;
     },
   ): Promise<void> {
     const key = uint8ArrayToBase64(auctionId.inner);
@@ -700,6 +701,7 @@ export class IndexedDb implements IndexedDbInterface {
     const noteCommitment =
       (value.noteCommitment?.toJson() as Jsonified<StateCommitment> | undefined) ??
       existingRecord?.noteCommitment;
+    const state = value.state ?? existingRecord?.state;
 
     await this.u.update({
       table: 'AUCTIONS',
@@ -707,6 +709,7 @@ export class IndexedDb implements IndexedDbInterface {
       value: {
         auction,
         noteCommitment,
+        state,
       },
     });
   }
@@ -715,6 +718,7 @@ export class IndexedDb implements IndexedDbInterface {
     // Add more auction union types as they are created
     auction?: DutchAuctionDescription;
     noteCommitment?: StateCommitment;
+    state?: bigint;
   }> {
     const result = await this.db.get('AUCTIONS', uint8ArrayToBase64(auctionId.inner));
 
@@ -723,6 +727,7 @@ export class IndexedDb implements IndexedDbInterface {
       noteCommitment: result?.noteCommitment
         ? StateCommitment.fromJson(result.noteCommitment)
         : undefined,
+      state: result?.state,
     };
   }
 }

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -691,7 +691,7 @@ export class IndexedDb implements IndexedDbInterface {
     value: {
       auction?: T;
       noteCommitment?: StateCommitment;
-      state?: bigint;
+      seqNum?: bigint;
     },
   ): Promise<void> {
     const key = uint8ArrayToBase64(auctionId.inner);
@@ -701,7 +701,7 @@ export class IndexedDb implements IndexedDbInterface {
     const noteCommitment =
       (value.noteCommitment?.toJson() as Jsonified<StateCommitment> | undefined) ??
       existingRecord?.noteCommitment;
-    const state = value.state ?? existingRecord?.state;
+    const seqNum = value.seqNum ?? existingRecord?.seqNum;
 
     await this.u.update({
       table: 'AUCTIONS',
@@ -709,7 +709,7 @@ export class IndexedDb implements IndexedDbInterface {
       value: {
         auction,
         noteCommitment,
-        state,
+        seqNum,
       },
     });
   }
@@ -718,7 +718,7 @@ export class IndexedDb implements IndexedDbInterface {
     // Add more auction union types as they are created
     auction?: DutchAuctionDescription;
     noteCommitment?: StateCommitment;
-    state?: bigint;
+    seqNum?: bigint;
   }> {
     const result = await this.db.get('AUCTIONS', uint8ArrayToBase64(auctionId.inner));
 
@@ -727,7 +727,7 @@ export class IndexedDb implements IndexedDbInterface {
       noteCommitment: result?.noteCommitment
         ? StateCommitment.fromJson(result.noteCommitment)
         : undefined,
-      state: result?.state,
+      seqNum: result?.seqNum,
     };
   }
 }

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -671,11 +671,11 @@ describe('IndexedDb', () => {
       });
     });
 
-    it('inserts an auction and state, and then updates with a note commitment when given the same auction ID', async () => {
+    it('inserts an auction and sequence number, and then updates with a note commitment when given the same auction ID', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
-      const state = 0n;
-      await db.upsertAuction(auctionId, { auction, state });
+      const seqNum = 0n;
+      await db.upsertAuction(auctionId, { auction, seqNum });
 
       let fetchedAuction = await db.getAuction(auctionId);
       expect(fetchedAuction).toBeTruthy();
@@ -689,11 +689,11 @@ describe('IndexedDb', () => {
       expect(fetchedAuction).toEqual({
         auction,
         noteCommitment,
-        state,
+        seqNum,
       });
     });
 
-    it('inserts a note commitment and then updates with an auction and state when given the same auction ID', async () => {
+    it('inserts a note commitment and then updates with an auction and sequence number when given the same auction ID', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { noteCommitment });
@@ -702,8 +702,8 @@ describe('IndexedDb', () => {
       expect(fetchedAuction).toBeTruthy();
 
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
-      const state = 0n;
-      await db.upsertAuction(auctionId, { auction, state });
+      const seqNum = 0n;
+      await db.upsertAuction(auctionId, { auction, seqNum });
 
       fetchedAuction = await db.getAuction(auctionId);
       expect(fetchedAuction).toBeTruthy();
@@ -711,7 +711,7 @@ describe('IndexedDb', () => {
       expect(fetchedAuction).toEqual({
         auction,
         noteCommitment,
-        state,
+        seqNum,
       });
     });
   });

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -714,5 +714,26 @@ describe('IndexedDb', () => {
         seqNum,
       });
     });
+
+    it('inserts all data, and then updates with a sequence number when given the same auction ID', async () => {
+      const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
+      const auction = new DutchAuctionDescription({ startHeight: 1234n });
+      const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
+      await db.upsertAuction(auctionId, { auction, noteCommitment, seqNum: 0n });
+
+      let fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toBeTruthy();
+
+      await db.upsertAuction(auctionId, { seqNum: 1n });
+
+      fetchedAuction = await db.getAuction(auctionId);
+      expect(fetchedAuction).toBeTruthy();
+
+      expect(fetchedAuction).toEqual({
+        auction,
+        noteCommitment,
+        seqNum: 1n,
+      });
+    });
   });
 });

--- a/packages/storage/src/indexed-db/indexed-db.test.ts
+++ b/packages/storage/src/indexed-db/indexed-db.test.ts
@@ -671,10 +671,11 @@ describe('IndexedDb', () => {
       });
     });
 
-    it('inserts an auction and then updates with a note commitment when given the same auction ID', async () => {
+    it('inserts an auction and state, and then updates with a note commitment when given the same auction ID', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
-      await db.upsertAuction(auctionId, { auction });
+      const state = 0n;
+      await db.upsertAuction(auctionId, { auction, state });
 
       let fetchedAuction = await db.getAuction(auctionId);
       expect(fetchedAuction).toBeTruthy();
@@ -688,10 +689,11 @@ describe('IndexedDb', () => {
       expect(fetchedAuction).toEqual({
         auction,
         noteCommitment,
+        state,
       });
     });
 
-    it('inserts a note commitment and then updates with an auction when given the same auction ID', async () => {
+    it('inserts a note commitment and then updates with an auction and state when given the same auction ID', async () => {
       const auctionId = new AuctionId({ inner: new Uint8Array([0, 1, 2, 3]) });
       const noteCommitment = new StateCommitment({ inner: new Uint8Array([0, 1, 2, 3]) });
       await db.upsertAuction(auctionId, { noteCommitment });
@@ -700,7 +702,8 @@ describe('IndexedDb', () => {
       expect(fetchedAuction).toBeTruthy();
 
       const auction = new DutchAuctionDescription({ startHeight: 1234n });
-      await db.upsertAuction(auctionId, { auction });
+      const state = 0n;
+      await db.upsertAuction(auctionId, { auction, state });
 
       fetchedAuction = await db.getAuction(auctionId);
       expect(fetchedAuction).toBeTruthy();
@@ -708,6 +711,7 @@ describe('IndexedDb', () => {
       expect(fetchedAuction).toEqual({
         auction,
         noteCommitment,
+        state,
       });
     });
   });

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -111,7 +111,7 @@ export interface IndexedDbInterface {
     value: {
       auction?: T;
       noteCommitment?: StateCommitment;
-      state?: bigint;
+      seqNum?: bigint;
     },
   ): Promise<void>;
 
@@ -119,6 +119,7 @@ export interface IndexedDbInterface {
     // Add more auction union types as they are created
     auction?: DutchAuctionDescription;
     noteCommitment?: StateCommitment;
+    seqNum?: bigint;
   }>;
 }
 
@@ -225,7 +226,7 @@ export interface PenumbraDb extends DBSchema {
        * `1n`: auction has ended
        * `2n`+: the user has withdrawn funds from the auction
        */
-      state?: bigint;
+      seqNum?: bigint;
     };
   };
 }

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -111,6 +111,7 @@ export interface IndexedDbInterface {
     value: {
       auction?: T;
       noteCommitment?: StateCommitment;
+      state?: bigint;
     },
   ): Promise<void>;
 
@@ -218,6 +219,13 @@ export interface PenumbraDb extends DBSchema {
       noteCommitment?: Jsonified<StateCommitment>;
       // Add more types to `auction` as more auction types are created
       auction?: Jsonified<DutchAuctionDescription>;
+      /**
+       * For Dutch auctions:
+       * `0n`: auction is active
+       * `1n`: auction has ended
+       * `2n`+: the user has withdrawn funds from the auction
+       */
+      state?: bigint;
     };
   };
 }

--- a/packages/types/src/protobuf.test.ts
+++ b/packages/types/src/protobuf.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { typeUrlMatchesTypeName } from './protobuf';
+
+describe('typeUrlMatchesTypeName()', () => {
+  it('returns `true` if the type URL is equal to the type name with a leading slash', () => {
+    expect(typeUrlMatchesTypeName('/foo', 'foo')).toBe(true);
+  });
+
+  it('returns `false` if the type URL is not equal to the type name with a leading slash', () => {
+    expect(typeUrlMatchesTypeName('/foo', 'bar')).toBe(false);
+  });
+
+  it('returns `false` if the type URL is undefined', () => {
+    expect(typeUrlMatchesTypeName(undefined, 'foo')).toBe(false);
+  });
+
+  it('returns `false` if the type name is undefined', () => {
+    expect(typeUrlMatchesTypeName('/foo', undefined)).toBe(false);
+  });
+});

--- a/packages/types/src/protobuf.ts
+++ b/packages/types/src/protobuf.ts
@@ -1,0 +1,10 @@
+/**
+ * When converting a type name to a type URL, you simply add a leading slash.
+ * This little helper allows you to pass the type URL of a Protobuf object, and
+ * the typename of a Protobuf class, to compare them. Useful when working with
+ * `Any`s.
+ *
+ * @see https://github.com/tokio-rs/prost/blob/215ae16/prost/src/name.rs#L27-L33
+ */
+export const typeUrlMatchesTypeName = (typeUrl?: string, typeName?: string): typeUrl is string =>
+  typeUrl !== undefined && typeName !== undefined && typeUrl === `/${typeName}`;

--- a/packages/types/src/querier.ts
+++ b/packages/types/src/querier.ts
@@ -17,6 +17,10 @@ import {
   ValidatorPenaltyResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 import { MerkleRoot } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
+import {
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
 export interface RootQuerierInterface {
   app: AppQuerierInterface;
@@ -26,6 +30,7 @@ export interface RootQuerierInterface {
   ibcClient: IbcClientQuerierInterface;
   staking: StakingQuerierInterface;
   cnidarium: CnidariumQuerierInterface;
+  auction: AuctionQuerierInterface;
 }
 
 export interface AppQuerierInterface {
@@ -64,4 +69,8 @@ export interface StakingQuerierInterface {
 
 export interface CnidariumQuerierInterface {
   fetchRemoteRoot(blockHeight: bigint): Promise<MerkleRoot>;
+}
+
+export interface AuctionQuerierInterface {
+  auctionStateById(id: AuctionId): Promise<DutchAuction | undefined>;
 }

--- a/packages/ui/components/ui/auction-id-component.tsx
+++ b/packages/ui/components/ui/auction-id-component.tsx
@@ -1,0 +1,31 @@
+import { CopyToClipboardIconButton } from './copy-to-clipboard-icon-button';
+import { useMemo } from 'react';
+import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { bech32mAuctionId, PENUMBRA_BECH32M_AUCTION_PREFIX } from '@penumbra-zone/bech32m/pauctid';
+
+const SEPARATOR_INDEX = PENUMBRA_BECH32M_AUCTION_PREFIX.length + 1;
+
+/**
+ * Renders an auction's `AuctionId` as a bech32-encoded string, along with a
+ * copy button.
+ *
+ * @example
+ * ```tsx
+ * <AuctionIdComponent auctionId={auctionId} />
+ * ```
+ */
+export const AuctionIdComponent = ({ auctionId }: { auctionId?: AuctionId }) => {
+  const id = useMemo(() => (auctionId ? bech32mAuctionId(auctionId) : undefined), [auctionId]);
+
+  if (!id) return null;
+
+  return (
+    <div className='flex min-w-0 items-center gap-2'>
+      <div className='min-w-0 truncate font-mono'>
+        <span className='text-muted-foreground'>{id.slice(0, SEPARATOR_INDEX)}</span>
+        {id.slice(SEPARATOR_INDEX)}
+      </div>
+      <CopyToClipboardIconButton text={id} />
+    </div>
+  );
+};

--- a/packages/ui/components/ui/dutch-auction-component.tsx
+++ b/packages/ui/components/ui/dutch-auction-component.tsx
@@ -6,6 +6,7 @@ import {
   ValueView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { Button } from './button';
 
 const getValueView = (amount?: Amount, metadata?: Metadata) =>
   new ValueView({
@@ -18,15 +19,31 @@ const getValueView = (amount?: Amount, metadata?: Metadata) =>
     },
   });
 
+interface BaseProps {
+  dutchAuction: DutchAuction;
+  inputMetadata?: Metadata;
+  outputMetadata?: Metadata;
+}
+
+interface PropsWithEndButton extends BaseProps {
+  showEndButton: true;
+  onClickEndButton: VoidFunction;
+}
+
+interface PropsWithoutEndButton extends BaseProps {
+  showEndButton?: false;
+  onClickEndButton?: undefined;
+}
+
+type Props = PropsWithEndButton | PropsWithoutEndButton;
+
 export const DutchAuctionComponent = ({
   dutchAuction,
   inputMetadata,
   outputMetadata,
-}: {
-  dutchAuction: DutchAuction;
-  inputMetadata?: Metadata;
-  outputMetadata?: Metadata;
-}) => {
+  showEndButton,
+  onClickEndButton,
+}: Props) => {
   const { description } = dutchAuction;
   if (!description) return null;
 
@@ -35,30 +52,40 @@ export const DutchAuctionComponent = ({
   const minOutput = getValueView(description.minOutput, outputMetadata);
 
   return (
-    <ActionDetails>
-      <ActionDetails.Row label='Input'>
-        <ValueViewComponent view={input} />
-      </ActionDetails.Row>
+    <div className='flex flex-col gap-8'>
+      <ActionDetails>
+        <ActionDetails.Row label='Input'>
+          <ValueViewComponent view={input} />
+        </ActionDetails.Row>
 
-      <ActionDetails.Row label='Output'>
-        <div className='flex flex-wrap justify-end gap-2'>
-          <div className='flex items-center gap-2'>
-            <span className='text-nowrap text-muted-foreground'>Max:</span>
-            <ValueViewComponent view={maxOutput} />
+        <ActionDetails.Row label='Output'>
+          <div className='flex flex-wrap justify-end gap-2'>
+            <div className='flex items-center gap-2'>
+              <span className='text-nowrap text-muted-foreground'>Max:</span>
+              <ValueViewComponent view={maxOutput} />
+            </div>
+            <div className='flex items-center gap-2'>
+              <span className='text-nowrap text-muted-foreground'>Min:</span>
+              <ValueViewComponent view={minOutput} />
+            </div>
           </div>
-          <div className='flex items-center gap-2'>
-            <span className='text-nowrap text-muted-foreground'>Min:</span>
-            <ValueViewComponent view={minOutput} />
-          </div>
+        </ActionDetails.Row>
+
+        <ActionDetails.Row label='Duration'>
+          <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
+          {description.startHeight.toString()}
+          <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
+          {description.endHeight.toString()}
+        </ActionDetails.Row>
+      </ActionDetails>
+
+      {showEndButton && (
+        <div className='self-end'>
+          <Button variant='destructiveSecondary' size='md' onClick={onClickEndButton}>
+            End auction
+          </Button>
         </div>
-      </ActionDetails.Row>
-
-      <ActionDetails.Row label='Duration'>
-        <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
-        {description.startHeight.toString()}
-        <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
-        {description.endHeight.toString()}
-      </ActionDetails.Row>
-    </ActionDetails>
+      )}
+    </div>
   );
 };

--- a/packages/ui/components/ui/tx/view/action-dutch-auction-end.tsx
+++ b/packages/ui/components/ui/tx/view/action-dutch-auction-end.tsx
@@ -1,0 +1,19 @@
+import { ActionDutchAuctionEnd } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { ViewBox } from './viewbox';
+import { AuctionIdComponent } from '../../auction-id-component';
+import { ActionDetails } from './action-details';
+
+export const ActionDutchAuctionEndComponent = ({ value }: { value: ActionDutchAuctionEnd }) => {
+  return (
+    <ViewBox
+      label='End a Dutch Auction'
+      visibleContent={
+        <ActionDetails>
+          <ActionDetails.Row label='Auction ID'>
+            <AuctionIdComponent auctionId={value.auctionId} />
+          </ActionDetails.Row>
+        </ActionDetails>
+      }
+    />
+  );
+};

--- a/packages/ui/components/ui/tx/view/action-view.tsx
+++ b/packages/ui/components/ui/tx/view/action-view.tsx
@@ -9,6 +9,7 @@ import { Ics20WithdrawalComponent } from './isc20-withdrawal';
 import { UnimplementedView } from './unimplemented-view';
 import { SwapViewComponent } from './swap';
 import { ActionDutchAuctionScheduleViewComponent } from './action-dutch-auction-schedule-view';
+import { ActionDutchAuctionEndComponent } from './action-dutch-auction-end';
 
 const CASE_TO_LABEL: Record<string, string> = {
   daoDeposit: 'DAO Deposit',
@@ -70,6 +71,9 @@ export const ActionViewComponent = ({ av: { actionView } }: { av: ActionView }) 
 
     case 'actionDutchAuctionSchedule':
       return <ActionDutchAuctionScheduleViewComponent value={actionView.value} />;
+
+    case 'actionDutchAuctionEnd':
+      return <ActionDutchAuctionEndComponent value={actionView.value} />;
 
     case 'validatorDefinition':
       return <UnimplementedView label='Validator Definition' />;


### PR DESCRIPTION
`AuctionsRequest`s have an `includeInactive` property that was not yet supported by our `auctions` implementation. This PR adds support for that property by A) keeping track of auctions' sequence numbers to determine whether they're active, and B) filtering out inactive auctions unless `includeInactive` is `true`.

## In this PR
- Add a `seqNum` column to the `AUCTIONS` table (to mimic the `state` column in [core](https://github.com/penumbra-zone/penumbra/blob/main/crates/view/src/storage/schema.sql#L136-L140)'s implementation)
- Upsert the `seqNum` in the block processor when we encounter a Dutch auction-related action.
- Add support for `includeInactive` in the `ViewService#auctions` RPC method.
- Bump the IndexedDB version number.

Relates to #980 (but doesn't close it yet, since `queryLatestState` is not yet supported)