### PR TITLE
fix: #1241: Fix destination validation in the ibc-out form

### DIFF
--- a/.changeset/cuddly-beds-move.md
+++ b/.changeset/cuddly-beds-move.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+fix destination address validation in the "shield funds" page

--- a/apps/minifront/src/state/ibc-out.test.ts
+++ b/apps/minifront/src/state/ibc-out.test.ts
@@ -110,6 +110,17 @@ describe('IBC Slice', () => {
 
       expect(validationErrors.recipientErr).toBeFalsy();
     });
+
+    test('destination address validation per selected chain fails with incorrect address', () => {
+      const osmoAddress = 'osmo1xxxxxx';
+
+      useStore.getState().ibcOut.setChain(chain);
+      useStore.getState().ibcOut.setDestinationChainAddress(osmoAddress);
+
+      const validationErrors = ibcValidationErrors(useStore.getState());
+
+      expect(validationErrors.recipientErr).toBeTruthy();
+    });
   });
 
   describe('setSelection', () => {

--- a/apps/minifront/src/state/ibc-out.test.ts
+++ b/apps/minifront/src/state/ibc-out.test.ts
@@ -12,9 +12,9 @@ import { produce } from 'immer';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { addressFromBech32m } from '@penumbra-zone/bech32m/penumbra';
 import { Chain } from '@penumbra-labs/registry';
-import { currentTimePlusTwoDaysRounded } from './ibc-out';
+import { currentTimePlusTwoDaysRounded, ibcValidationErrors } from './ibc-out';
 
-describe.skip('IBC Slice', () => {
+describe('IBC Slice', () => {
   const selectionExample = new BalancesResponse({
     balanceView: new ValueView({
       valueView: {
@@ -58,7 +58,8 @@ describe.skip('IBC Slice', () => {
       expect(useStore.getState().ibcOut.amount).toBe('2');
     });
 
-    test('validate high enough amount validates', () => {
+    // TODO [vanishmax, 2024-06-04]: Remove test skipping
+    test.skip('validate high enough amount validates', () => {
       const assetBalance = new Amount({ hi: 1n });
       const state = produce(selectionExample, draft => {
         draft.balanceView!.valueView.value!.amount = assetBalance;
@@ -71,7 +72,7 @@ describe.skip('IBC Slice', () => {
       expect(amountErr).toBeFalsy();
     });
 
-    test('validate error when too low the balance of the asset', () => {
+    test.skip('validate error when too low the balance of the asset', () => {
       const assetBalance = new Amount({ lo: 2n });
       const state = produce(selectionExample, draft => {
         draft.balanceView!.valueView.value!.amount = assetBalance;
@@ -85,18 +86,29 @@ describe.skip('IBC Slice', () => {
   });
 
   describe('setChain', () => {
-    test('chain can be set', () => {
-      const chain = {
-        displayName: 'Osmosis',
-        chainId: 'osmosis-test-5',
-        channelId: 'channel-0',
-        counterpartyChannelId: 'channel-999',
-        images: [{ svg: '/test.svg' }],
-        addressPrefix: 'osmo',
-      } satisfies Chain;
+    const chain = {
+      displayName: 'Osmosis',
+      chainId: 'osmosis-test-5',
+      channelId: 'channel-0',
+      counterpartyChannelId: 'channel-999',
+      images: [{ svg: '/test.svg' }],
+      addressPrefix: 'osmo',
+    } satisfies Chain;
 
+    test('chain can be set', () => {
       useStore.getState().ibcOut.setChain(chain);
       expect(useStore.getState().ibcOut.chain).toBe(chain);
+    });
+
+    test('destination address validation per selected chain', () => {
+      const osmoAddress = 'osmo1dyrr4r42ql4em7d46srcmnn5ymxk9asvcv95sg';
+
+      useStore.getState().ibcOut.setChain(chain);
+      useStore.getState().ibcOut.setDestinationChainAddress(osmoAddress);
+
+      const validationErrors = ibcValidationErrors(useStore.getState());
+
+      expect(validationErrors.recipientErr).toBeFalsy();
     });
   });
 

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -208,7 +208,7 @@ export const ibcValidationErrors = (state: AllSlices) => {
 
 /**
  * Matches the given address to the chain's address prefix.
- * We don't know what format foreign addresses are in. so this only checks:
+ * We don't know what format foreign addresses are in, so this only checks:
  * - it's valid bech32 OR valid bech32m
  * - the prefix matches the chain
  */

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -199,7 +199,7 @@ export const ibcValidationErrors = (state: AllSlices) => {
   return {
     recipientErr: !state.ibcOut.destinationChainAddress
       ? false
-      : validateUnknownAddress(state.ibcOut.chain, state.ibcOut.destinationChainAddress),
+      : !unknownAddrIsValid(state.ibcOut.chain, state.ibcOut.destinationChainAddress),
     amountErr: !state.ibcOut.selection
       ? false
       : amountMoreThanBalance(state.ibcOut.selection, state.ibcOut.amount),
@@ -207,16 +207,16 @@ export const ibcValidationErrors = (state: AllSlices) => {
 };
 
 /**
- * Matches the given address to the chain's address prefix. Returns `true` if the address is not valid.
+ * Matches the given address to the chain's address prefix.
  * We don't know what format foreign addresses are in. so this only checks:
  * - it's valid bech32 OR valid bech32m
  * - the prefix matches the chain
  */
-const validateUnknownAddress = (chain: Chain | undefined, address: string): boolean => {
+const unknownAddrIsValid = (chain: Chain | undefined, address: string): boolean => {
   if (!chain || address === '') return false;
   const { prefix, words } =
     bech32.decodeUnsafe(address, Infinity) ?? bech32m.decodeUnsafe(address, Infinity) ?? {};
-  return !words || prefix !== chain.addressPrefix;
+  return !!words && prefix === chain.addressPrefix;
 };
 
 /**

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -199,7 +199,7 @@ export const ibcValidationErrors = (state: AllSlices) => {
   return {
     recipientErr: !state.ibcOut.destinationChainAddress
       ? false
-      : !validateUnknownAddress(state.ibcOut.chain, state.ibcOut.destinationChainAddress),
+      : validateUnknownAddress(state.ibcOut.chain, state.ibcOut.destinationChainAddress),
     amountErr: !state.ibcOut.selection
       ? false
       : amountMoreThanBalance(state.ibcOut.selection, state.ibcOut.amount),
@@ -207,7 +207,8 @@ export const ibcValidationErrors = (state: AllSlices) => {
 };
 
 /**
- * we don't know what format foreign addresses are in. so this only checks:
+ * Matches the given address to the chain's address prefix. Returns `true` if the address is not valid.
+ * We don't know what format foreign addresses are in. so this only checks:
  * - it's valid bech32 OR valid bech32m
  * - the prefix matches the chain
  */


### PR DESCRIPTION
Closes #1241 

I noticed the tests were skipped in the `ibc-out.test.ts` file. I un-skipped the passing tests and added a comment for the future to fix the broken tests