### PR TITLE
change NOTES in db to ADVICE_NOTES

### DIFF
--- a/apps/extension/.env.testnet
+++ b/apps/extension/.env.testnet
@@ -1,4 +1,4 @@
 CHAIN_ID=penumbra-testnet-deimos-8
-IDB_VERSION=40
+IDB_VERSION=41
 MINIFRONT_URL=https://app.testnet.penumbra.zone
 PRAX=lkpmkhpnhknhmibgnmmhdhgdilepfghe

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -112,7 +112,7 @@ export class IndexedDb implements IndexedDbInterface {
         db.createObjectStore('FMD_PARAMETERS');
         db.createObjectStore('APP_PARAMETERS');
 
-        db.createObjectStore('NOTES');
+        db.createObjectStore('ADVICE_NOTES');
         db.createObjectStore('SWAPS', {
           keyPath: 'swapCommitment.inner',
         }).createIndex('nullifier', 'nullifier.inner');

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -193,10 +193,23 @@ export interface PenumbraDb extends DBSchema {
       nullifier: Jsonified<Required<SpendableNoteRecord>['nullifier']['inner']>; // base64
     };
   };
-  // Store for advice for future spendable notes
-  // Used in wasm crate to process swap and swap claim
-  // When we detect a swap we save advices, and when we detect a swap claim we use advices to get spendable notes
-  // This table is never written or queried by typescript
+
+  /**
+   * Store for advice for future spendable notes
+   * Used in wasm crate to process swap and swap claim
+   *
+   * This emphasizes the difference between Rust view service data storage and extension view service data storage.
+   * In the relational model (Rust view service), each 'SPENDABLE_NOTES' must have a corresponding record
+   * in the 'NOTES' table ('note_commitment' is used as a foreign key).
+   * Therefore, in Rust view service, the 'NOTES' table stores both notes that do not yet have an associated
+   * record in the 'SPENDABLE_NOTES' table (we call them advices)
+   * and notes that already have an associated record in 'SPENDABLE_NOTES'.
+   *
+   * In indexed-db (extension view service), we store advices separately in the 'ADVICE_NOTES' table,
+   * and store spendable notes along with nested notes in the 'SPENDABLE_NOTES' table.
+   *
+   * This table is never written or queried by TypeScript.
+   */
   ADVICE_NOTES: {
     // key is not part of the stored object
     key: Jsonified<StateCommitment['inner']>; // base64

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -193,10 +193,11 @@ export interface PenumbraDb extends DBSchema {
       nullifier: Jsonified<Required<SpendableNoteRecord>['nullifier']['inner']>; // base64
     };
   };
-  // Store for Notes that have been detected but cannot yet be spent
+  // Store for advice for future spendable notes
   // Used in wasm crate to process swap and swap claim
+  // When we detect a swap we save advices, and when we detect a swap claim we use advices to get spendable notes
   // This table is never written or queried by typescript
-  NOTES: {
+  ADVICE_NOTES: {
     // key is not part of the stored object
     key: Jsonified<StateCommitment['inner']>; // base64
     value: Jsonified<Note>;
@@ -282,7 +283,7 @@ export const IDB_TABLES: Tables = {
   assets: 'ASSETS',
   auctions: 'AUCTIONS',
   auction_outstanding_reserves: 'AUCTION_OUTSTANDING_RESERVES',
-  notes: 'NOTES',
+  advice_notes: 'ADVICE_NOTES',
   spendable_notes: 'SPENDABLE_NOTES',
   swaps: 'SWAPS',
   fmd_parameters: 'FMD_PARAMETERS',

--- a/packages/wasm/crate/src/storage.rs
+++ b/packages/wasm/crate/src/storage.rs
@@ -35,7 +35,7 @@ pub struct IndexedDbConstants {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Tables {
     pub assets: String,
-    pub notes: String,
+    pub advice_notes: String,
     pub spendable_notes: String,
     pub swaps: String,
     pub fmd_parameters: String,
@@ -239,8 +239,8 @@ impl IndexedDBStorage {
     pub async fn store_advice(&self, note: Note) -> WasmResult<()> {
         let tx = self
             .db
-            .transaction_on_one_with_mode(&self.constants.tables.notes, Readwrite)?;
-        let store = tx.object_store(&self.constants.tables.notes)?;
+            .transaction_on_one_with_mode(&self.constants.tables.advice_notes, Readwrite)?;
+        let store = tx.object_store(&self.constants.tables.advice_notes)?;
 
         let note_proto: penumbra_proto::core::component::shielded_pool::v1::Note =
             note.clone().into();
@@ -254,8 +254,10 @@ impl IndexedDBStorage {
     }
 
     pub async fn read_advice(&self, commitment: note::StateCommitment) -> WasmResult<Option<Note>> {
-        let tx = self.db.transaction_on_one(&self.constants.tables.notes)?;
-        let store = tx.object_store(&self.constants.tables.notes)?;
+        let tx = self
+            .db
+            .transaction_on_one(&self.constants.tables.advice_notes)?;
+        let store = tx.object_store(&self.constants.tables.advice_notes)?;
 
         let commitment_proto = commitment.to_proto();
 

--- a/packages/wasm/crate/tests/build.rs
+++ b/packages/wasm/crate/tests/build.rs
@@ -75,7 +75,7 @@ mod tests {
         #[derive(Clone, Debug, Serialize, Deserialize)]
         pub struct Tables {
             assets: String,
-            notes: String,
+            advice_notes: String,
             spendable_notes: String,
             swaps: String,
             fmd_parameters: String,
@@ -91,7 +91,7 @@ mod tests {
         // Define `IndexDB` table parameters and constants.
         let tables: Tables = Tables {
             assets: "ASSETS".to_string(),
-            notes: "NOTES".to_string(),
+            advice_notes: "ADVICE_NOTES".to_string(),
             spendable_notes: "SPENDABLE_NOTES".to_string(),
             swaps: "SWAPS".to_string(),
             fmd_parameters: "FMD_PARAMETERS".to_string(),


### PR DESCRIPTION
close #1152 

This also emphasizes the difference between rust view service data storage, where a relational database is used, and extension view service where a non-relational indexed-db is used. 

The point is that in the relational model, each `SPENDABLE_NOTES` must have a corresponding record in the `NOTES` table (`note_commitment` is used as a foreign key). Therefore, in rust view service the `NOTES` table stores both notes that do not yet have an associated record in the `SPENDABLE_NOTES` table (we call them advices) and notes that already have an associated record in `SPENDABLE_NOTES`

In indexed-db, we store advices separately in the `ADVICE_NOTES` table, and store spendable notes along with nested notes in the `SPENDABLE_NOTES` table