### PR TITLE
include transaction id when generating perspective

### DIFF
--- a/.changeset/strong-ears-smell.md
+++ b/.changeset/strong-ears-smell.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': patch
+---
+
+include transaction id when generating perspective

--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -206,6 +206,7 @@ pub async fn transaction_info_inner(
     // First, create a TxP with the payload keys visible to our FVK and no other data.
     let mut txp = penumbra_transaction::TransactionPerspective {
         payload_keys: tx.payload_keys(&fvk)?,
+        transaction_id: tx.id(),
         ..Default::default()
     };
 


### PR DESCRIPTION
fixes #1135

<img width="659" alt="Screenshot 2024-05-28 at 22 12 55" src="https://github.com/penumbra-zone/web/assets/134443988/2413c68f-837a-40d0-b573-f509cb953d35">
