### PR TITLE
feat: #1169: add swap query params

### DIFF
--- a/.changeset/lovely-teachers-relax.md
+++ b/.changeset/lovely-teachers-relax.md
@@ -1,0 +1,5 @@
+---
+'minifront': minor
+---
+
+Add query parameters to the swap page to allow pre-setting swap assets

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -73,7 +73,7 @@ export default function AssetsTable() {
             </TableHeader>
             <TableBody>
               {account.balances.filter(shouldDisplay).map((assetBalance, index) => (
-                <TableRow key={index}>
+                <TableRow className='group' key={index}>
                   <TableCell>
                     <ValueViewComponent view={assetBalance.balanceView} />
                   </TableCell>
@@ -81,8 +81,13 @@ export default function AssetsTable() {
                     <EquivalentValues valueView={assetBalance.balanceView} />
                   </TableCell>
                   <TableCell>
-                    <Link to={getTradeLink(assetBalance)}>
-                      <Button>Trade</Button>
+                    <Link
+                      className='transition group-hover:opacity-100 md:opacity-0'
+                      to={getTradeLink(assetBalance)}
+                    >
+                      <Button variant='secondary' size='md'>
+                        Trade
+                      </Button>
                     </Link>
                   </TableCell>
                 </TableRow>

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -1,4 +1,6 @@
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { AddressComponent, AddressIcon } from '@repo/ui/components/ui/address';
+import { Button } from '@repo/ui/components/ui/button';
 import {
   Table,
   TableBody,
@@ -12,6 +14,17 @@ import { EquivalentValues } from './equivalent-values';
 import { Fragment } from 'react';
 import { shouldDisplay } from './helpers';
 import { useBalancesByAccount } from '../../../state/balances';
+import { PagePath } from '../../metadata/paths';
+import { Link } from 'react-router-dom';
+import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import { getAddressIndex } from '@penumbra-zone/getters/address-view';
+
+const getTradeLink = (balance: BalancesResponse): string => {
+  const metadata = getMetadataFromBalancesResponseOptional(balance);
+  const accountIndex = getAddressIndex(balance.accountAddress).account;
+  const accountQuery = accountIndex ? `&account=${accountIndex}` : '';
+  return metadata ? `${PagePath.SWAP}?from=${metadata.symbol}${accountQuery}` : PagePath.SWAP;
+};
 
 export default function AssetsTable() {
   const balancesByAccount = useBalancesByAccount();
@@ -31,45 +44,53 @@ export default function AssetsTable() {
   }
 
   return (
-    <Table>
-      {balancesByAccount.data?.map(account => (
-        <Fragment key={account.account}>
-          <TableHeader className='group'>
-            <TableRow>
-              <TableHead colSpan={2}>
-                <div className='flex max-w-full flex-col justify-center gap-2 pt-8 group-[:first-of-type]:pt-0 md:flex-row'>
-                  <div className='flex items-center justify-center gap-2'>
-                    <AddressIcon address={account.address} size={20} />
-                    <h2 className='whitespace-nowrap font-bold md:text-base xl:text-xl'>
-                      Account #{account.account}
-                    </h2>
-                  </div>
+    <div className='w-full overflow-x-auto'>
+      <Table>
+        {balancesByAccount.data?.map(account => (
+          <Fragment key={account.account}>
+            <TableHeader className='group'>
+              <TableRow>
+                <TableHead colSpan={2}>
+                  <div className='flex max-w-full flex-col justify-center gap-2 pt-8 group-[:first-of-type]:pt-0 md:flex-row'>
+                    <div className='flex items-center justify-center gap-2'>
+                      <AddressIcon address={account.address} size={20} />
+                      <h2 className='whitespace-nowrap font-bold md:text-base xl:text-xl'>
+                        Account #{account.account}
+                      </h2>
+                    </div>
 
-                  <div className='max-w-72 truncate'>
-                    <AddressComponent address={account.address} />
+                    <div className='max-w-72 truncate'>
+                      <AddressComponent address={account.address} />
+                    </div>
                   </div>
-                </div>
-              </TableHead>
-            </TableRow>
-            <TableRow>
-              <TableHead>Balance</TableHead>
-              <TableHead>Estimated equivalent(s)</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {account.balances.filter(shouldDisplay).map((assetBalance, index) => (
-              <TableRow key={index}>
-                <TableCell>
-                  <ValueViewComponent view={assetBalance.balanceView} />
-                </TableCell>
-                <TableCell>
-                  <EquivalentValues valueView={assetBalance.balanceView} />
-                </TableCell>
+                </TableHead>
               </TableRow>
-            ))}
-          </TableBody>
-        </Fragment>
-      ))}
-    </Table>
+              <TableRow>
+                <TableHead>Balance</TableHead>
+                <TableHead>Value</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {account.balances.filter(shouldDisplay).map((assetBalance, index) => (
+                <TableRow key={index}>
+                  <TableCell>
+                    <ValueViewComponent view={assetBalance.balanceView} />
+                  </TableCell>
+                  <TableCell>
+                    <EquivalentValues valueView={assetBalance.balanceView} />
+                  </TableCell>
+                  <TableCell>
+                    <Link to={getTradeLink(assetBalance)}>
+                      <Button>Trade</Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Fragment>
+        ))}
+      </Table>
+    </div>
   );
 }

--- a/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
+++ b/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
@@ -37,7 +37,8 @@ const getAssetOutBalance = (
     const balanceViewMetadata = getMetadataFromBalancesResponse(balance);
 
     return (
-      balance.accountAddress?.equals(assetIn.accountAddress) && assetOut.equals(balanceViewMetadata)
+      getAddressIndex(balance.accountAddress).equals(getAddressIndex(assetIn.accountAddress)) &&
+      assetOut.equals(balanceViewMetadata)
     );
   });
   const matchedBalance = getBalanceView.optional()(match);

--- a/apps/minifront/src/state/swap/index.ts
+++ b/apps/minifront/src/state/swap/index.ts
@@ -23,6 +23,7 @@ import { getSwappableBalancesResponses, isSwappable } from '../../components/swa
 import { getAllAssets } from '../../fetchers/assets';
 import { isValidAmount } from '../helpers';
 import { setInitialAssets } from './set-initial-assets';
+import { setSwapQueryParams } from './query-params';
 
 export const { balancesResponses, useBalancesResponses } = createZQuery({
   name: 'balancesResponses',
@@ -34,7 +35,7 @@ export const { balancesResponses, useBalancesResponses } = createZQuery({
     useStore.setState(state => {
       state.swap.balancesResponses = newState;
     });
-    setInitialAssets(useStore.getState().swap);
+    setInitialAssets();
   },
 });
 
@@ -51,7 +52,7 @@ export const { swappableAssets, useSwappableAssets } = createZQuery({
     useStore.setState(state => {
       state.swap.swappableAssets = newState;
     });
-    setInitialAssets(useStore.getState().swap);
+    setInitialAssets();
   },
 });
 
@@ -133,6 +134,7 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get, store) 
         );
       }
     });
+    setSwapQueryParams(get());
   },
   setAssetOut: metadata => {
     get().swap.resetSubslices();
@@ -146,6 +148,7 @@ export const createSwapSlice = (): SliceCreator<SwapSlice> => (set, get, store) 
         );
       }
     });
