### PR TITLE
Fix issue with how error splash page was rendered

### DIFF
--- a/.changeset/cool-bats-change.md
+++ b/.changeset/cool-bats-change.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Fix error splash screen

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -34,12 +34,10 @@ export const rootRouter = createHashRouter([
             index: true,
             loader: AssetsLoader,
             element: <AssetsTable />,
-            errorElement: <ErrorBoundary />,
           },
           {
             path: PagePath.TRANSACTIONS,
             element: <TransactionTable />,
-            errorElement: <ErrorBoundary />,
           },
         ],
       },


### PR DESCRIPTION
## Before (from #960)
https://github.com/penumbra-zone/web/assets/16624263/7b28b6cd-ffa0-4c4e-8fca-20a1f746b356

## After
![image](https://github.com/penumbra-zone/web/assets/1121544/a14738f8-407c-455c-9f77-6e149bf642b3)

Closes #960