### PR TITLE
Move the Account column to the left of asset selectors; fix a few UI issues

### DIFF
--- a/apps/minifront/src/components/shared/selectors/asset-selector.tsx
+++ b/apps/minifront/src/components/shared/selectors/asset-selector.tsx
@@ -5,7 +5,7 @@ import {
   ValueView,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { ValueViewComponent } from '@repo/ui/components/ui/value';
-import { useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { IconInput } from '@repo/ui/components/ui/icon-input';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { Box } from '@repo/ui/components/ui/box';
@@ -13,6 +13,7 @@ import { motion } from 'framer-motion';
 import { metadataBySearch } from './search-filters';
 import { cn } from '@repo/ui/lib/utils';
 import { LoadingIndicator } from './loading-indicator';
+import { Table, TableBody, TableCell, TableRow } from '@repo/ui/components/ui/table';
 
 interface AssetSelectorProps {
   assets: Metadata[];
@@ -94,6 +95,13 @@ export const AssetSelector = ({ assets, loading, onChange, value, filter }: Asse
     [value],
   );
 
+  const isSelected = useCallback(
+    (metadata: Metadata) => {
+      return value?.equals(metadata);
+    },
+    [value],
+  );
+
   return (
     <>
       {!isOpen && (
@@ -139,21 +147,31 @@ export const AssetSelector = ({ assets, loading, onChange, value, filter }: Asse
                 />
               </Box>
 
-              {filteredAssets.map(metadata => (
-                <div key={metadata.display} className='flex flex-col'>
-                  <DialogClose>
-                    <div
-                      className={
-                        'flex cursor-pointer justify-start gap-[6px] overflow-hidden py-[10px] font-bold text-muted-foreground hover:-mx-4 hover:bg-light-brown hover:px-4'
-                      }
-                      onClick={() => onChange(metadata)}
-                    >
-                      <AssetIcon metadata={metadata} />
-                      <p className='truncate'>{metadata.symbol || 'Unknown asset'}</p>
-                    </div>
-                  </DialogClose>
-                </div>
-              ))}
+              <Table>
+                <TableBody>
+                  {filteredAssets.map(metadata => (
+                    <DialogClose asChild key={metadata.display}>
+                      <TableRow
+                        className='cursor-pointer justify-start overflow-hidden font-bold text-muted-foreground'
+                        onClick={() => onChange(metadata)}
+                        role='button'
+                      >
+                        <TableCell className='p-0'>
+                          <div
+                            className={cn(
+                              '-mx-4 flex h-full gap-[6px] p-4 hover:bg-light-brown',
+                              isSelected(metadata) && 'bg-light-brown',
+                            )}
+                          >
+                            <AssetIcon metadata={metadata} />
+                            <p className='truncate'>{metadata.symbol || 'Unknown asset'}</p>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    </DialogClose>
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           </div>
         </DialogContent>

--- a/apps/minifront/src/components/shared/selectors/balance-item.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-item.tsx
@@ -1,56 +1,64 @@
 import { BalanceOrMetadata, isBalance, isMetadata } from './helpers';
 import { getAddressIndex } from '@penumbra-zone/getters/address-view';
-import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import {
+  getMetadataFromBalancesResponse,
+  getMetadataFromBalancesResponseOptional,
+} from '@penumbra-zone/getters/balances-response';
 import { useMemo } from 'react';
 import { DialogClose } from '@repo/ui/components/ui/dialog';
 import { cn } from '@repo/ui/lib/utils';
 import { AssetIcon } from '@repo/ui/components/ui/asset-icon';
 import { ValueViewComponent } from '@repo/ui/components/ui/value';
+import { TableCell, TableRow } from '@repo/ui/components/ui/table';
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 
 interface BalanceItemProps {
   asset: BalanceOrMetadata;
-  value?: BalanceOrMetadata;
+  value?: BalancesResponse;
   onSelect: (value: BalanceOrMetadata) => void;
 }
 
 export const BalanceItem = ({ asset, value, onSelect }: BalanceItemProps) => {
   const account = isBalance(asset) ? getAddressIndex(asset.accountAddress).account : undefined;
-  const metadata = isMetadata(asset) ? asset : getMetadataFromBalancesResponseOptional(asset);
+  const metadataFromAsset = isMetadata(asset)
+    ? asset
+    : getMetadataFromBalancesResponseOptional(asset);
+  const metadataFromValue = getMetadataFromBalancesResponse.optional()(value);
 
   const isSelected = useMemo(() => {
     if (!value) return false;
-    if (isMetadata(value) && isMetadata(asset)) {
-      return value.equals(asset);
-    }
-    if (isBalance(value) && isBalance(asset)) {
-      return value.equals(asset);
-    }
+    if (isBalance(asset)) return value.equals(asset);
+    if (isMetadata(asset)) return metadataFromValue?.equals(metadataFromAsset);
     return false;
   }, [asset, value]);
 
   return (
-    <div className='flex flex-col'>
-      <DialogClose onClick={() => onSelect(asset)}>
-        <div
-          className={cn(
-            'grid grid-cols-5 py-[10px] gap-3 cursor-pointer hover:bg-light-brown hover:px-4 hover:-mx-4 font-bold text-muted-foreground',
-            isSelected && 'bg-light-brown px-4 -mx-4',
-          )}
-        >
-          <div className='col-span-2 flex items-center justify-start gap-1'>
-            <AssetIcon metadata={metadata} />
-            <p className='truncate'>{metadata?.symbol ? metadata.symbol : 'Unknown asset'}</p>
-          </div>
+    <DialogClose asChild onClick={() => onSelect(asset)}>
+      <TableRow
+        className={cn(
+          'cursor-pointer hover:bg-light-brown font-bold text-muted-foreground',
+          isSelected && 'bg-light-brown',
+        )}
+      >
+        <TableCell>{account}</TableCell>
 
+        <TableCell>
+          <div className='col-span-2 flex items-center justify-start gap-1'>
+            <AssetIcon metadata={metadataFromAsset} />
+            <p className='truncate'>
+              {metadataFromAsset?.symbol ? metadataFromAsset.symbol : 'Unknown asset'}
+            </p>
+          </div>
+        </TableCell>
+
+        <TableCell>
           <div className='col-span-2 flex justify-end'>
             {isBalance(asset) && (
               <ValueViewComponent showIcon={false} showDenom={false} view={asset.balanceView} />
             )}
           </div>
-
-          <p className='flex justify-center'>{account}</p>
-        </div>
-      </DialogClose>
-    </div>
+        </TableCell>
+      </TableRow>
+    </DialogClose>
   );
 };

--- a/apps/minifront/src/components/shared/selectors/balance-selector.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-selector.tsx
@@ -13,6 +13,7 @@ import { BalanceOrMetadata, isMetadata, mergeBalancesAndAssets } from './helpers
 import { BalanceItem } from './balance-item';
 import { cn } from '@repo/ui/lib/utils';
 import { LoadingIndicator } from './loading-indicator';
+import { Table, TableBody, TableHead, TableHeader, TableRow } from '@repo/ui/components/ui/table';
 
 interface BalanceSelectorProps {
   value: BalancesResponse | undefined;
@@ -95,16 +96,20 @@ export default function BalanceSelector({
                   placeholder='Search assets...'
                 />
               </Box>
-              <div className='mt-2 grid grid-cols-4 gap-3 font-headline text-base font-semibold'>
-                <p className='col-span-2 flex justify-start'>Asset</p>
-                <p className='flex justify-end'>Balance</p>
-                <p className='flex justify-center'>Account</p>
-              </div>
-              <div className='flex flex-col gap-2'>
-                {filteredBalances.map((asset, i) => (
-                  <BalanceItem key={i} asset={asset} value={value} onSelect={onSelect} />
-                ))}
-              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Account</TableHead>
+                    <TableHead>Asset</TableHead>
+                    <TableHead className='text-right'>Balance</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredBalances.map((asset, i) => (
+                    <BalanceItem key={i} asset={asset} value={value} onSelect={onSelect} />
+                  ))}
+                </TableBody>
+              </Table>
             </div>
           </div>
         </DialogContent>


### PR DESCRIPTION
I started by simply moving the Account column to the left, but then the headers and contents became misaligned:

<img width="499" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/4bbd38b5-d1a5-4da3-a930-4071295dbb6a">

I then realized that we weren't using a `<Table />` when we should have been, so I converted the `<BalanceSelector />` to use a `<Table />`, and that fixed the layout issues:

<img width="445" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/04e9b7a7-9689-4236-9a28-c3b949811c95">

But then that gave it borders, which no longer matched `<AssetSelector />`. Plus, its spacing was different. Rather than hack custom styles to make them match, I simply converted `<AssetSelector />` to a `<Table />` instead.

I also noticed that `<AssetSelector />` didn't have an indicator of which one was currently selected (like` <BalanceSelector />` did), so I added a light gray background to the currently selected asset.

I could have gone further (e.g., making the hover/selected background full-width on the `<BalanceSelector />`, but we're probably going to be reworking a lot of these components with the upcoming UI library anyway, and this ticket is just to move the column to the left, so I stopped there.

Closes #1382 