### PR TITLE
1043 minifront cannot claim unbonding tokens

### DIFF
--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -13,7 +13,7 @@ import {
 
 const getUndelegateClaimPlannerRequest =
   (endEpochIndex: bigint) => async (unbondingToken: ValueView) => {
-    console.log(unbondingToken)
+    console.log(unbondingToken);
     const unbondingStartHeight = getUnbondingStartHeightFromValueView(unbondingToken);
     const identityKey = getValidatorIdentityKeyFromValueView(unbondingToken);
     const { epoch: startEpoch } = await sctClient.epochByHeight({ height: unbondingStartHeight });

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -13,7 +13,6 @@ import {
 
 const getUndelegateClaimPlannerRequest =
   (endEpochIndex: bigint) => async (unbondingToken: ValueView) => {
-    console.log(unbondingToken);
     const unbondingStartHeight = getUnbondingStartHeightFromValueView(unbondingToken);
     const identityKey = getValidatorIdentityKeyFromValueView(unbondingToken);
     const { epoch: startEpoch } = await sctClient.epochByHeight({ height: unbondingStartHeight });

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -13,6 +13,7 @@ import {
 
 const getUndelegateClaimPlannerRequest =
   (endEpochIndex: bigint) => async (unbondingToken: ValueView) => {
+    console.log(unbondingToken)
     const unbondingStartHeight = getUnbondingStartHeightFromValueView(unbondingToken);
     const identityKey = getValidatorIdentityKeyFromValueView(unbondingToken);
     const { epoch: startEpoch } = await sctClient.epochByHeight({ height: unbondingStartHeight });

--- a/packages/getters/src/balances-response.ts
+++ b/packages/getters/src/balances-response.ts
@@ -12,4 +12,7 @@ export const getAssetIdFromBalancesResponseOptional = getBalanceView
   .pipe(getMetadata)
   .pipe(getAssetId);
 
-export const getDisplayFromBalancesResponse = getBalanceView.pipe(getMetadata).pipe(getDisplay);
+export const getDisplayFromBalancesResponse = getBalanceView
+  .pipe(getMetadata)
+  .optional()
+  .pipe(getDisplay);

--- a/packages/getters/src/get-validator-info-response.ts
+++ b/packages/getters/src/get-validator-info-response.ts
@@ -1,0 +1,9 @@
+import {createGetter} from "./utils/create-getter";
+import {
+    GetValidatorInfoResponse
+} from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb";
+
+
+export const getValidatorInfo = createGetter(
+    (validatorInfoResponse?: GetValidatorInfoResponse) => validatorInfoResponse?.validatorInfo,
+);

--- a/packages/getters/src/get-validator-info-response.ts
+++ b/packages/getters/src/get-validator-info-response.ts
@@ -1,9 +1,6 @@
-import {createGetter} from "./utils/create-getter";
-import {
-    GetValidatorInfoResponse
-} from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb";
-
+import { createGetter } from './utils/create-getter';
+import { GetValidatorInfoResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 
 export const getValidatorInfo = createGetter(
-    (validatorInfoResponse?: GetValidatorInfoResponse) => validatorInfoResponse?.validatorInfo,
+  (validatorInfoResponse?: GetValidatorInfoResponse) => validatorInfoResponse?.validatorInfo,
 );

--- a/packages/services/src/staking-service/get-validator-info.test.ts
+++ b/packages/services/src/staking-service/get-validator-info.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IndexedDbMock, MockServices } from '../test-utils';
+import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
+import { QueryService as StakingService } from '@buf/penumbra-zone_penumbra.connectrpc_es/penumbra/core/component/stake/v1/stake_connect';
+import { servicesCtx } from '../ctx/prax';
+import {
+  GetValidatorInfoRequest,
+  GetValidatorInfoResponse,
+  ValidatorState_ValidatorStateEnum,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
+import type { ServicesInterface } from '@penumbra-zone/types/services';
+import { getValidatorInfo } from './get-validator-info';
+
+describe('GetValidatorInfo request handler', () => {
+  let mockServices: MockServices;
+  let mockIndexedDb: IndexedDbMock;
+  let mockCtx: HandlerContext;
+  let req: GetValidatorInfoRequest;
+  const mockGetValidatorInfoResponse = new GetValidatorInfoResponse({
+    validatorInfo: {
+      validator: { name: 'Validator 1', identityKey: { ik: new Uint8Array(32) } },
+      status: { state: { state: ValidatorState_ValidatorStateEnum.ACTIVE } },
+    },
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockIndexedDb = {
+      getValidatorInfo: vi.fn(),
+    };
+    mockServices = {
+      getWalletServices: vi.fn(() =>
+        Promise.resolve({ indexedDb: mockIndexedDb }),
+      ) as MockServices['getWalletServices'],
+    };
+    mockCtx = createHandlerContext({
+      service: StakingService,
+      method: StakingService.methods.validatorInfo,
+      protocolName: 'mock',
+      requestMethod: 'MOCK',
+      url: '/mock',
+      contextValues: createContextValues().set(servicesCtx, () =>
+        Promise.resolve(mockServices as unknown as ServicesInterface),
+      ),
+    });
+
+    req = new GetValidatorInfoRequest({
+      identityKey: mockGetValidatorInfoResponse.validatorInfo?.validator?.identityKey,
+    });
+  });
+
+  it('should successfully get validator info when idb has them', async () => {
+    mockIndexedDb.getValidatorInfo?.mockResolvedValueOnce(
+      mockGetValidatorInfoResponse.validatorInfo,
+    );
+
+    const validatorInfoResponse = await getValidatorInfo(req, mockCtx);
+    expect(validatorInfoResponse.validatorInfo).toEqual(mockGetValidatorInfoResponse.validatorInfo);
+  });
+
+  it('should fail to get validator info when idb has none', async () => {
+    await expect(getValidatorInfo(req, mockCtx)).rejects.toThrow('No found validator info');
+  });
+
+  it('should fail to get validator info if identity key is not passed', async () => {
+    await expect(getValidatorInfo(new GetValidatorInfoRequest(), mockCtx)).rejects.toThrow(
+      'Missing identityKey in request',
+    );
+  });
+});

--- a/packages/services/src/staking-service/get-validator-info.ts
+++ b/packages/services/src/staking-service/get-validator-info.ts
@@ -1,0 +1,18 @@
+import { Impl } from './index';
+import { servicesCtx } from '../ctx/prax';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+export const getValidatorInfo: Impl['getValidatorInfo'] = async (req, ctx) => {
+  if (!req.identityKey) {
+    throw new ConnectError('Missing identityKey in request', Code.InvalidArgument);
+  }
+  const services = await ctx.values.get(servicesCtx)();
+  const { indexedDb } = await services.getWalletServices();
+
+  let validatorInfo = await indexedDb.getValidatorInfo(req.identityKey);
+
+  if (!validatorInfo) {
+    throw new ConnectError('No found validator info', Code.NotFound);
+  }
+  return { validatorInfo };
+};

--- a/packages/services/src/staking-service/get-validator-info.ts
+++ b/packages/services/src/staking-service/get-validator-info.ts
@@ -1,4 +1,4 @@
-import { Impl } from './index';
+import { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 import { Code, ConnectError } from '@connectrpc/connect';
 
@@ -9,7 +9,7 @@ export const getValidatorInfo: Impl['getValidatorInfo'] = async (req, ctx) => {
   const services = await ctx.values.get(servicesCtx)();
   const { indexedDb } = await services.getWalletServices();
 
-  let validatorInfo = await indexedDb.getValidatorInfo(req.identityKey);
+  const validatorInfo = await indexedDb.getValidatorInfo(req.identityKey);
 
   if (!validatorInfo) {
     throw new ConnectError('No found validator info', Code.NotFound);

--- a/packages/services/src/staking-service/index.ts
+++ b/packages/services/src/staking-service/index.ts
@@ -7,7 +7,10 @@ import { getValidatorInfo } from './get-validator-info';
 
 export type Impl = ServiceImpl<typeof StakingService>;
 
-export const stakingImpl: Pick<Impl, 'getValidatorInfo' | 'validatorInfo' | 'validatorPenalty'> = {
+export const stakingImpl: Omit<
+  Impl,
+  'currentValidatorRate' | 'validatorStatus' | 'validatorUptime'
+> = {
   getValidatorInfo,
   validatorInfo,
   validatorPenalty,

--- a/packages/services/src/staking-service/index.ts
+++ b/packages/services/src/staking-service/index.ts
@@ -3,10 +3,12 @@ import { ServiceImpl } from '@connectrpc/connect';
 
 import { validatorInfo } from './validator-info';
 import { validatorPenalty } from './validator-penalty';
+import { getValidatorInfo } from './get-validator-info';
 
 export type Impl = ServiceImpl<typeof StakingService>;
 
-export const stakingImpl: Pick<Impl, 'validatorInfo' | 'validatorPenalty'> = {
+export const stakingImpl: Pick<Impl, 'getValidatorInfo' | 'validatorInfo' | 'validatorPenalty'> = {
+  getValidatorInfo,
   validatorInfo,
   validatorPenalty,
 };

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -24,6 +24,7 @@ export interface IndexedDbMock {
   iterateSwaps?: () => Partial<AsyncIterable<Mock>>;
   iterateTransactions?: () => Partial<AsyncIterable<Mock>>;
   iterateValidatorInfos?: () => Partial<AsyncIterable<Mock>>;
+  getValidatorInfo?: Mock;
   subscribe?: (table: string) => Partial<AsyncIterable<Mock>>;
   getSwapByCommitment?: Mock;
   getEpochByHeight?: Mock;

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
@@ -11,11 +11,8 @@ import { status } from '../status';
 import { appParameters } from '../app-parameters';
 
 export const isUnbondingTokenBalance = (balancesResponse: PartialMessage<BalancesResponse>) => {
-  if (balancesResponse.balanceView?.valueView?.case === 'unknownAssetId') return false;
-
-  return assetPatterns.unbondingToken.matches(
-    getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),
-  );
+  const display = getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse));
+  return display ? assetPatterns.unbondingToken.matches(display) : false;
 };
 
 /**
@@ -42,6 +39,8 @@ export const getIsClaimable = async (
   if (!fullSyncHeight || !parameters?.stakeParams?.unbondingDelay) return false;
 
   const display = getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse));
+  if (!display) return false;
+
   const unbondingStartHeight = assetPatterns.unbondingToken.capture(display);
 
   if (unbondingStartHeight?.startAt) {

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
@@ -11,13 +11,12 @@ import { status } from '../status';
 import { appParameters } from '../app-parameters';
 
 export const isUnbondingTokenBalance = (balancesResponse: PartialMessage<BalancesResponse>) => {
-  if (balancesResponse?.balanceView?.valueView?.case === 'unknownAssetId')
-    return false;
+  if (balancesResponse?.balanceView?.valueView?.case === 'unknownAssetId') return false;
 
   return assetPatterns.unbondingToken.matches(
-      getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),
+    getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),
   );
-}
+};
 
 /**
  * Given a `BalancesResponse`, resolves to a boolean indicating whether the

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
@@ -11,7 +11,7 @@ import { status } from '../status';
 import { appParameters } from '../app-parameters';
 
 export const isUnbondingTokenBalance = (balancesResponse: PartialMessage<BalancesResponse>) => {
-  if (balancesResponse?.balanceView?.valueView?.case === 'unknownAssetId') return false;
+  if (balancesResponse.balanceView?.valueView?.case === 'unknownAssetId') return false;
 
   return assetPatterns.unbondingToken.matches(
     getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/helpers.ts
@@ -10,10 +10,14 @@ import { getDisplayFromBalancesResponse } from '@penumbra-zone/getters/balances-
 import { status } from '../status';
 import { appParameters } from '../app-parameters';
 
-export const isUnbondingTokenBalance = (balancesResponse: PartialMessage<BalancesResponse>) =>
-  assetPatterns.unbondingToken.matches(
-    getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),
+export const isUnbondingTokenBalance = (balancesResponse: PartialMessage<BalancesResponse>) => {
+  if (balancesResponse?.balanceView?.valueView?.case === 'unknownAssetId')
+    return false;
+
+  return assetPatterns.unbondingToken.matches(
+      getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)),
   );
+}
 
 /**
  * Given a `BalancesResponse`, resolves to a boolean indicating whether the

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/index.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/index.ts
@@ -6,9 +6,15 @@ import {
 import { Impl } from '..';
 import { balances } from '../balances';
 import { getIsClaimable, isUnbondingTokenBalance } from './helpers';
+import {getValidatorInfo} from "@penumbra-zone/getters/validator-info-response";
+import {Any} from "@bufbuild/protobuf";
+import {ValidatorInfo} from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb";
+import {stakingClientCtx} from "../../ctx/staking-client";
 
 export const unbondingTokensByAddressIndex: Impl['unbondingTokensByAddressIndex'] =
   async function* (req, ctx) {
+    const stakingClient = ctx.values.get(stakingClientCtx);
+    if (!stakingClient) throw new Error('Staking context not found');
     for await (const balancesResponse of balances(
       new BalancesRequest({ accountFilter: req.addressIndex }),
       ctx,
@@ -30,6 +36,14 @@ export const unbondingTokensByAddressIndex: Impl['unbondingTokensByAddressIndex'
       ) {
         continue;
       }
+
+
+      const validatorInfo = stakingClient.validatorInfo({ showInactive: true });
+      getValidatorInfo(va)
+      const extendedMetadata = new Any({
+        typeUrl: ValidatorInfo.typeName,
+        value: validatorInfo.toBinary(),
+      });
 
       yield new UnbondingTokensByAddressIndexResponse({
         claimable,

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/index.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/index.ts
@@ -58,7 +58,7 @@ export const unbondingTokensByAddressIndex: Impl['unbondingTokensByAddressIndex'
         value: validatorInfo.toBinary(),
       });
 
-      const withValidatorInfo = getBalanceView(new BalancesResponse(balancesResponse)).clone();
+      const withValidatorInfo = getBalanceView(new BalancesResponse(balancesResponse));
       if (withValidatorInfo.valueView.case !== 'knownAssetId')
         throw new Error(`Unexpected ValueView case: ${withValidatorInfo.valueView.case}`);
 

--- a/packages/services/src/view-service/unbonding-tokens-by-address-index/index.ts
+++ b/packages/services/src/view-service/unbonding-tokens-by-address-index/index.ts
@@ -1,5 +1,6 @@
 import {
-  BalancesRequest, BalancesResponse,
+  BalancesRequest,
+  BalancesResponse,
   UnbondingTokensByAddressIndexRequest_Filter,
   UnbondingTokensByAddressIndexResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
@@ -9,10 +10,13 @@ import { getIsClaimable, isUnbondingTokenBalance } from './helpers';
 import { Any } from '@bufbuild/protobuf';
 import { ValidatorInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 import { stakingClientCtx } from '../../ctx/staking-client';
-import {getValidatorInfo} from "@penumbra-zone/getters/get-validator-info-response";
-import {assetPatterns} from "@penumbra-zone/constants/assets";
-import {getBalanceView, getDisplayFromBalancesResponse} from "@penumbra-zone/getters/balances-response";
-import {identityKeyFromBech32m} from "@penumbra-zone/bech32m/penumbravalid";
+import { getValidatorInfo } from '@penumbra-zone/getters/get-validator-info-response';
+import { assetPatterns } from '@penumbra-zone/constants/assets';
+import {
+  getBalanceView,
+  getDisplayFromBalancesResponse,
+} from '@penumbra-zone/getters/balances-response';
+import { identityKeyFromBech32m } from '@penumbra-zone/bech32m/penumbravalid';
 
 export const unbondingTokensByAddressIndex: Impl['unbondingTokensByAddressIndex'] =
   async function* (req, ctx) {
@@ -40,11 +44,15 @@ export const unbondingTokensByAddressIndex: Impl['unbondingTokensByAddressIndex'
         continue;
       }
 
-      const regexResult = assetPatterns.unbondingToken.capture(getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)));
+      const regexResult = assetPatterns.unbondingToken.capture(
+        getDisplayFromBalancesResponse(new BalancesResponse(balancesResponse)) ?? '',
+      );
       if (!regexResult) throw new Error('expected delegation token identity key not present');
 
-      const validatorInfoResponse = await stakingClient.getValidatorInfo({ identityKey: identityKeyFromBech32m(regexResult.idKey) });
-      let validatorInfo = getValidatorInfo(validatorInfoResponse);
+      const validatorInfoResponse = await stakingClient.getValidatorInfo({
+        identityKey: identityKeyFromBech32m(regexResult.idKey),
+      });
+      const validatorInfo = getValidatorInfo(validatorInfoResponse);
       const extendedMetadata = new Any({
         typeUrl: ValidatorInfo.typeName,
         value: validatorInfo.toBinary(),

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -571,7 +571,7 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   async getValidatorInfo(identityKey: IdentityKey): Promise<ValidatorInfo | undefined> {
-    const key = uint8ArrayToBase64(identityKey.ik);
+    const key = bech32mIdentityKey(identityKey);
     const json = await this.db.get('VALIDATOR_INFOS', key);
     if (!json) return undefined;
     return ValidatorInfo.fromJson(json);

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -18,6 +18,7 @@ import {
 import { FmdParameters } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
 import {
   AddressIndex,
+  IdentityKey,
   WalletId,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
@@ -567,6 +568,13 @@ export class IndexedDb implements IndexedDbInterface {
     yield* new ReadableStream(
       new IdbCursorSource(this.db.transaction('VALIDATOR_INFOS').store.openCursor(), ValidatorInfo),
     );
+  }
+
+  async getValidatorInfo(identityKey: IdentityKey): Promise<ValidatorInfo | undefined> {
+    const key = uint8ArrayToBase64(identityKey.ik);
+    const json = await this.db.get('VALIDATOR_INFOS', key);
+    if (!json) return undefined;
+    return ValidatorInfo.fromJson(json);
   }
 
   async updatePrice(

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -30,7 +30,10 @@ import {
   Note,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
 import { ValidatorInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
-import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import {
+  AddressIndex,
+  IdentityKey,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import { Transaction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
@@ -97,6 +100,7 @@ export interface IndexedDbInterface {
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
   upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;
   iterateValidatorInfos(): AsyncGenerator<ValidatorInfo, void>;
+  getValidatorInfo(identityKey: IdentityKey): Promise<ValidatorInfo | undefined>;
   updatePrice(
     pricedAsset: AssetId,
     numeraire: AssetId,


### PR DESCRIPTION
> This is because getUndelegateClaimPlannerRequest cannot recover the IdentityKey from the token's value view. The reason for that is that the ValueView is missing extended_metadata which only get populated for bonding tokens.

Now extended_metadata fills in for unbonding tokens as well

close #1043