### PR TITLE
do not display zero balances

### DIFF
--- a/packages/getters/src/spendable-note-record.ts
+++ b/packages/getters/src/spendable-note-record.ts
@@ -4,3 +4,7 @@ import { SpendableNoteRecord } from '@buf/penumbra-zone_penumbra.bufbuild_es/pen
 export const getAssetIdFromRecord = createGetter(
   (noteRecord?: SpendableNoteRecord) => noteRecord?.note?.value?.assetId,
 );
+
+export const getAmountFromRecord = createGetter(
+  (noteRecord?: SpendableNoteRecord) => noteRecord?.note?.value?.amount,
+);

--- a/packages/services/src/view-service/balances.ts
+++ b/packages/services/src/view-service/balances.ts
@@ -1,7 +1,10 @@
 import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 import { getAmount } from '@penumbra-zone/getters/value-view';
-import { getAssetIdFromRecord } from '@penumbra-zone/getters/spendable-note-record';
+import {
+  getAmountFromRecord,
+  getAssetIdFromRecord,
+} from '@penumbra-zone/getters/spendable-note-record';
 import {
   AssetId,
   EquivalentValue,
@@ -28,7 +31,7 @@ import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/nu
 import { Base64Str, uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
 import { addLoHi } from '@penumbra-zone/types/lo-hi';
 import { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';
-import { multiplyAmountByNumber } from '@penumbra-zone/types/amount';
+import { isZero, multiplyAmountByNumber } from '@penumbra-zone/types/amount';
 import { Stringified } from '@penumbra-zone/types/jsonified';
 
 // Handles aggregating amounts and filtering by account number/asset id
@@ -44,6 +47,8 @@ export const balances: Impl['balances'] = async function* (req, ctx) {
 
   for await (const noteRecord of indexedDb.iterateSpendableNotes()) {
     if (noteRecord.heightSpent !== 0n) continue;
+    if (isZero(getAmountFromRecord(noteRecord))) continue;
+
     await aggregator.add(noteRecord);
   }
 


### PR DESCRIPTION
close #1112 

Based on Henry's suggestion:
> Zero-valued notes shouldn't need to be filtered out at the RPC or UI layers, because we should eliminate them at the scanning layer -- when we detect a note, we should skip recording it if it's zero-valued.

I was considering 3 options:
1. Filter out zero notes at the scanning stage in wasm 
2. Filter zero notes immediately before saving to indexed-db
3. Save zero notes, but filter them only on retrieval where necessary.

The first two options would obviously be preferable from a performance point of view 
- we would store less data in indexed-db
- we could hope that this would have a positive effect on synchronization speed. 

But, both of these options result in us not having enough data to properly display swap transaction info
![telegram-cloud-photo-size-2-5361817046565905198-y](https://github.com/penumbra-zone/web/assets/25391690/e791b9c3-b115-440c-b27e-6dde40d24b2b)


Therefore, I just settled on the option that does not lead to new bugs, or change the logic and worsen the display of swap transactions

Also of note https://github.com/penumbra-zone/web/issues/1112#issuecomment-2115431431

