### PR TITLE
UI for ending auctions

### DIFF
--- a/apps/extension/.env.testnet
+++ b/apps/extension/.env.testnet
@@ -1,4 +1,4 @@
 CHAIN_ID=penumbra-testnet-deimos-7
-IDB_VERSION=38
+IDB_VERSION=39
 MINIFRONT_URL=https://app.testnet.penumbra.zone
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -18,12 +18,13 @@ const getMetadata = (metadataByAssetId: Record<string, Metadata>, assetId?: Asse
 };
 
 const auctionsSelector = (state: AllSlices) => ({
-  auctions: state.dutchAuction.auctions,
+  auctionInfos: state.dutchAuction.auctionInfos,
   metadataByAssetId: state.dutchAuction.metadataByAssetId,
+  endAuction: state.dutchAuction.endAuction,
 });
 
 export const Auctions = () => {
-  const { auctions, metadataByAssetId } = useStoreShallow(auctionsSelector);
+  const { auctionInfos, metadataByAssetId, endAuction } = useStoreShallow(auctionsSelector);
 
   return (
     <>
@@ -32,17 +33,25 @@ export const Auctions = () => {
       </p>
 
       <div className='flex flex-col gap-2'>
-        {!auctions.length && "You don't currently have any auctions running."}
+        {!auctionInfos.length && "You don't currently have any auctions running."}
 
-        {auctions.map(auction => (
+        {auctionInfos.map(auctionInfo => (
           <ViewBox
-            key={auction.description?.nonce.toString()}
+            key={auctionInfo.auction.description?.nonce.toString()}
             label='Dutch Auction'
             visibleContent={
               <DutchAuctionComponent
-                dutchAuction={auction}
-                inputMetadata={getMetadata(metadataByAssetId, auction.description?.input?.assetId)}
-                outputMetadata={getMetadata(metadataByAssetId, auction.description?.outputId)}
+                dutchAuction={auctionInfo.auction}
+                inputMetadata={getMetadata(
+                  metadataByAssetId,
+                  auctionInfo.auction.description?.input?.assetId,
+                )}
+                outputMetadata={getMetadata(
+                  metadataByAssetId,
+                  auctionInfo.auction.description?.outputId,
+                )}
+                showEndButton
+                onClickEndButton={() => void endAuction(auctionInfo.id)}
               />
             }
           />

--- a/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
+++ b/apps/minifront/src/components/swap/dutch-auction/dutch-auction-loader.ts
@@ -7,7 +7,7 @@ export const DutchAuctionLoader = async () => {
   await throwIfPraxNotConnectedTimeout();
 
   // Load into state, but don't block rendering.
-  void useStore.getState().dutchAuction.loadAuctions();
+  void useStore.getState().dutchAuction.loadAuctionInfos();
 
   const [assets, balancesResponses] = await Promise.all([
     getAllAssets(),

--- a/apps/minifront/src/state/dutch-auction/assemble-schedule-request.test.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-schedule-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assembleRequest } from './assemble-request';
+import { assembleScheduleRequest } from './assemble-schedule-request';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { BLOCKS_PER_MINUTE, DURATION_IN_BLOCKS } from './constants';
@@ -42,7 +42,7 @@ const balancesResponse = new BalancesResponse({
   },
 });
 
-const ARGS: Parameters<typeof assembleRequest>[0] = {
+const ARGS: Parameters<typeof assembleScheduleRequest>[0] = {
   amount: '123',
   duration: '10min',
   minOutput: '1',
@@ -51,9 +51,9 @@ const ARGS: Parameters<typeof assembleRequest>[0] = {
   assetOut: metadata,
 };
 
-describe('assembleRequest()', () => {
+describe('assembleScheduleRequest()', () => {
   it('correctly converts durations to block heights', async () => {
-    const req = await assembleRequest({ ...ARGS, duration: '10min' });
+    const req = await assembleScheduleRequest({ ...ARGS, duration: '10min' });
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.startHeight).toBe(
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
@@ -62,7 +62,7 @@ describe('assembleRequest()', () => {
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE + DURATION_IN_BLOCKS['10min'],
     );
 
-    const req2 = await assembleRequest({ ...ARGS, duration: '48h' });
+    const req2 = await assembleScheduleRequest({ ...ARGS, duration: '48h' });
 
     expect(req2.dutchAuctionScheduleActions[0]!.description!.startHeight).toBe(
       MOCK_START_HEIGHT + BLOCKS_PER_MINUTE,
@@ -73,13 +73,13 @@ describe('assembleRequest()', () => {
   });
 
   it('uses a step count of 120', async () => {
-    const req = await assembleRequest(ARGS);
+    const req = await assembleScheduleRequest(ARGS);
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.stepCount).toBe(120n);
   });
 
   it('correctly parses the input based on the display denom exponent', async () => {
-    const req = await assembleRequest(ARGS);
+    const req = await assembleScheduleRequest(ARGS);
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.input?.amount).toEqual(
       new Amount({ hi: 0n, lo: 123_000_000n }),
@@ -87,7 +87,7 @@ describe('assembleRequest()', () => {
   });
 
   it('correctly parses the min/max outputs based on the display denom exponent', async () => {
-    const req = await assembleRequest(ARGS);
+    const req = await assembleScheduleRequest(ARGS);
 
     expect(req.dutchAuctionScheduleActions[0]!.description!.minOutput).toEqual(
       new Amount({ hi: 0n, lo: 1_000_000n }),

--- a/apps/minifront/src/state/dutch-auction/assemble-schedule-request.ts
+++ b/apps/minifront/src/state/dutch-auction/assemble-schedule-request.ts
@@ -17,7 +17,7 @@ import { fromString } from '@penumbra-zone/types/amount';
  */
 const getStartHeight = (fullSyncHeight: bigint) => fullSyncHeight + BLOCKS_PER_MINUTE;
 
-export const assembleRequest = async ({
+export const assembleScheduleRequest = async ({
   amount: amountAsString,
   assetIn,
   assetOut,

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -8,7 +8,7 @@ import {
   Metadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { planBuildBroadcast } from '../helpers';
-import { assembleRequest } from './assemble-request';
+import { assembleScheduleRequest } from './assemble-schedule-request';
 import { DurationOption } from './constants';
 import {
   AuctionId,
@@ -101,7 +101,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     });
 
     try {
-      const req = await assembleRequest(get().dutchAuction);
+      const req = await assembleScheduleRequest(get().dutchAuction);
       await planBuildBroadcast('dutchAuctionSchedule', req);
 
       get().dutchAuction.setAmount('');

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -105,6 +105,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
       await planBuildBroadcast('dutchAuctionSchedule', req);
 
       get().dutchAuction.setAmount('');
+      void get().dutchAuction.loadAuctionInfos();
     } finally {
       set(state => {
         state.dutchAuction.txInProgress = false;
@@ -156,6 +157,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     try {
       const req = new TransactionPlannerRequest({ dutchAuctionEndActions: [{ auctionId }] });
       await planBuildBroadcast('dutchAuctionEnd', req);
+      void get().dutchAuction.loadAuctionInfos();
     } finally {
       set(state => {
         state.dutchAuction.txInProgress = false;

--- a/packages/perspective/transaction/classification.ts
+++ b/packages/perspective/transaction/classification.ts
@@ -22,4 +22,8 @@ export type TransactionClassification =
   /** The transaction contains an `ics20Withdrawal` action. */
   | 'ics20Withdrawal'
   /** The transaction contains an `actionDutchAuctionSchedule` action. */
-  | 'dutchAuctionSchedule';
+  | 'dutchAuctionSchedule'
+  /** The transaction contains an `actionDutchAuctionEnd` action. */
+  | 'dutchAuctionEnd'
+  /** The transaction contains an `actionDutchAuctionWithdraw` action. */
+  | 'dutchAuctionWithdraw';

--- a/packages/perspective/transaction/classify.test.ts
+++ b/packages/perspective/transaction/classify.test.ts
@@ -320,30 +320,31 @@ describe('classifyTransaction()', () => {
   it('returns `dutchAuctionSchedule` for transactions with an `actionDutchAuctionSchedule` action', () => {
     const transactionView = new TransactionView({
       bodyView: {
-        actionViews: [
-          {
-            actionView: {
-              case: 'actionDutchAuctionSchedule',
-              value: {},
-            },
-          },
-          {
-            actionView: {
-              case: 'spend',
-              value: {},
-            },
-          },
-          {
-            actionView: {
-              case: 'output',
-              value: {},
-            },
-          },
-        ],
+        actionViews: [{ actionView: { case: 'actionDutchAuctionSchedule', value: {} } }],
       },
     });
 
     expect(classifyTransaction(transactionView)).toBe('dutchAuctionSchedule');
+  });
+
+  it('returns `dutchAuctionEnd` for transactions with an `actionDutchAuctionEnd` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [{ actionView: { case: 'actionDutchAuctionEnd', value: {} } }],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('dutchAuctionEnd');
+  });
+
+  it('returns `dutchAuctionWithdraw` for transactions with an `actionDutchAuctionWithdraw` action', () => {
+    const transactionView = new TransactionView({
+      bodyView: {
+        actionViews: [{ actionView: { case: 'actionDutchAuctionWithdraw', value: {} } }],
+      },
+    });
+
+    expect(classifyTransaction(transactionView)).toBe('dutchAuctionWithdraw');
   });
 
   it("returns `unknown` for transactions that don't fit the above categories", () => {

--- a/packages/perspective/transaction/classify.ts
+++ b/packages/perspective/transaction/classify.ts
@@ -16,6 +16,8 @@ export const classifyTransaction = (txv?: TransactionView): TransactionClassific
   if (allActionCases.has('undelegateClaim')) return 'undelegateClaim';
   if (allActionCases.has('ics20Withdrawal')) return 'ics20Withdrawal';
   if (allActionCases.has('actionDutchAuctionSchedule')) return 'dutchAuctionSchedule';
+  if (allActionCases.has('actionDutchAuctionEnd')) return 'dutchAuctionEnd';
+  if (allActionCases.has('actionDutchAuctionWithdraw')) return 'dutchAuctionWithdraw';
 
   const hasOpaqueSpend = txv.bodyView?.actionViews.some(
     a => a.actionView.case === 'spend' && a.actionView.value.spendView.case === 'opaque',
@@ -90,6 +92,8 @@ export const TRANSACTION_LABEL_BY_CLASSIFICATION: Record<TransactionClassificati
   undelegateClaim: 'Undelegate Claim',
   ics20Withdrawal: 'Ics20 Withdrawal',
   dutchAuctionSchedule: 'Dutch Auction Schedule',
+  dutchAuctionEnd: 'Dutch Auction End',
+  dutchAuctionWithdraw: 'Dutch Auction Withdraw',
 };
 
 export const getTransactionClassificationLabel = (txv?: TransactionView): string =>

--- a/packages/ui/components/ui/auction-id-component.tsx
+++ b/packages/ui/components/ui/auction-id-component.tsx
@@ -1,0 +1,31 @@
+import { CopyToClipboardIconButton } from './copy-to-clipboard-icon-button';
+import { useMemo } from 'react';
+import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { bech32mAuctionId, PENUMBRA_BECH32M_AUCTION_PREFIX } from '@penumbra-zone/bech32m/pauctid';
+
+const SEPARATOR_INDEX = PENUMBRA_BECH32M_AUCTION_PREFIX.length + 1;
+
+/**
+ * Renders an auction's `AuctionId` as a bech32-encoded string, along with a
+ * copy button.
+ *
+ * @example
+ * ```tsx
+ * <AuctionIdComponent auctionId={auctionId} />
+ * ```
+ */
+export const AuctionIdComponent = ({ auctionId }: { auctionId?: AuctionId }) => {
+  const id = useMemo(() => (auctionId ? bech32mAuctionId(auctionId) : undefined), [auctionId]);
+
+  if (!id) return null;
+
+  return (
+    <div className='flex min-w-0 items-center gap-2'>
+      <div className='min-w-0 truncate font-mono'>
+        <span className='text-muted-foreground'>{id.slice(0, SEPARATOR_INDEX)}</span>
+        {id.slice(SEPARATOR_INDEX)}
+      </div>
+      <CopyToClipboardIconButton text={id} />
+    </div>
+  );
+};

--- a/packages/ui/components/ui/dutch-auction-component.tsx
+++ b/packages/ui/components/ui/dutch-auction-component.tsx
@@ -6,6 +6,7 @@ import {
   ValueView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { Button } from './button';
 
 const getValueView = (amount?: Amount, metadata?: Metadata) =>
   new ValueView({
@@ -18,15 +19,31 @@ const getValueView = (amount?: Amount, metadata?: Metadata) =>
     },
   });
 
+interface BaseProps {
+  dutchAuction: DutchAuction;
+  inputMetadata?: Metadata;
+  outputMetadata?: Metadata;
+}
+
+interface PropsWithEndButton extends BaseProps {
+  showEndButton: true;
+  onClickEndButton: VoidFunction;
+}
+
+interface PropsWithoutEndButton extends BaseProps {
+  showEndButton?: false;
+  onClickEndButton?: undefined;
+}
+
+type Props = PropsWithEndButton | PropsWithoutEndButton;
+
 export const DutchAuctionComponent = ({
   dutchAuction,
   inputMetadata,
   outputMetadata,
-}: {
-  dutchAuction: DutchAuction;
-  inputMetadata?: Metadata;
-  outputMetadata?: Metadata;
-}) => {
+  showEndButton,
+  onClickEndButton,
+}: Props) => {
   const { description } = dutchAuction;
   if (!description) return null;
 
@@ -35,30 +52,38 @@ export const DutchAuctionComponent = ({
   const minOutput = getValueView(description.minOutput, outputMetadata);
 
   return (
-    <ActionDetails>
-      <ActionDetails.Row label='Input'>
-        <ValueViewComponent view={input} />
-      </ActionDetails.Row>
+    <div className='flex flex-col items-end gap-2'>
+      <ActionDetails>
+        <ActionDetails.Row label='Input'>
+          <ValueViewComponent view={input} />
+        </ActionDetails.Row>
 
-      <ActionDetails.Row label='Output'>
-        <div className='flex flex-wrap justify-end gap-2'>
-          <div className='flex items-center gap-2'>
-            <span className='text-nowrap text-muted-foreground'>Max:</span>
-            <ValueViewComponent view={maxOutput} />
+        <ActionDetails.Row label='Output'>
+          <div className='flex flex-wrap justify-end gap-2'>
+            <div className='flex items-center gap-2'>
+              <span className='text-nowrap text-muted-foreground'>Max:</span>
+              <ValueViewComponent view={maxOutput} />
+            </div>
+            <div className='flex items-center gap-2'>
+              <span className='text-nowrap text-muted-foreground'>Min:</span>
+              <ValueViewComponent view={minOutput} />
+            </div>
           </div>
-          <div className='flex items-center gap-2'>
-            <span className='text-nowrap text-muted-foreground'>Min:</span>
-            <ValueViewComponent view={minOutput} />
-          </div>
-        </div>
-      </ActionDetails.Row>
+        </ActionDetails.Row>
 
-      <ActionDetails.Row label='Duration'>
-        <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
-        {description.startHeight.toString()}
-        <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
-        {description.endHeight.toString()}
-      </ActionDetails.Row>
-    </ActionDetails>
+        <ActionDetails.Row label='Duration'>
+          <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
+          {description.startHeight.toString()}
+          <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
+          {description.endHeight.toString()}
+        </ActionDetails.Row>
+      </ActionDetails>
+
+      {showEndButton && (
+        <Button variant='destructiveSecondary' size='md' onClick={onClickEndButton}>
+          End auction
+        </Button>
+      )}
+    </div>
   );
 };

--- a/packages/ui/components/ui/dutch-auction-component.tsx
+++ b/packages/ui/components/ui/dutch-auction-component.tsx
@@ -52,7 +52,7 @@ export const DutchAuctionComponent = ({
   const minOutput = getValueView(description.minOutput, outputMetadata);
 
   return (
-    <div className='flex flex-col items-end gap-2'>
+    <div className='flex flex-col gap-8'>
       <ActionDetails>
         <ActionDetails.Row label='Input'>
           <ValueViewComponent view={input} />
@@ -80,9 +80,11 @@ export const DutchAuctionComponent = ({
       </ActionDetails>
 
       {showEndButton && (
-        <Button variant='destructiveSecondary' size='md' onClick={onClickEndButton}>
-          End auction
-        </Button>
+        <div className='self-end'>
+          <Button variant='destructiveSecondary' size='md' onClick={onClickEndButton}>
+            End auction
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/packages/ui/components/ui/tx/view/action-dutch-auction-end.tsx
+++ b/packages/ui/components/ui/tx/view/action-dutch-auction-end.tsx
@@ -1,0 +1,19 @@
+import { ActionDutchAuctionEnd } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { ViewBox } from './viewbox';
+import { AuctionIdComponent } from '../../auction-id-component';
+import { ActionDetails } from './action-details';
+
+export const ActionDutchAuctionEndComponent = ({ value }: { value: ActionDutchAuctionEnd }) => {
+  return (
+    <ViewBox
+      label='End a Dutch Auction'
+      visibleContent={
+        <ActionDetails>
+          <ActionDetails.Row label='Auction ID'>
+            <AuctionIdComponent auctionId={value.auctionId} />
+          </ActionDetails.Row>
+        </ActionDetails>
+      }
+    />
+  );
+};

--- a/packages/ui/components/ui/tx/view/action-view.tsx
+++ b/packages/ui/components/ui/tx/view/action-view.tsx
@@ -9,6 +9,7 @@ import { Ics20WithdrawalComponent } from './isc20-withdrawal';
 import { UnimplementedView } from './unimplemented-view';
 import { SwapViewComponent } from './swap';
 import { ActionDutchAuctionScheduleViewComponent } from './action-dutch-auction-schedule-view';
+import { ActionDutchAuctionEndComponent } from './action-dutch-auction-end';
 
 const CASE_TO_LABEL: Record<string, string> = {
   daoDeposit: 'DAO Deposit',
@@ -70,6 +71,9 @@ export const ActionViewComponent = ({ av: { actionView } }: { av: ActionView }) 
 
     case 'actionDutchAuctionSchedule':
       return <ActionDutchAuctionScheduleViewComponent value={actionView.value} />;
+
+    case 'actionDutchAuctionEnd':
+      return <ActionDutchAuctionEndComponent value={actionView.value} />;
 
     case 'validatorDefinition':
       return <UnimplementedView label='Validator Definition' />;


### PR DESCRIPTION
Now that auctions can be scheduled and viewed, it's time to allow users to end them!

https://github.com/penumbra-zone/web/assets/1121544/de0dcec0-0b31-461f-ad29-994e3d7ae9f2




## In this PR
- Modify `<DutchAuctionComponent />` to render an "End auction" button.
- Create `<ActionDutchAuctionEndComponent />` to render the action of ending an auction.
- Change metadata symbols for auction NFTs to include the sequence numbers (before: `auction(abcd1234...)`; after: `auction@1(abcd1234...)`
  - While I was at it, I changed all the customized symbols to use ellipses, since those display more nicely.
    Before:
    ![image](https://github.com/penumbra-zone/web/assets/1121544/41a451df-22aa-44bc-a98a-656c0011f9bb)

    After:
    ![image](https://github.com/penumbra-zone/web/assets/1121544/c8407463-66d6-4460-92bd-5ccad21c1f6b)
- Change the shape of the `dutchAuction` state slice; now, there's an `auctionInfos` array instead of an `auctions` array. Each `AuctionInfo` contains the auction ID and the `DutchAuction` (because the `auctions` array was just of type `DutchAuction[]`, which doesn't contain the auction ID, which we need for ending an auction).
- Rename `assembleRequest()` to `assembleScheduleRequest()`, to differentiate from the other types of requests that get assembled in the Dutch auction slice.
- Create new transaction classifications for Dutch auction withdraws and ends.

Closes #1019 