### PR TITLE
`formatAmount()` updated args [bug fix]

### DIFF
--- a/.changeset/breezy-birds-yell.md
+++ b/.changeset/breezy-birds-yell.md
@@ -1,0 +1,7 @@
+---
+'@penumbra-zone/types': major
+'minifront': patch
+'@penumbra-zone/ui': patch
+---
+
+formatAmount() takes new args

--- a/apps/minifront/src/components/swap/swap-form/output/estimated-output-explanation.tsx
+++ b/apps/minifront/src/components/swap/swap-form/output/estimated-output-explanation.tsx
@@ -17,10 +17,10 @@ export const EstimatedOutputExplanation = () => {
   );
 
   if (!estimatedOutput) return null;
-  const formattedAmount = formatAmount(
-    estimatedOutput,
-    getDisplayDenomExponent.optional()(assetOut),
-  );
+  const formattedAmount = formatAmount({
+    amount: estimatedOutput,
+    exponent: getDisplayDenomExponent.optional()(assetOut),
+  });
   const asssetInSymbol = getSymbolFromValueView.optional()(assetIn?.balanceView);
 
   return (

--- a/apps/minifront/src/components/swap/swap-form/simulate-swap-result/trace/price.tsx
+++ b/apps/minifront/src/components/swap/swap-form/simulate-swap-result/trace/price.tsx
@@ -2,7 +2,7 @@ import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { SwapExecution_Trace } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
-import { formatAmount } from '@penumbra-zone/types/amount';
+import { formatAmount, removeTrailingZeros } from '@penumbra-zone/types/amount';
 import { BigNumber } from 'bignumber.js';
 
 export const Price = ({
@@ -23,14 +23,22 @@ export const Price = ({
     if (firstValueMetadata?.symbol && lastValueMetadata?.symbol) {
       const inputDisplayDenomExponent = getDisplayDenomExponent.optional()(firstValueMetadata) ?? 0;
       const outputDisplayDenomExponent = getDisplayDenomExponent.optional()(lastValueMetadata) ?? 0;
-      const formattedInputAmount = formatAmount(inputValue.amount, inputDisplayDenomExponent);
-      const formattedOutputAmount = formatAmount(outputValue.amount, outputDisplayDenomExponent);
+      const formattedInputAmount = formatAmount({
+        amount: inputValue.amount,
+        exponent: inputDisplayDenomExponent,
+      });
+      const formattedOutputAmount = formatAmount({
+        amount: outputValue.amount,
+        exponent: outputDisplayDenomExponent,
+      });
 
       const outputToInputRatio = new BigNumber(formattedOutputAmount)
         .dividedBy(formattedInputAmount)
         .toFormat(outputDisplayDenomExponent);
 
-      price = `1 ${firstValueMetadata.symbol} = ${outputToInputRatio} ${lastValueMetadata.symbol}`;
+      const outputToInputFormatted = removeTrailingZeros(outputToInputRatio);
+
+      price = `1 ${firstValueMetadata.symbol} = ${outputToInputFormatted} ${lastValueMetadata.symbol}`;
     }
   }
 

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -77,10 +77,28 @@ export const formatNumber = (number: number, options: FormatOptions): string => 
     : parseFloat(number.toFixed(precision)).toString();
 };
 
-export const formatAmount = (amount: Amount, exponent = 0) =>
-  fromBaseUnitAmount(amount, exponent)
-    .toFormat(6)
-    .replace(/(\.\d*?[1-9])0+$|\.0*$/, '$1');
+export const removeTrailingZeros = (strNum: string): string => {
+  return strNum.replace(/(\.\d*?[1-9])0+$|\.0*$/, '$1');
+};
+
+export const formatAmount = ({
+  amount,
+  exponent = 0,
+  commas = false,
+  decimalPlaces = 6,
+}: {
+  amount: Amount;
+  exponent?: number;
+  commas?: boolean;
+  decimalPlaces?: number;
+}) => {
+  const result = fromBaseUnitAmount(amount, exponent).toFormat(decimalPlaces, {
+    decimalSeparator: '.',
+    groupSeparator: commas ? ',' : '',
+    groupSize: 3,
+  });
+  return removeTrailingZeros(result);
+};
 
 /**
  * Exchange rates in core are expressed as whole numbers on the order of 10 to

--- a/packages/ui/components/ui/balance-value-view.tsx
+++ b/packages/ui/components/ui/balance-value-view.tsx
@@ -7,7 +7,7 @@ import {
 } from '@penumbra-zone/getters/value-view';
 import { formatAmount } from '@penumbra-zone/types/amount';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 
 /**
  * Renders a `ValueView` as a balance with a wallet icon.
@@ -16,7 +16,7 @@ export const BalanceValueView = ({ valueView }: { valueView: ValueView }) => {
   const exponent = getDisplayDenomExponentFromValueView.optional()(valueView);
   const symbol = getSymbolFromValueView.optional()(valueView);
   const amount = getAmount.optional()(valueView) ?? new Amount({ hi: 0n, lo: 0n });
-  const formattedAmount = formatAmount(amount, exponent);
+  const formattedAmount = formatAmount({ amount, exponent, commas: true });
 
   return (
     <TooltipProvider>

--- a/packages/ui/components/ui/dutch-auction-component/expanded-details/index.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/expanded-details/index.tsx
@@ -46,7 +46,7 @@ export const ExpandedDetails = ({
     <div className='flex w-full flex-col overflow-hidden'>
       {maxPrice && (
         <Row label='Maximum'>
-          {formatAmount(maxPrice, outputExponent)}
+          {formatAmount({ amount: maxPrice, exponent: outputExponent })}
           {outputMetadata && (
             <span className='font-mono text-xs'>
               {' '}
@@ -59,7 +59,7 @@ export const ExpandedDetails = ({
 
       {showCurrent && (
         <Row label='Current' highlight>
-          {formatAmount(currentPrice, outputExponent)}
+          {formatAmount({ amount: currentPrice, exponent: outputExponent })}
           {outputMetadata && (
             <span className='font-mono text-xs'>
               {' '}
@@ -71,7 +71,7 @@ export const ExpandedDetails = ({
 
       {minPrice && (
         <Row label='Minimum'>
-          {formatAmount(minPrice, outputExponent)}
+          {formatAmount({ amount: minPrice, exponent: outputExponent })}
           {outputMetadata && (
             <span className='font-mono text-xs'>
               {' '}
@@ -84,14 +84,14 @@ export const ExpandedDetails = ({
 
       {inputReservesAmount && (
         <Row label='Input reserves'>
-          {formatAmount(inputReservesAmount, inputExponent)}
+          {formatAmount({ amount: inputReservesAmount, exponent: inputExponent })}
           {inputMetadata && <span className='font-mono text-xs'> {inputMetadata.symbol}</span>}
         </Row>
       )}
 
       {outputReservesAmount && (
         <Row label='Output reserves'>
-          {formatAmount(outputReservesAmount, outputExponent)}
+          {formatAmount({ amount: outputReservesAmount, exponent: outputExponent })}
           {outputMetadata && <span className='font-mono text-xs'> {outputMetadata.symbol}</span>}
         </Row>
       )}

--- a/packages/ui/components/ui/tx/view/value/index.tsx
+++ b/packages/ui/components/ui/tx/view/value/index.tsx
@@ -26,7 +26,7 @@ export const ValueViewComponent = ({
   if (view.valueView.case === 'knownAssetId' && view.valueView.value.metadata) {
     const { amount = new Amount(), metadata } = view.valueView.value;
     const exponent = getDisplayDenomExponent.optional()(metadata);
-    const formattedAmount = formatAmount(amount, exponent);
+    const formattedAmount = formatAmount({ amount, exponent, commas: true });
     const symbol = metadata.symbol || 'Unknown asset';
     return (
       <ValueComponent
@@ -44,7 +44,7 @@ export const ValueViewComponent = ({
 
   if (view.valueView.case === 'unknownAssetId') {
     const { amount = new Amount() } = view.valueView.value;
-    const formattedAmount = formatAmount(amount);
+    const formattedAmount = formatAmount({ amount, commas: true });
     const symbol = 'Unknown asset';
     return (
       <ValueComponent


### PR DESCRIPTION
For higher-precision decimal numbers, we were getting a `NaN` showing in the UI:

<img width="272" alt="Screenshot 2024-05-31 at 6 35 48 PM" src="https://github.com/penumbra-zone/web/assets/16624263/dc88e857-613c-40e3-8547-43dfbd658253">

Turns out because we were using `formatNumber()` sometimes returns a comma separated string which cannot be put inside the `new BigNumber()` constructor. This PR changes the API for that function to be explicit with commas usage, which fixes it:
<img width="317" alt="Screenshot 2024-05-31 at 6 39 14 PM" src="https://github.com/penumbra-zone/web/assets/16624263/08629ed6-781c-42a8-8b22-d5c4ee528981">

===

Extracted from https://github.com/penumbra-zone/web/pull/1151. Merging this will make that PR smaller.
