### PR TITLE
Shim Promise.withResolvers() for ZQuery and minifront tests

### DIFF
--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -64,6 +64,7 @@
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.3.0",
     "@types/react-helmet": "^6.1.11",
+    "promise.withresolvers": "^1.0.3",
     "vite": "^5.2.11"
   }
 }

--- a/apps/minifront/promise.withresolvers.d.ts
+++ b/apps/minifront/promise.withresolvers.d.ts
@@ -1,0 +1,4 @@
+declare module 'promise.withresolvers' {
+  const withResolvers: { shim: () => void };
+  export default withResolvers;
+}

--- a/apps/minifront/tests-setup.ts
+++ b/apps/minifront/tests-setup.ts
@@ -1,8 +1,10 @@
 import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import withResolvers from 'promise.withresolvers';
 
 import '@testing-library/jest-dom/vitest';
 
+withResolvers.shim();
 vi.mock('zustand');
 
 afterEach(() => {

--- a/apps/minifront/tsconfig.json
+++ b/apps/minifront/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@repo/tsconfig/vite.json",
-  "include": ["src", "tests-setup.ts", "__mocks__"],
+  "include": ["src", "tests-setup.ts", "__mocks__", "promise.withresolvers.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/zquery/package.json
+++ b/packages/zquery/package.json
@@ -20,6 +20,7 @@
     "@testing-library/react": "^15.0.7",
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.3.0",
+    "promise.withresolvers": "^1.0.3",
     "vitest": "^1.6.0"
   }
 }

--- a/packages/zquery/tests-setup.ts
+++ b/packages/zquery/tests-setup.ts
@@ -1,5 +1,8 @@
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import withResolvers from 'promise.withresolvers';
+
+withResolvers.shim();
 
 afterEach(() => {
   // Clear anything rendered by jsdom. (Without this, previous tests can leave

--- a/packages/zquery/tsconfig.json
+++ b/packages/zquery/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@repo/tsconfig/base.json",
-  "include": ["src", "tests-setup.ts", "promise.withresolvers.d.ts" ],
+  "include": ["src", "tests-setup.ts", "promise.withresolvers.d.ts"],
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
     "jsx": "react-jsx"

--- a/packages/zquery/tsconfig.json
+++ b/packages/zquery/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@repo/tsconfig/base.json",
-  "include": ["src", "tests-setup.ts"],
+  "include": ["src", "tests-setup.ts", "promise.withresolvers.d.ts" ],
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
     "jsx": "react-jsx"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@types/react-helmet':
         specifier: ^6.1.11
         version: 6.1.11
+      promise.withresolvers:
+        specifier: ^1.0.3
+        version: 1.0.3
       vite:
         specifier: ^5.2.11
         version: 5.3.1(@types/node@20.14.9)(terser@5.31.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -882,6 +882,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
+      promise.withresolvers:
+        specifier: ^1.0.3
+        version: 1.0.3
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.9)(@vitest/browser@1.6.0(playwright@1.45.0)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.31.1)
@@ -8677,6 +8680,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  promise.withresolvers@1.0.3:
+    resolution: {integrity: sha512-trMhLkMcpAUOsTEFqkfj+QGjiOOWkqbCGx2xAxhIPRrm1QpKcd/UHC+TNjlRXYQLlAZRrjvewc8qGQn3f6DroQ==}
+    engines: {node: '>= 0.4'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -21909,6 +21916,13 @@ snapshots:
   process-warning@1.0.0: {}
 
   process@0.11.10: {}
+
+  promise.withresolvers@1.0.3:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
+      es-errors: 1.3.0
 
   prompts@2.4.2:
     dependencies:


### PR DESCRIPTION
Not sure how this got removed. This PR makes sure tests pass when running with vitest — e.g., `pnpm vitest packages/zquery`

## Before
![image](https://github.com/penumbra-zone/web/assets/1121544/198ccf60-ebe7-47c7-843c-a10bb8e1a5b4)


## After

![image](https://github.com/penumbra-zone/web/assets/1121544/6b9c94e0-13f9-434a-ba4f-f9c0f5f24e71)
