### PR TITLE
Move the abortLoader to the root route

### DIFF
--- a/.changeset/light-clouds-look.md
+++ b/.changeset/light-clouds-look.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Fix issue where the connect page wasn't rendered right on some routes.

--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -20,6 +20,7 @@ export const rootRouter: Router = createHashRouter([
     path: '/',
     element: <Layout />,
     errorElement: <ErrorBoundary />,
+    loader: abortLoader,
     children: [
       { index: true, loader: () => redirect(PagePath.DASHBOARD) },
       {
@@ -28,7 +29,6 @@ export const rootRouter: Router = createHashRouter([
         children: [
           {
             index: true,
-            loader: abortLoader,
             element: <AssetsTable />,
           },
           {
@@ -43,7 +43,6 @@ export const rootRouter: Router = createHashRouter([
         children: [
           {
             index: true,
-            loader: abortLoader,
             element: <SendForm />,
           },
           {
@@ -54,23 +53,19 @@ export const rootRouter: Router = createHashRouter([
       },
       {
         path: PagePath.SWAP,
-        loader: abortLoader,
         element: <SwapLayout />,
       },
       {
         path: PagePath.TRANSACTION_DETAILS,
-        loader: abortLoader,
         element: <TxDetails />,
         errorElement: <TxDetailsErrorBoundary />,
       },
       {
         path: PagePath.STAKING,
-        loader: abortLoader,
         element: <StakingLayout />,
       },
       {
         path: PagePath.IBC,
-        loader: abortLoader,
         element: <IbcLayout />,
       },
     ],


### PR DESCRIPTION
This fixes an issue where some routes were missing the loader, so the landing page would not show up correctly when the extension was not yet connected.

Closes #1344

Note that #1344 only mentions the transactions page, but the same issue was also present on the `/send/receive` page, since it was also missing the `abortLoader`.