### PR TITLE
Stop using loader functions, part 1

### DIFF
--- a/.changeset/beige-fans-add.md
+++ b/.changeset/beige-fans-add.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/zquery': patch
+'minifront': patch
+---
+
+Stop using loader functions for most routes; fix typings issue in ZQuery

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-menubar": "^1.0.4",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-portal": "^1.0.4",
+    "@remix-run/router": "^1.16.1",
     "@repo/ui": "workspace:*",
     "@tanstack/react-query": "4.36.1",
     "bech32": "^2.0.0",

--- a/apps/minifront/src/abort-loader.ts
+++ b/apps/minifront/src/abort-loader.ts
@@ -28,8 +28,12 @@ const retry = async (fn: () => boolean, ms = 500, rate = Math.max(ms / 10, 50)) 
  * timeout. This is a temporary solution until loaders properly await Prax
  * connection.
  */
-export const abortLoader = async (): Promise<void> => {
+export const abortLoader = async (): Promise<null> => {
   await throwIfPraxNotInstalled();
   await retry(() => isPraxConnected());
   throwIfPraxNotConnected();
+
+  // Loaders are required to return a value, even if it's null. By returning
+  // `null` here, we can use this loader directly in the router.
+  return null;
 };

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -1,7 +1,5 @@
-import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { AddressIcon } from '@repo/ui/components/ui/address-icon';
 import { AddressComponent } from '@repo/ui/components/ui/address-component';
-import { BalancesByAccount, getBalancesByAccount } from '../../../fetchers/balances/by-account';
 import {
   Table,
   TableBody,
@@ -11,7 +9,6 @@ import {
   TableRow,
 } from '@repo/ui/components/ui/table';
 import { ValueViewComponent } from '@repo/ui/components/ui/tx/view/value';
-import { abortLoader } from '../../../abort-loader';
 import { EquivalentValues } from './equivalent-values';
 import { Fragment } from 'react';
 import { shouldDisplay } from './helpers';

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -15,16 +15,12 @@ import { abortLoader } from '../../../abort-loader';
 import { EquivalentValues } from './equivalent-values';
 import { Fragment } from 'react';
 import { shouldDisplay } from './helpers';
-
-export const AssetsLoader: LoaderFunction = async (): Promise<BalancesByAccount[]> => {
-  await abortLoader();
-  return await getBalancesByAccount();
-};
+import { useBalancesByAccount } from '../../../state/balances';
 
 export default function AssetsTable() {
-  const balancesByAccount = useLoaderData() as BalancesByAccount[];
+  const balancesByAccount = useBalancesByAccount();
 
-  if (balancesByAccount.length === 0) {
+  if (balancesByAccount.data?.length === 0) {
     return (
       <div className='flex flex-col gap-6'>
         <p>
@@ -40,7 +36,7 @@ export default function AssetsTable() {
 
   return (
     <Table>
-      {balancesByAccount.map(account => (
+      {balancesByAccount.data?.map(account => (
         <Fragment key={account.account}>
           <TableHeader className='group'>
             <TableRow>

--- a/apps/minifront/src/components/dashboard/transaction-table.tsx
+++ b/apps/minifront/src/components/dashboard/transaction-table.tsx
@@ -8,14 +8,11 @@ import {
 } from '@repo/ui/components/ui/table';
 import { Link } from 'react-router-dom';
 import { shorten } from '@penumbra-zone/types/string';
-import { useStore } from '../../state';
-import { memo, useEffect } from 'react';
-import { TransactionSummary } from '../../state/transactions';
+import { memo } from 'react';
+import { TransactionSummary, useSummaries } from '../../state/transactions';
 
 export default function TransactionTable() {
-  const { summaries, loadSummaries } = useStore(store => store.transactions);
-
-  useEffect(() => void loadSummaries(), [loadSummaries]);
+  const summaries = useSummaries();
 
   return (
     <Table className='md:table'>
@@ -28,9 +25,7 @@ export default function TransactionTable() {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {summaries.map(summary => (
-          <Row key={summary.hash} summary={summary} />
-        ))}
+        {summaries.data?.map(summary => <Row key={summary.hash} summary={summary} />)}
       </TableBody>
     </Table>
   );

--- a/apps/minifront/src/components/ibc/ibc-loader.ts
+++ b/apps/minifront/src/components/ibc/ibc-loader.ts
@@ -28,8 +28,8 @@ export const IbcLoader: LoaderFunction = async (): Promise<IbcLoaderResponse> =>
     const initialSelection = filterBalancesPerChain(
       assetBalances,
       initialChain,
-      stakingTokenMetadata,
       assets,
+      stakingTokenMetadata,
     )[0];
 
     // set initial account if accounts exist and asset if account has asset list

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -12,9 +12,11 @@ import InputToken from '../../shared/input-token';
 import { InputBlock } from '../../shared/input-block';
 import { IbcLoaderResponse } from '../ibc-loader';
 import { LockOpen2Icon } from '@radix-ui/react-icons';
+import { useStakingTokenMetadata } from '../../../state/shared';
 
 export const IbcOutForm = () => {
-  const { balances, stakingTokenMetadata, assets } = useLoaderData() as IbcLoaderResponse;
+  const stakingTokenMetadata = useStakingTokenMetadata();
+  const { balances, assets } = useLoaderData() as IbcLoaderResponse;
   const {
     sendIbcWithdraw,
     destinationChainAddress,
@@ -25,7 +27,12 @@ export const IbcOutForm = () => {
     setSelection,
     chain,
   } = useStore(ibcOutSelector);
-  const filteredBalances = filterBalancesPerChain(balances, chain, stakingTokenMetadata, assets);
+  const filteredBalances = filterBalancesPerChain(
+    balances,
+    chain,
+    assets,
+    stakingTokenMetadata.data,
+  );
   const validationErrors = useStore(ibcValidationErrors);
 
   return (

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -6,7 +6,7 @@ import TransactionTable from './dashboard/transaction-table';
 import { DashboardLayout } from './dashboard/layout';
 import { TxDetails, TxDetailsErrorBoundary, TxDetailsLoader } from './tx-details';
 import { SendLayout } from './send/layout';
-import { SendAssetBalanceLoader, SendForm } from './send/send-form';
+import { SendForm } from './send/send-form';
 import { Receive } from './send/receive';
 import { ErrorBoundary } from './shared/error-boundary';
 import { SwapLayout } from './swap/layout';
@@ -45,7 +45,7 @@ export const rootRouter: Router = createHashRouter([
         children: [
           {
             index: true,
-            loader: SendAssetBalanceLoader,
+            loader: abortLoader,
             element: <SendForm />,
           },
           {

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -14,8 +14,9 @@ import { SwapLoader } from './swap/swap-loader';
 import { StakingLayout, StakingLoader } from './staking/layout';
 import { IbcLoader } from './ibc/ibc-loader';
 import { IbcLayout } from './ibc/layout';
+import type { Router } from '@remix-run/router';
 
-export const rootRouter = createHashRouter([
+export const rootRouter: Router = createHashRouter([
   {
     path: '/',
     element: <Layout />,

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -4,7 +4,7 @@ import { Layout } from './layout';
 import AssetsTable from './dashboard/assets-table';
 import TransactionTable from './dashboard/transaction-table';
 import { DashboardLayout } from './dashboard/layout';
-import { TxDetails, TxDetailsErrorBoundary, TxDetailsLoader } from './tx-details';
+import { TxDetails, TxDetailsErrorBoundary } from './tx-details';
 import { SendLayout } from './send/layout';
 import { SendForm } from './send/send-form';
 import { Receive } from './send/receive';
@@ -61,7 +61,7 @@ export const rootRouter: Router = createHashRouter([
       },
       {
         path: PagePath.TRANSACTION_DETAILS,
-        loader: TxDetailsLoader,
+        loader: abortLoader,
         element: <TxDetails />,
         errorElement: <TxDetailsErrorBoundary />,
       },

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -1,7 +1,7 @@
 import { createHashRouter, redirect } from 'react-router-dom';
 import { PagePath } from './metadata/paths';
 import { Layout } from './layout';
-import AssetsTable, { AssetsLoader } from './dashboard/assets-table';
+import AssetsTable from './dashboard/assets-table';
 import TransactionTable from './dashboard/transaction-table';
 import { DashboardLayout } from './dashboard/layout';
 import { TxDetails, TxDetailsErrorBoundary, TxDetailsLoader } from './tx-details';
@@ -14,6 +14,7 @@ import { SwapLoader } from './swap/swap-loader';
 import { StakingLayout, StakingLoader } from './staking/layout';
 import { IbcLoader } from './ibc/ibc-loader';
 import { IbcLayout } from './ibc/layout';
+import { abortLoader } from '../abort-loader';
 import type { Router } from '@remix-run/router';
 
 export const rootRouter: Router = createHashRouter([
@@ -29,7 +30,7 @@ export const rootRouter: Router = createHashRouter([
         children: [
           {
             index: true,
-            loader: AssetsLoader,
+            loader: abortLoader,
             element: <AssetsTable />,
           },
           {

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -11,7 +11,7 @@ import { Receive } from './send/receive';
 import { ErrorBoundary } from './shared/error-boundary';
 import { SwapLayout } from './swap/layout';
 import { SwapLoader } from './swap/swap-loader';
-import { StakingLayout, StakingLoader } from './staking/layout';
+import { StakingLayout } from './staking/layout';
 import { IbcLoader } from './ibc/ibc-loader';
 import { IbcLayout } from './ibc/layout';
 import { abortLoader } from '../abort-loader';
@@ -67,7 +67,7 @@ export const rootRouter: Router = createHashRouter([
       },
       {
         path: PagePath.STAKING,
-        loader: StakingLoader,
+        loader: abortLoader,
         element: <StakingLayout />,
       },
       {

--- a/apps/minifront/src/components/send/send-form/index.tsx
+++ b/apps/minifront/src/components/send/send-form/index.tsx
@@ -1,42 +1,23 @@
 import { Button } from '@repo/ui/components/ui/button';
 import { Input } from '@repo/ui/components/ui/input';
 import { useStore } from '../../../state';
-import { sendSelector, sendValidationErrors } from '../../../state/send';
+import {
+  sendSelector,
+  sendValidationErrors,
+  useStakingTokenMetadata,
+  useTransferableBalancesResponses,
+} from '../../../state/send';
 import { InputBlock } from '../../shared/input-block';
-import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { useMemo, useState } from 'react';
-import { getTransferableBalancesResponses, penumbraAddrValidation } from '../helpers';
-import { abortLoader } from '../../../abort-loader';
+import { penumbraAddrValidation } from '../helpers';
 import InputToken from '../../shared/input-token';
 import { useRefreshFee } from './use-refresh-fee';
 import { GasFee } from '../../shared/gas-fee';
-import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
-import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { getStakingTokenMetadata } from '../../../fetchers/registry';
 import { hasStakingToken } from '../../../fetchers/staking-token';
 
-export interface SendLoaderResponse {
-  assetBalances: BalancesResponse[];
-  stakingAssetMetadata: Metadata;
-}
-
-export const SendAssetBalanceLoader: LoaderFunction = async (): Promise<SendLoaderResponse> => {
-  await abortLoader();
-  const assetBalances = await getTransferableBalancesResponses();
-
-  if (assetBalances[0]) {
-    // set initial account if accounts exist and asset if account has asset list
-    useStore.setState(state => {
-      state.send.selection = assetBalances[0];
-    });
-  }
-  const stakingAssetMetadata = await getStakingTokenMetadata();
-
-  return { assetBalances, stakingAssetMetadata };
-};
-
 export const SendForm = () => {
-  const { assetBalances, stakingAssetMetadata } = useLoaderData() as SendLoaderResponse;
+  const stakingTokenMetadata = useStakingTokenMetadata();
+  const transferableBalancesResponses = useTransferableBalancesResponses();
   const {
     selection,
     amount,
@@ -56,7 +37,10 @@ export const SendForm = () => {
   const [showNonNativeFeeWarning, setshowNonNativeFeeWarning] = useState(false);
 
   // Check if the user has native staking tokens
-  const stakingToken = hasStakingToken(assetBalances, stakingAssetMetadata);
+  const stakingToken = hasStakingToken(
+    transferableBalancesResponses.data,
+    stakingTokenMetadata.data,
+  );
 
   useRefreshFee();
 
@@ -106,7 +90,7 @@ export const SendForm = () => {
             checkFn: () => validationErrors.amountErr,
           },
         ]}
-        balances={assetBalances}
+        balances={transferableBalancesResponses.data ?? []}
       />
       {showNonNativeFeeWarning && (
         <div className='rounded border border-yellow-500 bg-gray-800 p-4 text-yellow-500'>
@@ -121,7 +105,7 @@ export const SendForm = () => {
       <GasFee
         fee={fee}
         feeTier={feeTier}
-        stakingAssetMetadata={stakingAssetMetadata}
+        stakingAssetMetadata={stakingTokenMetadata.data}
         setFeeTier={setFeeTier}
       />
 

--- a/apps/minifront/src/components/send/send-form/index.tsx
+++ b/apps/minifront/src/components/send/send-form/index.tsx
@@ -4,7 +4,6 @@ import { useStore } from '../../../state';
 import {
   sendSelector,
   sendValidationErrors,
-  useStakingTokenMetadata,
   useTransferableBalancesResponses,
 } from '../../../state/send';
 import { InputBlock } from '../../shared/input-block';
@@ -14,6 +13,7 @@ import InputToken from '../../shared/input-token';
 import { useRefreshFee } from './use-refresh-fee';
 import { GasFee } from '../../shared/gas-fee';
 import { hasStakingToken } from '../../../fetchers/staking-token';
+import { useStakingTokenMetadata } from '../../../state/shared';
 
 export const SendForm = () => {
   const stakingTokenMetadata = useStakingTokenMetadata();

--- a/apps/minifront/src/components/shared/gas-fee.tsx
+++ b/apps/minifront/src/components/shared/gas-fee.tsx
@@ -33,9 +33,11 @@ export const GasFee = ({
 }: {
   fee: Fee | undefined;
   feeTier: FeeTier_Tier;
-  stakingAssetMetadata: Metadata;
+  stakingAssetMetadata?: Metadata;
   setFeeTier: (feeTier: FeeTier_Tier) => void;
 }) => {
+  if (!stakingAssetMetadata) return null;
+
   let feeValueView: ValueView | undefined;
   if (fee?.amount)
     feeValueView = new ValueView({

--- a/apps/minifront/src/components/staking/account/delegation-value-view/index.test.tsx
+++ b/apps/minifront/src/components/staking/account/delegation-value-view/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { DelegationValueView } from '.';
 import { render } from '@testing-library/react';
 import {
@@ -47,7 +47,7 @@ const STAKING_TOKEN_METADATA = new Metadata({
 
 const validatorInfo = new ValidatorInfo({
   validator: {
-    identityKey: {},
+    identityKey: validatorIk,
     fundingStreams: [
       {
         recipient: {
@@ -98,27 +98,32 @@ const valueView = new ValueView({
   },
 });
 
+const mockUseStakingTokenMetadata = vi.hoisted(() => () => ({
+  data: STAKING_TOKEN_METADATA,
+  error: undefined,
+  loading: undefined,
+}));
+
+vi.mock('../../../../state/shared', async () => ({
+  ...(await vi.importActual('../../../../state/shared')),
+  useStakingTokenMetadata: mockUseStakingTokenMetadata,
+}));
+
 describe('<DelegationValueView />', () => {
   it('shows balance of the delegation token', () => {
-    const { container } = render(
-      <DelegationValueView valueView={valueView} stakingTokenMetadata={STAKING_TOKEN_METADATA} />,
-    );
+    const { container } = render(<DelegationValueView valueView={valueView} />);
 
     expect(container).toHaveTextContent('1delUM(abc...xyz)');
   });
 
   it("shows the delegation token's equivalent value in terms of the staking token", () => {
-    const { container } = render(
-      <DelegationValueView valueView={valueView} stakingTokenMetadata={STAKING_TOKEN_METADATA} />,
-    );
+    const { container } = render(<DelegationValueView valueView={valueView} />);
 
     expect(container).toHaveTextContent('1.33UM');
   });
 
   it('does not show other equivalent values', () => {
-    const { container } = render(
-      <DelegationValueView valueView={valueView} stakingTokenMetadata={STAKING_TOKEN_METADATA} />,
-    );
+    const { container } = render(<DelegationValueView valueView={valueView} />);
 
     expect(container).not.toHaveTextContent('2.66SOT');
   });

--- a/apps/minifront/src/components/staking/account/delegation-value-view/index.tsx
+++ b/apps/minifront/src/components/staking/account/delegation-value-view/index.tsx
@@ -1,7 +1,4 @@
-import {
-  Metadata,
-  ValueView,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { ValidatorInfoComponent } from './validator-info-component';
 import { ValueViewComponent } from '@repo/ui/components/ui/tx/view/value';
 import { StakingActions } from './staking-actions';
@@ -13,6 +10,7 @@ import {
   getValidatorInfoFromValueView,
 } from '@penumbra-zone/getters/value-view';
 import { asValueView } from '@penumbra-zone/getters/equivalent-value';
+import { useStakingTokenMetadata } from '../../../../state/shared';
 
 /**
  * Renders a `ValueView` that contains a delegation token, along with the
@@ -26,8 +24,6 @@ export const DelegationValueView = memo(
   ({
     valueView,
     votingPowerAsIntegerPercentage,
-    unstakedTokens,
-    stakingTokenMetadata,
   }: {
     /**
      * A `ValueView` representing the address's balance of the given delegation
@@ -35,24 +31,21 @@ export const DelegationValueView = memo(
      */
     valueView: ValueView;
     votingPowerAsIntegerPercentage?: number;
-    /**
-     * A `ValueView` representing the address's balance of staking (UM) tokens.
-     * Used to show the user how many tokens they have available to delegate.
-     */
-    unstakedTokens?: ValueView;
-    stakingTokenMetadata: Metadata;
   }) => {
+    const stakingTokenMetadata = useStakingTokenMetadata();
     const validatorInfo = getValidatorInfoFromValueView(valueView);
     const metadata = getMetadata(valueView);
 
     const equivalentValueOfStakingToken = useMemo(() => {
       const equivalentValue = getEquivalentValues(valueView).find(equivalentValue =>
-        equivalentValue.numeraire?.penumbraAssetId?.equals(stakingTokenMetadata.penumbraAssetId),
+        equivalentValue.numeraire?.penumbraAssetId?.equals(
+          stakingTokenMetadata.data?.penumbraAssetId,
+        ),
       );
 
       if (equivalentValue) return asValueView(equivalentValue);
       return undefined;
-    }, [valueView, stakingTokenMetadata.penumbraAssetId]);
+    }, [valueView, stakingTokenMetadata.data?.penumbraAssetId]);
 
     return (
       <div className='flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-8'>
@@ -76,11 +69,7 @@ export const DelegationValueView = memo(
           )}
         </div>
 
-        <StakingActions
-          validatorInfo={validatorInfo}
-          delegationTokens={valueView}
-          unstakedTokens={unstakedTokens}
-        />
+        <StakingActions validatorInfo={validatorInfo} delegationTokens={valueView} />
       </div>
     );
   },

--- a/apps/minifront/src/components/staking/account/delegation-value-view/staking-actions/index.test.tsx
+++ b/apps/minifront/src/components/staking/account/delegation-value-view/staking-actions/index.test.tsx
@@ -30,10 +30,7 @@ let MOCK_STAKING_TOKENS_AND_FILTER:
       unstakedTokensByAccount: Map<number, ValueView | undefined>;
       accountSwitcherFilter: number[];
     }
-  | undefined = vi.hoisted(() => ({
-  unstakedTokensByAccount: new Map(),
-  accountSwitcherFilter: [],
-}));
+  | undefined;
 
 vi.mock('../../../../../state/staking', async () => ({
   ...(await vi.importActual('../../../../../state/staking')),

--- a/apps/minifront/src/components/staking/account/delegation-value-view/staking-actions/index.test.tsx
+++ b/apps/minifront/src/components/staking/account/delegation-value-view/staking-actions/index.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StakingActions } from '.';
 import { render } from '@testing-library/react';
 import { ValidatorInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { AllSlices } from '../../../../../state';
 
 const nonZeroBalance = new ValueView({
   valueView: {
@@ -24,14 +25,48 @@ const zeroBalance = new ValueView({
 
 const validatorInfo = new ValidatorInfo({ validator: {} });
 
+let MOCK_STAKING_TOKENS_AND_FILTER:
+  | {
+      unstakedTokensByAccount: Map<number, ValueView | undefined>;
+      accountSwitcherFilter: number[];
+    }
+  | undefined = vi.hoisted(() => ({
+  unstakedTokensByAccount: new Map(),
+  accountSwitcherFilter: [],
+}));
+
+vi.mock('../../../../../state/staking', async () => ({
+  ...(await vi.importActual('../../../../../state/staking')),
+  useStakingTokensAndFilter: () => ({
+    data: MOCK_STAKING_TOKENS_AND_FILTER,
+    error: undefined,
+    loading: false,
+  }),
+}));
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
+vi.mock('../../../../../utils/use-store-shallow', async () => ({
+  ...(await vi.importActual('../../../../../utils/use-store-shallow')),
+  useStoreShallow: (selector: (state: RecursivePartial<AllSlices>) => unknown) =>
+    selector({ staking: { account: 0 } }),
+}));
+
 describe('<StakingActions />', () => {
+  beforeEach(() => {
+    MOCK_STAKING_TOKENS_AND_FILTER = undefined;
+  });
+
   it('renders an enabled Delegate button there is a non-zero balance of unstaked tokens', () => {
+    MOCK_STAKING_TOKENS_AND_FILTER = {
+      unstakedTokensByAccount: new Map([[0, nonZeroBalance]]),
+      accountSwitcherFilter: [],
+    };
+
     const { getByText } = render(
-      <StakingActions
-        delegationTokens={zeroBalance}
-        unstakedTokens={nonZeroBalance}
-        validatorInfo={validatorInfo}
-      />,
+      <StakingActions delegationTokens={zeroBalance} validatorInfo={validatorInfo} />,
     );
 
     expect(getByText('Delegate')).toBeEnabled();
@@ -39,47 +74,43 @@ describe('<StakingActions />', () => {
 
   it('renders an enabled Undelegate button when there is a non-zero balance of delegation tokens', () => {
     const { getByText } = render(
-      <StakingActions
-        delegationTokens={nonZeroBalance}
-        unstakedTokens={zeroBalance}
-        validatorInfo={validatorInfo}
-      />,
+      <StakingActions delegationTokens={nonZeroBalance} validatorInfo={validatorInfo} />,
     );
 
     expect(getByText('Undelegate')).toBeEnabled();
   });
 
   it('renders a disabled Delegate button when there is a zero balance of unstaked tokens', () => {
+    MOCK_STAKING_TOKENS_AND_FILTER = {
+      unstakedTokensByAccount: new Map([[0, zeroBalance]]),
+      accountSwitcherFilter: [],
+    };
+
     const { getByText } = render(
-      <StakingActions
-        delegationTokens={nonZeroBalance}
-        unstakedTokens={zeroBalance}
-        validatorInfo={validatorInfo}
-      />,
+      <StakingActions delegationTokens={nonZeroBalance} validatorInfo={validatorInfo} />,
     );
 
     expect(getByText('Delegate')).toBeDisabled();
   });
 
   it('renders a disabled Delegate button when unstaked tokens are undefined', () => {
+    MOCK_STAKING_TOKENS_AND_FILTER = undefined;
+
     const { getByText } = render(
-      <StakingActions
-        delegationTokens={nonZeroBalance}
-        unstakedTokens={undefined}
-        validatorInfo={validatorInfo}
-      />,
+      <StakingActions delegationTokens={nonZeroBalance} validatorInfo={validatorInfo} />,
     );
 
     expect(getByText('Delegate')).toBeDisabled();
   });
 
   it('renders a disabled Undelegate button when there is a zero balance of delegation tokens', () => {
+    MOCK_STAKING_TOKENS_AND_FILTER = {
+      unstakedTokensByAccount: new Map([[0, nonZeroBalance]]),
+      accountSwitcherFilter: [],
+    };
+
     const { getByText } = render(
-      <StakingActions
-        delegationTokens={zeroBalance}
-        unstakedTokens={nonZeroBalance}
-        validatorInfo={validatorInfo}
-      />,
+      <StakingActions delegationTokens={zeroBalance} validatorInfo={validatorInfo} />,
     );
 
     expect(getByText('Undelegate')).toBeDisabled();

--- a/apps/minifront/src/components/staking/account/delegations.tsx
+++ b/apps/minifront/src/components/staking/account/delegations.tsx
@@ -1,10 +1,7 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { AllSlices } from '../../../state';
 import { DelegationValueView } from './delegation-value-view';
-import {
-  Metadata,
-  ValueView,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { useStoreShallow } from '../../../utils/use-store-shallow';
 import { getValidatorIdentityKeyFromValueView } from '@penumbra-zone/getters/value-view';
 import { bech32mIdentityKey } from '@penumbra-zone/bech32m/penumbravalid';
@@ -18,13 +15,11 @@ const getVotingPowerAsIntegerPercentage = (
 
 const delegationsSelector = (state: AllSlices) => ({
   delegations: state.staking.delegationsByAccount.get(state.staking.account) ?? [],
-  unstakedTokens: state.staking.unstakedTokensByAccount.get(state.staking.account),
   votingPowerByValidatorInfo: state.staking.votingPowerByValidatorInfo,
 });
 
-export const Delegations = ({ stakingTokenMetadata }: { stakingTokenMetadata: Metadata }) => {
-  const { delegations, unstakedTokens, votingPowerByValidatorInfo } =
-    useStoreShallow(delegationsSelector);
+export const Delegations = () => {
+  const { delegations, votingPowerByValidatorInfo } = useStoreShallow(delegationsSelector);
 
   return (
     <div className='mt-8 flex flex-col gap-8'>
@@ -37,8 +32,6 @@ export const Delegations = ({ stakingTokenMetadata }: { stakingTokenMetadata: Me
           >
             <DelegationValueView
               valueView={delegation}
-              unstakedTokens={unstakedTokens}
-              stakingTokenMetadata={stakingTokenMetadata}
               votingPowerAsIntegerPercentage={getVotingPowerAsIntegerPercentage(
                 votingPowerByValidatorInfo,
                 delegation,

--- a/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
+++ b/apps/minifront/src/components/staking/account/header/unbonding-tokens.tsx
@@ -24,7 +24,7 @@ export const UnbondingTokens = ({
   tokens?: ValueView[];
   helpText: string;
   children?: ReactNode;
-  stakingTokenMetadata: Metadata;
+  stakingTokenMetadata?: Metadata;
 }) => {
   return (
     <TooltipProvider>

--- a/apps/minifront/src/components/staking/layout.tsx
+++ b/apps/minifront/src/components/staking/layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { AllSlices, useStore } from '../../state';
+import { AllSlices } from '../../state';
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/ui/card';
 import { Header } from './account/header';
 import { Delegations } from './account/delegations';

--- a/apps/minifront/src/components/staking/layout.tsx
+++ b/apps/minifront/src/components/staking/layout.tsx
@@ -1,22 +1,10 @@
 import { useEffect } from 'react';
 import { AllSlices, useStore } from '../../state';
-import { abortLoader } from '../../abort-loader';
 import { Card, CardContent, CardHeader, CardTitle } from '@repo/ui/components/ui/card';
 import { Header } from './account/header';
 import { Delegations } from './account/delegations';
-import { LoaderFunction, useLoaderData } from 'react-router-dom';
 import { useStoreShallow } from '../../utils/use-store-shallow';
 import { RestrictMaxWidth } from '../shared/restrict-max-width';
-import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { getStakingTokenMetadata } from '../../fetchers/registry';
-
-export const StakingLoader: LoaderFunction = async (): Promise<Metadata> => {
-  await abortLoader();
-  // Await to avoid screen flicker.
-  await useStore.getState().staking.loadAndReduceBalances();
-
-  return await getStakingTokenMetadata();
-};
 
 const stakingLayoutSelector = (state: AllSlices) => ({
   account: state.staking.account,
@@ -25,7 +13,6 @@ const stakingLayoutSelector = (state: AllSlices) => ({
 });
 
 export const StakingLayout = () => {
-  const stakingTokenMetadata = useLoaderData() as Metadata;
   const { account, loadDelegationsForCurrentAccount, loadUnbondingTokensForCurrentAccount } =
     useStoreShallow(stakingLayoutSelector);
 
@@ -44,7 +31,7 @@ export const StakingLayout = () => {
             <CardTitle>Delegation tokens</CardTitle>
           </CardHeader>
           <CardContent>
-            <Delegations stakingTokenMetadata={stakingTokenMetadata} />
+            <Delegations />
           </CardContent>
         </Card>
       </div>

--- a/apps/minifront/src/components/tx-details/index.tsx
+++ b/apps/minifront/src/components/tx-details/index.tsx
@@ -30,7 +30,7 @@ export const TxDetails = () => {
       <RestrictMaxWidth>
         <div className='relative grid grid-std-spacing lg:grid-cols-3'>
           <Card gradient className='flex-1 p-5 md:p-4 lg:col-span-2 lg:row-span-2 xl:p-5'>
-            <TxViewer txInfo={txInfo.data} hash={txInfo.data.id} />
+            <TxViewer txInfo={txInfo.data} />
           </Card>
           <EduInfoCard
             className='row-span-1'

--- a/apps/minifront/src/components/tx-details/tx-viewer.tsx
+++ b/apps/minifront/src/components/tx-details/tx-viewer.tsx
@@ -1,6 +1,5 @@
 import { JsonViewer } from '@repo/ui/components/ui/json-viewer';
 import { TransactionViewComponent } from '@repo/ui/components/ui/tx/view/transaction';
-import { TxDetailsLoaderResult } from '.';
 import { TransactionInfo } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import type { Jsonified } from '@penumbra-zone/types/jsonified';
 import { useState } from 'react';
@@ -10,6 +9,7 @@ import { typeRegistry } from '@penumbra-zone/protobuf';
 import { useQuery } from '@tanstack/react-query';
 import fetchReceiverView from './hooks';
 import { classifyTransaction } from '@penumbra-zone/perspective/transaction/classify';
+import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 
 export enum TxDetailsTab {
   PUBLIC = 'public',
@@ -23,11 +23,11 @@ const OPTIONS = [
   { label: 'Reciever View', value: TxDetailsTab.RECIEVER },
 ];
 
-export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
+export const TxViewer = ({ txInfo }: { txInfo?: TransactionInfo }) => {
   const [option, setOption] = useState(TxDetailsTab.PRIVATE);
 
   // classify the transaction type
-  const transactionClassification = classifyTransaction(txInfo.view);
+  const transactionClassification = classifyTransaction(txInfo?.view);
 
   // filter for reciever view
   const showReceiverTransactionView = transactionClassification === 'send';
@@ -38,7 +38,7 @@ export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
   // use React-Query to invoke custom hooks that call async translators.
   const { data: receiverView } = useQuery(
     ['receiverView', txInfo, option],
-    () => fetchReceiverView(txInfo),
+    () => fetchReceiverView(txInfo!),
     {
       enabled: option === TxDetailsTab.RECIEVER && !!txInfo,
     },
@@ -47,7 +47,9 @@ export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
   return (
     <div>
       <div className='text-xl font-bold'>Transaction View</div>
-      <div className='mb-8 break-all font-mono italic text-muted-foreground'>{hash}</div>
+      <div className='mb-8 break-all font-mono italic text-muted-foreground'>
+        {txInfo?.id && uint8ArrayToHex(txInfo.id.inner)}
+      </div>
 
       <div className='mx-auto mb-4 max-w-[70%]'>
         <SegmentedPicker
@@ -58,7 +60,7 @@ export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
           size='lg'
         />
       </div>
-      {option === TxDetailsTab.PRIVATE && (
+      {option === TxDetailsTab.PRIVATE && txInfo && (
         <>
           <TransactionViewComponent txv={txInfo.view!} />
           <div className='mt-8'>
@@ -70,7 +72,7 @@ export const TxViewer = ({ txInfo, hash }: TxDetailsLoaderResult) => {
       {option === TxDetailsTab.RECIEVER && receiverView && showReceiverTransactionView && (
         <TransactionViewComponent txv={receiverView} />
       )}
-      {option === TxDetailsTab.PUBLIC && (
+      {option === TxDetailsTab.PUBLIC && txInfo && (
         <TransactionViewComponent txv={asPublicTransactionView(txInfo.view)} />
       )}
     </div>

--- a/apps/minifront/src/fetchers/balances/index.ts
+++ b/apps/minifront/src/fetchers/balances/index.ts
@@ -1,4 +1,7 @@
-import { BalancesRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import {
+  BalancesRequest,
+  BalancesResponse,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
 import { viewClient } from '../../clients';
@@ -8,7 +11,9 @@ interface BalancesProps {
   assetIdFilter?: AssetId;
 }
 
-export const getBalances = ({ accountFilter, assetIdFilter }: BalancesProps = {}) => {
+export const getBalances = ({ accountFilter, assetIdFilter }: BalancesProps = {}): Promise<
+  BalancesResponse[]
+> => {
   const req = new BalancesRequest();
   if (accountFilter) req.accountFilter = accountFilter;
   if (assetIdFilter) req.assetIdFilter = assetIdFilter;

--- a/apps/minifront/src/fetchers/staking-token.ts
+++ b/apps/minifront/src/fetchers/staking-token.ts
@@ -4,8 +4,8 @@ import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
 import { getAssetId } from '@penumbra-zone/getters/metadata';
 
 export const hasStakingToken = (
-  assetBalances: BalancesResponse[],
-  stakingAssetMetadata: Metadata,
+  assetBalances: BalancesResponse[] = [],
+  stakingAssetMetadata?: Metadata,
 ): boolean => {
   return assetBalances.some(asset =>
     getAssetIdFromValueView(asset.balanceView).equals(getAssetId(stakingAssetMetadata)),

--- a/apps/minifront/src/state/balances.ts
+++ b/apps/minifront/src/state/balances.ts
@@ -1,0 +1,24 @@
+import { SliceCreator, useStore } from '.';
+import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
+import { BalancesByAccount, getBalancesByAccount } from '../fetchers/balances/by-account';
+
+export const { balancesByAccount, useBalancesByAccount } = createZQuery({
+  name: 'balancesByAccount',
+  fetch: getBalancesByAccount,
+  getUseStore: () => useStore,
+  get: state => state.balances.balancesByAccount,
+  set: setter => {
+    const newState = setter(useStore.getState().balances.balancesByAccount);
+    useStore.setState(state => {
+      state.balances.balancesByAccount = newState;
+    });
+  },
+});
+
+export interface BalancesSlice {
+  balancesByAccount: ZQueryState<BalancesByAccount[]>;
+}
+
+export const createBalancesSlice = (): SliceCreator<BalancesSlice> => () => ({
+  balancesByAccount,
+});

--- a/apps/minifront/src/state/ibc-in/index.tsx
+++ b/apps/minifront/src/state/ibc-in/index.tsx
@@ -1,8 +1,8 @@
-import { ChainInfo } from '../components/ibc/ibc-in/chain-dropdown';
-import { CosmosAssetBalance } from '../components/ibc/ibc-in/hooks';
+import { ChainInfo } from '../../components/ibc/ibc-in/chain-dropdown';
+import { CosmosAssetBalance } from '../../components/ibc/ibc-in/hooks';
 import { ChainWalletContext } from '@cosmos-kit/core';
-import { AllSlices, SliceCreator } from '.';
-import { getAddrByIndex } from '../fetchers/address';
+import { AllSlices, SliceCreator } from '..';
+import { getAddrByIndex } from '../../fetchers/address';
 import { bech32mAddress } from '@penumbra-zone/bech32m/penumbra';
 import { Toast } from '@repo/ui/lib/toast/toast';
 import { shorten } from '@penumbra-zone/types/string';
@@ -10,15 +10,16 @@ import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/k
 import { bech32CompatAddress } from '@penumbra-zone/bech32m/penumbracompat1';
 import { calculateFee, GasPrice, SigningStargateClient } from '@cosmjs/stargate';
 import { chains } from 'chain-registry';
-import { getChainId } from '../fetchers/chain-id';
-import { augmentToAsset, fromDisplayAmount } from '../components/ibc/ibc-in/asset-utils';
+import { getChainId } from '../../fetchers/chain-id';
+import { augmentToAsset, fromDisplayAmount } from '../../components/ibc/ibc-in/asset-utils';
 import { cosmos, ibc } from 'osmo-query';
-import { chainRegistryClient } from '../fetchers/registry';
-import { tendermintClient } from '../clients';
-import { BLOCKS_PER_HOUR } from './constants';
-import { currentTimePlusTwoDaysRounded } from './ibc-out';
+import { chainRegistryClient } from '../../fetchers/registry';
+import { tendermintClient } from '../../clients';
+import { BLOCKS_PER_HOUR } from '../constants';
+import { currentTimePlusTwoDaysRounded } from '../ibc-out';
 import { EncodeObject } from '@cosmjs/proto-signing';
 import { MsgTransfer } from 'osmo-query/ibc/applications/transfer/v1/tx';
+import { parseRevisionNumberFromChainId } from './parse-revision-number-from-chain-id';
 
 export interface IbcInSlice {
   selectedChain?: ChainInfo;
@@ -206,21 +207,6 @@ const getCounterpartyChannelId = (
   }
 
   return counterpartyChannelId;
-};
-
-/**
- * Examples:
- * getRevisionNumberFromChainId("grand-1") returns 1n
- * getRevisionNumberFromChainId("osmo-test-5") returns 5n
- * getRevisionNumberFromChainId("penumbra-testnet-deimos-7") returns 7n
- */
-export const parseRevisionNumberFromChainId = (chainId: string): bigint => {
-  const match = chainId.match(/-(\d+)$/);
-  if (match?.[1]) {
-    return BigInt(match[1]);
-  } else {
-    throw new Error(`No revision number found within chain id: ${chainId}`);
-  }
 };
 
 // Get timeout from penumbra chain blocks

--- a/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.test.ts
+++ b/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { parseRevisionNumberFromChainId } from './ibc-in';
+import { parseRevisionNumberFromChainId } from './parse-revision-number-from-chain-id';
 
 describe('parseRevisionNumberFromChainId', () => {
   test('should extract the number at the end of a well-formatted string as a BigInt', () => {

--- a/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.ts
+++ b/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Examples:
+ * getRevisionNumberFromChainId("grand-1") returns 1n
+ * getRevisionNumberFromChainId("osmo-test-5") returns 5n
+ * getRevisionNumberFromChainId("penumbra-testnet-deimos-7") returns 7n
+ */
+export const parseRevisionNumberFromChainId = (chainId: string): bigint => {
+  const match = chainId.match(/-(\d+)$/);
+  if (match?.[1]) {
+    return BigInt(match[1]);
+  } else {
+    throw new Error(`No revision number found within chain id: ${chainId}`);
+  }
+};

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -229,8 +229,8 @@ const unknownAddrIsValid = (chain: Chain | undefined, address: string): boolean 
 export const filterBalancesPerChain = (
   allBalances: BalancesResponse[],
   chain: Chain | undefined,
-  stakingTokenMetadata: Metadata,
   registryAssets: Metadata[],
+  stakingTokenMetadata?: Metadata,
 ): BalancesResponse[] => {
   const penumbraAssetId = getAssetId(stakingTokenMetadata);
   const assetsWithMatchingChannel = registryAssets

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -19,6 +19,10 @@ import { createSharedSlice, SharedSlice } from './shared';
  */
 enableMapSet();
 
+/**
+ * Slices are objects in state that have their own state and actions for a
+ * specific set of concerns.
+ */
 export interface AllSlices {
   balances: BalancesSlice;
   ibcIn: IbcInSlice;

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -10,6 +10,7 @@ import { createUnclaimedSwapsSlice, UnclaimedSwapsSlice } from './unclaimed-swap
 import { createTransactionsSlice, TransactionsSlice } from './transactions';
 import { createIbcInSlice, IbcInSlice } from './ibc-in';
 import { createBalancesSlice, BalancesSlice } from './balances';
+import { createSharedSlice, SharedSlice } from './shared';
 
 /**
  * Required to enable use of `Map`s in Zustand state when using Immer
@@ -23,6 +24,7 @@ export interface AllSlices {
   ibcIn: IbcInSlice;
   ibcOut: IbcOutSlice;
   send: SendSlice;
+  shared: SharedSlice;
   staking: StakingSlice;
   status: StatusSlice;
   swap: SwapSlice;
@@ -43,6 +45,7 @@ export const initializeStore = () => {
     ibcIn: createIbcInSlice()(setState, getState, store),
     ibcOut: createIbcOutSlice()(setState, getState, store),
     send: createSendSlice()(setState, getState, store),
+    shared: createSharedSlice()(setState, getState, store),
     staking: createStakingSlice()(setState, getState, store),
     status: createStatusSlice()(setState, getState, store),
     swap: createSwapSlice()(setState, getState, store),

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -9,7 +9,7 @@ import { createStatusSlice, StatusSlice } from './status';
 import { createUnclaimedSwapsSlice, UnclaimedSwapsSlice } from './unclaimed-swaps';
 import { createTransactionsSlice, TransactionsSlice } from './transactions';
 import { createIbcInSlice, IbcInSlice } from './ibc-in';
-import { BalancesSlice, createBalancesSlice } from './balances';
+import { createBalancesSlice, BalancesSlice } from './balances';
 
 /**
  * Required to enable use of `Map`s in Zustand state when using Immer

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -9,6 +9,7 @@ import { createStatusSlice, StatusSlice } from './status';
 import { createUnclaimedSwapsSlice, UnclaimedSwapsSlice } from './unclaimed-swaps';
 import { createTransactionsSlice, TransactionsSlice } from './transactions';
 import { createIbcInSlice, IbcInSlice } from './ibc-in';
+import { BalancesSlice, createBalancesSlice } from './balances';
 
 /**
  * Required to enable use of `Map`s in Zustand state when using Immer
@@ -18,6 +19,7 @@ import { createIbcInSlice, IbcInSlice } from './ibc-in';
 enableMapSet();
 
 export interface AllSlices {
+  balances: BalancesSlice;
   ibcIn: IbcInSlice;
   ibcOut: IbcOutSlice;
   send: SendSlice;
@@ -37,6 +39,7 @@ export type SliceCreator<SliceInterface> = StateCreator<
 
 export const initializeStore = () => {
   return immer((setState, getState: () => AllSlices, store) => ({
+    balances: createBalancesSlice()(setState, getState, store),
     ibcIn: createIbcInSlice()(setState, getState, store),
     ibcOut: createIbcOutSlice()(setState, getState, store),
     send: createSendSlice()(setState, getState, store),

--- a/apps/minifront/src/state/send.ts
+++ b/apps/minifront/src/state/send.ts
@@ -22,8 +22,6 @@ import { fromValueView } from '@penumbra-zone/types/amount';
 import { isAddress } from '@penumbra-zone/bech32m/penumbra';
 import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
 import { getTransferableBalancesResponses } from '../components/send/helpers';
-import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
-import { getStakingTokenMetadata } from '../fetchers/registry';
 
 export const { transferableBalancesResponses, useTransferableBalancesResponses } = createZQuery({
   name: 'transferableBalancesResponses',
@@ -48,22 +46,8 @@ export const { transferableBalancesResponses, useTransferableBalancesResponses }
   },
 });
 
-export const { stakingTokenMetadata, useStakingTokenMetadata } = createZQuery({
-  name: 'stakingTokenMetadata',
-  fetch: getStakingTokenMetadata,
-  getUseStore: () => useStore,
-  get: state => state.send.stakingTokenMetadata,
-  set: setter => {
-    const newState = setter(useStore.getState().send.stakingTokenMetadata);
-    useStore.setState(state => {
-      state.send.stakingTokenMetadata = newState;
-    });
-  },
-});
-
 export interface SendSlice {
   transferableBalancesResponses: ZQueryState<BalancesResponse[]>;
-  stakingTokenMetadata: ZQueryState<Metadata>;
   selection: BalancesResponse | undefined;
   setSelection: (selection: BalancesResponse) => void;
   amount: string;
@@ -83,7 +67,6 @@ export interface SendSlice {
 export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
   return {
     transferableBalancesResponses,
-    stakingTokenMetadata,
     selection: undefined,
     amount: '',
     recipient: '',

--- a/apps/minifront/src/state/shared.ts
+++ b/apps/minifront/src/state/shared.ts
@@ -1,0 +1,25 @@
+import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
+import { SliceCreator, useStore } from '.';
+import { getStakingTokenMetadata } from '../fetchers/registry';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+export const { stakingTokenMetadata, useStakingTokenMetadata } = createZQuery({
+  name: 'stakingTokenMetadata',
+  fetch: getStakingTokenMetadata,
+  getUseStore: () => useStore,
+  get: state => state.shared.stakingTokenMetadata,
+  set: setter => {
+    const newState = setter(useStore.getState().shared.stakingTokenMetadata);
+    useStore.setState(state => {
+      state.shared.stakingTokenMetadata = newState;
+    });
+  },
+});
+
+export interface SharedSlice {
+  stakingTokenMetadata: ZQueryState<Metadata>;
+}
+
+export const createSharedSlice = (): SliceCreator<SharedSlice> => () => ({
+  stakingTokenMetadata,
+});

--- a/apps/minifront/src/state/staking/index.test.ts
+++ b/apps/minifront/src/state/staking/index.test.ts
@@ -242,17 +242,14 @@ describe('Staking Slice', () => {
   it('has correct initial state', () => {
     expect(useStore.getState().staking).toEqual({
       account: 0,
-      accountSwitcherFilter: [],
       action: undefined,
       amount: '',
       validatorInfo: undefined,
       delegationsByAccount: new Map(),
-      unstakedTokensByAccount: new Map(),
       unbondingTokensByAccount: new Map(),
       setAccount: expect.any(Function) as unknown,
       loadDelegationsForCurrentAccount: expect.any(Function) as unknown,
       loadUnbondingTokensForCurrentAccount: expect.any(Function) as unknown,
-      loadAndReduceBalances: expect.any(Function) as unknown,
       delegate: expect.any(Function) as unknown,
       undelegate: expect.any(Function) as unknown,
       undelegateClaim: expect.any(Function) as unknown,
@@ -262,6 +259,7 @@ describe('Staking Slice', () => {
       error: undefined,
       loading: false,
       votingPowerByValidatorInfo: {},
+      stakingTokensAndFilter: expect.objectContaining({ data: undefined }) as unknown,
     });
   });
 
@@ -291,15 +289,5 @@ describe('Staking Slice', () => {
     expect(getState().staking.votingPowerByValidatorInfo).toEqual({});
     await getState().staking.loadDelegationsForCurrentAccount();
     expect(Object.values(getState().staking.votingPowerByValidatorInfo).length).toBe(4);
-  });
-
-  describe('loadAndReduceBalances()', () => {
-    beforeEach(async () => {
-      await useStore.getState().staking.loadAndReduceBalances();
-    });
-
-    it('includes accounts with tokens relevant to staking', () => {
-      expect(useStore.getState().staking.accountSwitcherFilter).toEqual([0]);
-    });
   });
 });

--- a/apps/minifront/src/state/transactions.ts
+++ b/apps/minifront/src/state/transactions.ts
@@ -1,41 +1,62 @@
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
-import { SliceCreator } from '.';
+import { SliceCreator, useStore } from '.';
 import { viewClient } from '../clients';
 import { getTransactionClassificationLabel } from '@penumbra-zone/perspective/transaction/classify';
+import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
+import { TransactionInfoResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 
 export interface TransactionSummary {
   height: number;
   hash: string;
   description: string;
 }
+const byHeight = (a: TransactionSummary, b: TransactionSummary) => b.height - a.height;
+
+const getHash = (tx: TransactionInfoResponse) =>
+  tx.txInfo?.id?.inner ? uint8ArrayToHex(tx.txInfo.id.inner) : 'unknown';
+
+export const { summaries, useSummaries } = createZQuery({
+  name: 'summaries',
+  fetch: () => viewClient.transactionInfo({}),
+  stream: () => {
+    const txIdsToKeep = new Set<string>();
+    return {
+      onValue: (prevState: TransactionSummary[] | undefined = [], tx: TransactionInfoResponse) => {
+        const hash = getHash(tx);
+        txIdsToKeep.add(hash);
+
+        const summary = {
+          height: Number(tx.txInfo?.height ?? 0n),
+          hash,
+          description: getTransactionClassificationLabel(tx.txInfo?.view),
+        };
+
+        const existingIndex = prevState.findIndex(summary => summary.hash === hash);
+
+        // Update existing transactions in place, rather than appending
+        // duplicates.
+        if (existingIndex >= 0) return prevState.toSpliced(existingIndex, 1, summary);
+        else return [...prevState, summary].sort(byHeight);
+      },
+
+      onEnd: (prevState: TransactionSummary[] | undefined = []) =>
+        prevState.filter(({ hash }) => txIdsToKeep.has(hash)),
+    };
+  },
+  getUseStore: () => useStore,
+  get: state => state.transactions.summaries,
+  set: setter => {
+    const newState = setter(useStore.getState().transactions.summaries);
+    useStore.setState(state => {
+      state.transactions.summaries = newState;
+    });
+  },
+});
 
 export interface TransactionsSlice {
-  summaries: TransactionSummary[];
-  loadSummaries: () => Promise<void>;
+  summaries: ZQueryState<TransactionSummary[]>;
 }
 
-export const createTransactionsSlice = (): SliceCreator<TransactionsSlice> => (set, get) => ({
-  summaries: [],
-
-  loadSummaries: async () => {
-    set(state => {
-      state.transactions.summaries = [];
-    });
-
-    for await (const tx of viewClient.transactionInfo({})) {
-      const summary = {
-        height: Number(tx.txInfo?.height ?? 0n),
-        hash: tx.txInfo?.id?.inner ? uint8ArrayToHex(tx.txInfo.id.inner) : 'unknown',
-        description: getTransactionClassificationLabel(tx.txInfo?.view),
-      };
-
-      const summaries = [...get().transactions.summaries, summary].sort(
-        (a, b) => b.height - a.height,
-      );
-
-      set(state => {
-        state.transactions.summaries = summaries;
-      });
-    }
-  },
+export const createTransactionsSlice = (): SliceCreator<TransactionsSlice> => () => ({
+  summaries,
 });

--- a/apps/minifront/src/state/transactions.ts
+++ b/apps/minifront/src/state/transactions.ts
@@ -3,7 +3,11 @@ import { SliceCreator, useStore } from '.';
 import { viewClient } from '../clients';
 import { getTransactionClassificationLabel } from '@penumbra-zone/perspective/transaction/classify';
 import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
-import { TransactionInfoResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import {
+  TransactionInfo,
+  TransactionInfoResponse,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { getTxInfoByHash } from '../fetchers/tx-info-by-hash';
 
 export interface TransactionSummary {
   height: number;
@@ -53,10 +57,25 @@ export const { summaries, useSummaries } = createZQuery({
   },
 });
 
+export const { transactionInfo, useTransactionInfo } = createZQuery({
+  name: 'transactionInfo',
+  fetch: getTxInfoByHash,
+  getUseStore: () => useStore,
+  get: state => state.transactions.transactionInfo,
+  set: setter => {
+    const newState = setter(useStore.getState().transactions.transactionInfo);
+    useStore.setState(state => {
+      state.transactions.transactionInfo = newState;
+    });
+  },
+});
+
 export interface TransactionsSlice {
+  transactionInfo: ZQueryState<TransactionInfo, Parameters<typeof getTxInfoByHash>>;
   summaries: ZQueryState<TransactionSummary[]>;
 }
 
 export const createTransactionsSlice = (): SliceCreator<TransactionsSlice> => () => ({
   summaries,
+  transactionInfo,
 });

--- a/apps/minifront/src/utils/zero-value-view.tsx
+++ b/apps/minifront/src/utils/zero-value-view.tsx
@@ -6,7 +6,7 @@ import {
  * A default `ValueView` to render when we don't have any balance data for a
  * particular token.
  */
-export const zeroValueView = (metadata: Metadata) =>
+export const zeroValueView = (metadata?: Metadata) =>
   new ValueView({
     valueView: {
       case: 'knownAssetId',

--- a/packages/zquery/src/types.ts
+++ b/packages/zquery/src/types.ts
@@ -84,7 +84,7 @@ export interface CreateZQueryUnaryProps<
    * })
    * ```
    */
-  set: (setter: <DataType, T extends ZQueryState<DataType>>(prevState: T) => T) => void;
+  set: (setter: <DataType, T extends ZQueryState<DataType, FetchArgs>>(prevState: T) => T) => void;
 }
 
 export interface CreateZQueryStreamingProps<
@@ -282,7 +282,7 @@ export interface CreateZQueryStreamingProps<
    * ```
    */
   set: (
-    setter: <DataType extends ProcessedDataType, T extends ZQueryState<DataType>>(
+    setter: <DataType extends ProcessedDataType, T extends ZQueryState<DataType, FetchArgs>>(
       prevState: T,
     ) => T,
   ) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@radix-ui/react-portal':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@remix-run/router':
+        specifier: ^1.16.1
+        version: 1.16.1
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
This PR goes through a bunch of routes where we're using react-router loaders, and replaces loader functionality with ZQuery. Note that this means some assumptions have changed about when data is available. react-router loaders wait to render their route components until data has loaded, which means your component can assume the data is already present. Since we're now effectively loading data from `useEffect()` (by way of ZQuery), we can't assume that data is present just because a component is rendered. So you'll see some instances of code that accounts for `undefined` where we didn't previously have to.

One of the benefits of this change is that route changes are instant. There's no lag time between when you click on a link to a route, and when the route changes, like there was before when route changes were blocked by loaders.

## Before (note the delayed route changes after I click)

https://github.com/penumbra-zone/web/assets/1121544/7fbb50a0-4acf-4789-b0d2-51d99c49fcef



## After (note the instant route changes after I click)

https://github.com/penumbra-zone/web/assets/1121544/22a7dba1-3ae8-4fef-a753-5e3f8479669e



## In this PR
- Remove the balances loader and create a `balances` slice with a `balancesByAccount` ZQuery object.
- Remove the Send form's loader and create a `transferableBalancesResponses` ZQuery object in the send state.
- Create a `shared` Zustand slice and added a `stakingTokenMetadata` ZQuery object to it, to be used by the send form and the IBC UIs.
- Remove the staking page's loader; in its place, use `state.shared.stakingTokenMetadata`, and combine the `accountSwitcherFilter` and `unstakedTokensByAccount` into a single ZQuery object, since they both depend on the same data.
- Remove the transactions' page's loader; in its place, convert its slice to use a ZQuery object.

## Future PRs
- Convert the `SwapLoader` and `IbcLoader` to ZQuery. Those look a bit involved and this PR is already touching a lot of files, so I haven't done those yet.
- Convert more of the staking slice to ZQuery. That would be a bit more involved as well, and doesn't involve getting rid of loaders, so I figured I'd punt on that for now.

Relates to #1243