### PR TITLE
vite don't clear terminal

### DIFF
--- a/apps/minifront/vite.config.ts
+++ b/apps/minifront/vite.config.ts
@@ -5,6 +5,7 @@ import { commitInfoPlugin } from './src/utils/commit-info-vite-plugin';
 import polyfillNode from 'vite-plugin-node-stdlib-browser';
 
 export default defineConfig({
+  clearScreen: false,
   base: './',
   plugins: [polyfillNode(), react(), basicSsl(), commitInfoPlugin()],
 });

--- a/apps/node-status/vite.config.ts
+++ b/apps/node-status/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  clearScreen: false,
   plugins: [react()],
 });


### PR DESCRIPTION
both node-status and minifront vite dev servers clear the terminal by default. this prevents that, so you can see full messages from all dev scripts.