### PR TITLE
add disconnect method to page api

### DIFF
--- a/.changeset/moody-bulldogs-mate.md
+++ b/.changeset/moody-bulldogs-mate.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/client': minor
+---
+
+add disconnect method

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -17,7 +17,11 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["injected-connection-port.js"],
+      "js": [
+        "injected-connection-port.js",
+        "injected-disconnect-listener.js",
+        "injected-request-listener.js"
+      ],
       "run_at": "document_start"
     },
     {
@@ -25,11 +29,6 @@
       "js": ["injected-penumbra-global.js"],
       "run_at": "document_start",
       "world": "MAIN"
-    },
-    {
-      "matches": ["<all_urls>"],
-      "js": ["injected-request-listener.js"],
-      "run_at": "document_start"
     }
   ],
   "options_ui": {

--- a/apps/extension/src/content-scripts/injected-disconnect-listener.ts
+++ b/apps/extension/src/content-scripts/injected-disconnect-listener.ts
@@ -5,7 +5,6 @@ const handleDisconnect = (ev: MessageEvent<unknown>) => {
   if (ev.origin === window.origin && isPraxEndMessageEvent(ev)) {
     window.removeEventListener('message', handleDisconnect);
     void chrome.runtime.sendMessage<PraxConnection>(PraxConnection.End);
-    //.then(() => window.location.reload());
   }
 };
 window.addEventListener('message', handleDisconnect);

--- a/apps/extension/src/content-scripts/injected-disconnect-listener.ts
+++ b/apps/extension/src/content-scripts/injected-disconnect-listener.ts
@@ -1,0 +1,11 @@
+import { isPraxEndMessageEvent } from './message-event';
+import { PraxConnection } from '../message/prax';
+
+const handleDisconnect = (ev: MessageEvent<unknown>) => {
+  if (ev.origin === window.origin && isPraxEndMessageEvent(ev)) {
+    window.removeEventListener('message', handleDisconnect);
+    void chrome.runtime.sendMessage<PraxConnection>(PraxConnection.End);
+    //.then(() => window.location.reload());
+  }
+};
+window.addEventListener('message', handleDisconnect);

--- a/apps/extension/src/content-scripts/injected-penumbra-global.ts
+++ b/apps/extension/src/content-scripts/injected-penumbra-global.ts
@@ -5,54 +5,101 @@
  *
  * The global is identified by `Symbol.for('penumbra')` and consists of a record
  * with string keys referring to `PenumbraInjection` objects that contain a
- * simple api. The identifiers on this record should be unique and correspond to
- * an id in a manifest, and providers should provide a link to the manifest in
- * their record entry.
+ * simple API. The identifiers on this record should be unique, and correspond
+ * to a browser extension id. Providers should provide a link to their extension
+ * manifest in their record entry.
  *
- * The global is frozen to prevent mutation, but you should consider that the
+ * The global is frozen to discourage mutation, but you should consider that the
  * global and everything on it is only as trustable as the scripts running on
- * the page. Imports, includes, and packages your webapp depends on could all
- * mutate or preempt the global. User-agent injections like userscripts or other
- * content scripts could interfere or intercept connections.
+ * the page. Imports, requires, includes, script tags, packages your webapp
+ * depends on, userscripts, or other extensions' content scripts could all
+ * mutate or preempt this, and all have the power to interfere or intercept
+ * connections.
  */
 
 import { PenumbraInjection, PenumbraRequestFailure, PenumbraSymbol } from '@penumbra-zone/client';
-import { isPraxFailureMessageEvent, isPraxPortMessageEvent, PraxMessage } from './message-event';
+
+import {
+  isPraxFailureMessageEvent,
+  isPraxPortMessageEvent,
+  PraxMessage,
+  unwrapPraxMessage,
+} from './message-event';
 
 import { PraxConnection } from '../message/prax';
 
-const request = Promise.withResolvers<void>();
+type PromiseSettledResultStatus = PromiseSettledResult<unknown>['status'];
 
-// this is just withResolvers, plus a sync-queryable state attribute
-const connection = Object.assign(Promise.withResolvers<MessagePort>(), { state: false });
-connection.promise.then(
-  () => {
-    connection.state = true;
-    request.resolve();
-  },
-  () => {
-    connection.state = false;
-    request.reject();
-  },
-);
+class PraxInjection {
+  private static singleton?: PraxInjection = new PraxInjection();
 
-// this resolves the connection promise when the isolated port script indicates
-const connectionListener = (msg: MessageEvent<unknown>) => {
-  if (isPraxPortMessageEvent(msg) && msg.origin === window.origin) {
-    // @ts-expect-error - ts can't understand the injected string
-    const praxPort: unknown = msg.data[PRAX];
-    if (praxPort instanceof MessagePort) connection.resolve(praxPort);
+  public static get penumbra() {
+    return PraxInjection.singleton!.injection;
   }
-};
-window.addEventListener('message', connectionListener);
-void connection.promise.finally(() => window.removeEventListener('message', connectionListener));
 
-// declared outside of postRequest to prevent attaching multiple identical listeners
-const requestResponseListener = (msg: MessageEvent<unknown>) => {
-  if (msg.origin === window.origin) {
-    if (isPraxFailureMessageEvent(msg)) {
-      // @ts-expect-error - ts can't understand the injected string
-      const status = msg.data[PRAX] as PraxConnection;
+  private manifestUrl = `${PRAX_ORIGIN}/manifest.json`;
+  private _request = Promise.withResolvers<void>();
+  private _connect = Promise.withResolvers<MessagePort>();
+  private _disconnect = Promise.withResolvers<void>();
+
+  private connectState?: PromiseSettledResultStatus;
+  private requestState?: PromiseSettledResultStatus;
+  private disconnectState?: PromiseSettledResultStatus;
+
+  private injection: Readonly<PenumbraInjection> = Object.freeze({
+    disconnect: () => this.endConnection(),
+    connect: () => (this.state() !== false ? this._connect.promise : this.connectionFailure),
+    isConnected: () => this.state(),
+    request: () => this.postRequest(),
+    manifest: String(this.manifestUrl),
+  });
+
+  private constructor() {
+    if (PraxInjection.singleton) return PraxInjection.singleton;
+
+    window.addEventListener('message', this.connectionListener);
+
+    void this._connect.promise
+      .then(
+        () => (this.connectState ??= 'fulfilled'),
+        () => (this.connectState ??= 'rejected'),
+      )
+      .finally(() => window.removeEventListener('message', this.connectionListener));
+
+    void this._disconnect.promise.then(
+      () => (this.disconnectState = 'fulfilled'),
+      () => (this.disconnectState = 'rejected'),
+    );
+
+    void this._request.promise.then(
+      () => (this.requestState = 'fulfilled'),
+      () => (this.requestState = 'rejected'),
+    );
+  }
+
+  private state(): boolean | undefined {
+    if (this.disconnectState) return false;
+    if (this.requestState === 'rejected') return false;
+    return this.connectState && this.connectState === 'fulfilled';
+  }
+
+  // this listener will resolve the connection promise AND request promise when
+  // the isolated content script injected-connection-port sends a `MessagePort`
+  private connectionListener = (msg: MessageEvent<unknown>) => {
+    if (msg.origin === window.origin && isPraxPortMessageEvent(msg)) {
+      const praxPort = unwrapPraxMessage(msg);
+      if (praxPort instanceof MessagePort) {
+        this._connect.resolve(praxPort);
+        this._request.resolve();
+      }
+    }
+  };
+
+  // this listener only rejects the request promise. success of the request
+  // promise is indicated by the connection promise being resolved.
+  private requestFailureListener = (msg: MessageEvent<unknown>) => {
+    if (msg.origin === window.origin && isPraxFailureMessageEvent(msg)) {
+      const status = unwrapPraxMessage(msg);
       const failure = new Error('Connection request failed');
       switch (status) {
         case PraxConnection.Denied:
@@ -65,44 +112,90 @@ const requestResponseListener = (msg: MessageEvent<unknown>) => {
           failure.cause = 'Unknown';
           break;
       }
-      request.reject(failure);
+      this._request.reject(failure);
     }
-  }
-};
+  };
 
-// Called to request a connection to the extension.
-const postRequest = () => {
-  if (!connection.state) {
-    window.addEventListener('message', requestResponseListener);
+  // always reject with the most important reason at time of access
+  // 1. disconnect
+  // 2. connection failure
+  // 3. request
+  private get connectionFailure() {
+    // Promise.race checks in order of the list index. so if more than one
+    // promise is settled, Promise.race responds with the earlier index
+    return Promise.race([
+      // rejects with disconnect success, rejects with disconnect failure
+      this._disconnect.promise.then(() => Promise.reject(Error('Disconnected'))),
+      // ignores connection success, rejects with connection failure
+      this._connect.promise.then(() => new Promise<never>(() => null)),
+      // rejects with previous success, rejects with previous failure
+      this._request.promise.then(() => Promise.reject(Error('Disconnected'))),
+      // this should be unreachable
+      Promise.reject(Error('Unknown failure')),
+    ]);
+  }
+
+  private postRequest() {
+    const state = this.state();
+    if (state === true)
+      // connection is already active
+      this._request.resolve();
+    else if (state === false) {
+      // connection is already failed
+      const failure = this.connectionFailure;
+      failure.catch((u: unknown) => this._request.reject(u));
+      // a previous request may have succeeded, so return the failure directly
+      return failure;
+    } else {
+      // no request made yet. attach listener and emit
+      window.addEventListener('message', this.requestFailureListener);
+      void this._request.promise.finally(() =>
+        window.removeEventListener('message', this.requestFailureListener),
+      );
+      window.postMessage(
+        {
+          [PRAX]: PraxConnection.Request,
+        } satisfies PraxMessage<PraxConnection.Request>,
+        window.origin,
+      );
+    }
+
+    return this._request.promise;
+  }
+
+  private endConnection() {
+    // attempt actual disconnect
+    void this._connect.promise
+      .then(
+        port => {
+          port.postMessage(false);
+          port.close();
+        },
+        (e: unknown) => console.warn('Could not attempt disconnect', e),
+      )
+      .catch((e: unknown) => console.error('Disconnect failed', e));
     window.postMessage(
-      {
-        [PRAX]: PraxConnection.Request,
-      } satisfies PraxMessage<PraxConnection.Request>,
-      window.origin,
+      { [PRAX]: PraxConnection.End } satisfies PraxMessage<PraxConnection.End>,
+      '/',
     );
-    request.promise
-      .catch((e: unknown) => connection.reject(e))
-      .finally(() => window.removeEventListener('message', requestResponseListener));
-  }
-  return request.promise;
-};
 
-// the actual object we attach to the global record, frozen
-const praxProvider: PenumbraInjection = Object.freeze({
-  manifest: `${PRAX_ORIGIN}/manifest.json`,
-  connect: () => connection.promise,
-  isConnected: () => connection.state,
-  request: () => postRequest(),
-});
+    // resolve the promise by state
+    const state = this.state();
+    if (state === true) this._disconnect.resolve();
+    else if (state === false) this._disconnect.reject(Error('Connection already inactive'));
+    else this._disconnect.reject(Error('Connection not yet active'));
+
+    return this._disconnect.promise;
+  }
+}
 
 // if the global isn't present, create it.
-if (!window[PenumbraSymbol]) {
+if (!window[PenumbraSymbol])
   Object.defineProperty(window, PenumbraSymbol, { value: {}, writable: false });
-}
 
 // reveal
 Object.defineProperty(window[PenumbraSymbol], PRAX_ORIGIN, {
-  value: praxProvider,
+  value: PraxInjection.penumbra,
   writable: false,
   enumerable: true,
 });

--- a/apps/extension/src/content-scripts/message-event.ts
+++ b/apps/extension/src/content-scripts/message-event.ts
@@ -25,8 +25,18 @@ export const isPraxFailureMessageEvent = (
   return status === PraxConnection.Denied || status === PraxConnection.NeedsLogin;
 };
 
+export const isPraxEndMessageEvent = (
+  ev: MessageEvent<unknown>,
+): ev is MessageEvent<PraxMessage<PraxConnection.End>> =>
+  // @ts-expect-error - ts can't understand the injected string
+  isPraxMessageEventData(ev.data) && ev.data[PRAX] === PraxConnection.End;
+
 export const isPraxPortMessageEvent = (
   ev: MessageEvent<unknown>,
 ): ev is MessageEvent<PraxMessage<MessagePort>> =>
   // @ts-expect-error - ts can't understand the injected string
   isPraxMessageEventData(ev.data) && ev.data[PRAX] instanceof MessagePort;
+
+export const unwrapPraxMessage = <T = unknown>(ev: MessageEvent<PraxMessage<T>>): T =>
+  // @ts-expect-error - ts can't understand the injected string
+  ev.data[PRAX] as T;

--- a/apps/extension/src/listeners/message-prax-request.ts
+++ b/apps/extension/src/listeners/message-prax-request.ts
@@ -8,7 +8,6 @@ import { UserChoice } from '@penumbra-zone/types/user-choice';
 // this is the only message we handle from an unapproved content script.
 chrome.runtime.onMessage.addListener(
   (req: PraxConnection.Request | JsonValue, sender, respond: (arg: PraxConnection) => void) => {
-    console.log('prax request', req, sender);
     switch (req) {
       case PraxConnection.End:
         void removeOrigin(sender);

--- a/apps/extension/src/listeners/message-prax-request.ts
+++ b/apps/extension/src/listeners/message-prax-request.ts
@@ -1,5 +1,5 @@
 import { Code, ConnectError } from '@connectrpc/connect';
-import { approveOrigin } from '../approve-origin';
+import { approveOrigin, removeOrigin } from '../origin';
 import { PraxConnection } from '../message/prax';
 import { JsonValue } from '@bufbuild/protobuf';
 import { UserChoice } from '@penumbra-zone/types/user-choice';
@@ -8,29 +8,37 @@ import { UserChoice } from '@penumbra-zone/types/user-choice';
 // this is the only message we handle from an unapproved content script.
 chrome.runtime.onMessage.addListener(
   (req: PraxConnection.Request | JsonValue, sender, respond: (arg: PraxConnection) => void) => {
-    if (req !== PraxConnection.Request) return false; // instruct chrome we will not respond
-
-    void approveOrigin(sender).then(
-      status => {
-        // user made a choice
-        if (status === UserChoice.Approved) {
-          respond(PraxConnection.Init);
-          void chrome.tabs.sendMessage(sender.tab!.id!, PraxConnection.Init);
-        } else {
-          respond(PraxConnection.Denied);
-        }
-      },
-      e => {
-        if (process.env['NODE_ENV'] === 'development') {
-          console.warn('Connection request listener failed:', e);
-        }
-        if (e instanceof ConnectError && e.code === Code.Unauthenticated) {
-          respond(PraxConnection.NeedsLogin);
-        } else {
-          respond(PraxConnection.Denied);
-        }
-      },
-    );
-    return true; // instruct chrome to wait for the response
+    console.log('prax request', req, sender);
+    switch (req) {
+      case PraxConnection.End:
+        void removeOrigin(sender);
+        respond(PraxConnection.End);
+        return true; // instruct chrome to wait for the response
+      case PraxConnection.Request:
+        void approveOrigin(sender).then(
+          status => {
+            // user made a choice
+            if (status === UserChoice.Approved) {
+              respond(PraxConnection.Init);
+              void chrome.tabs.sendMessage(sender.tab!.id!, PraxConnection.Init);
+            } else {
+              respond(PraxConnection.Denied);
+            }
+          },
+          e => {
+            if (process.env['NODE_ENV'] === 'development') {
+              console.warn('Connection request listener failed:', e);
+            }
+            if (e instanceof ConnectError && e.code === Code.Unauthenticated) {
+              respond(PraxConnection.NeedsLogin);
+            } else {
+              respond(PraxConnection.Denied);
+            }
+          },
+        );
+        return true; // instruct chrome to wait for the response
+      default:
+        return false; // instruct chrome we will not respond
+    }
   },
 );

--- a/apps/extension/src/listeners/tabs-updated-prax-init.ts
+++ b/apps/extension/src/listeners/tabs-updated-prax-init.ts
@@ -1,4 +1,4 @@
-import { originAlreadyApproved } from '../approve-origin';
+import { originAlreadyApproved } from '../origin';
 import { PraxConnection } from '../message/prax';
 
 // trigger injected-connection-port to init when a known page is loaded.

--- a/apps/extension/src/message/prax.ts
+++ b/apps/extension/src/message/prax.ts
@@ -1,6 +1,7 @@
 export enum PraxConnection {
   Init = 'Init',
   Request = 'Request',
+  End = 'End',
   Denied = 'Denied',
   NeedsLogin = 'NeedsLogin',
 }

--- a/apps/extension/src/origin.ts
+++ b/apps/extension/src/origin.ts
@@ -11,6 +11,29 @@ export const originAlreadyApproved = async (url: string): Promise<boolean> => {
   return existingRecord?.choice === UserChoice.Approved;
 };
 
+export const removeOrigin = async (sender: chrome.runtime.MessageSender): Promise<void> => {
+  // parses the origin and returns a consistent format
+  const { origin: senderOrigin } = sender;
+
+  if (!senderOrigin) {
+    console.warn('No record for origin', sender);
+    return;
+  }
+
+  const urlOrigin = new URL(senderOrigin).origin;
+  const knownSites = await localExtStorage.get('knownSites');
+  const sansDeletant = knownSites.filter(site => site.origin !== urlOrigin);
+
+  if (sansDeletant.length === knownSites.length) {
+    console.warn('No site record found:', urlOrigin);
+    return;
+  }
+
+  if (!sansDeletant.length) console.warn('No site records remaining:', sansDeletant);
+
+  void localExtStorage.set('knownSites', sansDeletant);
+};
+
 export const approveOrigin = async ({
   origin: senderOrigin,
   tab,

--- a/apps/extension/src/origin.ts
+++ b/apps/extension/src/origin.ts
@@ -22,16 +22,14 @@ export const removeOrigin = async (sender: chrome.runtime.MessageSender): Promis
 
   const urlOrigin = new URL(senderOrigin).origin;
   const knownSites = await localExtStorage.get('knownSites');
-  const sansDeletant = knownSites.filter(site => site.origin !== urlOrigin);
+  const knownSitesWithoutDeletedSite = knownSites.filter(site => site.origin !== urlOrigin);
 
-  if (sansDeletant.length === knownSites.length) {
+  if (knownSitesWithoutDeletedSite.length === knownSites.length) {
     console.warn('No site record found:', urlOrigin);
     return;
   }
 
-  if (!sansDeletant.length) console.warn('No site records remaining:', sansDeletant);
-
-  void localExtStorage.set('knownSites', sansDeletant);
+  void localExtStorage.set('knownSites', knownSitesWithoutDeletedSite);
 };
 
 export const approveOrigin = async ({

--- a/apps/extension/webpack.config.ts
+++ b/apps/extension/webpack.config.ts
@@ -40,6 +40,7 @@ const config: webpack.Configuration = {
     'injected-connection-port': path.join(injectDir, 'injected-connection-port.ts'),
     'injected-penumbra-global': path.join(injectDir, 'injected-penumbra-global.ts'),
     'injected-request-listener': path.join(injectDir, 'injected-request-listener.ts'),
+    'injected-disconnect-listener': path.join(injectDir, 'injected-disconnect-listener.ts'),
     'offscreen-handler': path.join(entryDir, 'offscreen-handler.ts'),
     'page-root': path.join(entryDir, 'page-root.tsx'),
     'popup-root': path.join(entryDir, 'popup-root.tsx'),

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,6 +5,7 @@ export const PenumbraSymbol = Symbol.for('penumbra');
 export interface PenumbraInjection {
   readonly connect: () => Promise<MessagePort>;
   readonly request: () => Promise<void>;
+  readonly disconnect: () => Promise<void>;
   readonly isConnected: () => boolean | undefined;
   readonly manifest: string;
 }

--- a/packages/transport-chrome/src/session-client.ts
+++ b/packages/transport-chrome/src/session-client.ts
@@ -24,32 +24,32 @@ import { ChannelLabel, nameConnection } from './channel-names';
 import { isTransportInitChannel, TransportInitChannel } from './message';
 import { PortStreamSink, PortStreamSource } from './stream';
 
-const localErrorJson = (e: unknown, m?: unknown) =>
-  e instanceof Error
+const localErrorJson = (err: unknown, relevantMessage?: unknown) =>
+  err instanceof Error
     ? {
-        message: e.message,
+        message: err.message,
         details: [
           {
-            type: e.name,
-            value: e.cause,
+            type: err.name,
+            value: err.cause,
           },
-          m,
+          relevantMessage,
         ],
       }
     : {
-        message: String(e),
+        message: String(err),
         details: [
           {
             type: String(
-              typeof e === 'function'
-                ? e.name
-                : typeof e === 'object'
-                  ? (Object.getPrototypeOf(e) as unknown)?.constructor?.name ?? String(e)
-                  : typeof e,
+              typeof err === 'function'
+                ? err.name
+                : typeof err === 'object'
+                  ? (Object.getPrototypeOf(err) as unknown)?.constructor?.name ?? String(err)
+                  : typeof err,
             ),
-            value: e,
+            value: err,
           },
-          m,
+          relevantMessage,
         ],
       };
 
@@ -108,15 +108,15 @@ export class CRSessionClient {
     }
   };
 
-  private serviceListener = (m: unknown) => {
+  private serviceListener = (msg: unknown) => {
     try {
-      if (m === true) this.clientPort.postMessage(true);
-      else if (isTransportError(m) || isTransportMessage(m)) this.clientPort.postMessage(m);
-      else if (isTransportInitChannel(m))
-        this.clientPort.postMessage(...this.acceptChannelStreamResponse(m));
-      else console.warn('Unknown item from service', m);
+      if (msg === true) this.clientPort.postMessage(true);
+      else if (isTransportError(msg) || isTransportMessage(msg)) this.clientPort.postMessage(msg);
+      else if (isTransportInitChannel(msg))
+        this.clientPort.postMessage(...this.acceptChannelStreamResponse(msg));
+      else console.warn('Unknown item from service', msg);
     } catch (e) {
-      this.clientPort.postMessage({ error: localErrorJson(e, m) });
+      this.clientPort.postMessage({ error: localErrorJson(e, msg) });
     }
   };
 

--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -86,7 +86,11 @@ export const createChannelTransport = ({
   };
 
   const transportListener = ({ data }: MessageEvent<unknown>) => {
-    if (isTransportEvent(data)) {
+    if (!data) {
+      console.warn(data);
+      // likely 'false' indicating a disconnect
+      listenerError.reject(new ConnectError('Connection closed', Code.Unavailable));
+    } else if (isTransportEvent(data)) {
       // this is a response to a specific request.  the port may be shared, so it
       // may contain a requestId we don't know about.  the response may be
       // successful, or contain an error conveyed only to the caller.


### PR DESCRIPTION
adds disconnect method to page api

page injection is refactored as a class to more explicitly represent and control injection state

adds listeners in prax to handle disconnect

for some reason, connection stalls on the ibc page, but works everywhere else.

minifront ui in subsequent pr