### PR TITLE
Update to latest registry [Starling addition]

### DIFF
--- a/.changeset/bright-toys-unite.md
+++ b/.changeset/bright-toys-unite.md
@@ -1,0 +1,8 @@
+---
+'@penumbra-zone/services-context': minor
+'@penumbra-zone/storage': minor
+'chrome-extension': minor
+'minifront': minor
+---
+
+Update registry to latest (fixes labs + adds starling)

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -20,7 +20,7 @@
     "@bufbuild/protobuf": "^1.9.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-web": "^1.4.0",
-    "@penumbra-labs/registry": "7.3.0",
+    "@penumbra-labs/registry": "7.4.1",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/client": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -23,7 +23,7 @@
     "@cosmos-kit/core": "^2.10.0",
     "@cosmos-kit/react": "^2.12.0",
     "@interchain-ui/react": "^1.23.13",
-    "@penumbra-labs/registry": "7.3.0",
+    "@penumbra-labs/registry": "7.4.1",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/client": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",

--- a/packages/services-context/package.json
+++ b/packages/services-context/package.json
@@ -14,7 +14,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@penumbra-labs/registry": "7.3.0",
+    "@penumbra-labs/registry": "7.4.1",
     "@penumbra-zone/query": "workspace:*",
     "@penumbra-zone/storage": "workspace:*",
     "@penumbra-zone/types": "workspace:*",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,7 +19,7 @@
     "./indexed-db/*": "./src/indexed-db/*.ts"
   },
   "dependencies": {
-    "@penumbra-labs/registry": "7.3.0",
+    "@penumbra-labs/registry": "7.4.1",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@bufbuild/protobuf@1.9.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.9.0))
       '@penumbra-labs/registry':
-        specifier: 7.3.0
-        version: 7.3.0
+        specifier: 7.4.1
+        version: 7.4.1
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../../packages/bech32m
@@ -341,8 +341,8 @@ importers:
         specifier: ^1.23.13
         version: 1.23.13(@types/react@18.3.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@penumbra-labs/registry':
-        specifier: 7.3.0
-        version: 7.3.0
+        specifier: 7.4.1
+        version: 7.4.1
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../../packages/bech32m
@@ -764,8 +764,8 @@ importers:
   packages/services-context:
     dependencies:
       '@penumbra-labs/registry':
-        specifier: 7.3.0
-        version: 7.3.0
+        specifier: 7.4.1
+        version: 7.4.1
       '@penumbra-zone/query':
         specifier: workspace:*
         version: link:../query
@@ -792,8 +792,8 @@ importers:
   packages/storage:
     dependencies:
       '@penumbra-labs/registry':
-        specifier: 7.3.0
-        version: 7.3.0
+        specifier: 7.4.1
+        version: 7.4.1
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -3148,8 +3148,8 @@ packages:
     resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
     engines: {node: '>= 10.0.0'}
 
-  '@penumbra-labs/registry@7.3.0':
-    resolution: {integrity: sha512-4zmtFRpJZP4dc+HQK7IAXO54cLetcxyMm1VgxPZV1VP5Pc8BIT/+9chPt6zwSM0LCJid9MIdol9fEkQmCJllqg==}
+  '@penumbra-labs/registry@7.4.1':
+    resolution: {integrity: sha512-WBFoEV/NARidHR/HHfKgGLzMfHVFozVKLTOaiB458ZCMJ75JqZJw6hjqbzX1uoegVmHi6mfVP6kzEbpEbdm4Wg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -15323,7 +15323,7 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@penumbra-labs/registry@7.3.0': {}
+  '@penumbra-labs/registry@7.4.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
Update registry to latest:
- Fixes Penumbra labs icons+asset ids
- Adds metadata for Starling

@plaidfinch, registries are loaded into the extension. So when we deploy that early next week, this will be visible 🤩

<img width="1217" alt="Screenshot 2024-05-24 at 1 43 16 PM" src="https://github.com/penumbra-zone/web/assets/16624263/d0405fef-92fb-4ff8-abb4-698b397f2cf5">

