### PR TITLE
Remove mobile wallets from cosmos-kit

### DIFF
--- a/apps/minifront/src/components/ibc/ibc-in/chain-provider.tsx
+++ b/apps/minifront/src/components/ibc/ibc-in/chain-provider.tsx
@@ -28,21 +28,8 @@ export const IbcChainProvider = ({ registry, children }: IbcProviderProps) => {
     <ChainProvider
       chains={chainsToDisplay}
       assetLists={assets}
-      wallets={wallets}
-      walletConnectOptions={{
-        signClient: {
-          projectId: 'a8510432ebb71e6948cfd6cde54b70f7', // TODO: get penumbra project id
-          relayUrl: 'wss://relay.walletconnect.org',
-          metadata: {
-            name: 'IBC into Penumbra',
-            description: 'Penumbra is a cosmos IBC-connected zk privacy chain',
-            url: 'https://penumbra.zone/',
-            icons: [
-              'https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png',
-            ],
-          },
-        },
-      }}
+      // Not using mobile wallets as WalletConnect is a centralized service that requires an account
+      wallets={wallets.extension}
       signerOptions={signerOptions}
       modalTheme={{ defaultTheme: 'light' }}
     >


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/1050

All of these require the project to have a WalletConnect account and API key. Not compatible with a decentralized project. Removing from the list:

<img width="349" alt="Screenshot 2024-06-18 at 11 45 16 AM" src="https://github.com/penumbra-zone/web/assets/16624263/9e9d897b-d4c2-4504-b699-53c3094e9134">

Normal chrome extension integrations still in place:

<img width="345" alt="Screenshot 2024-06-18 at 11 48 09 AM" src="https://github.com/penumbra-zone/web/assets/16624263/f97fb257-d629-4577-9dd4-ce15a3065a2f">
