### PR TITLE
Synchronize buf deps

### DIFF
--- a/apps/minifront/CHANGELOG.md
+++ b/apps/minifront/CHANGELOG.md
@@ -1,5 +1,18 @@
 # minifront
 
+## 6.5.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/getters@10.0.0
+  - @penumbra-zone/perspective@9.0.0
+  - @penumbra-zone/protobuf@5.3.0
+  - @penumbra-zone/types@12.0.0
+  - @repo/ui@6.2.1
+  - @penumbra-zone/client@10.0.0
+  - @penumbra-zone/crypto-web@8.0.0
+
 ## 6.5.0
 
 ### Minor Changes

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minifront",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "type": "module",

--- a/apps/node-status/CHANGELOG.md
+++ b/apps/node-status/CHANGELOG.md
@@ -1,5 +1,13 @@
 # node-status
 
+## 4.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/protobuf@5.3.0
+  - @repo/ui@6.2.1
+
 ## 4.1.0
 
 ### Minor Changes

--- a/apps/node-status/package.json
+++ b/apps/node-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-status",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "type": "module",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @penumbra-zone/client
 
+## 10.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/protobuf@5.3.0
+
 ## 9.0.1
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/client",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "license": "(MIT OR Apache-2.0)",
   "description": "Package for connecting to any Penumbra extension, including Prax.",
   "type": "module",

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @penumbra-zone/crypto-web
 
+## 8.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/types@12.0.0
+
 ## 7.0.0
 
 ### Patch Changes

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/crypto-web",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "engine": {

--- a/packages/getters/CHANGELOG.md
+++ b/packages/getters/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @penumbra-zone/getters
 
+## 10.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/protobuf@5.3.0
+
 ## 9.0.0
 
 ### Minor Changes

--- a/packages/getters/package.json
+++ b/packages/getters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/getters",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "license": "(MIT OR Apache-2.0)",
   "description": "Convenience getters for the deeply nested optionals of Penumbra's protobuf types",
   "type": "module",

--- a/packages/perspective/CHANGELOG.md
+++ b/packages/perspective/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @penumbra-zone/perspective
 
+## 9.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/getters@10.0.0
+  - @penumbra-zone/wasm@12.0.0
+
 ## 8.0.0
 
 ### Patch Changes

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/perspective",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "license": "(MIT OR Apache-2.0)",
   "description": "Tools for assuming different perspectives of Penumbra transactions",
   "type": "module",

--- a/packages/protobuf/CHANGELOG.md
+++ b/packages/protobuf/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-zone/protobuf
 
+## 5.3.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
 ## 5.2.0
 
 ### Minor Changes

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/protobuf",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "license": "(MIT OR Apache-2.0)",
   "description": "Exports a `@bufbuild/protobuf` type registry with all message types necessary to communicate with a Penumbra extension",
   "type": "module",

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @penumbra-zone/query
 
+## 9.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/getters@10.0.0
+  - @penumbra-zone/protobuf@5.3.0
+  - @penumbra-zone/types@12.0.0
+  - @penumbra-zone/wasm@12.0.0
+  - @penumbra-zone/crypto-web@8.0.0
+
 ## 8.0.0
 
 ### Patch Changes

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/query",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "engine": {

--- a/packages/services/CHANGELOG.md
+++ b/packages/services/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @penumbra-zone/router
 
+## 10.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/getters@10.0.0
+  - @penumbra-zone/perspective@9.0.0
+  - @penumbra-zone/protobuf@5.3.0
+  - @penumbra-zone/query@9.0.0
+  - @penumbra-zone/storage@9.0.0
+  - @penumbra-zone/types@12.0.0
+  - @penumbra-zone/wasm@12.0.0
+  - @penumbra-zone/crypto-web@8.0.0
+
 ## 9.0.0
 
 ### Minor Changes

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/services",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "engine": {

--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @penumbra-zone/storage
 
+## 9.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/getters@10.0.0
+  - @penumbra-zone/types@12.0.0
+  - @penumbra-zone/wasm@12.0.0
+
 ## 8.0.0
 
 ### Major Changes

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/storage",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "engine": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @penumbra-zone/types
 
+## 12.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/getters@10.0.0
+
 ## 11.0.0
 
 ### Major Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/types",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "engine": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @penumbra-zone/ui
 
+## 6.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/types@12.0.0
+
 ## 6.2.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/ui",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "type": "module",

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @penumbra-zone/wasm
 
+## 12.0.0
+
+### Minor Changes
+
+- Synchronize published @buf deps
+
+### Patch Changes
+
+- Updated dependencies
+  - @penumbra-zone/protobuf@5.3.0
+  - @penumbra-zone/types@12.0.0
+
 ## 11.0.0
 
 ### Patch Changes

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-zone/wasm",
-  "version": "11.0.0",
+  "version": "12.0.0",
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "engine": {


### PR DESCRIPTION
Protobuf package was not published with recent version bumps. This causes peer dependency issues with consumers.

Going to merge this without review to unblock release.