### PR TITLE
Add missing scripts to ZQuery package and fix tests

### DIFF
--- a/.changeset/flat-cups-behave.md
+++ b/.changeset/flat-cups-behave.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/zquery': patch
+---
+
+Add missing scripts and fix tests

--- a/packages/zquery/package.json
+++ b/packages/zquery/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "main": "src/index.ts",
+  "scripts": {
+    "lint": "eslint src",
+    "test": "vitest run"
+  },
   "dependencies": {
     "react": "^18.3.1",
     "zustand": "^4.5.2"

--- a/packages/zquery/src/index.test.ts
+++ b/packages/zquery/src/index.test.ts
@@ -25,6 +25,7 @@ describe('createZQuery()', () => {
       get: () => ({
         _zQueryInternal: {
           fetch: vi.fn(),
+          referenceCount: 0,
         },
         loading: false,
         revalidate: vi.fn(),
@@ -49,6 +50,7 @@ describe('createZQuery()', () => {
         _zQueryInternal: {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           fetch: expect.any(Function),
+          referenceCount: 0,
         },
       });
     });


### PR DESCRIPTION
While pairing with @VanishMax on ZQuery, I noticed that there was a TypeScript error in the ZQuery tests that wasn't being caught, and that the ZQuery tests were failing without breaking the build. That was because the `test` script (as well as others) was missing from ZQuery's `package.json`. This PR fixes that, as well as the broken test.