### PR TITLE
fix(ui): format time in UTC for withdrawal transactions

### DIFF
--- a/.changeset/silent-cycles-rush.md
+++ b/.changeset/silent-cycles-rush.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Render the timeout time in withdrawal transactions in UTC format

--- a/packages/ui/components/ui/tx/actions-views/isc20-withdrawal.tsx
+++ b/packages/ui/components/ui/tx/actions-views/isc20-withdrawal.tsx
@@ -4,6 +4,16 @@ import { ActionDetails } from './action-details';
 import { joinLoHiAmount } from '@penumbra-zone/types/amount';
 import { bech32mAddress } from '@penumbra-zone/bech32m/penumbra';
 
+const getUtcTime = (time: bigint) => {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'long',
+    timeZone: 'UTC',
+  });
+  const date = new Date(Number(time / 1_000_000n));
+  return formatter.format(date);
+};
+
 export const Ics20WithdrawalComponent = ({ value }: { value: Ics20Withdrawal }) => {
   return (
     <ViewBox
@@ -42,7 +52,7 @@ export const Ics20WithdrawalComponent = ({ value }: { value: Ics20Withdrawal }) 
           )}
 
           <ActionDetails.Row label='Timeout Time'>
-            {new Date(Number(BigInt(value.timeoutTime) / 1_000_000n)).toString()}
+            {getUtcTime(value.timeoutTime)}
           </ActionDetails.Row>
         </ActionDetails>
       }


### PR DESCRIPTION
Relates to https://github.com/prax-wallet/web/pull/90

Renders the withdrawal transaction like this:

<img width="1477" alt="image" src="https://github.com/penumbra-zone/web/assets/29180358/e347b196-d7cc-4b52-8bc6-d3064f3a9025">
