### PR TITLE
WIP: 962 unavailable page links to app not node status page

### DIFF
--- a/apps/minifront/src/components/extension-unavailable.tsx
+++ b/apps/minifront/src/components/extension-unavailable.tsx
@@ -16,12 +16,7 @@ export const ExtensionUnavailable = () => {
           and see if that fixes the issue.
         </p>
         <p>
-          If it doesn&apos;t, the RPC node that you&apos;re connected to could be down. Check{' '}
-          <a href={NODE_STATUS_PAGE_URL} className='underline'>
-            the node&apos;s status page
-          </a>{' '}
-          and, if it is down, consider switching to a different RPC URL in the Penumbra
-          extension&apos;s settings.
+          If it doesn&apos;t, please check the status page of the rpc provider in your extension
         </p>
       </SplashPage>
     </>

--- a/apps/minifront/src/components/extension-unavailable.tsx
+++ b/apps/minifront/src/components/extension-unavailable.tsx
@@ -1,9 +1,6 @@
 import { SplashPage } from '@penumbra-zone/ui/components/ui/splash-page';
 import { HeadTag } from './metadata/head-tag';
 
-const NODE_STATUS_PAGE_URL =
-  window.location.hostname === 'localhost' ? 'http://localhost:5174' : '/';
-
 export const ExtensionUnavailable = () => {
   return (
     <>


### PR DESCRIPTION
WIP 
This essentially fixes #962, but needs to also solve #990 to be able to show the user in the extension toast with a link to the node status page 