### PR TITLE
Fix auction pre-filled amounts

### DIFF
--- a/.changeset/nine-students-fry.md
+++ b/.changeset/nine-students-fry.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Tweak max/min outputs

--- a/apps/minifront/src/components/swap/swap-form/output/index.tsx
+++ b/apps/minifront/src/components/swap/swap-form/output/index.tsx
@@ -61,6 +61,7 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
               onChange={e => setMaxOutput(e.target.value)}
               inputMode='decimal'
               step={outputStepSize}
+              placeholder='0'
               className='text-right'
             />
 
@@ -80,6 +81,7 @@ export const Output = ({ layoutId }: { layoutId: string }) => {
               onChange={e => setMinOutput(e.target.value)}
               inputMode='decimal'
               step={outputStepSize}
+              placeholder='0'
               className='text-right'
             />
 

--- a/apps/minifront/src/components/swap/swap-form/output/index.tsx
+++ b/apps/minifront/src/components/swap/swap-form/output/index.tsx
@@ -20,6 +20,8 @@ const outputSelector = (state: AllSlices) => ({
     ? 1 / 10 ** getDisplayDenomExponent(state.swap.assetOut)
     : 'any',
   error:
+    !!state.swap.dutchAuction.minOutput.length &&
+    !!state.swap.dutchAuction.maxOutput.length &&
     Number(state.swap.dutchAuction.minOutput) >= Number(state.swap.dutchAuction.maxOutput)
       ? 'The maximum output must be greater than the minimum output.'
       : undefined,

--- a/apps/minifront/src/state/swap/dutch-auction/index.test.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.test.ts
@@ -162,6 +162,12 @@ describe('Dutch auction slice', () => {
       );
     });
 
+    it('allows updating `maxOutput` to an empty string', () => {
+      useStore.getState().swap.dutchAuction.setMaxOutput('');
+
+      expect(useStore.getState().swap.dutchAuction.maxOutput).toBe('');
+    });
+
     describe('when passed `0`', () => {
       it("updates `maxOutput` to the smallest possible value above 0 for the given asset's display denom exponent", () => {
         useStore.getState().swap.dutchAuction.setMaxOutput('0');
@@ -214,6 +220,12 @@ describe('Dutch auction slice', () => {
       expect(useStore.getState().swap.dutchAuction.minOutput).toBe(
         outputLimitDividedByExponent.toString(),
       );
+    });
+
+    it('allows updating `minOutput` to an empty string', () => {
+      useStore.getState().swap.dutchAuction.setMinOutput('');
+
+      expect(useStore.getState().swap.dutchAuction.minOutput).toBe('');
     });
 
     describe('when passed `0`', () => {

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -88,8 +88,8 @@ export const { auctionInfos, useAuctionInfos, useRevalidateAuctionInfos } = crea
 export type DutchAuctionSlice = Actions & State;
 
 const INITIAL_STATE: State = {
-  minOutput: '1',
-  maxOutput: '1000',
+  minOutput: '',
+  maxOutput: '',
   txInProgress: false,
   auctionInfos,
   filter: 'active',
@@ -104,17 +104,21 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
   ...INITIAL_STATE,
   setMinOutput: minOutput => {
     set(({ swap }) => {
-      const minMinOutput = getSmallestPossibleAmountAboveZero(get().swap.assetOut);
-      const exponent = getDisplayDenomExponent.optional()(get().swap.assetOut) ?? 0;
-      const minOutputAsBaseUnit = Number(minOutput) * 10 ** exponent;
-      const outputLimitAsDisplayUnit = (OUTPUT_LIMIT / 10 ** exponent).toString();
-
-      if (minOutputAsBaseUnit > OUTPUT_LIMIT) {
-        swap.dutchAuction.minOutput = outputLimitAsDisplayUnit;
-      } else if (Number(minOutput) > 0) {
-        swap.dutchAuction.minOutput = minOutput;
+      if (minOutput === '') {
+        swap.dutchAuction.minOutput = '';
       } else {
-        swap.dutchAuction.minOutput = minMinOutput.toString();
+        const minMinOutput = getSmallestPossibleAmountAboveZero(get().swap.assetOut);
+        const exponent = getDisplayDenomExponent.optional()(get().swap.assetOut) ?? 0;
+        const minOutputAsBaseUnit = Number(minOutput) * 10 ** exponent;
+        const outputLimitAsDisplayUnit = (OUTPUT_LIMIT / 10 ** exponent).toString();
+
+        if (minOutputAsBaseUnit > OUTPUT_LIMIT) {
+          swap.dutchAuction.minOutput = outputLimitAsDisplayUnit;
+        } else if (Number(minOutput) > 0) {
+          swap.dutchAuction.minOutput = minOutput;
+        } else {
+          swap.dutchAuction.minOutput = minMinOutput.toString();
+        }
       }
 
       swap.dutchAuction.estimatedOutput = undefined;
@@ -122,17 +126,21 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
   },
   setMaxOutput: maxOutput => {
     set(({ swap }) => {
-      const minMaxOutput = getSmallestPossibleAmountAboveZero(get().swap.assetOut);
-      const exponent = getDisplayDenomExponent.optional()(get().swap.assetOut) ?? 0;
-      const maxOutputAsBaseUnit = Number(maxOutput) * 10 ** exponent;
-      const outputLimitAsDisplayUnit = (OUTPUT_LIMIT / 10 ** exponent).toString();
-
-      if (maxOutputAsBaseUnit > OUTPUT_LIMIT) {
-        swap.dutchAuction.maxOutput = outputLimitAsDisplayUnit;
-      } else if (Number(maxOutput) > 0) {
-        swap.dutchAuction.maxOutput = maxOutput;
+      if (maxOutput === '') {
+        swap.dutchAuction.maxOutput = '';
       } else {
-        swap.dutchAuction.maxOutput = minMaxOutput.toString();
+        const minMaxOutput = getSmallestPossibleAmountAboveZero(get().swap.assetOut);
+        const exponent = getDisplayDenomExponent.optional()(get().swap.assetOut) ?? 0;
+        const maxOutputAsBaseUnit = Number(maxOutput) * 10 ** exponent;
+        const outputLimitAsDisplayUnit = (OUTPUT_LIMIT / 10 ** exponent).toString();
+
+        if (maxOutputAsBaseUnit > OUTPUT_LIMIT) {
+          swap.dutchAuction.maxOutput = outputLimitAsDisplayUnit;
+        } else if (Number(maxOutput) > 0) {
+          swap.dutchAuction.maxOutput = maxOutput;
+        } else {
+          swap.dutchAuction.maxOutput = minMaxOutput.toString();
+        }
       }
 
       swap.dutchAuction.estimatedOutput = undefined;


### PR DESCRIPTION
- Start with empty max/min output amounts
- Allow users to empty the fields as well
- Only show an error when invalid values have been entered in the fields (not when the fields are empty)
- Show a `0` placeholder to indicate that it's a text field

<img width="731" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/85959878-0197-490a-9803-6f18b2fdd51d">


Closes #1387