### PR TITLE
block processor serialization

### DIFF
--- a/packages/wasm/crate/src/view_server.rs
+++ b/packages/wasm/crate/src/view_server.rs
@@ -113,13 +113,10 @@ impl ViewServer {
     /// Use `flush_updates()` to get the scan results
     /// Returns: `bool`
     #[wasm_bindgen]
-    pub async fn scan_block(&mut self, compact_block: JsValue) -> WasmResult<bool> {
+    pub async fn scan_block(&mut self, compact_block: &[u8]) -> WasmResult<bool> {
         utils::set_panic_hook();
 
-        let block_proto: penumbra_proto::core::component::compact_block::v1::CompactBlock =
-            serde_wasm_bindgen::from_value(compact_block)?;
-
-        let block: CompactBlock = block_proto.try_into()?;
+        let block = CompactBlock::decode(compact_block)?;
 
         let mut found_new_data: bool = false;
 

--- a/packages/wasm/crate/src/view_server.rs
+++ b/packages/wasm/crate/src/view_server.rs
@@ -1,6 +1,3 @@
-use std::collections::BTreeMap;
-use std::convert::TryInto;
-
 use penumbra_asset::asset::{Id, Metadata};
 use penumbra_compact_block::{CompactBlock, StatePayload};
 use penumbra_keys::FullViewingKey;
@@ -11,6 +8,7 @@ use penumbra_tct as tct;
 use penumbra_tct::Witness::*;
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::Serializer;
+use std::collections::BTreeMap;
 use tct::storage::{StoreCommitment, StoreHash, StoredPosition, Updates};
 use tct::{Forgotten, Tree};
 use wasm_bindgen::prelude::wasm_bindgen;

--- a/packages/wasm/src/build.ts
+++ b/packages/wasm/src/build.ts
@@ -29,7 +29,7 @@ export const buildParallel = (
   authData: AuthorizationData,
 ): Transaction => {
   const result = build_parallel(
-    batchActions.map(action => action.toJson()),
+    batchActions.map(action => action.toBinary()),
     txPlan.toBinary(),
     witnessData.toBinary(),
     authData.toBinary(),

--- a/packages/wasm/src/build.ts
+++ b/packages/wasm/src/build.ts
@@ -29,7 +29,7 @@ export const buildParallel = (
   authData: AuthorizationData,
 ): Transaction => {
   const result = build_parallel(
-    batchActions.map(action => action.toBinary()),
+    batchActions.map(action => action.toJson()),
     txPlan.toBinary(),
     witnessData.toBinary(),
     authData.toBinary(),

--- a/packages/wasm/src/view-server.ts
+++ b/packages/wasm/src/view-server.ts
@@ -58,7 +58,7 @@ export class ViewServer implements ViewServerInterface {
   // Makes update to internal state-commitment-tree as a side effect.
   // Should extract updates via this.flushUpdates().
   async scanBlock(compactBlock: CompactBlock): Promise<boolean> {
-    const res = compactBlock.toJson();
+    const res = compactBlock.toBinary();
     return this.wasmViewServer.scan_block(res);
   }
 


### PR DESCRIPTION
remove the existing call `toJson` and replaces it with `toBinary`.