### PR TITLE
Remove '0' from token swap input

### DIFF
--- a/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
+++ b/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
@@ -110,16 +110,18 @@ export const TokenSwapInput = () => {
             </div>
           </div>
         </div>
-        {priceHistory.startMetadata && priceHistory.endMetadata && priceHistory.candles.length && (
-          <CandlestickPlot
-            className='h-[480px] w-full bg-charcoal'
-            candles={priceHistory.candles}
-            startMetadata={priceHistory.startMetadata}
-            endMetadata={priceHistory.endMetadata}
-            latestKnownBlockHeight={Number(latestKnownBlockHeight)}
-            getBlockDate={getBlockDate}
-          />
-        )}
+        {priceHistory.startMetadata &&
+          priceHistory.endMetadata &&
+          !!priceHistory.candles.length && (
+            <CandlestickPlot
+              className='h-[480px] w-full bg-charcoal'
+              candles={priceHistory.candles}
+              startMetadata={priceHistory.startMetadata}
+              endMetadata={priceHistory.endMetadata}
+              latestKnownBlockHeight={Number(latestKnownBlockHeight)}
+              getBlockDate={getBlockDate}
+            />
+          )}
       </div>
     </Box>
   );


### PR DESCRIPTION
Numbers being used as booleans need to be coerced to a boolean in component markup or else they'll show up as `0` when they're equal to `0`. 

## Before
![image](https://github.com/penumbra-zone/web/assets/1121544/3d3b2c11-445c-4b9a-b377-df0c1bbb3f9e)

## After
![image](https://github.com/penumbra-zone/web/assets/1121544/a3ce3223-69ea-4454-a46f-0151db7adc53)
