### PR TITLE
fix: #1195: Hide the redundant scroll caused by long addresses

### DIFF
--- a/.changeset/old-candles-compete.md
+++ b/.changeset/old-candles-compete.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+fix delegation prompting window being too wide

--- a/.changeset/shiny-steaks-sleep.md
+++ b/.changeset/shiny-steaks-sleep.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Add ActionDetails.TruncatedText component

--- a/packages/ui/components/ui/box.tsx
+++ b/packages/ui/components/ui/box.tsx
@@ -34,19 +34,21 @@ export const Box = ({
   layout,
   layoutId,
   headerContent,
+  className,
 }: PropsWithChildren<
   VariantProps<typeof variants> & {
     label?: ReactNode;
     layout?: boolean;
     layoutId?: string;
     headerContent?: ReactNode;
+    className?: string;
   }
 >) => {
   return (
     <motion.div
       layout={layout ?? !!layoutId}
       layoutId={layoutId}
-      className={cn('flex flex-col gap-4', variants({ spacing, state }))}
+      className={cn('flex flex-col gap-4', className, variants({ spacing, state }))}
       /**
        * Set the border radius via the style prop so it doesn't get distorted by framer-motion.
        *

--- a/packages/ui/components/ui/box.tsx
+++ b/packages/ui/components/ui/box.tsx
@@ -16,6 +16,9 @@ const variants = cva('rounded-lg border bg-background', {
       default: '',
       error: 'border-red',
     },
+    overflow: {
+      xHidden: 'overflow-x-hidden',
+    },
   },
   defaultVariants: {
     spacing: 'default',
@@ -31,24 +34,23 @@ export const Box = ({
   label,
   spacing,
   state,
+  overflow,
   layout,
   layoutId,
   headerContent,
-  className,
 }: PropsWithChildren<
   VariantProps<typeof variants> & {
     label?: ReactNode;
     layout?: boolean;
     layoutId?: string;
     headerContent?: ReactNode;
-    className?: string;
   }
 >) => {
   return (
     <motion.div
       layout={layout ?? !!layoutId}
       layoutId={layoutId}
-      className={cn('flex flex-col gap-4', className, variants({ spacing, state }))}
+      className={cn('flex flex-col gap-4', variants({ spacing, state, overflow }))}
       /**
        * Set the border radius via the style prop so it doesn't get distorted by framer-motion.
        *

--- a/packages/ui/components/ui/tx/view/action-details.tsx
+++ b/packages/ui/components/ui/tx/view/action-details.tsx
@@ -1,6 +1,7 @@
-import { ReactNode } from 'react';
+import { KeyboardEventHandler, ReactNode, useState } from 'react';
 import { IncognitoIcon } from '../../icons/incognito';
 import { Separator } from '../../separator';
+import { cn } from '../../../../lib/utils';
 
 /**
  * Render key/value pairs inside a `<ViewBox />`.
@@ -24,19 +25,40 @@ export const ActionDetails = ({ children, label }: { children: ReactNode; label?
   );
 };
 
+/**
+ * Renders an accessible truncated text that can be expanded by clicking or pressing on it
+ */
+const ActionDetailsTruncatedText = ({ children }: { children?: ReactNode }) => {
+  const [isTruncated, setIsTruncated] = useState(true);
+
+  const toggleTruncate = () => setIsTruncated(prev => !prev);
+  const toggleTruncateEnter: KeyboardEventHandler<HTMLButtonElement> = event => {
+    if (event.key === 'Enter') {
+      toggleTruncate();
+    }
+  };
+
+  return (
+    <span
+      className={cn('hover:underline', { truncate: isTruncated })}
+      title={isTruncated && typeof children === 'string' ? children : undefined}
+      role='button'
+      tabIndex={0}
+      onClick={toggleTruncate}
+      onKeyDown={toggleTruncateEnter}
+    >
+      {children}
+    </span>
+  );
+};
+
 const ActionDetailsRow = ({
   label,
   children,
-  truncate,
   isOpaque,
 }: {
   label: string;
   children?: ReactNode;
-  /**
-   * If `children` is a string, passing `truncate` will automatically truncate
-   * the text if it doesn't fit in a single line.
-   */
-  truncate?: boolean;
   /**
    * If set to true, add styles indicating that the row's data is _not_ visible.
    */
@@ -57,9 +79,10 @@ const ActionDetailsRow = ({
 
       <Separator />
 
-      {truncate ? <span className='truncate'>{children}</span> : children}
+      {children}
     </div>
   );
 };
 
 ActionDetails.Row = ActionDetailsRow;
+ActionDetails.TruncatedText = ActionDetailsTruncatedText;

--- a/packages/ui/components/ui/tx/view/delegate.tsx
+++ b/packages/ui/components/ui/tx/view/delegate.tsx
@@ -29,8 +29,10 @@ export const DelegateComponent = ({ value }: { value: Delegate }) => {
 
           {/** @todo: Render validator name/etc. after fetching? */}
           {!!value.validatorIdentity && (
-            <ActionDetails.Row label='Validator identity' truncate>
-              {bech32mIdentityKey(value.validatorIdentity)}
+            <ActionDetails.Row label='Validator identity'>
+              <ActionDetails.TruncatedText>
+                {bech32mIdentityKey(value.validatorIdentity)}
+              </ActionDetails.TruncatedText>
             </ActionDetails.Row>
           )}
         </ActionDetails>

--- a/packages/ui/components/ui/tx/view/undelegate.tsx
+++ b/packages/ui/components/ui/tx/view/undelegate.tsx
@@ -27,8 +27,10 @@ export const UndelegateComponent = ({ value }: { value: Undelegate }) => {
 
           {/** @todo: Render validator name/etc. after fetching? */}
           {!!value.validatorIdentity && (
-            <ActionDetails.Row label='Validator identity' truncate>
-              {bech32mIdentityKey(value.validatorIdentity)}
+            <ActionDetails.Row label='Validator identity'>
+              <ActionDetails.TruncatedText>
+                {bech32mIdentityKey(value.validatorIdentity)}
+              </ActionDetails.TruncatedText>
             </ActionDetails.Row>
           )}
         </ActionDetails>

--- a/packages/ui/components/ui/tx/view/viewbox.tsx
+++ b/packages/ui/components/ui/tx/view/viewbox.tsx
@@ -17,7 +17,7 @@ export const ViewBox = ({ label, visibleContent, isOpaque }: ViewBoxProps) => {
   // if isOpaque is undefined, set it to !visibleContent
   isOpaque = isOpaque ?? !visibleContent;
   return (
-    <Box className='overflow-hidden'>
+    <Box overflow='xHidden'>
       <div
         className={cn(
           'flex flex-col gap-1 break-all overflow-hidden',

--- a/packages/ui/components/ui/tx/view/viewbox.tsx
+++ b/packages/ui/components/ui/tx/view/viewbox.tsx
@@ -17,7 +17,7 @@ export const ViewBox = ({ label, visibleContent, isOpaque }: ViewBoxProps) => {
   // if isOpaque is undefined, set it to !visibleContent
   isOpaque = isOpaque ?? !visibleContent;
   return (
-    <Box>
+    <Box className='overflow-hidden'>
       <div
         className={cn(
           'flex flex-col gap-1 break-all overflow-hidden',


### PR DESCRIPTION
Closes #1195 

Screenshot of the problem:

<img width="401" alt="image" src="https://github.com/penumbra-zone/web/assets/29180358/e0ac7885-d7ff-4cc6-a267-33fd380f1f4e">
