### PR TITLE
Always show the asset logo in swaps

### DIFF
--- a/packages/ui/components/ui/tx/view/swap/one-way-swap.tsx
+++ b/packages/ui/components/ui/tx/view/swap/one-way-swap.tsx
@@ -1,7 +1,7 @@
 import { ValueViewComponent } from '../value';
 import { ArrowRight } from 'lucide-react';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { getAmount, getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
+import { getAmount } from '@penumbra-zone/getters/value-view';
 
 /**
  * Renders a one-way swap (which should be the only kind of swap that ever
@@ -18,7 +18,7 @@ export const OneWaySwap = ({ input, output }: { input: ValueView; output: ValueV
 
       <ArrowRight />
 
-      {outputAmount ? <ValueViewComponent view={output} /> : getSymbolFromValueView(output)}
+      <ValueViewComponent view={output} showValue={!!outputAmount} />
     </div>
   );
 };


### PR DESCRIPTION
## Before
![image](https://github.com/penumbra-zone/web/assets/1121544/5822da2f-a306-4b4a-bf9b-807efa9e3363)


## After

![image](https://github.com/penumbra-zone/web/assets/1121544/0648918f-05bc-4e26-8b8f-af36f56bc9b9)

Closes #1227