+    setSwapQueryParams(get());
   },
   setAmount: amount => {
     get().swap.resetSubslices();

--- a/apps/minifront/src/state/swap/index.ts
+++ b/apps/minifront/src/state/swap/index.ts
@@ -21,22 +21,47 @@ import { getMetadata } from '@penumbra-zone/getters/value-view';
 import { createZQuery, ZQueryState } from '@penumbra-zone/zquery';
 import { getSwappableBalancesResponses, isSwappable } from '../../components/swap/helpers';
 import { getAllAssets } from '../../fetchers/assets';
-import { emptyBalanceResponse } from '../../utils/empty-balance-response';
 import { isValidAmount } from '../helpers';
+import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import { emptyBalanceResponse } from '../../utils/empty-balance-response';
 
 // When both `balancesResponses` and `swappableAssets` are loaded, set initial assetIn and assetOut
 const setInitialAssets = (state: SwapSlice) => {
   if (state.swappableAssets.loading || state.balancesResponses.loading) return;
 
-  const firstBalancesResponse = state.balancesResponses.data?.[0];
+  // Get the `from` and `to` query params and match them to the balances and metadata
+  const searchParams = new URLSearchParams(window.location.hash.split('?')[1] ?? '');
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  let balanceFrom = from
+    ? state.balancesResponses.data?.find(
+        balance => getMetadataFromBalancesResponseOptional(balance)?.symbol === from,
+      )
+    : undefined;
+  if (!balanceFrom) {
+    const matchingMetadata = state.swappableAssets.data?.find(metadata => metadata.symbol === from);
+    balanceFrom = matchingMetadata ? emptyBalanceResponse(matchingMetadata) : undefined;
+  }
+  const metadataTo = to
+    ? state.swappableAssets.data?.find(metadata => metadata.symbol === to)
+    : undefined;
+
   const firstMetadata = state.swappableAssets.data?.[0];
-  const secondMetadata = state.swappableAssets.data?.[0];
-  if (firstBalancesResponse) {
+  const secondMetadata = state.swappableAssets.data?.[1];
+  const firstBalancesResponse = state.balancesResponses.data?.[0];
+
+  if (balanceFrom) {
+    state.setAssetIn(balanceFrom);
+  } else if (firstBalancesResponse) {
     state.setAssetIn(firstBalancesResponse);
-    state.setAssetOut(firstMetadata);
   } else if (firstMetadata) {
     state.setAssetIn(emptyBalanceResponse(firstMetadata));
-    state.setAssetOut(secondMetadata);
+  }
+
+  if (metadataTo) {
+    state.setAssetOut(metadataTo);
+  } else {
+    state.setAssetOut(firstBalancesResponse ? firstMetadata : secondMetadata);
   }
 };
 

--- a/apps/minifront/src/state/swap/index.ts
+++ b/apps/minifront/src/state/swap/index.ts
@@ -22,48 +22,7 @@ import { createZQuery, ZQueryState } from '@penumbra-zone/zquery';
 import { getSwappableBalancesResponses, isSwappable } from '../../components/swap/helpers';
 import { getAllAssets } from '../../fetchers/assets';
 import { isValidAmount } from '../helpers';
-import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
-import { emptyBalanceResponse } from '../../utils/empty-balance-response';
-
-// When both `balancesResponses` and `swappableAssets` are loaded, set initial assetIn and assetOut
-const setInitialAssets = (state: SwapSlice) => {
-  if (state.swappableAssets.loading || state.balancesResponses.loading) return;
-
-  // Get the `from` and `to` query params and match them to the balances and metadata
-  const searchParams = new URLSearchParams(window.location.hash.split('?')[1] ?? '');
-  const from = searchParams.get('from');
-  const to = searchParams.get('to');
-  let balanceFrom = from
-    ? state.balancesResponses.data?.find(
-        balance => getMetadataFromBalancesResponseOptional(balance)?.symbol === from,
-      )
-    : undefined;
-  if (!balanceFrom) {
-    const matchingMetadata = state.swappableAssets.data?.find(metadata => metadata.symbol === from);
-    balanceFrom = matchingMetadata ? emptyBalanceResponse(matchingMetadata) : undefined;
-  }
-  const metadataTo = to
-    ? state.swappableAssets.data?.find(metadata => metadata.symbol === to)
-    : undefined;
-
-  const firstMetadata = state.swappableAssets.data?.[0];
-  const secondMetadata = state.swappableAssets.data?.[1];
-  const firstBalancesResponse = state.balancesResponses.data?.[0];
-
-  if (balanceFrom) {
-    state.setAssetIn(balanceFrom);
-  } else if (firstBalancesResponse) {
-    state.setAssetIn(firstBalancesResponse);
-  } else if (firstMetadata) {
-    state.setAssetIn(emptyBalanceResponse(firstMetadata));
-  }
-
-  if (metadataTo) {
-    state.setAssetOut(metadataTo);
-  } else {
-    state.setAssetOut(firstBalancesResponse ? firstMetadata : secondMetadata);
-  }
-};
+import { setInitialAssets } from './set-initial-assets';
 
 export const { balancesResponses, useBalancesResponses } = createZQuery({
   name: 'balancesResponses',

--- a/apps/minifront/src/state/swap/index.ts
+++ b/apps/minifront/src/state/swap/index.ts
@@ -35,7 +35,7 @@ export const { balancesResponses, useBalancesResponses } = createZQuery({
     useStore.setState(state => {
       state.swap.balancesResponses = newState;
     });
-    setInitialAssets();
+    setInitialAssets(useStore);
   },
 });
 
@@ -52,7 +52,7 @@ export const { swappableAssets, useSwappableAssets } = createZQuery({
     useStore.setState(state => {
       state.swap.swappableAssets = newState;
     });
-    setInitialAssets();
+    setInitialAssets(useStore);
   },
 });
 

--- a/apps/minifront/src/state/swap/query-params.test.ts
+++ b/apps/minifront/src/state/swap/query-params.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setSwapQueryParams, getSwapQueryParams } from './query-params';
+import { AllSlices } from '..';
+import { emptyBalanceResponse } from '../../utils/empty-balance-response';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+
+describe('swap query params', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal('location', { hash: '#swap' });
+  });
+
+  it('parses the query correctly on full data', () => {
+    vi.stubGlobal('location', { hash: '#swap?from=TestUSD&to=USDC&account=1' });
+
+    const { from, to, account } = getSwapQueryParams();
+    expect(from).toBe('TestUSD');
+    expect(to).toBe('USDC');
+    expect(account).toBe(1);
+  });
+
+  it('parses the query correctly on partial data', () => {
+    vi.stubGlobal('location', { hash: 'swap?from=TestUSD' });
+
+    const { from, to, account } = getSwapQueryParams();
+    expect(from).toBe('TestUSD');
+    expect(to).toBe(undefined);
+    expect(account).toBe(undefined);
+  });
+
+  it('parses the query correctly on empty data', () => {
+    vi.stubGlobal('location', { hash: '' });
+
+    const { from, to, account } = getSwapQueryParams();
+    expect(from).toBe(undefined);
+    expect(to).toBe(undefined);
+    expect(account).toBe(undefined);
+  });
+
+  it('parses the query correctly on irrelevant data', () => {
+    vi.stubGlobal('location', { hash: 'swap?abc=def&hij=klm' });
+
+    const { from, to, account } = getSwapQueryParams();
+    expect(from).toBe(undefined);
+    expect(to).toBe(undefined);
+    expect(account).toBe(undefined);
+  });
+
+  it('sets the hash query correctly', () => {
+    const state = {
+      swap: {
+        assetIn: emptyBalanceResponse(new Metadata({ symbol: 'UM' }), 1),
+        assetOut: new Metadata({ symbol: 'USDC' }),
+      },
+    } as AllSlices;
+
+    setSwapQueryParams(state);
+
+    const hash = window.location.hash;
+    expect(hash).toBe('#swap?from=UM&to=USDC&account=1');
+  });
+
+  it('sets the hash query correctly on partial data', () => {
+    const state = {
+      swap: {
+        assetIn: emptyBalanceResponse(new Metadata({ symbol: 'UM' })),
+      },
+    } as AllSlices;
+
+    setSwapQueryParams(state);
+
+    const hash = window.location.hash;
+    expect(hash).toBe('#swap?from=UM');
+  });
+});

