### PR TITLE
Redesign Duration display for Dutch auctions with live-updating price visualization.

### DIFF
--- a/apps/minifront/src/components/Status.tsx
+++ b/apps/minifront/src/components/Status.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useStore } from '../state';
+
+/**
+ * A component that simply keeps the Zustand state up to date with the latest
+ * output of `viewClient.status()`.
+ */
+export const Status = () => {
+  const start = useStore(state => state.status.start);
+
+  useEffect(() => void start(), [start]);
+
+  return null;
+};

--- a/apps/minifront/src/components/header/sync-status-section.tsx
+++ b/apps/minifront/src/components/header/sync-status-section.tsx
@@ -1,19 +1,22 @@
-import { useStream } from '../../fetchers/stream';
-import { useMemo } from 'react';
-import { viewClient } from '../../clients';
 import { CondensedBlockSyncStatus } from '@penumbra-zone/ui/components/ui/block-sync-status/condensed';
+import { AllSlices } from '../../state';
+import { useStoreShallow } from '../../utils/use-store-shallow';
+
+const syncStatusSectionSelector = (state: AllSlices) => ({
+  fullSyncHeight: state.status.fullSyncHeight,
+  latestKnownBlockHeight: state.status.latestKnownBlockHeight,
+  error: state.status.error,
+});
 
 export const SyncStatusSection = () => {
-  const syncStream = useMemo(() => viewClient.statusStream({}), []);
-  const { data, error } = useStream(syncStream);
+  const { fullSyncHeight, latestKnownBlockHeight, error } =
+    useStoreShallow(syncStatusSectionSelector);
 
   return (
     <div className='relative z-30 flex w-full flex-col'>
       <CondensedBlockSyncStatus
-        fullSyncHeight={data?.fullSyncHeight ? Number(data.fullSyncHeight) : undefined}
-        latestKnownBlockHeight={
-          data?.latestKnownBlockHeight ? Number(data.latestKnownBlockHeight) : undefined
-        }
+        fullSyncHeight={fullSyncHeight ? Number(fullSyncHeight) : undefined}
+        latestKnownBlockHeight={latestKnownBlockHeight ? Number(latestKnownBlockHeight) : undefined}
         error={error}
       />
     </div>

--- a/apps/minifront/src/components/layout.tsx
+++ b/apps/minifront/src/components/layout.tsx
@@ -14,6 +14,7 @@ import '@penumbra-zone/ui/styles/globals.css';
 import { getChainId } from '../fetchers/chain-id';
 import { useEffect, useState } from 'react';
 import { TestnetBanner } from '@penumbra-zone/ui/components/ui/testnet-banner';
+import { Status } from './Status';
 
 export interface LayoutLoaderResult {
   isInstalled: boolean;
@@ -40,6 +41,7 @@ export const Layout = () => {
 
   return (
     <>
+      <Status />
       <TestnetBanner chainId={chainId} />
       <HeadTag />
       <div className='flex min-h-screen w-full flex-col'>

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -21,10 +21,12 @@ const auctionsSelector = (state: AllSlices) => ({
   auctionInfos: state.dutchAuction.auctionInfos,
   metadataByAssetId: state.dutchAuction.metadataByAssetId,
   endAuction: state.dutchAuction.endAuction,
+  fullSyncHeight: state.status.fullSyncHeight,
 });
 
 export const Auctions = () => {
-  const { auctionInfos, metadataByAssetId, endAuction } = useStoreShallow(auctionsSelector);
+  const { auctionInfos, metadataByAssetId, endAuction, fullSyncHeight } =
+    useStoreShallow(auctionsSelector);
 
   return (
     <>
@@ -52,6 +54,7 @@ export const Auctions = () => {
                 )}
                 showEndButton
                 onClickEndButton={() => void endAuction(auctionInfo.id)}
+                fullSyncHeight={fullSyncHeight}
               />
             }
           />

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -6,6 +6,7 @@ import { createSwapSlice, SwapSlice } from './swap';
 import { createIbcOutSlice, IbcOutSlice } from './ibc-out';
 import { createSendSlice, SendSlice } from './send';
 import { createStakingSlice, StakingSlice } from './staking';
+import { createStatusSlice, StatusSlice } from './status';
 import { createUnclaimedSwapsSlice, UnclaimedSwapsSlice } from './unclaimed-swaps';
 import { createTransactionsSlice, TransactionsSlice } from './transactions';
 import { createIbcInSlice, IbcInSlice } from './ibc-in';
@@ -23,6 +24,7 @@ export interface AllSlices {
   dutchAuction: DutchAuctionSlice;
   send: SendSlice;
   staking: StakingSlice;
+  status: StatusSlice;
   swap: SwapSlice;
   transactions: TransactionsSlice;
   unclaimedSwaps: UnclaimedSwapsSlice;
@@ -42,6 +44,7 @@ export const initializeStore = () => {
     dutchAuction: createDutchAuctionSlice()(setState, getState, store),
     send: createSendSlice()(setState, getState, store),
     staking: createStakingSlice()(setState, getState, store),
+    status: createStatusSlice()(setState, getState, store),
     swap: createSwapSlice()(setState, getState, store),
     transactions: createTransactionsSlice()(setState, getState, store),
     unclaimedSwaps: createUnclaimedSwapsSlice()(setState, getState, store),

--- a/apps/minifront/src/state/status.ts
+++ b/apps/minifront/src/state/status.ts
@@ -1,0 +1,28 @@
+import { SliceCreator } from '.';
+import { viewClient } from '../clients';
+
+export interface StatusSlice {
+  start: () => Promise<void>;
+  fullSyncHeight?: bigint;
+  latestKnownBlockHeight?: bigint;
+  error?: unknown;
+}
+
+export const createStatusSlice = (): SliceCreator<StatusSlice> => set => ({
+  start: async () => {
+    const stream = viewClient.statusStream({});
+
+    try {
+      for await (const result of stream) {
+        set(state => {
+          state.status.fullSyncHeight = result.fullSyncHeight;
+          state.status.latestKnownBlockHeight = result.latestKnownBlockHeight;
+        });
+      }
+    } catch (error) {
+      set(state => {
+        state.status.error = error;
+      });
+    }
+  },
+});

--- a/packages/ui/components/ui/dutch-auction-component/duration.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/duration.tsx
@@ -1,11 +1,79 @@
+import {
+  Metadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { Progress } from '../progress';
+import { getProgress } from './get-progress';
+import { getPrice } from './get-price';
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { ValueViewComponent } from '../tx/view/value';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+const getValueView = (amount: Amount, metadata: Metadata) =>
+  new ValueView({ valueView: { case: 'knownAssetId', value: { amount, metadata } } });
+
 export const Duration = ({
-  startHeight,
-  endHeight,
+  auctionDescription,
+  inputMetadata,
+  outputMetadata,
   fullSyncHeight,
 }: {
-  startHeight: bigint;
-  endHeight: bigint;
+  auctionDescription: DutchAuctionDescription;
+  inputMetadata?: Metadata;
+  outputMetadata?: Metadata;
   fullSyncHeight?: bigint;
 }) => {
-  return <>Hello</>;
+  const price = getPrice(auctionDescription, inputMetadata, fullSyncHeight);
+  const progress = getProgress(
+    auctionDescription.startHeight,
+    auctionDescription.endHeight,
+    fullSyncHeight,
+  );
+
+  const priceValueView = useMemo(
+    () => (price && outputMetadata ? getValueView(price, outputMetadata) : undefined),
+    [price, outputMetadata],
+  );
+  const priceWrapper = useRef<HTMLDivElement | null>(null);
+  const [priceWrapperLeft, setPriceWrapperLeft] = useState('');
+
+  useLayoutEffect(() => {
+    if (!priceWrapper.current) return;
+    setPriceWrapperLeft(
+      `clamp(${priceWrapper.current.offsetWidth / 2}px, 100% - ${priceWrapper.current.offsetWidth / 2}px, ${progress * 100}%)`,
+    );
+  }, [progress]);
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {!!priceValueView && (
+        <div className='relative'>
+          <div
+            className='absolute w-min -translate-x-1/2'
+            ref={priceWrapper}
+            style={{ left: priceWrapperLeft }}
+          >
+            <ValueViewComponent view={priceValueView} size='sm' />
+          </div>
+
+          {/* placeholder for absolute-positioned value view */}
+          <div className='opacity-0'>
+            <ValueViewComponent view={priceValueView} size='sm' />
+          </div>
+        </div>
+      )}
+
+      <Progress value={progress * 100} status='in-progress' size='sm' background='stone' />
+      <div className='flex justify-between'>
+        <span className='text-xs text-muted-foreground'>
+          {auctionDescription.startHeight.toString()}
+        </span>
+        <span className='text-xs text-muted-foreground'>Block height</span>
+        <span className='text-xs text-muted-foreground'>
+          {auctionDescription.endHeight.toString()}
+        </span>
+      </div>
+    </div>
+  );
 };

--- a/packages/ui/components/ui/dutch-auction-component/duration.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/duration.tsx
@@ -50,16 +50,20 @@ export const Duration = ({
       {!!priceValueView && (
         <div className='relative'>
           <div
-            className='absolute w-min -translate-x-1/2'
+            className='absolute flex w-min -translate-x-1/2 flex-col items-center gap-1'
             ref={priceWrapper}
             style={{ left: priceWrapperLeft }}
           >
             <ValueViewComponent view={priceValueView} size='sm' />
+            {inputMetadata?.symbol && (
+              <span className='text-xs text-muted-foreground'>per {inputMetadata.symbol}</span>
+            )}
           </div>
 
           {/* placeholder for absolute-positioned value view */}
-          <div className='opacity-0'>
+          <div className='flex flex-col gap-1 opacity-0'>
             <ValueViewComponent view={priceValueView} size='sm' />
+            {inputMetadata?.symbol && <span className='text-xs text-muted-foreground'>per</span>}
           </div>
         </div>
       )}

--- a/packages/ui/components/ui/dutch-auction-component/duration.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/duration.tsx
@@ -1,0 +1,11 @@
+export const Duration = ({
+  startHeight,
+  endHeight,
+  fullSyncHeight,
+}: {
+  startHeight: bigint;
+  endHeight: bigint;
+  fullSyncHeight?: bigint;
+}) => {
+  return <>Hello</>;
+};

--- a/packages/ui/components/ui/dutch-auction-component/get-price.test.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-price.test.ts
@@ -60,7 +60,7 @@ describe('getPrice()', () => {
     expect(getPrice(auction, metadata, 9n)).toEqual(new Amount({ hi: 0n, lo: 200_000n }));
   });
 
-  it.only("rounds to the nearest whole number if it can't be divided evenly", () => {
+  it("rounds to the nearest whole number if it can't be divided evenly", () => {
     const metadata = new Metadata({
       display: 'penumbra',
       base: 'upenumbra',

--- a/packages/ui/components/ui/dutch-auction-component/get-price.test.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-price.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { getPrice } from './get-price';
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+describe('getPrice()', () => {
+  it('returns `undefined` if `fullSyncHeight` is `undefined`', () => {
+    expect(getPrice(new DutchAuctionDescription(), new Metadata())).toBeUndefined();
+  });
+
+  it('returns the correct price at various sync heights', () => {
+    const metadata = new Metadata({
+      display: 'penumbra',
+      base: 'upenumbra',
+      denomUnits: [
+        { denom: 'penumbra', exponent: 6 },
+        { denom: 'upenumbra', exponent: 0 },
+      ],
+    });
+    const auction = new DutchAuctionDescription({
+      minOutput: {
+        hi: 0n,
+        lo: 1n,
+      },
+      maxOutput: {
+        hi: 0n,
+        lo: 10n,
+      },
+      stepCount: 10n,
+      startHeight: 1n,
+      endHeight: 10n,
+      input: {
+        amount: { hi: 0n, lo: 10n },
+      },
+    });
+
+    // At the first step, we're selling 10 of the input for 10 of the output
+    // (i.e., the `maxOutput`). Thus, there's a 1:1 ratio between the input and
+    // output. We then scale up the price by the _input's_ display denom
+    // exponent, to show what one input token is worth in terms of the output
+    // token.
+    expect(getPrice(auction, metadata, 1n)).toEqual(new Amount({ hi: 0n, lo: 1_000_000n }));
+
+    // At the last step, we're selling 10 of the input for 1 of the output
+    // (i.e., the `minOutput`). Thus, there's a 10:1 ratio between the input and
+    // output. We then scale up the price by the _input's_ display denom
+    // exponent, to show what one input token is worth in terms of the output
+    // token.
+    expect(getPrice(auction, metadata, 10n)).toEqual(new Amount({ hi: 0n, lo: 100_000n }));
+
+    // Let's sanity check all the intermediate prices as well.
+    expect(getPrice(auction, metadata, 2n)).toEqual(new Amount({ hi: 0n, lo: 900_000n }));
+    expect(getPrice(auction, metadata, 3n)).toEqual(new Amount({ hi: 0n, lo: 800_000n }));
+    expect(getPrice(auction, metadata, 4n)).toEqual(new Amount({ hi: 0n, lo: 700_000n }));
+    expect(getPrice(auction, metadata, 5n)).toEqual(new Amount({ hi: 0n, lo: 600_000n }));
+    expect(getPrice(auction, metadata, 6n)).toEqual(new Amount({ hi: 0n, lo: 500_000n }));
+    expect(getPrice(auction, metadata, 7n)).toEqual(new Amount({ hi: 0n, lo: 400_000n }));
+    expect(getPrice(auction, metadata, 8n)).toEqual(new Amount({ hi: 0n, lo: 300_000n }));
+    expect(getPrice(auction, metadata, 9n)).toEqual(new Amount({ hi: 0n, lo: 200_000n }));
+  });
+
+  it.only("rounds to the nearest whole number if it can't be divided evenly", () => {
+    const metadata = new Metadata({
+      display: 'penumbra',
+      base: 'upenumbra',
+      denomUnits: [
+        { denom: 'penumbra', exponent: 6 },
+        { denom: 'upenumbra', exponent: 0 },
+      ],
+    });
+    const auction = new DutchAuctionDescription({
+      minOutput: {
+        hi: 0n,
+        lo: 0n,
+      },
+      maxOutput: {
+        hi: 0n,
+        lo: 10n,
+      },
+      stepCount: 4n,
+      startHeight: 1n,
+      endHeight: 4n,
+      input: {
+        amount: { hi: 0n, lo: 10n },
+      },
+    });
+
+    expect(getPrice(auction, metadata, 2n)).toEqual(new Amount({ hi: 0n, lo: 666_667n }));
+  });
+});

--- a/packages/ui/components/ui/dutch-auction-component/get-price.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-price.ts
@@ -45,13 +45,9 @@ export const getPrice = (
   // The input, scaled up by `step_count` to match.
   const inputScaled = (stepCount - 1n) * input;
 
-  // The trading function interpolates between (input, 0) and (0, target_output)
-  const p = targetOutputScaled;
-  const q = inputScaled;
-
   const inputDisplayDenomExponent = getDisplayDenomExponent.optional()(inputMetadata);
   const multiplier = 10 ** (inputDisplayDenomExponent ?? 0);
-  const price = Math.round((Number(p) / Number(q)) * multiplier);
+  const price = Math.round((Number(targetOutputScaled) / Number(inputScaled)) * multiplier);
 
   return new Amount(splitLoHi(BigInt(price)));
 };

--- a/packages/ui/components/ui/dutch-auction-component/get-price.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-price.ts
@@ -1,0 +1,57 @@
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { getStepIndex } from './get-step-index';
+import { joinLoHiAmount } from '@penumbra-zone/types/amount';
+import { splitLoHi } from '@penumbra-zone/types/lo-hi';
+import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+/**
+ * Returns the price, _in the output asset_, for one _display_ denom of the
+ * input asset.
+ *
+ * For example, if you're selling 100 UM in a Dutch auction with a max output of
+ * 1000 USDC and min output of 10 USDC, the value of 1 UM ranges from 10 USDC
+ * (at the start of the auction) to 0.1 USDC (at the end). This function will
+ * return an `Amount` that represents whatever value the input is, _per display
+ * token_, in terms of the output asset, at the given block height.
+ *
+ * Adapted from
+ * https://github.com/penumbra-zone/penumbra/blob/e0291fb/crates/core/component/auction/src/component/dutch_auction.rs#L548-L572
+ */
+export const getPrice = (
+  auctionDescription: DutchAuctionDescription,
+  inputMetadata?: Metadata,
+  fullSyncHeight?: bigint,
+): Amount | undefined => {
+  const stepIndex = getStepIndex(auctionDescription, fullSyncHeight);
+  if (
+    stepIndex === undefined ||
+    !auctionDescription.maxOutput ||
+    !auctionDescription.minOutput ||
+    !auctionDescription.input?.amount
+  )
+    return undefined;
+
+  const maxOutput = joinLoHiAmount(auctionDescription.maxOutput);
+  const minOutput = joinLoHiAmount(auctionDescription.minOutput);
+  const input = joinLoHiAmount(auctionDescription.input.amount);
+  const stepCount = auctionDescription.stepCount;
+
+  // The target output, scaled up by `step_count` to avoid divisions.
+  // Linearly interpolate between `max_output` at `step_index = 0`
+  //                          and `min_output` at `step_index = step_count - 1`.
+  const targetOutputScaled = (stepCount - stepIndex - 1n) * maxOutput + stepIndex * minOutput;
+  // The input, scaled up by `step_count` to match.
+  const inputScaled = (stepCount - 1n) * input;
+
+  // The trading function interpolates between (input, 0) and (0, target_output)
+  const p = targetOutputScaled;
+  const q = inputScaled;
+
+  const inputDisplayDenomExponent = getDisplayDenomExponent.optional()(inputMetadata);
+  const multiplier = 10 ** (inputDisplayDenomExponent ?? 0);
+  const price = Math.round((Number(p) / Number(q)) * multiplier);
+
+  return new Amount(splitLoHi(BigInt(price)));
+};

--- a/packages/ui/components/ui/dutch-auction-component/get-progress.test.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-progress.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getProgress } from './get-progress';
+
+describe('getProgress()', () => {
+  const startHeight = 1_001n;
+  const endHeight = 2_000n;
+
+  it('returns 0 when `fullSyncHeight` is undefined', () => {
+    expect(getProgress(startHeight, endHeight, undefined)).toBe(0);
+  });
+
+  it('returns a decimal representing the progress between the start and end heights', () => {
+    const fullSyncHeight = 1_500n;
+
+    expect(getProgress(startHeight, endHeight, fullSyncHeight)).toBe(0.5);
+  });
+
+  it('clamps to 0 if the start height has not yet been reached', () => {
+    const fullSyncHeight = 500n;
+
+    expect(getProgress(startHeight, endHeight, fullSyncHeight)).toBe(0);
+  });
+
+  it('clamps to 1 if the end height has been passed', () => {
+    const fullSyncHeight = 10_000n;
+
+    expect(getProgress(startHeight, endHeight, fullSyncHeight)).toBe(1);
+  });
+});

--- a/packages/ui/components/ui/dutch-auction-component/get-progress.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-progress.ts
@@ -1,0 +1,16 @@
+const clampToDecimal = (value: number) => Math.min(Math.max(value, 0), 1);
+
+export const getProgress = (
+  startHeight: bigint,
+  endHeight: bigint,
+  fullSyncHeight?: bigint,
+): number => {
+  if (!fullSyncHeight) return 0;
+
+  const currentDistanceFromStartHeightInclusive = Number(fullSyncHeight) - Number(startHeight) + 1;
+  const endHeightDistanceFromStartHeightInclusive = Number(endHeight) - Number(startHeight) + 1;
+  const progress =
+    currentDistanceFromStartHeightInclusive / endHeightDistanceFromStartHeightInclusive;
+
+  return clampToDecimal(progress);
+};

--- a/packages/ui/components/ui/dutch-auction-component/get-progress.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-progress.ts
@@ -1,3 +1,8 @@
+/**
+ * We want to represent progress as a decimal between 0 and 1 (inclusive),
+ * without letting it go above 1 or below 0 if the full sync height is after the
+ * end of the auction or before the beginning, respectively.
+ */
 const clampToDecimal = (value: number) => Math.min(Math.max(value, 0), 1);
 
 export const getProgress = (

--- a/packages/ui/components/ui/dutch-auction-component/get-step-index.test.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-step-index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getStepIndex } from './get-step-index';
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+
+describe('getStepIndex()', () => {
+  const dutchAuctionDescription = new DutchAuctionDescription({
+    startHeight: 1_001n,
+    endHeight: 2_000n,
+    stepCount: 100n, // 1000 blocks / 100 steps = 10 blocks per step
+  });
+
+  it('returns undefined if `fullSyncHeight` is undefined', () => {
+    expect(getStepIndex(new DutchAuctionDescription())).toBeUndefined();
+  });
+
+  it('returns the correct step index at various heights', () => {
+    expect(getStepIndex(dutchAuctionDescription, 1_001n)).toBe(0n);
+    expect(getStepIndex(dutchAuctionDescription, 1_501n)).toBe(50n);
+    expect(getStepIndex(dutchAuctionDescription, 2_000n)).toBe(99n);
+  });
+
+  it('returns the correct step index when step sizes are small', () => {
+    const smallStepSize = new DutchAuctionDescription({
+      startHeight: 1n,
+      endHeight: 5n,
+      stepCount: 5n,
+    });
+
+    expect(getStepIndex(smallStepSize, 1n)).toBe(0n);
+    expect(getStepIndex(smallStepSize, 2n)).toBe(1n);
+    expect(getStepIndex(smallStepSize, 3n)).toBe(2n);
+    expect(getStepIndex(smallStepSize, 4n)).toBe(3n);
+    expect(getStepIndex(smallStepSize, 5n)).toBe(4n);
+  });
+
+  it('rounds down to the nearest step index', () => {
+    expect(getStepIndex(dutchAuctionDescription, 1_009n)).toBe(0n);
+    expect(getStepIndex(dutchAuctionDescription, 1_509n)).toBe(50n);
+  });
+
+  it("clamps the step index to 0 if the auction hasn't started yet", () => {
+    const fullSyncHeight = 500n;
+
+    expect(getStepIndex(dutchAuctionDescription, fullSyncHeight)).toBe(0n);
+  });
+
+  it('clamps the step index to `stepCount` if the auction period has passed', () => {
+    const fullSyncHeight = 2_500n;
+
+    expect(getStepIndex(dutchAuctionDescription, fullSyncHeight)).toBe(99n);
+  });
+});

--- a/packages/ui/components/ui/dutch-auction-component/get-step-index.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-step-index.ts
@@ -1,5 +1,9 @@
 import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 
+/**
+ * A step index can't be below 0 or after the full step count, so we'll clamp
+ * the step index to the step count.
+ */
 const clampBetweenZeroAnd = (max: bigint, value: bigint) =>
   value > max ? max : value < 0n ? 0n : value;
 

--- a/packages/ui/components/ui/dutch-auction-component/get-step-index.ts
+++ b/packages/ui/components/ui/dutch-auction-component/get-step-index.ts
@@ -1,0 +1,24 @@
+import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
+
+const clampBetweenZeroAnd = (max: bigint, value: bigint) =>
+  value > max ? max : value < 0n ? 0n : value;
+
+export const getStepIndex = (
+  {
+    startHeight,
+    endHeight,
+    stepCount,
+  }: Pick<DutchAuctionDescription, 'startHeight' | 'endHeight' | 'stepCount'>,
+  fullSyncHeight?: bigint,
+): bigint | undefined => {
+  if (fullSyncHeight === undefined) return undefined;
+  if (fullSyncHeight >= endHeight) return stepCount - 1n; // zero-indexed
+  if (fullSyncHeight <= startHeight) return 0n;
+
+  const currentDistanceFromStartHeight = fullSyncHeight - startHeight;
+  const endHeightDistanceFromStartHeightInclusive = endHeight - startHeight + 1n;
+  const stepSize = endHeightDistanceFromStartHeightInclusive / stepCount;
+  const stepIndex = currentDistanceFromStartHeight / stepSize;
+
+  return clampBetweenZeroAnd(stepCount, stepIndex);
+};

--- a/packages/ui/components/ui/dutch-auction-component/index.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/index.tsx
@@ -1,5 +1,4 @@
 import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
-import { ActionDetails } from '../tx/view/action-details';
 import { ValueViewComponent } from '../tx/view/value';
 import {
   Metadata,
@@ -76,22 +75,12 @@ export const DutchAuctionComponent = ({
         </div>
       </div>
 
-      {!!fullSyncHeight && (
-        <Duration
-          startHeight={description.startHeight}
-          endHeight={description.endHeight}
-          fullSyncHeight={fullSyncHeight}
-        />
-      )}
-
-      <ActionDetails>
-        <ActionDetails.Row label='Duration'>
-          <span className='mx-1 text-nowrap text-muted-foreground'>Height </span>
-          {description.startHeight.toString()}
-          <span className='mx-1 text-nowrap text-muted-foreground'> to </span>
-          {description.endHeight.toString()}
-        </ActionDetails.Row>
-      </ActionDetails>
+      <Duration
+        auctionDescription={description}
+        inputMetadata={inputMetadata}
+        outputMetadata={outputMetadata}
+        fullSyncHeight={fullSyncHeight}
+      />
 
       {showEndButton && (
         <div className='self-end'>

--- a/packages/ui/components/ui/dutch-auction-component/index.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/index.tsx
@@ -1,13 +1,14 @@
 import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
-import { ActionDetails } from './tx/view/action-details';
-import { ValueViewComponent } from './tx/view/value';
+import { ActionDetails } from '../tx/view/action-details';
+import { ValueViewComponent } from '../tx/view/value';
 import {
   Metadata,
   ValueView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
-import { Button } from './button';
+import { Button } from '../button';
 import { ArrowRight } from 'lucide-react';
+import { Duration } from './duration';
 
 const getValueView = (amount?: Amount, metadata?: Metadata) =>
   new ValueView({
@@ -24,6 +25,7 @@ interface BaseProps {
   dutchAuction: DutchAuction;
   inputMetadata?: Metadata;
   outputMetadata?: Metadata;
+  fullSyncHeight?: bigint;
 }
 
 interface PropsWithEndButton extends BaseProps {
@@ -44,6 +46,7 @@ export const DutchAuctionComponent = ({
   outputMetadata,
   showEndButton,
   onClickEndButton,
+  fullSyncHeight,
 }: Props) => {
   const { description } = dutchAuction;
   if (!description) return null;
@@ -72,6 +75,14 @@ export const DutchAuctionComponent = ({
           </div>
         </div>
       </div>
+
+      {!!fullSyncHeight && (
+        <Duration
+          startHeight={description.startHeight}
+          endHeight={description.endHeight}
+          fullSyncHeight={fullSyncHeight}
+        />
+      )}
 
       <ActionDetails>
         <ActionDetails.Row label='Duration'>

--- a/packages/ui/components/ui/dutch-auction-component/index.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/index.tsx
@@ -7,7 +7,7 @@ import {
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { Button } from '../button';
 import { ArrowRight } from 'lucide-react';
-import { Duration } from './duration';
+import { PriceGraph } from './price-graph';
 
 const getValueView = (amount?: Amount, metadata?: Metadata) =>
   new ValueView({
@@ -75,7 +75,7 @@ export const DutchAuctionComponent = ({
         </div>
       </div>
 
-      <Duration
+      <PriceGraph
         auctionDescription={description}
         inputMetadata={inputMetadata}
         outputMetadata={outputMetadata}

--- a/packages/ui/components/ui/dutch-auction-component/price-graph.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/price-graph.tsx
@@ -13,7 +13,7 @@ import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 const getValueView = (amount: Amount, metadata: Metadata) =>
   new ValueView({ valueView: { case: 'knownAssetId', value: { amount, metadata } } });
 
-export const Duration = ({
+export const PriceGraph = ({
   auctionDescription,
   inputMetadata,
   outputMetadata,

--- a/packages/ui/components/ui/dutch-auction-component/price-graph.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/price-graph.tsx
@@ -28,10 +28,12 @@ export const PriceGraph = ({
   const maxPrice = getPrice(auctionDescription, inputMetadata, auctionDescription.startHeight);
   const price = getPrice(auctionDescription, inputMetadata, fullSyncHeight);
   const minPrice = getPrice(auctionDescription, inputMetadata, auctionDescription.endHeight);
+
   const maxPriceValueView =
     maxPrice && outputMetadata ? getValueView(maxPrice, outputMetadata) : undefined;
   const minPriceValueView =
     minPrice && outputMetadata ? getValueView(minPrice, outputMetadata) : undefined;
+
   const progress = getProgress(
     auctionDescription.startHeight,
     auctionDescription.endHeight,

--- a/packages/ui/components/ui/dutch-auction-component/price-graph.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/price-graph.tsx
@@ -8,7 +8,8 @@ import { getPrice } from './get-price';
 import { DutchAuctionDescription } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1alpha1/auction_pb';
 import { ValueViewComponent } from '../tx/view/value';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { ReactNode, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '../../../lib/utils';
 
 const getValueView = (amount: Amount, metadata: Metadata) =>
   new ValueView({ valueView: { case: 'knownAssetId', value: { amount, metadata } } });
@@ -59,19 +60,15 @@ export const PriceGraph = ({
   return (
     <div className='flex flex-col gap-2'>
       <div className='flex items-center gap-4'>
-        <div className='grow basis-1/4 text-right text-xs text-muted-foreground'>
-          {auctionDescription.startHeight.toString()}
+        <div className='grow basis-1/4 text-right'>
+          <Label muted>{auctionDescription.startHeight.toString()}</Label>
         </div>
 
         <div className='w-1 grow-0' />
 
         <div className='flex grow basis-3/4 items-center gap-1'>
           <ValueViewComponent view={maxPriceValueView} size='sm' />
-          {inputMetadata?.symbol && (
-            <span className='text-nowrap text-xs text-muted-foreground'>
-              per {inputMetadata.symbol}
-            </span>
-          )}
+          {inputMetadata?.symbol && <Label muted>per {inputMetadata.symbol}</Label>}
         </div>
       </div>
 
@@ -79,10 +76,10 @@ export const PriceGraph = ({
         <div className='relative grow basis-1/4'>
           {showProgress && (
             <div
-              className='absolute w-full -translate-y-1/2 text-right text-xs'
+              className='absolute w-full -translate-y-1/2 text-right'
               style={{ top: positionTop }}
             >
-              {fullSyncHeight.toString()}
+              <Label>{fullSyncHeight.toString()}</Label>
             </div>
           )}
         </div>
@@ -101,32 +98,28 @@ export const PriceGraph = ({
               style={{ top: positionTop }}
             >
               <ValueViewComponent view={priceValueView} size='sm' />
-              {inputMetadata?.symbol && (
-                <span className='text-nowrap text-xs text-muted-foreground'>
-                  per {inputMetadata.symbol}
-                </span>
-              )}
+              {inputMetadata?.symbol && <Label muted>per {inputMetadata.symbol}</Label>}
             </div>
           )}
         </div>
       </div>
 
       <div className='flex items-center gap-4'>
-        <div className='grow basis-1/4 text-right text-xs text-muted-foreground'>
-          {auctionDescription.endHeight.toString()}
+        <div className='grow basis-1/4 text-right'>
+          <Label muted>{auctionDescription.endHeight.toString()}</Label>
         </div>
 
         <div className='w-1 grow-0' />
 
         <div className='flex grow basis-3/4 items-center gap-1'>
           <ValueViewComponent view={minPriceValueView} size='sm' />
-          {inputMetadata?.symbol && (
-            <span className='text-nowrap text-xs text-muted-foreground'>
-              per {inputMetadata.symbol}
-            </span>
-          )}
+          {inputMetadata?.symbol && <Label muted>per {inputMetadata.symbol}</Label>}
         </div>
       </div>
     </div>
   );
 };
+
+const Label = ({ children, muted }: { children: ReactNode; muted?: boolean }) => (
+  <span className={cn('text-nowrap text-xs', muted && 'text-muted-foreground')}>{children}</span>
+);

--- a/packages/ui/components/ui/progress.tsx
+++ b/packages/ui/components/ui/progress.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as React from 'react';
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 import { cn } from '../../lib/utils';
 import { cva, VariantProps } from 'class-variance-authority';
@@ -24,42 +23,37 @@ const progressVariants = cva('', {
   },
 });
 
-interface ProgressProps
-  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>,
-    VariantProps<typeof progressVariants> {
+interface ProgressProps extends VariantProps<typeof progressVariants> {
   size?: 'lg' | 'sm';
+  value?: number;
 }
 
-const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(
-  (
-    { className, value, status, shape = 'rounded', background = 'black', size = 'lg', ...props },
-    ref,
-  ) => {
-    return (
-      <ProgressPrimitive.Root
-        ref={ref}
-        className={cn(
-          'relative z-0',
-          size === 'lg' && 'h-3',
-          size === 'sm' && 'h-1',
-          'w-full overflow-hidden',
-          progressVariants({ shape }),
-          progressVariants({ background }),
-          className,
-        )}
-        {...props}
-      >
-        <ProgressPrimitive.Indicator
-          className={cn(
-            'h-full w-full flex-1 transition-all z-20',
-            progressVariants({ shape }),
-            progressVariants({ status }),
-          )}
-          style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
-        />
-      </ProgressPrimitive.Root>
-    );
-  },
+const Progress = ({
+  value,
+  status,
+  shape = 'rounded',
+  background = 'black',
+  size = 'lg',
+}: ProgressProps) => (
+  <ProgressPrimitive.Root
+    className={cn(
+      'relative z-0',
+      size === 'lg' && 'h-3',
+      size === 'sm' && 'h-1',
+      'w-full overflow-hidden',
+      progressVariants({ shape }),
+      progressVariants({ background }),
+    )}
+  >
+    <ProgressPrimitive.Indicator
+      className={cn(
+        'h-full w-full flex-1 transition-all z-20',
+        progressVariants({ shape }),
+        progressVariants({ status }),
+      )}
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
 );
 Progress.displayName = ProgressPrimitive.Root.displayName;
 

--- a/packages/ui/components/ui/tx/view/asset-icon/index.tsx
+++ b/packages/ui/components/ui/tx/view/asset-icon/index.tsx
@@ -11,12 +11,17 @@ export const AssetIcon = ({
   size = 'sm',
 }: {
   metadata?: Metadata;
-  size?: 'sm' | 'lg';
+  size?: 'xs' | 'sm' | 'lg';
 }) => {
   // Image default is "" and thus cannot do nullish-coalescing
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const icon = metadata?.images[0]?.png || metadata?.images[0]?.svg;
-  const className = cn('rounded-full', size === 'sm' && 'size-6', size === 'lg' && 'size-12');
+  const className = cn(
+    'rounded-full',
+    size === 'xs' && 'size-4',
+    size === 'sm' && 'size-6',
+    size === 'lg' && 'size-12',
+  );
   const display = getDisplay.optional()(metadata);
   const isDelegationToken = display ? assetPatterns.delegationToken.matches(display) : false;
   const isUnbondingToken = display ? assetPatterns.unbondingToken.matches(display) : false;
@@ -37,7 +42,7 @@ export const AssetIcon = ({
       ) : (
         <Identicon
           uniqueIdentifier={metadata?.symbol ?? '?'}
-          size={size === 'lg' ? 48 : 24}
+          size={size === 'lg' ? 48 : size === 'sm' ? 24 : 16}
           type='solid'
         />
       )}

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -46,9 +46,9 @@ export const ValueViewComponent = ({
     return (
       <Pill variant={variant === 'default' ? 'default' : 'dashed'}>
         <div className='flex min-w-0 items-center gap-1'>
-          {showIcon && size === 'default' && (
-            <div className='-ml-2 mr-1 flex size-6 shrink-0 items-center justify-center rounded-full'>
-              <AssetIcon metadata={metadata} />
+          {showIcon && (
+            <div className='-ml-2 mr-1 flex shrink-0 items-center justify-center rounded-full'>
+              <AssetIcon metadata={metadata} size={size === 'default' ? 'sm' : 'xs'} />
             </div>
           )}
           {showValue && (

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -7,6 +7,7 @@ import { CopyIcon } from '@radix-ui/react-icons';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { fromBaseUnitAmount } from '@penumbra-zone/types/amount';
 import { Pill } from '../../../pill';
+import { cn } from '../../../../../lib/utils';
 
 interface ValueViewProps {
   view: ValueView | undefined;
@@ -18,6 +19,7 @@ interface ValueViewProps {
   showDenom?: boolean;
   showValue?: boolean;
   showIcon?: boolean;
+  size?: 'default' | 'sm';
 }
 
 export const ValueViewComponent = ({
@@ -26,6 +28,7 @@ export const ValueViewComponent = ({
   showDenom = true,
   showValue = true,
   showIcon = true,
+  size = 'default',
 }: ValueViewProps) => {
   if (!view) return <></>;
 
@@ -43,13 +46,13 @@ export const ValueViewComponent = ({
     return (
       <Pill variant={variant === 'default' ? 'default' : 'dashed'}>
         <div className='flex min-w-0 items-center gap-1'>
-          {showIcon && (
+          {showIcon && size === 'default' && (
             <div className='-ml-2 mr-1 flex size-6 shrink-0 items-center justify-center rounded-full'>
               <AssetIcon metadata={metadata} />
             </div>
           )}
           {showValue && (
-            <span className='-mb-0.5 text-nowrap leading-[15px]'>
+            <span className={cn('-mb-0.5 text-nowrap leading-[15px]', size === 'sm' && 'text-xs')}>
               {variant === 'equivalent' && <>~ </>}
               {formattedAmount}
             </span>

--- a/packages/ui/lib/toast/transaction-toast.test.tsx
+++ b/packages/ui/lib/toast/transaction-toast.test.tsx
@@ -67,13 +67,9 @@ describe('TransactionToast', () => {
         'Building Send transaction',
         expect.objectContaining({
           description: (
-            <Progress
-              status='in-progress'
-              background='stone'
-              value={50}
-              size='sm'
-              className='mt-2'
-            />
+            <div className='mt-2'>
+              <Progress status='in-progress' background='stone' value={50} size='sm' />
+            </div>
           ),
           duration: Infinity,
           id: MOCK_TOAST_ID,
@@ -97,7 +93,11 @@ describe('TransactionToast', () => {
       expect(mockToastFn.loading).toHaveBeenCalledWith(
         'Building Send transaction',
         expect.objectContaining({
-          description: <Progress status='done' value={100} size='sm' className='mt-2' />,
+          description: (
+            <div className='mt-2'>
+              <Progress status='done' value={100} size='sm' />
+            </div>
+          ),
           duration: Infinity,
           id: MOCK_TOAST_ID,
         }),

--- a/packages/ui/lib/toast/transaction-toast.tsx
+++ b/packages/ui/lib/toast/transaction-toast.tsx
@@ -25,16 +25,21 @@ const getBuildStatusDescription = (
 ): ReactNode | undefined => {
   if (status?.case === 'buildProgress')
     return (
-      <Progress
-        status='in-progress'
-        value={Math.round(status.value.progress * 100)}
-        size='sm'
-        className='mt-2'
-        background='stone'
-      />
+      <div className='mt-2'>
+        <Progress
+          status='in-progress'
+          value={Math.round(status.value.progress * 100)}
+          size='sm'
+          background='stone'
+        />
+      </div>
     );
   if (status?.case === 'complete')
-    return <Progress status='done' value={100} size='sm' className='mt-2' />;
+    return (
+      <div className='mt-2'>
+        <Progress status='done' value={100} size='sm' />
+      </div>
+    );
   return undefined;
 };
 


### PR DESCRIPTION
Scrub through this video to get a timelapse of part of a 10-minute auction.

https://github.com/penumbra-zone/web/assets/1121544/ad04a0cf-3020-4560-939d-0bd69a15020f

This is a bit of a frilly PR that I prob shouldn't have spent as much time on as I did... Basically it visualizes to the user what the current price is of the input asset in terms of the output asset, as well as how far along we are in the auction.

Again, this is by no means a finalized design, but it's at least an improvement on what we had before.

## In this PR
- Design a live-updating display for Dutch auctions.
- Create a new Zustand `status` slice for storing the sync status (`fullSyncHeight` and `latestKnownBlockHeight`) so it can be used both in the header and in places like Dutch auctions.
- Simplify `<Progress />` to only accept a few specific props, rather than the full default set (which we neither need nor want).
- Add size variants to both `<AssetIcon />` and `<ValueViewComponent />`.


Closes #1088 