### PR TITLE
Return a TxInfo struct [#1255 follow up]

### DIFF
--- a/.changeset/mean-seahorses-run.md
+++ b/.changeset/mean-seahorses-run.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': patch
+---
+
+Update transaction_perspective_and_view return type

--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -162,7 +162,7 @@ pub fn build_parallel(
 }
 
 #[wasm_bindgen(getter_with_clone)]
-pub struct TxInfo {
+pub struct TxpAndTxvBytes {
     pub txp: Vec<u8>,
     pub txv: Vec<u8>,
 }
@@ -178,7 +178,7 @@ pub async fn transaction_perspective_and_view(
     full_viewing_key: &[u8],
     tx: &[u8],
     idb_constants: JsValue,
-) -> WasmResult<TxInfo> {
+) -> WasmResult<TxpAndTxvBytes> {
     utils::set_panic_hook();
 
     let transaction = Transaction::decode(tx)?;
@@ -186,7 +186,7 @@ pub async fn transaction_perspective_and_view(
     let fvk = FullViewingKey::decode(full_viewing_key)?;
     let (txp, txv) = transaction_info_inner(fvk, transaction, constants).await?;
 
-    Ok(TxInfo {
+    Ok(TxpAndTxvBytes {
         txp: txp.encode_to_vec(),
         txv: txv.encode_to_vec(),
     })

--- a/packages/wasm/crate/src/tx.rs
+++ b/packages/wasm/crate/src/tx.rs
@@ -16,10 +16,10 @@ use penumbra_transaction::plan::TransactionPlan;
 use penumbra_transaction::txhash::TransactionId;
 use penumbra_transaction::Action;
 use penumbra_transaction::{AuthorizationData, Transaction, WitnessData};
+use prost::Message;
 use rand_core::OsRng;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
-use web_sys::js_sys;
 
 use crate::error::{WasmError, WasmResult};
 use crate::storage::IndexedDBStorage;
@@ -161,22 +161,24 @@ pub fn build_parallel(
     Ok(tx.encode_to_vec())
 }
 
+#[wasm_bindgen(getter_with_clone)]
+pub struct TxInfo {
+    pub txp: Vec<u8>,
+    pub txv: Vec<u8>,
+}
+
 /// Get transaction perspective, transaction view
 /// Arguments:
 ///     full_viewing_key: `FullViewingKey` inner bytes
 ///     tx: Binary-encoded `Transaction` message
 ///     idb_constants: IndexedDbConstants
 /// Returns: `{ txp: Uint8Array, txv: Uint8Array }` representing binary-encoded `TransactionPerspective` and `TransactionView`
-#[wasm_bindgen(typescript_custom_section)]
-const TRANSACTION_VIEW_PERSPECTIVE_TS: &'static str = r#"
-export function transaction_perspective_and_view(full_viewing_key: Uint8Array, tx: Uint8Array, idb_constants: any): Promise<{ txp: Uint8Array, txv: Uint8Array }>;
-"#;
-#[wasm_bindgen(skip_typescript)]
+#[wasm_bindgen]
 pub async fn transaction_perspective_and_view(
     full_viewing_key: &[u8],
     tx: &[u8],
     idb_constants: JsValue,
-) -> WasmResult<js_sys::Object> {
+) -> WasmResult<TxInfo> {
     utils::set_panic_hook();
 
     let transaction = Transaction::decode(tx)?;
@@ -184,23 +186,10 @@ pub async fn transaction_perspective_and_view(
     let fvk = FullViewingKey::decode(full_viewing_key)?;
     let (txp, txv) = transaction_info_inner(fvk, transaction, constants).await?;
 
-    let response = js_sys::Object::new();
-
-    js_sys::Reflect::set(
-        &response,
-        &"txp".into(),
-        &js_sys::Uint8Array::from(prost::Message::encode_to_vec(&txp).as_slice()),
-    )
-    .expect("Must set txp");
-
-    js_sys::Reflect::set(
-        &response,
-        &"txv".into(),
-        &js_sys::Uint8Array::from(prost::Message::encode_to_vec(&txv).as_slice()),
-    )
-    .expect("Must set txv");
-
-    Ok(response)
+    Ok(TxInfo {
+        txp: txp.encode_to_vec(),
+        txv: txv.encode_to_vec(),
+    })
 }
 
 async fn transaction_info_inner(


### PR DESCRIPTION
Defining a wasm-bindgen struct allows for a simpler return value while keeping the same type signature.

Follow up from: https://github.com/penumbra-zone/web/pull/1255#pullrequestreview-2101210513