### PR TITLE
Update auctions in place

### DIFF
--- a/.changeset/four-forks-turn.md
+++ b/.changeset/four-forks-turn.md
@@ -1,0 +1,8 @@
+---
+'@penumbra-zone/zquery': major
+'minifront': minor
+---
+
+Beef up ZQuery's handling of streams; take advantage of it in minifront.
+
+BREAKING CHANGE: The `stream` property passed to `createZQuery()` should now return an object containing at least an `onValue` method. See the docs for the `stream` property for more info.

--- a/apps/minifront/src/components/swap/auction-list/index.tsx
+++ b/apps/minifront/src/components/swap/auction-list/index.tsx
@@ -49,7 +49,7 @@ export const AuctionList = () => {
       [...getFilteredAuctionInfos(auctionInfos.data ?? [], filter, status?.fullSyncHeight)].sort(
         SORT_FUNCTIONS[filter],
       ),
-    [auctionInfos, filter, status?.fullSyncHeight],
+    [auctionInfos.data, filter, status?.fullSyncHeight],
   );
 
   return (

--- a/apps/minifront/src/components/swap/auction-list/query-latest-state-button.tsx
+++ b/apps/minifront/src/components/swap/auction-list/query-latest-state-button.tsx
@@ -5,9 +5,11 @@ import {
   TooltipTrigger,
 } from '@penumbra-zone/ui/components/ui/tooltip';
 import { ReloadIcon } from '@radix-ui/react-icons';
-import { useRevalidateAuctionInfos } from '../../../state/swap/dutch-auction';
+import { useAuctionInfos, useRevalidateAuctionInfos } from '../../../state/swap/dutch-auction';
+import { cn } from '@penumbra-zone/ui/lib/utils';
 
 export const QueryLatestStateButton = () => {
+  const { loading } = useAuctionInfos();
   const revalidate = useRevalidateAuctionInfos();
 
   return (
@@ -16,8 +18,15 @@ export const QueryLatestStateButton = () => {
         <TooltipTrigger
           onClick={() => revalidate({ queryLatestState: true })}
           aria-label='Get the current auction reserves (makes a request to a fullnode)'
+          disabled={loading}
         >
-          <div className='p-2'>
+          <div
+            className={cn(
+              'p-2 transition-transform',
+              loading && 'animate-spin text-muted-foreground',
+              !loading && 'hover:rotate-45',
+            )}
+          >
             <ReloadIcon />
           </div>
         </TooltipTrigger>

--- a/apps/minifront/src/state/status.ts
+++ b/apps/minifront/src/state/status.ts
@@ -11,9 +11,11 @@ interface Status {
 export const { status, useStatus } = createZQuery({
   name: 'status',
   fetch: getStatusStream,
-  stream: (_prevState: Status | undefined, item: Status): Status => ({
-    fullSyncHeight: item.fullSyncHeight,
-    latestKnownBlockHeight: item.latestKnownBlockHeight,
+  stream: () => ({
+    onValue: (_prevState: Status | undefined, item: Status): Status => ({
+      fullSyncHeight: item.fullSyncHeight,
+      latestKnownBlockHeight: item.latestKnownBlockHeight,
+    }),
   }),
   getUseStore: () => useStore,
   get: state => state.status.status,

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -11,6 +11,7 @@ import { errorToast } from '@penumbra-zone/ui/lib/toast/presets';
 import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
 import { AuctionInfo, getAuctionInfos } from '../../../fetchers/auction-infos';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { bech32mAuctionId } from '@penumbra-zone/bech32m/pauctid';
 
 /**
  * Multipliers to use with the output of the swap simulation, to determine
@@ -52,10 +53,27 @@ interface State {
 export const { auctionInfos, useAuctionInfos, useRevalidateAuctionInfos } = createZQuery({
   name: 'auctionInfos',
   fetch: getAuctionInfos,
-  stream: (prevState: AuctionInfo[] | undefined, auctionInfo: AuctionInfo) => [
-    ...(prevState ?? []),
-    auctionInfo,
-  ],
+  stream: () => {
+    // Keep track of which auction IDs have appeared in this stream, so that we
+    // can discard any auctions from a previous stream once this stream has
+    // finished.
+    const auctionIdsToKeep = new Set<string>();
+
+    return {
+      onValue: (prevState: AuctionInfo[] | undefined = [], auctionInfo: AuctionInfo) => {
+        auctionIdsToKeep.add(bech32mAuctionId(auctionInfo.id));
+
+        const existingIndex = prevState.findIndex(({ id }) => id.equals(auctionInfo.id));
+
+        if (existingIndex >= 0) return prevState.toSpliced(existingIndex, 1, auctionInfo);
+        else return [...prevState, auctionInfo];
+      },
+
+      onEnd: (prevState = []) =>
+        // Discard any auctions from a previous stream.
+        prevState.filter(auctionInfo => auctionIdsToKeep.has(bech32mAuctionId(auctionInfo.id))),
+    };
+  },
   getUseStore: () => useStore,
   set: setter => {
     const newState = setter(useStore.getState().swap.dutchAuction.auctionInfos);

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -65,6 +65,7 @@ export const { auctionInfos, useAuctionInfos, useRevalidateAuctionInfos } = crea
 
         const existingIndex = prevState.findIndex(({ id }) => id.equals(auctionInfo.id));
 
+        // Update existing auctions in place, rather than appending duplicates.
         if (existingIndex >= 0) return prevState.toSpliced(existingIndex, 1, auctionInfo);
         else return [...prevState, auctionInfo];
       },

--- a/packages/ui/components/ui/dutch-auction-component/expanded-details/index.tsx
+++ b/packages/ui/components/ui/dutch-auction-component/expanded-details/index.tsx
@@ -10,6 +10,7 @@ import { getPrice } from './get-price';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 import { cn } from '../../../../lib/utils';
 import { AuctionIdComponent } from '../../auction-id-component';
+import { motion } from 'framer-motion';
 
 export const ExpandedDetails = ({
   auctionId,
@@ -114,11 +115,11 @@ const Row = ({
   children: ReactNode;
   highlight?: boolean;
 }) => (
-  <div className='flex items-center justify-between'>
+  <motion.div layout className='flex items-center justify-between'>
     <span className={cn('font-mono text-nowrap', !highlight && 'text-muted-foreground')}>
       {label}
     </span>
     <Separator />
     <span className={cn('overflow-hidden', !highlight && 'text-muted-foreground')}>{children}</span>
-  </div>
+  </motion.div>
 );

--- a/packages/zquery/src/types.ts
+++ b/packages/zquery/src/types.ts
@@ -97,14 +97,9 @@ export interface CreateZQueryStreamingProps<
   /** A function that executes the query. */
   fetch: (...args: FetchArgs) => AsyncIterable<DataType>;
   /**
-   * Set to `true` if `fetch` will return a streaming response in the form of an
-   * `AsyncIterable`.
-   *
-   * Or, if you wish to modify the streaming results as they come in before
-   * they're added to the state, set this to a function that takes the current state
-   * as its first argument and the streamed item as its second, and returns the
-   * desired new state (or a promise containing the desired new state). This can
-   * be useful for e.g. sorting items in the state as new items are streamed.
+   * A function that takes the current state as its first argument and the
+   * streamed item as its second, and returns the desired new state. This can be
+   * useful for e.g. sorting items in the state as new items are streamed.
    */
   stream: (prevData: ProcessedDataType | undefined, item: DataType) => ProcessedDataType;
   /**


### PR DESCRIPTION
Previously, ZQuery provided no way to update items in place when a stream was restarted. Instead, when a stream was restarted, ZQuery would set the state to `undefined`, then start processing streaming responses again.

With this PR's change, we can now handle streams a bit more intelligently. ZQuery no longer sets the state to `undefined` when restarting a stream; instead, it calls a new `onStart()` reducer (if it's passed to `createZQuery()`). Similarly, when a stream ends, errors, or is aborted, it calls handlers for those. It also calls an `onValue()` reducer when a value is received from the stream.

All those reducers are now returned by a `stream` function that consumers pass to `createZQuery()`, which allows consumers to maintain a JavaScript scope over the life of a stream. This allows you to update streamed items in place, and — in combination with `onEnd()` — discard any items from a previous stream that aren't present in the current stream. (See the implementation and docs for more detail.)

## Before
https://github.com/penumbra-zone/web/assets/1121544/bc55c820-3cc9-4a9c-acdc-ba6ddea0fa75

## After
https://github.com/penumbra-zone/web/assets/1121544/d67538c4-4f05-4033-be28-1b26b60952ad

Closes #1090