### PR TITLE
Redesign the input/output UI of a Dutch auction to better illustrate what's happening

### DIFF
--- a/packages/ui/components/ui/dutch-auction-component.tsx
+++ b/packages/ui/components/ui/dutch-auction-component.tsx
@@ -7,6 +7,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { Button } from './button';
+import { ArrowRight } from 'lucide-react';
 
 const getValueView = (amount?: Amount, metadata?: Metadata) =>
   new ValueView({
@@ -53,24 +54,26 @@ export const DutchAuctionComponent = ({
 
   return (
     <div className='flex flex-col gap-8'>
-      <ActionDetails>
-        <ActionDetails.Row label='Input'>
+      <div className='flex items-center justify-between'>
+        <div>
           <ValueViewComponent view={input} />
-        </ActionDetails.Row>
+        </div>
 
-        <ActionDetails.Row label='Output'>
-          <div className='flex flex-wrap justify-end gap-2'>
-            <div className='flex items-center gap-2'>
-              <span className='text-nowrap text-muted-foreground'>Max:</span>
-              <ValueViewComponent view={maxOutput} />
-            </div>
-            <div className='flex items-center gap-2'>
-              <span className='text-nowrap text-muted-foreground'>Min:</span>
-              <ValueViewComponent view={minOutput} />
-            </div>
+        <ArrowRight />
+
+        <div className='flex w-min flex-wrap justify-end gap-2'>
+          <div className='flex items-center gap-2'>
+            <span className='text-nowrap text-muted-foreground'>Max:</span>
+            <ValueViewComponent view={maxOutput} />
           </div>
-        </ActionDetails.Row>
+          <div className='flex items-center gap-2'>
+            <span className='text-nowrap text-muted-foreground'>Min:</span>
+            <ValueViewComponent view={minOutput} />
+          </div>
+        </div>
+      </div>
 
+      <ActionDetails>
         <ActionDetails.Row label='Duration'>
           <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
           {description.startHeight.toString()}

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -49,7 +49,7 @@ export const ValueViewComponent = ({
             </div>
           )}
           {showValue && (
-            <span className='-mb-0.5 leading-[15px]'>
+            <span className='-mb-0.5 text-nowrap leading-[15px]'>
               {variant === 'equivalent' && <>~ </>}
               {formattedAmount}
             </span>


### PR DESCRIPTION
This is by no means a finalized design — just a little improvement from the key/value layout before. A future PR will improve the design of the duration field.

## Before
<img width="358" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/d31b99a3-56bb-4d14-83ab-72a4d9f24b19">


## After
<img width="357" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/feac74d5-9b6b-43dd-bed8-b039aa11b69b">

Closes #1081