### PR TITLE
Fix React warnings about nested <li> elements

### DIFF
--- a/apps/minifront/src/components/header/menu/provider.tsx
+++ b/apps/minifront/src/components/header/menu/provider.tsx
@@ -51,30 +51,32 @@ export const ProviderMenu = () => {
           {chainId}
         </NavigationMenu.Trigger>
         <NavigationMenu.Content className={cn(...dropdownStyle, 'w-64')}>
-          <NavigationMenu.Item className={cn(...itemStyle)}>
-            <NavigationMenu.Link className={cn(...linkStyle, 'p-0', 'leading-normal')}>
-              <div className='ml-4 text-muted-foreground'>
-                <span className='font-headline text-muted'>
-                  {providerManifest.name} {providerManifest.version}
+          <ul>
+            <NavigationMenu.Item className={cn(...itemStyle)}>
+              <NavigationMenu.Link className={cn(...linkStyle, 'p-0', 'leading-normal')}>
+                <div className='ml-4 text-muted-foreground'>
+                  <span className='font-headline text-muted'>
+                    {providerManifest.name} {providerManifest.version}
+                  </span>
+                  <p>{providerManifest.description}</p>
+                </div>
+              </NavigationMenu.Link>
+            </NavigationMenu.Item>
+            <NavigationMenu.Item
+              hidden={
+                // hide if injection does not contain disconnect
+                !window[PenumbraSymbol]?.[providerOrigin]?.disconnect
+              }
+              className={cn(...itemStyle)}
+            >
+              <NavigationMenu.Link className={cn(...linkStyle)} onSelect={disconnect}>
+                <span>
+                  <LinkBreak1Icon className={cn('size-[1em]', 'inline-block')} />
+                  &nbsp;Disconnect
                 </span>
-                <p>{providerManifest.description}</p>
-              </div>
-            </NavigationMenu.Link>
-          </NavigationMenu.Item>
-          <NavigationMenu.Item
-            hidden={
-              // hide if injection does not contain disconnect
-              !window[PenumbraSymbol]?.[providerOrigin]?.disconnect
-            }
-            className={cn(...itemStyle)}
-          >
-            <NavigationMenu.Link className={cn(...linkStyle)} onSelect={disconnect}>
-              <span>
-                <LinkBreak1Icon className={cn('size-[1em]', 'inline-block')} />
-                &nbsp;Disconnect
-              </span>
-            </NavigationMenu.Link>
-          </NavigationMenu.Item>
+              </NavigationMenu.Link>
+            </NavigationMenu.Item>
+          </ul>
         </NavigationMenu.Content>
       </NavigationMenu.Item>
       <NavigationMenu.Viewport className='absolute z-50' />

--- a/apps/minifront/src/components/header/menu/tablet-nav.tsx
+++ b/apps/minifront/src/components/header/menu/tablet-nav.tsx
@@ -19,13 +19,15 @@ export const TabletNav = () => {
           <CaretDownIcon className='inline-block text-right align-middle transition duration-200 group-data-[state=open]:-scale-y-100' />
         </NavigationMenu.Trigger>
         <NavigationMenu.Content className={cn('w-[138px]', ...dropdownStyle)}>
-          {[dashboardLink, ...headerLinks].map(({ href, label }) => (
-            <NavigationMenu.Item key={href} className={cn(...itemStyle)}>
-              <NavigationMenu.Link className={cn(...linkStyle)} onSelect={() => navigate(href)}>
-                {label}
-              </NavigationMenu.Link>
-            </NavigationMenu.Item>
-          ))}
+          <ul>
+            {[dashboardLink, ...headerLinks].map(({ href, label }) => (
+              <NavigationMenu.Item key={href} className={cn(...itemStyle)}>
+                <NavigationMenu.Link className={cn(...linkStyle)} onSelect={() => navigate(href)}>
+                  {label}
+                </NavigationMenu.Link>
+              </NavigationMenu.Item>
+            ))}
+          </ul>
         </NavigationMenu.Content>
       </NavigationMenu.Item>
       <NavigationMenu.Viewport className='absolute z-50' />


### PR DESCRIPTION
This removes the borders between items in the menu dropdown, but that's fine as we're overhauling the design system soon anyway.

## Before (note the warnings in the console)
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/75065d6c-1286-4675-86fe-880c7ee32f1b">

<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/eb0e2db8-6627-43ee-aafd-826abfdd234c">


## After
<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/c4fc2d4d-370b-431d-b8ac-d218c014cd92">

<img width="1912" alt="image" src="https://github.com/penumbra-zone/web/assets/1121544/5b699826-1688-4c44-af7a-b33b98d64d39">
