### PR TITLE
views: extract receiver view into transaction view

### DIFF
--- a/apps/minifront/src/components/tx-details/hooks.ts
+++ b/apps/minifront/src/components/tx-details/hooks.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { asReceiverTransactionView } from '@penumbra-zone/perspective/translators/transaction-view';
+import { viewClient } from '../../clients';
+import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
+import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+
+interface UseReceiverViewResult {
+  receiverView: TransactionView | null;
+}
+
+const useReceiverView = (
+  txInfo: TransactionInfo | undefined,
+  option: string,
+): UseReceiverViewResult => {
+  const [receiverView, setReceiverView] = useState<TransactionView | null>(null);
+
+  useEffect(() => {
+    const fetchReceiverView = async (): Promise<void> => {
+      if (txInfo) {
+        try {
+          const asReceiver = await asReceiverTransactionView(txInfo.view, {
+            isControlledAddress: address =>
+              viewClient
+                .indexByAddress({ address })
+                .then(({ addressIndex }) => Boolean(addressIndex)),
+          });
+          setReceiverView(asReceiver);
+        } catch (error) {
+          console.error('Failed to fetch receiver view:', error);
+        }
+      }
+    };
+
+    if (option === 'reciever') {
+      fetchReceiverView();
+    }
+  }, [option, txInfo]);
+
+  return { receiverView };
+};
+
+export default useReceiverView;

--- a/apps/minifront/src/components/tx-details/hooks.ts
+++ b/apps/minifront/src/components/tx-details/hooks.ts
@@ -1,42 +1,13 @@
-import { useEffect, useState } from 'react';
 import { asReceiverTransactionView } from '@penumbra-zone/perspective/translators/transaction-view';
 import { viewClient } from '../../clients';
 import { TransactionView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 
-interface UseReceiverViewResult {
-  receiverView: TransactionView | null;
-}
-
-const useReceiverView = (
-  txInfo: TransactionInfo | undefined,
-  option: string,
-): UseReceiverViewResult => {
-  const [receiverView, setReceiverView] = useState<TransactionView | null>(null);
-
-  useEffect(() => {
-    const fetchReceiverView = async (): Promise<void> => {
-      if (txInfo) {
-        try {
-          const asReceiver = await asReceiverTransactionView(txInfo.view, {
-            isControlledAddress: address =>
-              viewClient
-                .indexByAddress({ address })
-                .then(({ addressIndex }) => Boolean(addressIndex)),
-          });
-          setReceiverView(asReceiver);
-        } catch (error) {
-          console.error('Failed to fetch receiver view:', error);
-        }
-      }
-    };
-
-    if (option === 'reciever') {
-      fetchReceiverView();
-    }
-  }, [option, txInfo]);
-
-  return { receiverView };
+const fetchReceiverView = async (txInfo: TransactionInfo): Promise<TransactionView> => {
+  return await asReceiverTransactionView(txInfo.view, {
+    isControlledAddress: async address =>
+      viewClient.indexByAddress({ address }).then(({ addressIndex }) => Boolean(addressIndex)),
+  });
 };
 
-export default useReceiverView;
+export default fetchReceiverView;

--- a/apps/minifront/src/components/tx-details/tx-viewer.tsx
+++ b/apps/minifront/src/components/tx-details/tx-viewer.tsx
@@ -27,7 +27,7 @@ export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
   const [option, setOption] = useState(TxDetailsTab.PRIVATE);
 
   // classify the transaction type
-  let transactionClassification = classifyTransaction(txInfo.view);
+  const transactionClassification = classifyTransaction(txInfo.view);
 
   // filter for reciever view
   const showReceiverTransactionView = transactionClassification === 'send';

--- a/packages/types/src/environment.ts
+++ b/packages/types/src/environment.ts
@@ -13,7 +13,7 @@ enum Environment {
 declare global {
   interface Window {
     // This file has many environments running it. Makes it hard to please every runtime.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     chrome?: {
       runtime?: {


### PR DESCRIPTION
References #483 and https://github.com/penumbra-zone/web/issues/1251#issuecomment-2150629725

@jessepinho the `asReceiverTransactionView` translator from the transaction approval dialog is reused in the transaction view page. Currently, i'm displaying _every_ transaction with an associated receiver view which obviously is **not** correct. 

There seems to be some misdirection in the `TransactionViewSwitcher` component that I couldn't quite parse, mainly where the actual filtering is happening that determines if the receiver view should be present or not. Is there a simple way to propagate this filtering to the transaction view page in this PR?