### PR TITLE
Use an AbortController to cancel in-flight streaming responses when a new request starts

### DIFF
--- a/.changeset/empty-panthers-guess.md
+++ b/.changeset/empty-panthers-guess.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Fix a bug where multiple responses streamed to the same state variable simultaneously

--- a/apps/minifront/src/state/dutch-auction/index.ts
+++ b/apps/minifront/src/state/dutch-auction/index.ts
@@ -130,6 +130,15 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     /** @todo: Sort by... something? */
     for await (const response of viewClient.auctions(
       { queryLatestState, includeInactive: true },
+      /**
+       * Weirdly, just passing the newAbortController.signal here doesn't seem to
+       * have any effect, despite the ConnectRPC docs saying that it should
+       * work. I still left this line in, though, since it seems right and
+       * perhaps will be fixed in a later ConnectRPC release. But in the
+       * meantime, returning early from the `for` loop below fixes this issue.
+       *
+       * @see https://connectrpc.com/docs/web/cancellation-and-timeouts/
+       */
       { signal: newAbortController.signal },
     )) {
       if (newAbortController.signal.aborted) return;


### PR DESCRIPTION
## Bug description

### Steps to reproduce
1. Load the auctions page.
2. Observe that auctions are loading.
3. Click the "Query latest state" button.

### Expected behavior
The auctions list gets wiped out and reloaded from scratch.

### Actual behavior
The auctions list does not get wiped out; and eventually, we get thousands of errors about duplicate React keys being used (because the same auction is being rendered multiple times).

### Reason
The reason behind this is that one request to get auctions is still getting a streaming response while the next request fires off and gets its own streaming response, thus resulting in multiple streams of the same auctions being streamed simultaneously. 

To fix this, I introduced an `AbortController` that gets aborted when a new request starts.

Once I work on #965, we'll hopefully have a more elegant solution to this.

## Before

https://github.com/penumbra-zone/web/assets/1121544/f64ea9fb-823a-4041-89d7-84e7b4525e49



## After

https://github.com/penumbra-zone/web/assets/1121544/229002c0-1872-4a86-8451-680e97d9ef7d