--- a/apps/minifront/src/state/swap/query-params.ts
+++ b/apps/minifront/src/state/swap/query-params.ts
@@ -1,0 +1,53 @@
+import type { AllSlices } from '..';
+import {
+  getAddressIndex,
+  getMetadataFromBalancesResponseOptional,
+} from '@penumbra-zone/getters/balances-response';
+
+interface SwapQueryParams {
+  from?: string;
+  to?: string;
+  account?: number;
+}
+
+/**
+ * Extracts and parses the swap query parameters from the URL hash: from, to, account
+ */
+export const getSwapQueryParams = (): SwapQueryParams => {
+  const searchParams = new URLSearchParams(window.location.hash.split('?')[1] ?? '');
+
+  const from = searchParams.get('from') ?? undefined;
+  const to = searchParams.get('to') ?? undefined;
+  const account = Number(searchParams.get('account')) || undefined;
+
+  return {
+    from,
+    to,
+    account,
+  };
+};
+
+/**
+ * Sets the swap query parameters in the URL hash based on the store state
+ */
+export const setSwapQueryParams = (state: AllSlices): void => {
+  const fromSymbol = getMetadataFromBalancesResponseOptional(state.swap.assetIn)?.symbol;
+  const toSymbol = state.swap.assetOut?.symbol;
+  const accountIndex = getAddressIndex.optional()(state.swap.assetIn)?.account;
+
+  const searchParams = new URLSearchParams();
+  if (fromSymbol) {
+    searchParams.append('from', fromSymbol);
+  }
+
+  if (toSymbol) {
+    searchParams.append('to', toSymbol);
+  }
+
+  if (accountIndex) {
+    searchParams.append('account', accountIndex.toString());
+  }
+
+  const pagePath = window.location.hash.split('?')[0];
+  window.location.hash = `${pagePath}?${searchParams.toString()}`;
+};

