### PR TITLE
Fix unknown assets for ibc-out

### DIFF
--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -8,6 +8,7 @@ import { ClientState } from '@buf/cosmos_ibc.bufbuild_es/ibc/lightclients/tender
 import { Height } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/client/v1/client_pb';
 import { ibcChannelClient, ibcClient, ibcConnectionClient, viewClient } from '../clients';
 import {
+  getAssetIdFromValueView,
   getDisplayDenomExponentFromValueView,
   getMetadata,
 } from '@penumbra-zone/getters/value-view';
@@ -242,7 +243,6 @@ export const filterBalancesPerChain = (
   const assetIdsToCheck = [penumbraAssetId, ...assetsWithMatchingChannel];
 
   return allBalances.filter(({ balanceView }) => {
-    const metadata = getMetadata(balanceView);
-    return assetIdsToCheck.some(assetId => assetId.equals(metadata.penumbraAssetId));
+    return assetIdsToCheck.some(assetId => assetId.equals(getAssetIdFromValueView(balanceView)));
   });
 };


### PR DESCRIPTION
The ibc page is broken if you have unknown assets on your balance
![telegram-cloud-photo-size-2-5325986573956797599-y](https://github.com/penumbra-zone/web/assets/25391690/35320bbc-2204-4687-bf3e-9d8ab7513013)
