### PR TITLE
Update WASM crate to point to SHA of core that includes correct middleware

### DIFF
--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "decaf377-fmd"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "decaf377-ka"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "penumbra-asset"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "penumbra-auction"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "penumbra-community-pool"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2202,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "penumbra-compact-block"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "penumbra-dex"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "penumbra-distributions"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "penumbra-fee"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "penumbra-funding"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2344,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "penumbra-governance"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2388,6 +2388,7 @@ dependencies = [
  "rand_core",
  "regex",
  "serde",
+ "serde_json",
  "tap",
  "tendermint",
  "thiserror",
@@ -2397,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "penumbra-ibc"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2430,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "penumbra-keys"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "aes",
  "anyhow",
@@ -2474,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "penumbra-num"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2510,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "penumbra-proof-params"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2536,7 +2537,7 @@ dependencies = [
 [[package]]
 name = "penumbra-proto"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2563,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "penumbra-sct"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2594,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "penumbra-shielded-pool"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2642,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "penumbra-stake"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2684,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "penumbra-tct"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2712,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "penumbra-transaction"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2763,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "penumbra-txhash"
 version = "0.74.0-alpha.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=a500f2c72#a500f2c72206e805a85c9aa7e4b0381901ff6896"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=519f0f023#519f0f023cd900172fa4bf047edc9a76ebee0761"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -17,20 +17,20 @@ mock-database = []
 [dependencies]
 # TODO: Use `tag` instead of `rev` once auctions land in a tagged release of
 # core.
-penumbra-auction         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-auction", default-features = false }
-penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-compact-block", default-features = false }
-penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-dex", default-features = false }
-penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-fee", default-features = false }
-penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-keys" }
-penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-num" }
-penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-proof-params", default-features = false }
-penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-proto", default-features = false }
-penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-stake", default-features = false }
-penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-tct" }
-penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "a500f2c72", package = "penumbra-transaction", default-features = false }
+penumbra-auction         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-auction", default-features = false }
+penumbra-asset         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-compact-block", default-features = false }
+penumbra-dex           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-dex", default-features = false }
+penumbra-fee           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-fee", default-features = false }
+penumbra-keys          = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-keys" }
+penumbra-num           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-num" }
+penumbra-proof-params  = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-proof-params", default-features = false }
+penumbra-proto         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-proto", default-features = false }
+penumbra-sct           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake         = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-stake", default-features = false }
+penumbra-tct           = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-tct" }
+penumbra-transaction   = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "519f0f023", package = "penumbra-transaction", default-features = false }
 
 anyhow                   = "1.0.80"
 ark-ff                   = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -78,20 +78,18 @@ impl ActionList {
         // to the fee is ideally small, hopefully it doesn't matter.
         let mut gas = Gas::zero();
         for action in &self.actions {
-            // TODO missing AddAssign
-            gas = gas + action.gas_cost();
+            gas += action.gas_cost();
         }
         for action in self.change_outputs.values() {
-            // TODO missing AddAssign
             // TODO missing GasCost impl on OutputPlan
-            gas = gas + ActionPlan::from(action.clone()).gas_cost();
+            gas += ActionPlan::from(action.clone()).gas_cost();
         }
 
         gas
     }
 
     fn fee_estimate(&self, gas_prices: &GasPrices, fee_tier: &FeeTier) -> Fee {
-        let base_fee = Fee::from_staking_token_amount(gas_prices.fee(&self.gas_estimate()));
+        let base_fee = gas_prices.fee(&self.gas_estimate());
         base_fee.apply_tier(*fee_tier)
     }
 
@@ -538,14 +536,14 @@ pub async fn plan_transaction(
     };
 
     if let Some(pb_memo_plaintext) = request.memo {
-        plan.memo = Some(MemoPlan::new(&mut OsRng, pb_memo_plaintext.try_into()?)?);
+        plan.memo = Some(MemoPlan::new(&mut OsRng, pb_memo_plaintext.try_into()?));
     } else if plan.output_plans().next().is_some() {
         // If a memo was not provided, but is required (because we have outputs),
         // auto-create one with the change address.
         plan.memo = Some(MemoPlan::new(
             &mut OsRng,
             MemoPlaintext::new(change_address, String::new())?,
-        )?);
+        ));
     }
 
     plan.populate_detection_data(&mut OsRng, fmd_params.precision_bits.into());

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -140,6 +140,7 @@ mod tests {
             as_of_block_height: 1u64,
         };
         let gas_prices = GasPrices {
+            asset_id: None,
             block_space_price: 0,
             compact_block_space_price: 0,
             verification_price: 0,


### PR DESCRIPTION
Core was previously missing a necessary middleware for its auction endpoint. As a result, calls to that endpoint would fail due to a missing trailer.

This was [recently fixed](https://github.com/penumbra-zone/penumbra/pull/4351), so this PR points the WASM crate to the SHA that fixed that issue, so that calls to get the latest auction state from the fullnode will succeed.

This PR also addresses a couple typings changes from core that resulted from the update.