### PR TITLE
Remove testnet warning from ext

### DIFF
--- a/apps/extension/src/routes/popup/home/index-header.tsx
+++ b/apps/extension/src/routes/popup/home/index-header.tsx
@@ -5,7 +5,6 @@ import { Network } from '@penumbra-zone/ui/components/ui/network';
 import { useChainIdQuery } from '../../../hooks/chain-id';
 import { motion } from 'framer-motion';
 import { useStore } from '../../../state';
-import { TestnetBanner } from '@penumbra-zone/ui/components/ui/testnet-banner';
 
 export const IndexHeader = () => {
   const navigate = usePopupNav();
@@ -31,7 +30,6 @@ export const IndexHeader = () => {
           <div className='m-[19px]' />
         )}
       </div>
-      <TestnetBanner chainId={chainId} />
     </header>
   );
 };


### PR DESCRIPTION
Removing this:
<img width="385" alt="Screenshot 2024-05-16 at 8 28 48 AM" src="https://github.com/penumbra-zone/web/assets/16624263/9881547d-f514-4a15-909f-45ba0ca0d379">

It's only needed in minifront. We don't show any balances in the extension.
