### PR TITLE
Properly format if no metadata

### DIFF
--- a/.changeset/shaggy-knives-protect.md
+++ b/.changeset/shaggy-knives-protect.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/types': patch
+---
+
+Bug fix in getFormattedAmtFromValueView: support known assets without metadata

--- a/packages/types/src/value-view.test.ts
+++ b/packages/types/src/value-view.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Metadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
+import { getFormattedAmtFromValueView } from './value-view';
+
+describe('getFormattedAmtFromValueView', () => {
+  it('should format amount with known asset ID and metadata', () => {
+    const valueView = new ValueView({
+      valueView: {
+        case: 'knownAssetId',
+        value: {
+          amount: new Amount({ lo: 1000000n }),
+          metadata: new Metadata({
+            display: 'test_usd',
+            denomUnits: [{ denom: 'test_usd', exponent: 6 }],
+          }),
+        },
+      },
+    });
+
+    const formattedAmount = getFormattedAmtFromValueView(valueView);
+    expect(formattedAmount).toBe('1');
+  });
+
+  it('should format amount with known asset ID, but no metadata', () => {
+    const valueView = new ValueView({
+      valueView: {
+        case: 'knownAssetId',
+        value: {
+          amount: new Amount({ lo: 1000000n }),
+        },
+      },
+    });
+
+    const formattedAmount = getFormattedAmtFromValueView(valueView);
+    expect(formattedAmount).toBe('1000000');
+  });
+
+  it('should format amount with unknown asset ID', () => {
+    const valueView = new ValueView({
+      valueView: {
+        case: 'unknownAssetId',
+        value: {
+          amount: new Amount({ lo: 1000000n }),
+        },
+      },
+    });
+
+    const formattedAmount = getFormattedAmtFromValueView(valueView);
+    expect(formattedAmount).toBe('1000000');
+  });
+
+  it('should throw an error when value view is undefined', () => {
+    const valueView = new ValueView();
+
+    expect(() => getFormattedAmtFromValueView(valueView)).toThrowError(
+      `Cannot derive formatted amount from value view: ${JSON.stringify(valueView.toJson())}`,
+    );
+  });
+
+  it('should format amount with commas when specified', () => {
+    const valueView = new ValueView({
+      valueView: {
+        case: 'unknownAssetId',
+        value: {
+          amount: new Amount({ lo: 1000000n }),
+        },
+      },
+    });
+
+    const formattedAmount = getFormattedAmtFromValueView(valueView, true);
+    expect(formattedAmount).toBe('1,000,000');
+  });
+});

--- a/packages/types/src/value-view.ts
+++ b/packages/types/src/value-view.ts
@@ -5,13 +5,18 @@ import { formatAmount } from './amount';
 
 // Uses exponent in metadata to display amount in terms of display denom
 export const getFormattedAmtFromValueView = (v: ValueView, commas = false): string => {
+  if (!v.valueView.value) {
+    throw new Error(
+      `Cannot derive formatted amount from value view: ${JSON.stringify(v.toJson())}`,
+    );
+  }
+
   if (v.valueView.case === 'knownAssetId' && v.valueView.value.metadata) {
     const { amount = new Amount(), metadata } = v.valueView.value;
     const exponent = getDisplayDenomExponent.optional()(metadata);
     return formatAmount({ amount, exponent, commas });
-  } else if (v.valueView.case === 'unknownAssetId') {
+  } else {
     const { amount = new Amount() } = v.valueView.value;
     return formatAmount({ amount, commas });
   }
-  throw new Error(`Cannot derive formatted amount from value view: ${JSON.stringify(v.toJson())}`);
 };


### PR DESCRIPTION
Reported by @VanishMax

Follow up from https://github.com/penumbra-zone/web/pull/1151

When an asset is known, but has no metadata, we should also be able to format correctly (at the moment, an error bubbles up blocking page view). Added tests as well to cover this case.