### PR TITLE
Skip unknownAssetId when checking isUnbondingTokenBalance()

### DIFF
--- a/packages/getters/src/balances-response.ts
+++ b/packages/getters/src/balances-response.ts
@@ -12,4 +12,7 @@ export const getAssetIdFromBalancesResponseOptional = getBalanceView
   .pipe(getMetadata)
   .pipe(getAssetId);
 
-export const getDisplayFromBalancesResponse = getBalanceView.pipe(getMetadata).pipe(getDisplay);
+export const getDisplayFromBalancesResponse = getBalanceView
+  .pipe(getMetadata)
+  .optional()
+  .pipe(getDisplay);

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
@@ -11,11 +11,8 @@ import { status } from '../status';
 import { appParameters } from '../app-parameters';
 
 export const isUnbondingTokenBalance = (balancesResponse: PartialMessage<BalancesResponse>) => {
-  if (balancesResponse.balanceView?.valueView?.case === 'unknownAssetId') return false;
-
-  return assetPatterns.unbondingToken.matches(
-    getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),
-  );
+  const display = getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse));
+  return display ? assetPatterns.unbondingToken.matches(display) : false;
 };
 
 /**
@@ -42,6 +39,8 @@ export const getIsClaimable = async (
   if (!fullSyncHeight || !parameters?.stakeParams?.unbondingDelay) return false;
 
   const display = getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse));
+  if (!display) return false;
+
   const unbondingStartHeight = assetPatterns.unbondingToken.capture(display);
 
   if (unbondingStartHeight?.startAt) {


### PR DESCRIPTION
While working on https://github.com/penumbra-zone/web/issues/1043 I discovered a issue 

If a user has unknown tokens in their balance, they will receive a log error and invalid Unbonding amount and Claimable amount values

in addition to https://github.com/penumbra-zone/web/pull/1010

<img width="500" alt="image" src="https://github.com/penumbra-zone/web/assets/25391690/ba3c1821-f2be-4091-a19b-3e44590ff6aa">

Before:
<img width="500" alt="image" src="https://github.com/penumbra-zone/web/assets/25391690/3c3ad210-569b-4579-baec-3c80f0a92660">
After: 
<img width="500" alt="image" src="https://github.com/penumbra-zone/web/assets/25391690/7570d093-87f6-48e6-bf90-009b599461ad">

