### PR TITLE
Create UI to allow users to query latest auction state

### DIFF
--- a/apps/minifront/src/components/shared/edu-panels/edu-info-card.tsx
+++ b/apps/minifront/src/components/shared/edu-panels/edu-info-card.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@penumbra-zone/ui/components/ui/card';
 import { cn } from '@penumbra-zone/ui/lib/utils';
+import { GradientHeader } from '@penumbra-zone/ui/components/ui/gradient-header';
 import { EduPanel, eduPanelContent } from './content';
 
 interface HelperCardProps {
@@ -14,9 +15,7 @@ export const EduInfoCard = ({ src, label, className, content }: HelperCardProps)
     <Card gradient className={cn('p-5 row-span-1', className)}>
       <div className='flex gap-2'>
         <img src={src} alt='icons' className='size-[30px] md:size-8' />
-        <p className='bg-text-linear bg-clip-text font-headline text-xl font-semibold leading-[30px] text-transparent md:text-2xl md:font-bold md:leading-9'>
-          {label}
-        </p>
+        <GradientHeader>{label}</GradientHeader>
       </div>
       <p className='mt-4 text-muted-foreground md:mt-2'>{eduPanelContent[content]}</p>
     </Card>

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -8,6 +8,7 @@ import {
 import { useStoreShallow } from '../../../utils/use-store-shallow';
 import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
 import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb';
+import { GradientHeader } from '@penumbra-zone/ui/components/ui/gradient-header';
 
 const getMetadata = (metadataByAssetId: Record<string, Metadata>, assetId?: AssetId) => {
   let metadata: Metadata | undefined;
@@ -48,9 +49,9 @@ export const Auctions = () => {
 
   return (
     <>
-      <p className='mb-2 bg-text-linear bg-clip-text font-headline text-xl font-semibold leading-[30px] text-transparent md:text-2xl md:font-bold md:leading-9'>
-        My auctions
-      </p>
+      <div className='mb-2'>
+        <GradientHeader>My Auctions</GradientHeader>
+      </div>
 
       <div className='flex flex-col gap-2'>
         {!auctionInfos.length && "You don't currently have any auctions running."}

--- a/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/auctions.tsx
@@ -9,6 +9,7 @@ import { useStoreShallow } from '../../../utils/use-store-shallow';
 import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
 import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb';
 import { GradientHeader } from '@penumbra-zone/ui/components/ui/gradient-header';
+import { QueryLatestStateButton } from './query-latest-state-button';
 
 const getMetadata = (metadataByAssetId: Record<string, Metadata>, assetId?: AssetId) => {
   let metadata: Metadata | undefined;
@@ -49,8 +50,9 @@ export const Auctions = () => {
 
   return (
     <>
-      <div className='mb-2'>
+      <div className='mb-2 flex items-center justify-between'>
         <GradientHeader>My Auctions</GradientHeader>
+        {!!auctionInfos.length && <QueryLatestStateButton />}
       </div>
 
       <div className='flex flex-col gap-2'>

--- a/apps/minifront/src/components/swap/dutch-auction/query-latest-state-button.tsx
+++ b/apps/minifront/src/components/swap/dutch-auction/query-latest-state-button.tsx
@@ -1,0 +1,33 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@penumbra-zone/ui/components/ui/tooltip';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { useStore } from '../../../state';
+
+export const QueryLatestStateButton = () => {
+  const loadAuctionInfos = useStore(state => state.dutchAuction.loadAuctionInfos);
+  const handleClick = () => void loadAuctionInfos(true);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          onClick={handleClick}
+          aria-label='Get the current auction reserves (makes a request to a fullnode)'
+        >
+          <div className='p-2'>
+            <ReloadIcon />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          Get the current auction reserves
+          <br />
+          (makes a request to a fullnode)
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/apps/minifront/src/components/swap/swap/unclaimed-swaps.tsx
+++ b/apps/minifront/src/components/swap/swap/unclaimed-swaps.tsx
@@ -7,6 +7,7 @@ import { useStore } from '../../../state';
 import { unclaimedSwapsSelector } from '../../../state/unclaimed-swaps';
 import { getSwapRecordCommitment } from '@penumbra-zone/getters/swap-record';
 import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
+import { GradientHeader } from '@penumbra-zone/ui/components/ui/gradient-header';
 
 export const UnclaimedSwaps = () => {
   const { unclaimedSwaps } = useLoaderData() as SwapLoaderResponse;
@@ -27,9 +28,7 @@ const _UnclaimedSwaps = ({ unclaimedSwaps }: { unclaimedSwaps: UnclaimedSwapsWit
 
   return (
     <Card className='order-1 md:order-3 xl:order-1'>
-      <p className='bg-text-linear bg-clip-text font-headline text-xl font-semibold leading-[30px] text-transparent md:text-2xl md:font-bold md:leading-9'>
-        Unclaimed Swaps
-      </p>
+      <GradientHeader>Unclaimed Swaps</GradientHeader>
       <p className='text-gray-400'>
         Swaps on Penumbra are a two step process. The first transaction issues the request and the
         second claims the result of the swap action. For some reason, these second transactions were

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -40,7 +40,7 @@ export interface DutchAuctionSlice {
   onSubmit: () => Promise<void>;
   txInProgress: boolean;
   auctionInfos: AuctionInfo[];
-  loadAuctionInfos: () => Promise<void>;
+  loadAuctionInfos: (queryLatestState?: boolean) => Promise<void>;
   loadMetadata: (assetId?: AssetId) => Promise<void>;
   metadataByAssetId: Record<string, Metadata>;
   endAuction: (auctionId: AuctionId) => Promise<void>;
@@ -117,13 +117,13 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
   txInProgress: false,
 
   auctionInfos: [],
-  loadAuctionInfos: async () => {
+  loadAuctionInfos: async (queryLatestState = false) => {
     set(state => {
       state.dutchAuction.auctionInfos = [];
     });
 
     /** @todo: Sort by... something? */
-    for await (const response of viewClient.auctions({ includeInactive: true })) {
+    for await (const response of viewClient.auctions({ queryLatestState, includeInactive: true })) {
       if (!response.auction || !response.id) continue;
       const auction = DutchAuction.fromBinary(response.auction.value);
       const auctions = [...get().dutchAuction.auctionInfos, { id: response.id, auction }];

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -31,6 +31,7 @@ export interface IndexedDbMock {
   saveAssetsMetadata?: Mock;
   getPricesForAsset?: Mock;
   getAuction?: Mock;
+  getAuctionOutstandingReserves?: Mock;
 }
 
 export interface AuctionMock {

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -239,7 +239,7 @@ describe('Auctions request handler', () => {
     results.forEach(result => {
       const dutchAuction = DutchAuction.fromBinary(result.auction!.value!);
 
-      if (AUCTION_ID_2.equals(new AuctionId(result.id!))) {
+      if (AUCTION_ID_2.equals(new AuctionId(result.id))) {
         expect(dutchAuction.state?.inputReserves).toEqual(new Amount({ hi: 0n, lo: 1234n }));
         expect(dutchAuction.state?.outputReserves).toEqual(new Amount({ hi: 0n, lo: 5678n }));
       } else {

--- a/packages/services/src/view-service/auctions.test.ts
+++ b/packages/services/src/view-service/auctions.test.ts
@@ -19,6 +19,8 @@ import { HandlerContext, createContextValues, createHandlerContext } from '@conn
 import { servicesCtx } from '../ctx/prax';
 import { IndexedDbMock, MockQuerier, MockServices } from '../test-utils';
 import { StateCommitment } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb';
+import { Value } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 
 const AUCTION_ID_1 = new AuctionId({ inner: new Uint8Array(Array(32).fill(1)) });
 const BECH32M_AUCTION_ID_1 = bech32mAuctionId(AUCTION_ID_1);
@@ -128,6 +130,7 @@ describe('Auctions request handler', () => {
         Promise.resolve(TEST_DATA.find(({ id }) => id.equals(auctionId))?.value),
       ),
       getSpendableNoteByCommitment: vi.fn().mockResolvedValue(MOCK_SPENDABLE_NOTE_RECORD),
+      getAuctionOutstandingReserves: vi.fn().mockResolvedValue(undefined),
     };
 
     mockQuerier = {
@@ -204,14 +207,45 @@ describe('Auctions request handler', () => {
   });
 
   it('includes the latest state from the fullnode if `queryLatestState` is `true`', async () => {
+    expect.hasAssertions();
+
     const req = new AuctionsRequest({ queryLatestState: true });
     const results = await Array.fromAsync(auctions(req, mockCtx));
 
     results.forEach(result => {
-      if (!result.auction?.value) throw new Error('missing data');
-      const dutchAuction = DutchAuction.fromBinary(result.auction.value);
+      const dutchAuction = DutchAuction.fromBinary(result.auction!.value!);
 
       expect(dutchAuction.state?.seq).toBe(1234n);
+    });
+  });
+
+  it('includes the outstanding reserves if any exist in the database (i.e., for an ended auction)', async () => {
+    expect.hasAssertions();
+
+    mockIndexedDb.getAuctionOutstandingReserves?.mockImplementation((auctionId: AuctionId) => {
+      if (auctionId.equals(AUCTION_ID_2)) {
+        return {
+          input: new Value({ amount: { hi: 0n, lo: 1234n } }),
+          output: new Value({ amount: { hi: 0n, lo: 5678n } }),
+        };
+      }
+
+      return undefined;
+    });
+
+    const req = new AuctionsRequest({ includeInactive: true });
+    const results = await Array.fromAsync(auctions(req, mockCtx));
+
+    results.forEach(result => {
+      const dutchAuction = DutchAuction.fromBinary(result.auction!.value!);
+
+      if (AUCTION_ID_2.equals(new AuctionId(result.id!))) {
+        expect(dutchAuction.state?.inputReserves).toEqual(new Amount({ hi: 0n, lo: 1234n }));
+        expect(dutchAuction.state?.outputReserves).toEqual(new Amount({ hi: 0n, lo: 5678n }));
+      } else {
+        expect(dutchAuction.state?.inputReserves).toBeUndefined();
+        expect(dutchAuction.state?.outputReserves).toBeUndefined();
+      }
     });
   });
 });

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -68,10 +68,9 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
       state = auction?.state;
     }
 
-    const outstandingReserves = await indexedDb.getAuctionOutstandingReserves(id);
-
     let auction: Any | undefined;
     if (!!value.auction || state) {
+      const outstandingReserves = await indexedDb.getAuctionOutstandingReserves(id);
       auction = new Any({
         typeUrl: DutchAuction.typeName,
         value: new DutchAuction({

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -63,7 +63,10 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
     }
 
     let state: DutchAuctionState | undefined;
-    if (queryLatestState) state = (await querier.auction.auctionStateById(id))?.state;
+    if (queryLatestState) {
+      const auction = await querier.auction.auctionStateById(id);
+      state = auction?.state;
+    }
 
     const outstandingReserves = await indexedDb.getAuctionOutstandingReserves(id);
 

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -65,12 +65,18 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
     let state: DutchAuctionState | undefined;
     if (queryLatestState) state = (await querier.auction.auctionStateById(id))?.state;
 
+    const outstandingReserves = await indexedDb.getAuctionOutstandingReserves(id);
+
     let auction: Any | undefined;
     if (!!value.auction || state) {
       auction = new Any({
         typeUrl: DutchAuction.typeName,
         value: new DutchAuction({
-          state: state ?? { seq: value.seqNum },
+          state: state ?? {
+            seq: value.seqNum,
+            inputReserves: outstandingReserves?.input.amount,
+            outputReserves: outstandingReserves?.output.amount,
+          },
           description: value.auction,
         }).toBinary(),
       });

--- a/packages/ui/components/ui/dutch-auction-component/index.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/index.tsx
@@ -8,6 +8,7 @@ import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/nu
 import { Button } from '../button';
 import { ArrowRight } from 'lucide-react';
 import { PriceGraph } from './price-graph';
+import { Reserves } from './reserves';
 
 const getValueView = (amount?: Amount, metadata?: Metadata) =>
   new ValueView({
@@ -80,6 +81,12 @@ export const DutchAuctionComponent = ({
         inputMetadata={inputMetadata}
         outputMetadata={outputMetadata}
         fullSyncHeight={fullSyncHeight}
+      />
+
+      <Reserves
+        dutchAuction={dutchAuction}
+        inputMetadata={inputMetadata}
+        outputMetadata={outputMetadata}
       />
 
       {buttonType === 'withdraw' && (

--- a/packages/ui/components/ui/dutch-auction-component/reserves.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/reserves.tsx
@@ -1,0 +1,43 @@
+import {
+  Metadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { ValueViewComponent } from '../tx/view/value';
+import { DutchAuction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { ActionDetails } from '../tx/view/action-details';
+
+const getValueView = (amount: Amount, metadata?: Metadata) =>
+  new ValueView({
+    valueView: {
+      case: 'knownAssetId',
+      value: {
+        amount,
+        metadata,
+      },
+    },
+  });
+
+export const Reserves = ({
+  dutchAuction,
+  inputMetadata,
+  outputMetadata,
+}: {
+  dutchAuction: DutchAuction;
+  inputMetadata?: Metadata;
+  outputMetadata?: Metadata;
+}) => {
+  const inputAmount = dutchAuction.state?.inputReserves;
+  const outputAmount = dutchAuction.state?.outputReserves;
+
+  if (!inputAmount && !outputAmount) return null;
+
+  return (
+    <ActionDetails.Row label='Current reserves'>
+      <div className='flex flex-col items-end gap-2'>
+        {inputAmount && <ValueViewComponent view={getValueView(inputAmount, inputMetadata)} />}
+        {outputAmount && <ValueViewComponent view={getValueView(outputAmount, outputMetadata)} />}
+      </div>
+    </ActionDetails.Row>
+  );
+};

--- a/packages/ui/components/ui/gradient-header.tsx
+++ b/packages/ui/components/ui/gradient-header.tsx
@@ -1,0 +1,8 @@
+/**
+ * A header with text whose color is a gradient of brand colors.
+ */
+export const GradientHeader = ({ children }: { children: string }) => (
+  <p className='bg-text-linear bg-clip-text font-headline text-xl font-semibold leading-[30px] text-transparent md:text-2xl md:font-bold md:leading-9'>
+    {children}
+  </p>
+);


### PR DESCRIPTION
![screencap](https://github.com/penumbra-zone/web/assets/1121544/fd789ad3-f825-4982-aea8-06e6b6cbc934)


## In this PR
- Add a button to the auctions list to query the latest auction state.
- Show the current reserves of the auction if we have them.
- Extract a `<GradientHeader />` component, to avoid having to copy a bunch of Tailwind classes.
- Show an auction's outstanding reserves if there is an entry in the `AUCTION_OUTSTANDING_RESERVES` IDB table (i.e., when an auction has ended but its reserves haven't yet been claimed).
  - I realized we could have been doing this all along without even querying the latest state, since we know an auction's reserves when it ends.

Closes #1059 