### PR TITLE
Tweak getters to allow .optional() to be called at any point in a getter chain

### DIFF
--- a/.changeset/gentle-laws-unite.md
+++ b/.changeset/gentle-laws-unite.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/getters': minor
+---
+
+Allow calling .optional() at any point in a getter chain

--- a/packages/getters/src/utils/create-getter.test.ts
+++ b/packages/getters/src/utils/create-getter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { assertType, describe, expect, it } from 'vitest';
 import { createGetter } from './create-getter';
 
 interface Address {
@@ -83,6 +83,28 @@ describe('createGetter()', () => {
           getAddress.optional().pipe(getCity).pipe(getFirstLetter)(employee),
         ).not.toThrow();
       });
+
+      it('does not throw when a later getter is used with `.optional()` and some value in the chain is undefined', () => {
+        const baseGetter = getAddress.pipe(getCity).pipe(getFirstLetter);
+
+        // Before testing that it _doesn't_ throw with `.optional()`, first make
+        // sure that it _does_ throw without it, to ensure that this test is
+        // valid.
+        expect(() => baseGetter(employee)).toThrow();
+        expect(() => baseGetter.optional()(employee)).not.toThrow();
+      });
+
+      it('does throw when used without `.optional()` and some value in the chain is undefined', () => {
+        expect(() => getAddress.pipe(getCity).pipe(getFirstLetter)(employee)).toThrow();
+      });
     });
   });
+
+  // Type assertions - these will be run at build time, rather than at test
+  // time.
+  assertType<string>(getAddress.pipe(getCity)(employee));
+  // @ts-expect-error - Assert that `string` on its own is incorrect for an
+  // optional getter -- it should be `string | undefined`.
+  assertType<string>(getAddress.pipe(getCity).optional()(employee));
+  assertType<string | undefined>(getAddress.pipe(getCity).optional()(employee));
 });

--- a/packages/getters/src/utils/create-getter.ts
+++ b/packages/getters/src/utils/create-getter.ts
@@ -19,8 +19,8 @@ export const createGetter = <SourceType, TargetType, Optional extends boolean = 
       try {
         return getterFunction(value);
       } catch (e) {
-        if (!(e instanceof GetterMissingValueError)) throw e;
-        else return undefined;
+        if (e instanceof GetterMissingValueError) return undefined;
+        else throw e;
       }
     }, true);
 

--- a/packages/getters/src/utils/create-getter.ts
+++ b/packages/getters/src/utils/create-getter.ts
@@ -15,7 +15,14 @@ export const createGetter = <SourceType, TargetType, Optional extends boolean = 
   };
 
   getter.optional = () =>
-    createGetter<SourceType, TargetType, true>(value => getterFunction(value), true);
+    createGetter<SourceType, TargetType, true>(value => {
+      try {
+        return getterFunction(value);
+      } catch (e) {
+        if (!(e instanceof GetterMissingValueError)) throw e;
+        else return undefined;
+      }
+    }, true);
 
   getter.pipe = <PipedTargetType = unknown>(
     next: Getter<TargetType, PipedTargetType, Optional>,


### PR DESCRIPTION
Well, this turned out to be easier than expected!

Previously, we couldn't call `.optional()` at just any point in a getter chain; instead, we had to call it on the first getter in the chain. e.g., 

```ts
const myGetter1 = getter1.optional().pipe(getter2).pipe(getter3) // Will truly be optional
const myGetter2 = getter1.pipe(getter2).pipe(getter3).optional() // Will throw if any getter in the chain returns `undefined`
```

With this PR's change, `.optional()` can now be called at any point in the chain, and it will work as expected!

Closes #1153 