### PR TITLE
fix: request for connection upon false isConnected state

### DIFF
--- a/.changeset/cuddly-files-share.md
+++ b/.changeset/cuddly-files-share.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/client': patch
+---
+
+emit approval request upon `false` isConnected state

--- a/packages/client/src/create.ts
+++ b/packages/client/src/create.ts
@@ -76,7 +76,7 @@ export const assertProviderManifest = async (
  */
 export const getPenumbraPort = async (requireProvider?: string) => {
   const provider = await assertProviderManifest(requireProvider ?? availableOrigin());
-  if (provider.isConnected() === undefined) await provider.request();
+  if (!provider.isConnected()) await provider.request();
   return provider.connect();
 };
 


### PR DESCRIPTION
fix should allow minifront to resume deployment at head of main.

this is technically incorrect by the design described but will accommodate the misaligned logic in released providers.

emitting an inappropriate request at this point is harmless because the promise will just be immediately denied

https://github.com/penumbra-zone/web/blob/649e3e7d25f0a2f855ac5a63bc869328b056bd19/packages/client/src/index.ts#L5-L32