### PR TITLE
expose wasm asset id generation

### DIFF
--- a/.changeset/polite-coins-lie.md
+++ b/.changeset/polite-coins-lie.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': patch
+---
+
+add base denom string to binary AssetId conversion utility

--- a/packages/wasm/crate/src/asset.rs
+++ b/packages/wasm/crate/src/asset.rs
@@ -15,5 +15,5 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn get_asset_id_inner(input_id_bin: &[u8]) -> WasmResult<Vec<u8>> {
     let input_id = Id::decode(input_id_bin)?;
-    return Ok(input_id.to_bytes().to_vec());
+    Ok(input_id.to_bytes().to_vec())
 }

--- a/packages/wasm/crate/src/asset.rs
+++ b/packages/wasm/crate/src/asset.rs
@@ -1,0 +1,19 @@
+use crate::error::WasmResult;
+use penumbra_asset::asset::Id;
+use penumbra_proto::DomainType;
+use wasm_bindgen::prelude::*;
+
+/// generate the appropriate binary inner id for a binary-serialized protobuf
+/// `AssetId` potentially containing an `altBaseDenom` or `altBech32m` string
+/// field
+///
+/// Arguments:
+///     input_id_bin: `Uint8Array` representing a binary-serialized `AssetId`
+///
+/// Returns:
+///     `Uint8Array` representing the literal inner id
+#[wasm_bindgen]
+pub fn get_asset_id_inner(input_id_bin: &[u8]) -> WasmResult<Vec<u8>> {
+    let input_id = Id::decode(input_id_bin)?;
+    return Ok(input_id.to_bytes().to_vec());
+}

--- a/packages/wasm/crate/src/lib.rs
+++ b/packages/wasm/crate/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate core;
 
+pub mod asset;
 pub mod auction;
 pub mod build;
 pub mod dex;

--- a/packages/wasm/src/asset.test.ts
+++ b/packages/wasm/src/asset.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'vitest';
+import { assetIdFromBaseDenom } from './asset';
+import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { randomBytes } from 'crypto';
+import { assetIdFromBech32m } from '@penumbra-zone/bech32m/passet';
+
+// not human legible or restricted to any charset
+const randomString = (byteLength = 32) =>
+  randomBytes(1 + Math.random() * (byteLength - 1)).toString();
+
+describe('assetIdFromBaseDenom', () => {
+  test('should return the correct asset id for a known asset id', () => {
+    const upenumbraFromBech32m = new AssetId(
+      assetIdFromBech32m('passet1984fctenw8m2fpl8a9wzguzp7j34d7vravryuhft808nyt9fdggqxmanqm'),
+    );
+
+    const upenumbraFromBaseDenom = assetIdFromBaseDenom('upenumbra');
+
+    expect(AssetId.equals(upenumbraFromBech32m, upenumbraFromBaseDenom)).toBeTruthy();
+  });
+
+  test('should return a 32-byte asset id for any string', () => {
+    const randomIds = Array.from(Array(10), randomString).map(denom => assetIdFromBaseDenom(denom));
+
+    expect(
+      randomIds.every(
+        id => id instanceof AssetId && id.inner instanceof Uint8Array && id.inner.length == 32,
+      ),
+    ).toBeTruthy();
+  });
+
+  test('should return same asset id for same string', () => {
+    const sameAltBaseDenom = randomString();
+    const a1 = assetIdFromBaseDenom(sameAltBaseDenom);
+    const a2 = assetIdFromBaseDenom(sameAltBaseDenom);
+
+    expect(a1.inner).toEqual(a2.inner);
+  });
+
+  test(
+    'should return different asset id for different strings',
+    { retry: 2 }, // there is a chance that this test could fail randomly :)
+    () => {
+      const someAltBaseDenom = randomString();
+      const differentAltBaseDenom = randomString();
+      const a = assetIdFromBaseDenom(someAltBaseDenom);
+      const b = assetIdFromBaseDenom(differentAltBaseDenom);
+
+      expect(a.inner).not.toEqual(b.inner);
+    },
+  );
+});

--- a/packages/wasm/src/asset.test.ts
+++ b/packages/wasm/src/asset.test.ts
@@ -24,7 +24,7 @@ describe('assetIdFromBaseDenom', () => {
 
     expect(
       randomIds.every(
-        id => id instanceof AssetId && id.inner instanceof Uint8Array && id.inner.length == 32,
+        id => id instanceof AssetId && id.inner instanceof Uint8Array && id.inner.length === 32,
       ),
     ).toBeTruthy();
   });

--- a/packages/wasm/src/asset.ts
+++ b/packages/wasm/src/asset.ts
@@ -1,0 +1,12 @@
+import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { get_asset_id_inner } from '../wasm';
+
+/**
+ * Converts a base denom name string to an `AssetId` with inner binary field
+ * @param altBaseDenom an asset's base denomination name
+ * @returns the appropriate `AssetId` with binary inner field
+ */
+export const assetIdFromBaseDenom = (altBaseDenom: string) => {
+  const inner = get_asset_id_inner(new AssetId({ altBaseDenom }).toBinary());
+  return new AssetId({ inner });
+};


### PR DESCRIPTION
this allows a caller to convert from an altBaseDenom string to the binary asset id, by using the core class's acceptance of altBaseDenom as hash input