### PR TITLE
properly output esm

### DIFF
--- a/.changeset/funny-schools-kick.md
+++ b/.changeset/funny-schools-kick.md
@@ -1,0 +1,18 @@
+---
+'@penumbra-zone/transport-chrome': minor
+'@penumbra-zone/transport-dom': minor
+'@penumbra-zone/perspective': minor
+'@penumbra-zone/protobuf': minor
+'@penumbra-zone/services': minor
+'@repo/tsconfig': minor
+'@penumbra-zone/bech32m': minor
+'@penumbra-zone/getters': minor
+'@penumbra-zone/storage': minor
+'@penumbra-zone/client': minor
+'@penumbra-zone/crypto-web': minor
+'@penumbra-zone/query': minor
+'@penumbra-zone/types': minor
+'@penumbra-zone/wasm': minor
+---
+
+properly build esm relative paths

--- a/.changeset/poor-rabbits-deny.md
+++ b/.changeset/poor-rabbits-deny.md
@@ -1,6 +1,6 @@
 ---
 'minifront': minor
-'@penumbra-zone/ui': minor
+'@repo/ui': minor
 ---
 
 UI: add `compact` prop to render a minimalistic version of the AccountSwitcher component.

--- a/buf-replacer.js
+++ b/buf-replacer.js
@@ -1,0 +1,6 @@
+exports.default = function ({ orig }) {
+  if (orig.startsWith("from '@buf/") && !orig.endsWith(".js'")) {
+    return orig.slice(0, -1) + ".js'";
+  }
+  return orig;
+};

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "syncpack": "^12.3.2",
     "tailwindcss": "^3.4.3",
     "tailwindcss-animate": "^1.0.7",
+    "tsc-alias": "^1.8.10",
     "turbo": "^1.13.3",
     "typescript": "5.5.1-rc",
     "vite": "^5.2.11",

--- a/packages/bech32m/package.json
+++ b/packages/bech32m/package.json
@@ -8,8 +8,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "tsc --noEmit && eslint src",
     "test": "vitest run"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,8 +8,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src"
   },
   "files": [

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/getters/package.json
+++ b/packages/getters/package.json
@@ -8,8 +8,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -8,8 +8,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -8,8 +8,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src"
   },
   "files": [

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && tsc-alias",
     "clean": "rm -rfv dist package penumbra-zone-transport-dom-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/transport-chrome/package.json
+++ b/packages/transport-chrome/package.json
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && tsc-alias",
     "clean": "rm -rfv dist package penumbra-zone-transport-dom-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/transport-dom/package.json
+++ b/packages/transport-dom/package.json
@@ -7,7 +7,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && tsc-alias",
     "clean": "rm -rfv dist package penumbra-zone-transport-dom-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -29,6 +29,12 @@
   },
   "tsc-alias": {
     "verbose": true,
-    "resolveFullPaths": true
+    "resolveFullPaths": true,
+    "replacers": {
+      "buf-js": {
+        "enabled": true,
+        "file": "../../buf-replacer.js"
+      }
+    }
   }
 }

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -26,5 +26,9 @@
     "resolveJsonModule": true,
     "target": "ESNext",
     "module": "ES2022"
+  },
+  "tsc-alias": {
+    "verbose": true,
+    "resolveFullPaths": true
   }
 }

--- a/packages/tsconfig/vite.json
+++ b/packages/tsconfig/vite.json
@@ -3,8 +3,8 @@
   "display": "Vite",
   "extends": "./base.json",
   "compilerOptions": {
+    "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
-    "noEmit": true
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"]
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
-    "clean": "rm -rfv dist package penumbra-zone-*.tgz tsconfig.tsbuildinfo",
+    "build": "tsc --build && tsc-alias",
+    "clean": "rm -rfv dist package penumbra-zone-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "extends": "@repo/tsconfig/base.json",
-  "include": ["components", "lib", "tests-setup.ts"],
-  "compilerOptions": {
-    "noEmit": true,
-    "declarationMap": false,
-    "declaration": false,
-    "sourceMap": false,
-    "jsx": "react-jsx"
-  }
+  "extends": "@repo/tsconfig/vite.json",
+  "include": ["components", "lib", "tests-setup.ts"]
 }

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && tsc-alias",
     "clean": "rm -rfv dist wasm package penumbra-zone-wasm-*.tgz",
     "clean:rust": "cargo clean --manifest-path ./crate/Cargo.toml",
     "compile": "cd crate && wasm-pack build --no-pack --target bundler --out-name index --out-dir ../wasm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.1(@swc/helpers@0.5.11))(@types/node@20.14.4)(typescript@5.5.1-rc)))
+      tsc-alias:
+        specifier: ^1.8.10
+        version: 1.8.10
       turbo:
         specifier: ^1.13.3
         version: 1.13.4
@@ -5950,6 +5953,10 @@ packages:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
@@ -8051,6 +8058,10 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  mylas@2.1.13:
+    resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
+    engines: {node: '>=12.0.0'}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -8464,6 +8475,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  plimit-lit@1.6.1:
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
+
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
     engines: {node: '>=10'}
@@ -8664,6 +8679,10 @@ packages:
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
+  queue-lit@1.5.2:
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9655,6 +9674,10 @@ packages:
 
   ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
+
+  tsc-alias@1.8.10:
+    resolution: {integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==}
+    hasBin: true
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -16294,7 +16317,7 @@ snapshots:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.1
+      prettier-fallback: prettier@3.3.2
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.2
@@ -18699,6 +18722,8 @@ snapshots:
   commander@4.1.1: {}
 
   commander@6.2.1: {}
+
+  commander@9.5.0: {}
 
   commondir@1.0.1: {}
 
@@ -21144,6 +21169,8 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  mylas@2.1.13: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -21633,6 +21660,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  plimit-lit@1.6.1:
+    dependencies:
+      queue-lit: 1.5.2
+
   polished@4.3.1:
     dependencies:
       '@babel/runtime': 7.24.7
@@ -21856,6 +21887,8 @@ snapshots:
   querystring-es3@0.2.1: {}
 
   querystringify@2.2.0: {}
+
+  queue-lit@1.5.2: {}
 
   queue-microtask@1.2.3: {}
 
@@ -23050,6 +23083,15 @@ snapshots:
       '@swc/core': 1.6.1(@swc/helpers@0.5.11)
 
   ts-toolbelt@9.6.0: {}
+
+  tsc-alias@1.8.10:
+    dependencies:
+      chokidar: 3.6.0
+      commander: 9.5.0
+      globby: 11.1.0
+      mylas: 2.1.13
+      normalize-path: 3.0.0
+      plimit-lit: 1.6.1
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
uses `tsc-alias` to generate correct import paths for esm support

this may have been related to issues @VanishMax was experiencing

this should permit esm resolution to work properly for the packages' internal modules

edit: okay, tsc-alias doesn't completely solve the issue - 

bundlers are fine now, but anything that needs to use node module resolution (vitest, many consumers) will encounter problems because our packages currently use nonstandard module resolution to identify imports from external dependencies.

the tsc-alias tool is only indended for internal paths.

probably we should just comply with esm path spec internally, but that would require changing nearly every import in the codebase, so this PR now combines tsc-alias and changes imports to name external 'js' files that are not resolved via package.json exports.

this mainly just means pb types imports now require a 'js' extension, because those generated packages don't actually define any exports or main configuration.

there's hundreds of pb type imports, so it's a large diff. but this means we don't have to configure a bundler for every package, and the packages should have much better support for many consumers.

edit again:

instead of literally modifying imports, now mutating in a more custom way

this solution is bad. eventually a larger linter/bundler reconfig should happen