### PR TITLE
fix BalanceItem

### DIFF
--- a/apps/minifront/src/components/dashboard/assets-table/helpers.ts
+++ b/apps/minifront/src/components/dashboard/assets-table/helpers.ts
@@ -2,16 +2,14 @@ import { assetPatterns } from '@penumbra-zone/types/assets';
 import { getDisplay } from '@penumbra-zone/getters/metadata';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { getMetadata } from '@penumbra-zone/getters/value-view';
+import { isKnown } from '../../swap/helpers';
 
 // We don't have to disclose auctionNft to the user since it is a kind of utility asset needed only
 // for the implementation of the Dutch auction
 const hiddenAssetPatterns = [assetPatterns.auctionNft, assetPatterns.lpNft];
 
-export const isUnknown = (balancesResponse: BalancesResponse) =>
-  balancesResponse.balanceView?.valueView.case === 'unknownAssetId';
-
 export const shouldDisplay = (balance: BalancesResponse) =>
-  isUnknown(balance) ||
+  isKnown(balance) &&
   hiddenAssetPatterns.every(
     pattern => !pattern.matches(getDisplay(getMetadata(balance.balanceView))),
   );

--- a/apps/minifront/src/components/send/helpers.ts
+++ b/apps/minifront/src/components/send/helpers.ts
@@ -6,7 +6,7 @@ import { getDisplay } from '@penumbra-zone/getters/metadata';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { getBalances } from '../../fetchers/balances';
 import { getMetadata } from '@penumbra-zone/getters/value-view';
-import { isUnknown } from '../dashboard/assets-table/helpers';
+import { isKnown } from '../swap/helpers';
 
 export const penumbraAddrValidation = (): Validation => {
   return {
@@ -28,6 +28,6 @@ export const isTransferable = (metadata: Metadata) =>
 export const getTransferableBalancesResponses = async (): Promise<BalancesResponse[]> => {
   const balancesResponses = await getBalances();
   return balancesResponses.filter(
-    balance => isUnknown(balance) || isTransferable(getMetadata(balance.balanceView)),
+    balance => isKnown(balance) && isTransferable(getMetadata(balance.balanceView)),
   );
 };

--- a/apps/minifront/src/components/shared/selectors/balance-item.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-item.tsx
@@ -39,9 +39,7 @@ export const BalanceItem = ({ asset, value, onSelect }: BalanceItemProps) => {
         >
           <div className='col-span-2 flex items-center justify-start gap-1'>
             <AssetIcon metadata={metadata} />
-            <p className='truncate'>
-              {metadata && metadata.symbol ? metadata.symbol : 'Unknown asset'}
-            </p>
+            <p className='truncate'>{metadata?.symbol ? metadata.symbol : 'Unknown asset'}</p>
           </div>
 
           <div className='col-span-2 flex justify-end'>

--- a/apps/minifront/src/components/shared/selectors/balance-item.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-item.tsx
@@ -37,12 +37,12 @@ export const BalanceItem = ({ asset, value, onSelect }: BalanceItemProps) => {
             isSelected && 'bg-light-brown px-4 -mx-4',
           )}
         >
-          {metadata && (
-            <div className='col-span-2 flex items-center justify-start gap-1'>
-              <AssetIcon metadata={metadata} />
-              <p className='truncate'>{metadata.symbol || 'Unknown asset'}</p>
-            </div>
-          )}
+          <div className='col-span-2 flex items-center justify-start gap-1'>
+            <AssetIcon metadata={metadata} />
+            <p className='truncate'>
+              {metadata && metadata.symbol ? metadata.symbol : 'Unknown asset'}
+            </p>
+          </div>
 
           <div className='col-span-2 flex justify-end'>
             {isBalance(asset) && (


### PR DESCRIPTION
Closes #1372 

Filter out unknown assets from the asset list and from the asset selection. Also fixed the display of unknown assets in case we want to go back to them

<img width="446" alt="image" src="https://github.com/penumbra-zone/web/assets/25391690/3dca8f19-1ff1-4b1c-98c0-447b2daf584f">


