### PR TITLE
Update revision number parsing

### DIFF
--- a/.changeset/tasty-pugs-develop.md
+++ b/.changeset/tasty-pugs-develop.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Update revision number parsing logic

--- a/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.test.ts
+++ b/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.test.ts
@@ -1,35 +1,21 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { parseRevisionNumberFromChainId } from './parse-revision-number-from-chain-id';
 
 describe('parseRevisionNumberFromChainId', () => {
-  test('should extract the number at the end of a well-formatted string as a BigInt', () => {
-    expect(parseRevisionNumberFromChainId('grand-1')).toEqual(1n);
-    expect(parseRevisionNumberFromChainId('osmo-test-5')).toEqual(5n);
-    expect(parseRevisionNumberFromChainId('penumbra-testnet-deimos-7')).toEqual(7n);
+  it('should return 0 for non-epoch formatted chain IDs', () => {
+    expect(parseRevisionNumberFromChainId('chain--a-0')).toBe(0n);
+    expect(parseRevisionNumberFromChainId('chainA')).toBe(0n);
+    expect(parseRevisionNumberFromChainId('plainid-')).toBe(0n);
   });
 
-  test('should throw an error if there is no number at the end', () => {
-    expect(() => parseRevisionNumberFromChainId('grand')).toThrow(
-      'No revision number found within chain id: grand',
-    );
-    expect(() => parseRevisionNumberFromChainId('osmo-test-beta')).toThrow(
-      'No revision number found within chain id: osmo-test-beta',
-    );
+  it('should parse the revision number correctly from epoch formatted chain IDs', () => {
+    expect(parseRevisionNumberFromChainId('ibc-10')).toBe(10n);
+    expect(parseRevisionNumberFromChainId('cosmos-hub-97')).toBe(97n);
+    expect(parseRevisionNumberFromChainId('testnet-helloworld-2')).toBe(2n);
   });
 
-  test('should throw an error if the string ends with a hyphen', () => {
-    expect(() => parseRevisionNumberFromChainId('test-chain-')).toThrow(
-      'No revision number found within chain id: test-chain-',
-    );
-  });
-
-  test('should throw an error if the string does not contain any hyphens', () => {
-    expect(() => parseRevisionNumberFromChainId('testchain5')).toThrow(
-      'No revision number found within chain id: testchain5',
-    );
-  });
-
-  test('should handle cases with multiple hyphens correctly', () => {
-    expect(parseRevisionNumberFromChainId('multi-part-chain-id-123')).toEqual(123n);
+  it('should handle chain IDs with multiple dashes correctly', () => {
+    expect(parseRevisionNumberFromChainId('my-chain-id-45')).toBe(45n);
+    expect(parseRevisionNumberFromChainId('another-test-100')).toBe(100n);
   });
 });

--- a/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.ts
+++ b/apps/minifront/src/state/ibc-in/parse-revision-number-from-chain-id.ts
@@ -1,14 +1,32 @@
 /**
- * Examples:
- * getRevisionNumberFromChainId("grand-1") returns 1n
- * getRevisionNumberFromChainId("osmo-test-5") returns 5n
- * getRevisionNumberFromChainId("penumbra-testnet-deimos-7") returns 7n
+ * Reference implementation: https://github.com/penumbra-zone/ibc-types/blob/73da5ee5d06b5f62c186b31ce37f7669edc8bbf2/crates/ibc-types-core-connection/src/identifier.rs#L76-L87
+ *
+ * Extract the version from the given chain identifier.
+ * Example outputs:
+ * - chainVersion("chain--a-0") -> 0
+ * - chainVersion("ibc-10") -> 10
+ * - chainVersion("cosmos-hub-97") -> 97
+ * - chainVersion("testnet-helloworld-2") -> 2
  */
 export const parseRevisionNumberFromChainId = (chainId: string): bigint => {
-  const match = chainId.match(/-(\d+)$/);
-  if (match?.[1]) {
-    return BigInt(match[1]);
-  } else {
-    throw new Error(`No revision number found within chain id: ${chainId}`);
+  if (!isEpochFormat(chainId)) {
+    return 0n;
   }
+
+  const numStr = chainId.split('-').pop()!;
+  return BigInt(numStr);
+};
+
+/**
+ * isEpochFormat() checks if a chain_id is in the format required for parsing epochs.
+ * The chainID must be in the form: {chainID}-{version}
+ * Example outputs:
+ * - isEpochFormat("chainA-0") -> false
+ * - isEpochFormat("chainA") -> false
+ * - isEpochFormat("chainA-1") -> true
+ * - isEpochFormat("c-1") -> true
+ */
+const isEpochFormat = (chainId: string): boolean => {
+  const regex = /.*[^-]-[1-9][0-9]*$/;
+  return regex.test(chainId);
 };


### PR DESCRIPTION
Our current parsing is inconsistent with the way the Rust core code is doing this. This PR aligns with the core implementation: https://github.com/penumbra-zone/ibc-types/blob/73da5ee5d06b5f62c186b31ce37f7669edc8bbf2/crates/ibc-types-core-connection/src/identifier.rs#L76-L87 so as to prevent bugs with potential chain ids.