### PR TITLE
docs: add security email info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,8 @@ personal profile.
 4. Activate the extension to enter onboarding.
    - You may set a blank password.
    - You can pin the Prax extension button to your toolbar for quick access.
+
+## Security
+If you believe you've found a security-related issue with Penumbra,
+please disclose responsibly by contacting the Penumbra Labs team at
+security@penumbralabs.xyz.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ personal profile.
    - You can pin the Prax extension button to your toolbar for quick access.
 
 ## Security
+
 If you believe you've found a security-related issue with Penumbra,
 please disclose responsibly by contacting the Penumbra Labs team at
 security@penumbralabs.xyz.


### PR DESCRIPTION
We have an email alias set up for team leads, so that external parties have a single entrypoint to disclose security-related issues. This language matches what's already in the Penumbra monorepo, as of [0].

[0] https://github.com/penumbra-zone/penumbra/pull/4298