### PR TITLE
Enforce sane inputs for the swap/auction UI

### DIFF
--- a/.changeset/smart-plums-float.md
+++ b/.changeset/smart-plums-float.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Ensure sane inputs for the swap/auction UI

--- a/apps/minifront/src/components/swap/swap-form/index.tsx
+++ b/apps/minifront/src/components/swap/swap-form/index.tsx
@@ -9,6 +9,7 @@ import { Card } from '@penumbra-zone/ui/components/ui/card';
 import { SimulateSwap } from './simulate-swap';
 import { LayoutGroup } from 'framer-motion';
 import { useId } from 'react';
+import { submitButtonDisabledSelector } from '../../../state/swap';
 
 const swapFormSelector = (state: AllSlices) => ({
   onSubmit:
@@ -16,7 +17,7 @@ const swapFormSelector = (state: AllSlices) => ({
       ? state.swap.instantSwap.initiateSwapTx
       : state.swap.dutchAuction.onSubmit,
   submitButtonLabel: state.swap.duration === 'instant' ? 'Swap' : 'Start auctions',
-  submitButtonDisabled: state.swap.dutchAuction.txInProgress || !state.swap.amount,
+  submitButtonDisabled: submitButtonDisabledSelector(state),
   duration: state.swap.duration,
 });
 

--- a/apps/minifront/src/components/swap/swap-form/output/estimated-output-explanation.tsx
+++ b/apps/minifront/src/components/swap/swap-form/output/estimated-output-explanation.tsx
@@ -1,6 +1,6 @@
 import { AllSlices } from '../../../../state';
 import { useStoreShallow } from '../../../../utils/use-store-shallow';
-import { formatAmount } from '@penumbra-zone/types/amount';
+import { formatAmount, isZero } from '@penumbra-zone/types/amount';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 import { getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
 
@@ -9,24 +9,33 @@ const estimatedOutputExplanationSelector = (state: AllSlices) => ({
   amount: state.swap.amount,
   assetIn: state.swap.assetIn,
   assetOut: state.swap.assetOut,
+  noLiquidityAvailable:
+    state.swap.dutchAuction.estimatedOutput && isZero(state.swap.dutchAuction.estimatedOutput),
 });
 
 export const EstimatedOutputExplanation = () => {
-  const { amount, assetIn, estimatedOutput, assetOut } = useStoreShallow(
+  const { amount, assetIn, estimatedOutput, assetOut, noLiquidityAvailable } = useStoreShallow(
     estimatedOutputExplanationSelector,
   );
 
   if (!estimatedOutput) return null;
+
   const formattedAmount = formatAmount({
     amount: estimatedOutput,
     exponent: getDisplayDenomExponent.optional()(assetOut),
   });
-  const asssetInSymbol = getSymbolFromValueView.optional()(assetIn?.balanceView);
+  const assetInSymbol = getSymbolFromValueView.optional()(assetIn?.balanceView);
 
   return (
     <div className='text-xs text-muted-foreground'>
-      Based on the current estimated market price of {formattedAmount} {assetOut?.symbol} for{' '}
-      {amount} {asssetInSymbol}.
+      {noLiquidityAvailable ? (
+        'No liquidity is currently available for this swap, so it is impossible to estimate maximum and minimum outputs.'
+      ) : (
+        <>
+          Based on the current estimated market price of {formattedAmount} {assetOut?.symbol} for{' '}
+          {amount} {assetInSymbol}.
+        </>
+      )}
     </div>
   );
 };

--- a/apps/minifront/src/components/swap/swap-form/output/index.tsx
+++ b/apps/minifront/src/components/swap/swap-form/output/index.tsx
@@ -19,6 +19,10 @@ const outputSelector = (state: AllSlices) => ({
   outputStepSize: state.swap.assetOut
     ? 1 / 10 ** getDisplayDenomExponent(state.swap.assetOut)
     : 'any',
+  error:
+    Number(state.swap.dutchAuction.minOutput) >= Number(state.swap.dutchAuction.maxOutput)
+      ? 'The maximum output must be greater than the minimum output.'
+      : undefined,
 });
 
 export const Output = ({ layoutId }: { layoutId: string }) => {
@@ -31,6 +35,7 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
     estimate,
     estimateButtonDisabled,
     outputStepSize,
+    error,
   } = useStoreShallow(outputSelector);
 
   return (
@@ -83,6 +88,8 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
         </motion.div>
 
         <EstimatedOutputExplanation />
+
+        {error && <span className='text-xs text-red'>{error}</span>}
       </motion.div>
     </Box>
   );

--- a/apps/minifront/src/components/swap/swap-form/output/index.tsx
+++ b/apps/minifront/src/components/swap/swap-form/output/index.tsx
@@ -5,6 +5,7 @@ import { Input } from '@penumbra-zone/ui/components/ui/input';
 import { EstimateButton } from '../estimate-button';
 import { EstimatedOutputExplanation } from './estimated-output-explanation';
 import { motion } from 'framer-motion';
+import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 
 const outputSelector = (state: AllSlices) => ({
   assetOut: state.swap.assetOut,
@@ -15,6 +16,9 @@ const outputSelector = (state: AllSlices) => ({
   estimate: state.swap.dutchAuction.estimate,
   estimateButtonDisabled:
     state.swap.txInProgress || !state.swap.amount || state.swap.dutchAuction.estimateLoading,
+  outputStepSize: state.swap.assetOut
+    ? 1 / 10 ** getDisplayDenomExponent(state.swap.assetOut)
+    : 'any',
 });
 
 export const Output = ({ layoutId }: { layoutId: string }) => {
@@ -26,6 +30,7 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
     setMaxOutput,
     estimate,
     estimateButtonDisabled,
+    outputStepSize,
   } = useStoreShallow(outputSelector);
 
   return (
@@ -47,7 +52,7 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
               onChange={e => setMaxOutput(e.target.value)}
               type='number'
               inputMode='decimal'
-              step='any'
+              step={outputStepSize}
               className='text-right'
             />
 
@@ -67,7 +72,7 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
               onChange={e => setMinOutput(e.target.value)}
               type='number'
               inputMode='decimal'
-              step='any'
+              step={outputStepSize}
               className='text-right'
             />
 

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -4,7 +4,7 @@ import { planBuildBroadcast } from '../../helpers';
 import { assembleScheduleRequest } from './assemble-schedule-request';
 import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb';
 import { sendSimulateTradeRequest } from '../helpers';
-import { fromBaseUnitAmount, multiplyAmountByNumber } from '@penumbra-zone/types/amount';
+import { fromBaseUnitAmount, isZero, multiplyAmountByNumber } from '@penumbra-zone/types/amount';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb';
 import { errorToast } from '@penumbra-zone/ui/lib/toast/presets';
@@ -155,16 +155,21 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
         const exponent = getDisplayDenomExponent(assetOut);
 
         set(({ swap }) => {
-          swap.dutchAuction.maxOutput = fromBaseUnitAmount(
-            multiplyAmountByNumber(estimatedOutputAmount, MAX_OUTPUT_ESTIMATE_MULTIPLIER),
-            exponent,
-          ).toString();
-          swap.dutchAuction.minOutput = fromBaseUnitAmount(
-            multiplyAmountByNumber(estimatedOutputAmount, MIN_OUTPUT_ESTIMATE_MULTIPLIER),
-            exponent,
-          ).toString();
           swap.dutchAuction.estimatedOutput = estimatedOutputAmount;
         });
+
+        if (!isZero(estimatedOutputAmount)) {
+          set(({ swap }) => {
+            swap.dutchAuction.maxOutput = fromBaseUnitAmount(
+              multiplyAmountByNumber(estimatedOutputAmount, MAX_OUTPUT_ESTIMATE_MULTIPLIER),
+              exponent,
+            ).toString();
+            swap.dutchAuction.minOutput = fromBaseUnitAmount(
+              multiplyAmountByNumber(estimatedOutputAmount, MIN_OUTPUT_ESTIMATE_MULTIPLIER),
+              exponent,
+            ).toString();
+          });
+        }
       }
     } catch (e) {
       errorToast(e, 'Error estimating swap').render();

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -10,6 +10,7 @@ import { Amount } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/nu
 import { errorToast } from '@penumbra-zone/ui/lib/toast/presets';
 import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
 import { AuctionInfo, getAuctionInfos } from '../../../fetchers/auction-infos';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 
 /**
  * Multipliers to use with the output of the swap simulation, to determine
@@ -70,17 +71,28 @@ const INITIAL_STATE: State = {
   estimatedOutput: undefined,
 };
 
+const getSmallestPossibleAmountAboveZero = (metadata?: Metadata): number =>
+  metadata ? 1 / 10 ** getDisplayDenomExponent(metadata) : 0;
+
 export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (set, get) => ({
   ...INITIAL_STATE,
   setMinOutput: minOutput => {
     set(({ swap }) => {
-      swap.dutchAuction.minOutput = minOutput;
+      const minMinOutput = getSmallestPossibleAmountAboveZero(get().swap.assetOut);
+
+      if (Number(minOutput) > 0) swap.dutchAuction.minOutput = minOutput;
+      else swap.dutchAuction.minOutput = minMinOutput.toString();
+
       swap.dutchAuction.estimatedOutput = undefined;
     });
   },
   setMaxOutput: maxOutput => {
     set(({ swap }) => {
-      swap.dutchAuction.maxOutput = maxOutput;
+      const minMaxOutput = getSmallestPossibleAmountAboveZero(get().swap.assetOut);
+
+      if (Number(maxOutput) > 0) swap.dutchAuction.maxOutput = maxOutput;
+      else swap.dutchAuction.maxOutput = minMaxOutput.toString();
+
       swap.dutchAuction.estimatedOutput = undefined;
     });
   },

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -1,5 +1,5 @@
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import { SliceCreator, useStore } from '../..';
+import { AllSlices, SliceCreator, useStore } from '../..';
 import { planBuildBroadcast } from '../../helpers';
 import { assembleScheduleRequest } from './assemble-schedule-request';
 import { AuctionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb';
@@ -192,3 +192,8 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     }
   },
 });
+
+export const dutchAuctionSubmitButtonDisabledSelector = (state: AllSlices) =>
+  state.swap.duration !== 'instant' &&
+  (Number(state.swap.dutchAuction.minOutput) >= Number(state.swap.dutchAuction.maxOutput) ||
+    state.swap.dutchAuction.txInProgress);

--- a/apps/minifront/src/state/swap/index.ts
+++ b/apps/minifront/src/state/swap/index.ts
@@ -4,10 +4,18 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { SwapExecution_Trace } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import { SliceCreator } from '..';
+import { AllSlices, SliceCreator } from '..';
 import { DurationOption } from './constants';
-import { DutchAuctionSlice, createDutchAuctionSlice } from './dutch-auction';
-import { InstantSwapSlice, createInstantSwapSlice } from './instant-swap';
+import {
+  DutchAuctionSlice,
+  createDutchAuctionSlice,
+  dutchAuctionSubmitButtonDisabledSelector,
+} from './dutch-auction';
+import {
+  InstantSwapSlice,
+  createInstantSwapSlice,
+  instantSwapSubmitButtonDisabledSelector,
+} from './instant-swap';
 import { PriceHistorySlice, createPriceHistorySlice } from './price-history';
 import { getMetadata } from '@penumbra-zone/getters/value-view';
 
@@ -132,3 +140,8 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get, store) 
     get().swap.instantSwap.reset();
   },
 });
+
+export const submitButtonDisabledSelector = (state: AllSlices) =>
+  !state.swap.amount ||
+  dutchAuctionSubmitButtonDisabledSelector(state) ||
+  instantSwapSubmitButtonDisabledSelector(state);

--- a/apps/minifront/src/state/swap/instant-swap.ts
+++ b/apps/minifront/src/state/swap/instant-swap.ts
@@ -1,4 +1,4 @@
-import { SliceCreator } from '..';
+import { AllSlices, SliceCreator } from '..';
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { planBuildBroadcast } from '../helpers';
 import {
@@ -233,3 +233,6 @@ const getMatchingAmount = (values: Value[], toMatch: AssetId): Amount => {
 
   return match.amount;
 };
+
+export const instantSwapSubmitButtonDisabledSelector = (state: AllSlices) =>
+  state.swap.duration === 'instant' && state.swap.instantSwap.txInProgress;

--- a/packages/getters/src/balances-response.ts
+++ b/packages/getters/src/balances-response.ts
@@ -12,9 +12,7 @@ export const getAssetIdFromBalancesResponseOptional = getBalanceView
   .pipe(getMetadata)
   .pipe(getAssetId);
 
-export const getMetadataFromBalancesResponse = createGetter((balancesResponse?: BalancesResponse) =>
-  getBalanceView.optional().pipe(getMetadata)(balancesResponse),
-);
+export const getMetadataFromBalancesResponse = getBalanceView.pipe(getMetadata);
 
 export const getDisplayFromBalancesResponse = getMetadataFromBalancesResponse
   .optional()

--- a/packages/getters/src/balances-response.ts
+++ b/packages/getters/src/balances-response.ts
@@ -12,7 +12,9 @@ export const getAssetIdFromBalancesResponseOptional = getBalanceView
   .pipe(getMetadata)
   .pipe(getAssetId);
 
-export const getMetadataFromBalancesResponse = getBalanceView.pipe(getMetadata);
+export const getMetadataFromBalancesResponse = createGetter((balancesResponse?: BalancesResponse) =>
+  getBalanceView.optional().pipe(getMetadata)(balancesResponse),
+);
 
 export const getDisplayFromBalancesResponse = getMetadataFromBalancesResponse
   .optional()


### PR DESCRIPTION
- [x] Max output > min output
- [x] Min output > 0 (incl. when the user clicks "Estimate" and there's no liquidity)
- [x] Input asset !== output asset (somehow this got lost)
- [x] Max/min outputs can not be greater than [core's built-in limit](https://github.com/penumbra-zone/web/issues/1224#issuecomment-2164419140) of $2^{52} - 1$

Enforcing that max output is greater than min output, and that the two assets are not the same:

https://github.com/penumbra-zone/web/assets/1121544/760f109e-f1e3-4378-8396-b809588af08e

Enforcing a value greater than 0 for outputs:


https://github.com/penumbra-zone/web/assets/1121544/35c59fba-1dd2-47e8-a55e-3a96726a6739




Closes #1284
Closes #1224