--- a/apps/minifront/src/state/swap/set-initial-assets.test.ts
+++ b/apps/minifront/src/state/swap/set-initial-assets.test.ts
@@ -1,0 +1,124 @@
+import { create } from 'zustand';
+import { AllSlices, initializeStore } from '..';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Metadata,
+  ValueView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { AddressView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { ZQueryState } from '@penumbra-zone/zquery';
+import { emptyBalanceResponse } from '../../utils/empty-balance-response';
+import { setInitialAssets } from './set-initial-assets';
+
+describe('set-initial-assets', () => {
+  const umToken = new Metadata({ symbol: 'UM', penumbraAssetId: { inner: new Uint8Array([1]) } });
+  const usdcToken = new Metadata({
+    symbol: 'USDC',
+    penumbraAssetId: { inner: new Uint8Array([2]) },
+  });
+  const osmoToken = new Metadata({
+    symbol: 'OSMO',
+    penumbraAssetId: { inner: new Uint8Array([3]) },
+  });
+
+  const swappableAssets: ZQueryState<Metadata[]> = {
+    data: [umToken, usdcToken, osmoToken],
+    loading: false,
+  } as ZQueryState<Metadata[]>;
+  const emptySwappableAssets = {
+    data: [] as Metadata[],
+    loading: false,
+  } as ZQueryState<Metadata[]>;
+
+  const umBalance = new BalancesResponse({
+    balanceView: new ValueView({
+      valueView: {
+        case: 'knownAssetId',
+        value: {
+          amount: { hi: 0n, lo: 1n },
+          metadata: umToken,
+        },
+      },
+    }),
+    accountAddress: new AddressView({
+      addressView: {
+        case: 'decoded',
+        value: {
+          index: { account: 0 },
+        },
+      },
+    }),
+  });
+  const usdcBalance = emptyBalanceResponse(usdcToken, 1);
+
+  const balancesResponses = {
+    data: [umBalance, usdcBalance],
+    loading: false,
+  } as ZQueryState<BalancesResponse[]>;
+  const emptyBalancesResponses: ZQueryState<BalancesResponse[]> = {
+    data: [] as BalancesResponse[],
+    loading: false,
+  } as ZQueryState<BalancesResponse[]>;
+
+  let useStore = create<AllSlices>()(initializeStore());
+  beforeEach(() => {
+    useStore = create<AllSlices>()(initializeStore());
+    vi.restoreAllMocks();
+    vi.stubGlobal('location', { hash: '#swap' });
+  });
+
+  it(`doesn't set data if balancesResponses or swappableAssets are empty`, () => {
+    useStore.setState(state => {
+      state.swap.balancesResponses = emptyBalancesResponses;
+      state.swap.swappableAssets = emptySwappableAssets;
+      return state;
+    });
+
+    setInitialAssets(useStore);
+
+    expect(useStore.getState().swap.assetIn).toBeUndefined();
+    expect(useStore.getState().swap.assetOut).toBeUndefined();
+  });
+
+  it('uses swappableAssets[0] to set assetIn and swappableAssets[1] to set assetOut when balancesResponses are empty', () => {
+    useStore.setState(state => {
+      state.swap.balancesResponses = emptyBalancesResponses;
+      state.swap.swappableAssets = swappableAssets;
+      return state;
+    });
+
+    setInitialAssets(useStore);
+
+    expect(useStore.getState().swap.assetIn).toStrictEqual(emptyBalanceResponse(umToken, 0));
+    expect(useStore.getState().swap.assetOut).toStrictEqual(swappableAssets.data![1]);
+  });
+
+  it('uses balancesResponses[0] to set assetIn and swappableAssets[0] to set assetOut', () => {
+    useStore.setState(state => {
+      state.swap.balancesResponses = balancesResponses;
+      state.swap.swappableAssets = swappableAssets;
+      return state;
+    });
+
+    setInitialAssets(useStore);
+
+    expect(useStore.getState().swap.assetIn).toStrictEqual(balancesResponses.data![0]);
+    expect(useStore.getState().swap.assetOut).toStrictEqual(swappableAssets.data![0]);
+  });
+
+  it('correctly sets assetIn and assetOut based on query params', () => {
+    vi.stubGlobal('location', { hash: '#swap?from=USDC&to=OSMO&account=1' });
+
+    useStore.setState(state => {
+      state.swap.balancesResponses = balancesResponses;
+      state.swap.swappableAssets = swappableAssets;
+      return state;
+    });
+
+    setInitialAssets(useStore);
+
+    expect(useStore.getState().swap.assetIn).toStrictEqual(usdcBalance);
+    expect(useStore.getState().swap.assetOut).toStrictEqual(osmoToken);
+  });
+});

--- a/apps/minifront/src/state/swap/set-initial-assets.ts
+++ b/apps/minifront/src/state/swap/set-initial-assets.ts
@@ -4,15 +4,14 @@ import {
 } from '@penumbra-zone/getters/balances-response';
 import { emptyBalanceResponse } from '../../utils/empty-balance-response';
 import { getSwapQueryParams } from './query-params';
-import { useStore } from '..';
+import type { useStore } from '..';
 
 /**
  * When both `balancesResponses` and `swappableAssets` are loaded, set initial assetIn and assetOut
  */
-export const setInitialAssets = () => {
-  useStore.setState(state => {
-    const swap = useStore.getState().swap;
-
+export const setInitialAssets = (store: typeof useStore) => {
+  const swap = store.getState().swap;
+  store.setState(state => {
     if (swap.swappableAssets.loading || swap.balancesResponses.loading) return;
 
     const { from, to, account } = getSwapQueryParams();
@@ -59,5 +58,7 @@ export const setInitialAssets = () => {
     } else {
       state.swap.assetOut = firstBalancesResponse ? firstMetadata : secondMetadata;
     }
+
+    return state;
   });
 };

--- a/apps/minifront/src/state/swap/set-initial-assets.ts
+++ b/apps/minifront/src/state/swap/set-initial-assets.ts
@@ -1,61 +1,63 @@
-import { SwapSlice } from '.';
 import {
   getAddressIndex,
   getMetadataFromBalancesResponseOptional,
 } from '@penumbra-zone/getters/balances-response';
 import { emptyBalanceResponse } from '../../utils/empty-balance-response';
+import { getSwapQueryParams } from './query-params';
+import { useStore } from '..';
 
 /**
  * When both `balancesResponses` and `swappableAssets` are loaded, set initial assetIn and assetOut
  */
-export const setInitialAssets = (state: SwapSlice) => {
-  if (state.swappableAssets.loading || state.balancesResponses.loading) return;
+export const setInitialAssets = () => {
+  useStore.setState(state => {
+    const swap = useStore.getState().swap;
 
-  // Get the `from` and `to` query params and match them to the balances and metadata
-  const searchParams = new URLSearchParams(window.location.hash.split('?')[1] ?? '');
-  const from = searchParams.get('from');
-  const to = searchParams.get('to');
-  const account = searchParams.get('account');
+    if (swap.swappableAssets.loading || swap.balancesResponses.loading) return;
 
-  // If `account` is present, filter balances by it
-  const balancesByAccount = account
-    ? state.balancesResponses.data?.filter(b => getAddressIndex(b).account === Number(account)) ??
-      []
-    : state.balancesResponses.data ?? [];
+    const { from, to, account } = getSwapQueryParams();
 
-  // Find the balance matching the `from` symbol. If balance is not found, take the asset metadata by `from` symbol
-  let balanceFrom = from
-    ? balancesByAccount.find(
-        balance => getMetadataFromBalancesResponseOptional(balance)?.symbol === from,
-      )
-    : undefined;
-  if (!balanceFrom) {
-    const matchingMetadata = state.swappableAssets.data?.find(metadata => metadata.symbol === from);
-    balanceFrom = matchingMetadata ? emptyBalanceResponse(matchingMetadata) : undefined;
-  }
+    // If `account` is present, filter balances by it
+    const balancesByAccount = account
+      ? swap.balancesResponses.data?.filter(b => getAddressIndex(b).account === account) ?? []
+      : swap.balancesResponses.data ?? [];
 
-  // Find the metadata matching the `to` symbol
-  const metadataTo = to
-    ? state.swappableAssets.data?.find(metadata => metadata.symbol === to)
-    : undefined;
+    // Find the balance matching the `from` symbol. If balance is not found, take the asset metadata by `from` symbol
+    let balanceFrom = from
+      ? balancesByAccount.find(
+          balance => getMetadataFromBalancesResponseOptional(balance)?.symbol === from,
+        )
+      : undefined;
+    if (!balanceFrom) {
+      const matchingMetadata = swap.swappableAssets.data?.find(
+        metadata => metadata.symbol === from,
+      );
+      balanceFrom = matchingMetadata ? emptyBalanceResponse(matchingMetadata, account) : undefined;
+    }
 
-  const firstMetadata = state.swappableAssets.data?.[0];
-  const secondMetadata = state.swappableAssets.data?.[1];
-  const firstBalancesResponse = state.balancesResponses.data?.[0];
+    // Find the metadata matching the `to` symbol
+    const metadataTo = to
+      ? swap.swappableAssets.data?.find(metadata => metadata.symbol === to)
+      : undefined;
 
-  // Set the initial `assetIn`
-  if (balanceFrom) {
-    state.setAssetIn(balanceFrom);
-  } else if (firstBalancesResponse) {
-    state.setAssetIn(firstBalancesResponse);
-  } else if (firstMetadata) {
-    state.setAssetIn(emptyBalanceResponse(firstMetadata));
-  }
+    const firstMetadata = swap.swappableAssets.data?.[0];
+    const secondMetadata = swap.swappableAssets.data?.[1];
+    const firstBalancesResponse = swap.balancesResponses.data?.[0];
 
-  // Set the initial `assetOut`
-  if (metadataTo) {
-    state.setAssetOut(metadataTo);
-  } else {
-    state.setAssetOut(firstBalancesResponse ? firstMetadata : secondMetadata);
-  }
+    // Set the initial `assetIn`
+    if (balanceFrom) {
+      state.swap.assetIn = balanceFrom;
+    } else if (firstBalancesResponse) {
+      state.swap.assetIn = firstBalancesResponse;
+    } else if (firstMetadata) {
+      state.swap.assetIn = emptyBalanceResponse(firstMetadata, account);
+    }
+
+    // Set the initial `assetOut`
+    if (metadataTo) {
+      state.swap.assetOut = metadataTo;
+    } else {
+      state.swap.assetOut = firstBalancesResponse ? firstMetadata : secondMetadata;
+    }
+  });
 };

--- a/apps/minifront/src/state/swap/set-initial-assets.ts
+++ b/apps/minifront/src/state/swap/set-initial-assets.ts
@@ -1,0 +1,61 @@
+import { SwapSlice } from '.';
+import {
+  getAddressIndex,
+  getMetadataFromBalancesResponseOptional,
+} from '@penumbra-zone/getters/balances-response';
+import { emptyBalanceResponse } from '../../utils/empty-balance-response';
+
+/**
+ * When both `balancesResponses` and `swappableAssets` are loaded, set initial assetIn and assetOut
+ */
+export const setInitialAssets = (state: SwapSlice) => {
+  if (state.swappableAssets.loading || state.balancesResponses.loading) return;
+
+  // Get the `from` and `to` query params and match them to the balances and metadata
+  const searchParams = new URLSearchParams(window.location.hash.split('?')[1] ?? '');
+  const from = searchParams.get('from');
+  const to = searchParams.get('to');
+  const account = searchParams.get('account');
+
+  // If `account` is present, filter balances by it
+  const balancesByAccount = account
+    ? state.balancesResponses.data?.filter(b => getAddressIndex(b).account === Number(account)) ??
+      []
+    : state.balancesResponses.data ?? [];
+
+  // Find the balance matching the `from` symbol. If balance is not found, take the asset metadata by `from` symbol
+  let balanceFrom = from
+    ? balancesByAccount.find(
+        balance => getMetadataFromBalancesResponseOptional(balance)?.symbol === from,
+      )
+    : undefined;
+  if (!balanceFrom) {
+    const matchingMetadata = state.swappableAssets.data?.find(metadata => metadata.symbol === from);
+    balanceFrom = matchingMetadata ? emptyBalanceResponse(matchingMetadata) : undefined;
+  }
+
+  // Find the metadata matching the `to` symbol
+  const metadataTo = to
+    ? state.swappableAssets.data?.find(metadata => metadata.symbol === to)
+    : undefined;
+
+  const firstMetadata = state.swappableAssets.data?.[0];
+  const secondMetadata = state.swappableAssets.data?.[1];
+  const firstBalancesResponse = state.balancesResponses.data?.[0];
+
+  // Set the initial `assetIn`
+  if (balanceFrom) {
+    state.setAssetIn(balanceFrom);
+  } else if (firstBalancesResponse) {
+    state.setAssetIn(firstBalancesResponse);
+  } else if (firstMetadata) {
+    state.setAssetIn(emptyBalanceResponse(firstMetadata));
+  }
+
+  // Set the initial `assetOut`
+  if (metadataTo) {
+    state.setAssetOut(metadataTo);
+  } else {
+    state.setAssetOut(firstBalancesResponse ? firstMetadata : secondMetadata);
+  }
+};

--- a/apps/minifront/src/utils/empty-balance-response.ts
+++ b/apps/minifront/src/utils/empty-balance-response.ts
@@ -6,14 +6,14 @@ import { zeroValueView } from './zero-value-view';
 /**
  * Transforms an asset metadata to a `BalanceResponse` with a zero balance on account 0.
  */
-export const emptyBalanceResponse = (metadata: Metadata) => {
+export const emptyBalanceResponse = (metadata: Metadata, accountIndex = 0) => {
   return new BalancesResponse({
     balanceView: zeroValueView(metadata),
     accountAddress: new AddressView({
       addressView: {
         case: 'decoded',
         value: {
-          index: { account: 0 },
+          index: { account: accountIndex },
         },
       },
     }),


### PR DESCRIPTION
Closes #1169 

Adds support for `from`, `to`, and `account` query parameters on the Swap page. Also, adds a link from the assets table to trade each available asset.

Query params save `asset.symbol` string and compute the matches by it.

https://github.com/penumbra-zone/web/assets/29180358/ef89dba7-f00f-4d8b-b41d-88431b6a90a3

