### PR TITLE
transaction info height key

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc --build && tsc-alias",
-    "clean": "rm -rfv dist package penumbra-zone-transport-dom-*.tgz",
+    "clean": "rm -rfv dist package penumbra-zone-storage-*.tgz",
     "lint": "eslint src",
     "test": "vitest run"
   },

--- a/packages/storage/src/indexed-db/config.ts
+++ b/packages/storage/src/indexed-db/config.ts
@@ -2,4 +2,4 @@
  * The version number for the IndexedDB schema. This version number is used to manage
  * database upgrades and ensure that the correct schema version is applied.
  */
-export const IDB_VERSION = 43;
+export const IDB_VERSION = 44;

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -72,7 +72,10 @@ export interface IndexedDbInterface {
   iterateSpendableNotes(): AsyncGenerator<SpendableNoteRecord, void>;
   saveTransaction(id: TransactionId, height: bigint, tx: Transaction): Promise<void>;
   getTransaction(txId: TransactionId): Promise<TransactionInfo | undefined>;
-  iterateTransactions(): AsyncGenerator<TransactionInfo, void>;
+  iterateTransactions(
+    startHeight?: bigint,
+    endHeight?: bigint,
+  ): AsyncGenerator<TransactionInfo, void>;
   getAssetsMetadata(assetId: AssetId): Promise<Metadata | undefined>;
   saveAssetsMetadata(metadata: Metadata): Promise<void>;
   iterateAssetsMetadata(): AsyncGenerator<Metadata, void>;
@@ -181,6 +184,9 @@ export interface PenumbraDb extends DBSchema {
   TRANSACTIONS: {
     key: string; // base64 TransactionInfo['id']['inner'];
     value: Jsonified<TransactionInfo>; // TransactionInfo with undefined view and perspective
+    indexes: {
+      height: Jsonified<TransactionInfo['height']>;
+    };
   };
   REGISTRY_VERSION: {
     key: 'commit';


### PR DESCRIPTION
some work on #1363 

this also uses idb cursor bounds instead of sorting and filtering in a loop