### PR TITLE
fix(minifront): #1210: change unclaimed swap styles

### DIFF
--- a/.changeset/tidy-nails-destroy.md
+++ b/.changeset/tidy-nails-destroy.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Change styles of the unclaimed swap block

--- a/apps/minifront/src/components/swap/layout.tsx
+++ b/apps/minifront/src/components/swap/layout.tsx
@@ -13,13 +13,13 @@ export const SwapLayout = () => {
           <div className='flex flex-col overflow-hidden grid-std-spacing md:col-span-2'>
             <SwapForm />
 
+            <UnclaimedSwaps />
+
             <AuctionList />
           </div>
 
           <div className='flex flex-col grid-std-spacing'>
             <SwapInfoCard />
-
-            <UnclaimedSwaps />
           </div>
         </div>
       </LayoutGroup>

--- a/apps/minifront/src/components/swap/unclaimed-swaps.tsx
+++ b/apps/minifront/src/components/swap/unclaimed-swaps.tsx
@@ -29,26 +29,23 @@ const _UnclaimedSwaps = ({ unclaimedSwaps }: { unclaimedSwaps: UnclaimedSwapsWit
   return (
     <Card layout>
       <GradientHeader layout>Unclaimed Swaps</GradientHeader>
-      <p className='text-gray-400'>
-        Swaps on Penumbra are a two step process. The first transaction issues the request and the
-        second claims the result of the swap action. For some reason, these second transactions were
-        not completed. Claim them!
-      </p>
       {unclaimedSwaps.map(({ swap, asset1, asset2 }) => {
         const id = uint8ArrayToBase64(getSwapRecordCommitment(swap).inner);
 
         return (
-          <div key={id} className='mt-4 flex justify-between'>
-            <div className='flex flex-col gap-2'>
-              <div>Block Height: {Number(swap.outputData?.height)}</div>
-              <div className='flex items-center gap-2'>
-                <AssetIcon metadata={asset1} />
-                <span>↔</span>
-                <AssetIcon metadata={asset2} />
-              </div>
+          <div key={id} className='mt-4 flex items-center gap-4 rounded-md border p-2'>
+            <div className='flex items-center gap-2'>
+              <AssetIcon metadata={asset1} />
+              <p className='truncate'>{asset1.symbol || 'Unknown asset'}</p>
+              <span>↔</span>
+              <AssetIcon metadata={asset2} />
+              <p className='truncate'>{asset2.symbol || 'Unknown asset'}</p>
             </div>
+
+            <div className='hidden sm:block'>Block Height: {Number(swap.outputData?.height)}</div>
+
             <Button
-              className='w-20'
+              className='ml-auto w-20'
               onClick={() => void claimSwap(id, swap, revalidate)}
               disabled={isInProgress(id)}
             >


### PR DESCRIPTION
Closes #1210 

<img width="1379" alt="image" src="https://github.com/penumbra-zone/web/assets/29180358/eca45ee9-136d-4347-b8cb-733ef56d8ce8">

Not really happy about the result – moving the block makes it wider, which makes it more difficult for the UI, so I also rendered a border for the unclaimed assets and added assets symbol next to the logo.