### PR TITLE
Use localSeq for determining which sequence number Prax has saved for an auction

### DIFF
--- a/.changeset/wet-fireants-rush.md
+++ b/.changeset/wet-fireants-rush.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/services': patch
+'minifront': patch
+---
+
+Use the localSeq property to fix auction UI bugs

--- a/apps/minifront/src/components/swap/auction-list/get-filtered-auction-infos.test.ts
+++ b/apps/minifront/src/components/swap/auction-list/get-filtered-auction-infos.test.ts
@@ -19,6 +19,7 @@ const MOCK_AUCTION_ID_1 = new AuctionId({ inner: new Uint8Array([1]) });
 const MOCK_AUCTION_INFO_1: AuctionInfo = {
   auction: MOCK_AUCTION_1,
   id: MOCK_AUCTION_ID_1,
+  localSeqNum: 0n,
 };
 
 const MOCK_AUCTION_2 = new DutchAuction({
@@ -34,6 +35,7 @@ const MOCK_AUCTION_ID_2 = new AuctionId({ inner: new Uint8Array([2]) });
 const MOCK_AUCTION_INFO_2: AuctionInfo = {
   auction: MOCK_AUCTION_2,
   id: MOCK_AUCTION_ID_2,
+  localSeqNum: 0n,
 };
 
 const MOCK_AUCTION_3 = new DutchAuction({
@@ -49,6 +51,7 @@ const MOCK_AUCTION_ID_3 = new AuctionId({ inner: new Uint8Array([3]) });
 const MOCK_AUCTION_INFO_3: AuctionInfo = {
   auction: MOCK_AUCTION_3,
   id: MOCK_AUCTION_ID_3,
+  localSeqNum: 0n,
 };
 
 const MOCK_AUCTION_4 = new DutchAuction({
@@ -64,6 +67,7 @@ const MOCK_AUCTION_ID_4 = new AuctionId({ inner: new Uint8Array([4]) });
 const MOCK_AUCTION_INFO_4: AuctionInfo = {
   auction: MOCK_AUCTION_4,
   id: MOCK_AUCTION_ID_4,
+  localSeqNum: 0n,
 };
 
 const MOCK_FULL_SYNC_HEIGHT = 15n;

--- a/apps/minifront/src/components/swap/auction-list/index.tsx
+++ b/apps/minifront/src/components/swap/auction-list/index.tsx
@@ -25,14 +25,17 @@ const getButtonProps = (
   auctionId: AuctionId,
   endAuction: (auctionId: AuctionId) => Promise<void>,
   withdraw: (auctionId: AuctionId, seqNum: bigint) => Promise<void>,
-  seqNum?: bigint,
+  localSeqNum?: bigint,
 ):
   | { buttonType: 'end' | 'withdraw'; onClickButton: VoidFunction }
   | { buttonType: undefined; onClickButton: undefined } => {
-  if (seqNum === 0n) return { buttonType: 'end', onClickButton: () => void endAuction(auctionId) };
+  if (localSeqNum === 0n) {
+    return { buttonType: 'end', onClickButton: () => void endAuction(auctionId) };
+  }
 
-  if (seqNum === 1n)
-    return { buttonType: 'withdraw', onClickButton: () => void withdraw(auctionId, seqNum) };
+  if (localSeqNum === 1n) {
+    return { buttonType: 'withdraw', onClickButton: () => void withdraw(auctionId, localSeqNum) };
+  }
 
   return { buttonType: undefined, onClickButton: undefined };
 };
@@ -93,12 +96,7 @@ export const AuctionList = () => {
                 inputMetadata={auctionInfo.inputMetadata}
                 outputMetadata={auctionInfo.outputMetadata}
                 fullSyncHeight={status?.fullSyncHeight}
-                {...getButtonProps(
-                  auctionInfo.id,
-                  endAuction,
-                  withdraw,
-                  auctionInfo.auction.state?.seq,
-                )}
+                {...getButtonProps(auctionInfo.id, endAuction, withdraw, auctionInfo.localSeqNum)}
                 renderButtonPlaceholder
               />
             </div>

--- a/apps/minifront/src/fetchers/auction-infos.ts
+++ b/apps/minifront/src/fetchers/auction-infos.ts
@@ -9,6 +9,7 @@ import { getInputAssetId, getOutputAssetId } from '@penumbra-zone/getters/dutch-
 export interface AuctionInfo {
   id: AuctionId;
   auction: DutchAuction;
+  localSeqNum: bigint;
   inputMetadata?: Metadata;
   outputMetadata?: Metadata;
 }
@@ -41,6 +42,7 @@ export const getAuctionInfos = async function* ({
     yield {
       id: response.id,
       auction,
+      localSeqNum: response.localSeq,
       inputMetadata: inputMetadata?.denomMetadata,
       outputMetadata: outputMetadata?.denomMetadata,
     };

--- a/packages/services/src/view-service/auctions.ts
+++ b/packages/services/src/view-service/auctions.ts
@@ -88,6 +88,7 @@ export const auctions: Impl['auctions'] = async function* (req, ctx) {
       id,
       auction,
       noteRecord,
+      localSeq: value.seqNum,
     });
   }
 };


### PR DESCRIPTION
Full context for this PR, if reviewers are interested:

Dutch auctions have a concept of a ["sequence number"](https://github.com/penumbra-zone/penumbra/blob/v0.77.1/proto/penumbra/penumbra/core/component/auction/v1/auction.proto#L100-L104), which represents which state the auction is in. `0` means the auction is open, `1` means it's closed, and `2`+ means the user has withdrawn the funds from the auction after it's closed. (The user can theoretically do an infinite number of withdrawals, but the first withdrawal results in all funds being withdrawn, so any future withdrawals have no financial impact. For this reason, minifront only shows a Withdraw button for auctions with a sequence number of `1`, and hides the Withdraw button if the sequence number is >= `2`.)

These sequence states are encoded into the NFTs the user holds for those auctions. So, when a user starts an auction, they get an NFT with the prefix `auctionnft_0_pauctid1...` The `0` in the token name refers to the sequence number.

When a user ends an auction, they exchange their `auctionnft_0_...` for an `auctionnft_1_...`. Similarly, when they withdraw funds from an auction, they change their `auctionnft_1_...` for an `auctionnft_2_...`. A user can only exchange an auction NFT of sequence number `N` for an auction NFT of sequence number `N + 1` — that is, they can't jump from `auctionnft_0_...` to `auctionnft_2_...`.

The user can end an auction while it's in progress, or after the allotted time (measured in number of blocks) for that auction has passed. Regardless of when the user ends an auction, they have to take the manual action of ending the auction for their `auctionnft_0_...` to be exchanged for an `auctionnft_1_...`. That is, the chain doesn't automatically exchange their tokens for them — they have to do it themselves, even if the auction's allotted time has already passed.

This is where things can get a little out of sync between the user's client (Prax) and the fullnode. The fullnode automatically considers an auction to have a sequence number of `1` once the allotted time has passed (ignoring, for a moment, the case where the user manually ends the auction sooner). But the user's NFT won't reflect that sequence number until the user manually ends the auction; that is, the user will have an `auctionnft_0_...` even though the fullnode consider the auction to have a sequence number of `1`. This causes a problem when the user clicks the "Query latest state" button:

![image](https://github.com/penumbra-zone/web/assets/1121544/cf4b54e5-c8c4-4cc7-b940-42b67fab9318)

That button queries the fullnode for the auction state, at which point minifront gets back a response showing the auction state as `1`. Then, minifront would render a Withdraw button rather than an End button, since the auction has ended (as far as the fullnode is concerned). But the problem is, the user still has an `auctionnft_0_...`, and thus the user needs to end the auction before they can withdraw funds from it.

To fix this, the core team introduced [a `local_seq` property](https://github.com/penumbra-zone/penumbra/blob/v0.77.1/proto/penumbra/penumbra/view/v1/view.proto#L176-L185) on `AuctionsResponse` that reflects _the local view service's_ version of the sequence number, which may lag behind the fullnode's, but will always be in sync with which version of the auction NFT the user holds because [it is updated whenever the user exchanges one auction NFT for another](https://github.com/penumbra-zone/web/blob/v8.1.0/packages/query/src/block-processor.ts#L416-L433). This property can then be used to correctly determine which button to show, and prevent showing the "Withdraw" button to the user when they can't yet withdraw.

Closes #1285 
Closes #1242