### PR TITLE
injection state and event subscription

### DIFF
--- a/.changeset/ten-bugs-walk.md
+++ b/.changeset/ten-bugs-walk.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/client': minor
+---
+
+add injection state method and events

--- a/apps/minifront/src/components/shared/error-boundary.tsx
+++ b/apps/minifront/src/components/shared/error-boundary.tsx
@@ -1,6 +1,6 @@
 import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
 import {
-  PenumbraProviderNotInstalledError,
+  PenumbraNotInstalledError,
   PenumbraProviderNotConnectedError,
 } from '@penumbra-zone/client';
 import { ExtensionNotConnected } from '../extension-not-connected';
@@ -15,7 +15,7 @@ export const ErrorBoundary = () => {
 
   if (error instanceof ConnectError && error.code === Code.Unavailable)
     return <ExtensionTransportDisconnected />;
-  if (error instanceof PenumbraProviderNotInstalledError) return <ExtensionNotInstalled />;
+  if (error instanceof PenumbraNotInstalledError) return <ExtensionNotInstalled />;
   if (error instanceof PenumbraProviderNotConnectedError) return <ExtensionNotConnected />;
   if (isRouteErrorResponse(error) && error.status === 404) return <NotFound />;
 

--- a/packages/client/src/create.ts
+++ b/packages/client/src/create.ts
@@ -1,16 +1,15 @@
 import { createPromiseClient, type Transport } from '@connectrpc/connect';
-import type { PenumbraService } from '@penumbra-zone/protobuf';
-import { jsonOptions } from '@penumbra-zone/protobuf';
+import { jsonOptions, type PenumbraService } from '@penumbra-zone/protobuf';
 import {
   createChannelTransport,
   type ChannelTransportOptions,
 } from '@penumbra-zone/transport-dom/create';
+import { PenumbraSymbol, type PenumbraInjection } from '.';
 import {
+  PenumbraNotInstalledError,
   PenumbraProviderNotAvailableError,
   PenumbraProviderNotConnectedError,
-  PenumbraNotInstalledError,
 } from './error';
-import { PenumbraSymbol, type PenumbraInjection } from '.';
 
 // Naively return the first available provider origin, or `undefined`.
 const availableOrigin = () => Object.keys(window[PenumbraSymbol] ?? {})[0];

--- a/packages/client/src/error.ts
+++ b/packages/client/src/error.ts
@@ -3,50 +3,32 @@ export enum PenumbraRequestFailure {
   NeedsLogin = 'NeedsLogin',
 }
 
-export class PenumbraNotAvailableError extends Error {
-  constructor(
-    message = "Penumbra global `window[Symbol.for('penumbra')]` is not available",
-    public opts?: ErrorOptions,
-  ) {
-    super(message, opts);
-    this.name = 'PenumbraNotAvailableError';
-  }
-}
 export class PenumbraProviderNotAvailableError extends Error {
-  constructor(
-    providerOrigin?: string,
-    public opts?: ErrorOptions,
-  ) {
+  constructor(providerOrigin?: string, opts?: ErrorOptions) {
     super(`Penumbra provider ${providerOrigin} is not available`, opts);
-    this.name = 'PenumbraNotAvailableError';
+    this.name = 'PenumbraProviderNotAvailableError';
   }
 }
 
 export class PenumbraProviderNotConnectedError extends Error {
-  constructor(
-    providerOrigin?: string,
-    public opts?: ErrorOptions,
-  ) {
+  constructor(providerOrigin?: string, opts?: ErrorOptions) {
     super(`Penumbra provider ${providerOrigin} is not connected`, opts);
-    this.name = 'PenumbraNotConnectedError';
+    this.name = 'PenumbraProviderNotConnectedError';
   }
 }
 
 export class PenumbraProviderRequestError extends Error {
-  constructor(
-    providerOrigin?: string,
-    public opts?: ErrorOptions & { cause: PenumbraRequestFailure },
-  ) {
+  constructor(providerOrigin?: string, opts?: ErrorOptions & { cause: PenumbraRequestFailure }) {
     super(`Penumbra provider ${providerOrigin} did not approve request`, opts);
-    this.name = 'PenumbraRequestError';
+    this.name = 'PenumbraProviderRequestError';
   }
 }
-export class PenumbraProviderNotInstalledError extends Error {
+export class PenumbraNotInstalledError extends Error {
   constructor(
-    providerOrigin?: string,
-    public opts?: ErrorOptions,
+    message = "Penumbra global `window[Symbol.for('penumbra')]` is not present.",
+    opts?: ErrorOptions,
   ) {
-    super(`Penumbra provider ${providerOrigin} is not installed`, opts);
+    super(message, opts);
     this.name = 'PenumbraNotInstalledError';
   }
 }

--- a/packages/client/src/event.ts
+++ b/packages/client/src/event.ts
@@ -1,0 +1,15 @@
+import { PenumbraInjectionState, PenumbraSymbol } from '.';
+
+export class PenumbraInjectionStateEvent extends CustomEvent<{
+  origin: string;
+  state?: PenumbraInjectionState;
+}> {
+  constructor(injectionProviderOrigin: string, injectionState?: PenumbraInjectionState) {
+    super('penumbrastate', {
+      detail: {
+        state: injectionState ?? window[PenumbraSymbol]?.[injectionProviderOrigin]?.state(),
+        origin: injectionProviderOrigin,
+      },
+    });
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,5 @@
 export * from './error';
+export * from './event';
 
 export const PenumbraSymbol = Symbol.for('penumbra');
 
@@ -67,12 +68,6 @@ export interface PenumbraInjection {
    * `PenumbraInjectionState` value. */
   readonly addEventListener: EventTarget['addEventListener'];
   readonly removeEventListener: EventTarget['removeEventListener'];
-}
-
-export class PenumbraInjectionStateEvent extends CustomEvent<PenumbraInjectionState> {
-  constructor(override readonly detail: PenumbraInjectionState) {
-    super('penumbrastate', { detail });
-  }
 }
 
 export enum PenumbraInjectionState {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,21 +2,28 @@ export * from './error';
 
 export const PenumbraSymbol = Symbol.for('penumbra');
 
-/** This interface describes the simple API to request, connect, or disconnect a provider.
+/**
+ * This interface describes the simple API to request, connect, or disconnect a
+ * provider. These methods allow a page to acquire permission to connect, and
+ * obtain a `MessagePort` to be used for client creation.
  *
- * There are three states for each provider, which may be identified by calling
- * the synchronous method `isConnected()`:
+ * There are three connection states for each provider, which may be identified
+ * by calling the synchronous method `isConnected()`:
  * - `true`: a connection is available, and a call to `connect` should resolve
  * - `false`: no connection available. calls to `connect` or `request` will fail
- * - `undefined`: a `request` may be pending, or no `request` has been made
+ * - `undefined`: a call may be pending, or no call has been made
+ *
+ * Each injection may should also track state-changing actions, so calling
+ * `.state()` should provide more detail including currently pending state,
+ * enumerated by `PenumbraInjectionState`.
  *
  * Any script in page scope may create an object like this, so clients should
- * confirm a provider is actually present by confirming provider origin and
- * fetching the provider manifest. Provider details such as name, version,
- * website, brief descriptive text, and icons should be available in the
- * manifest.
+ * confirm a provider is actually present. Presence can be securely verified by
+ * fetching the identified provider manifest from the provider's origin.
  *
- * Presently clients may expect the manifest is a chrome extension manifest v3.
+ * Presently clients can expect the manifest is a chrome extension manifest v3.
+ * Provider details such as name, version, website, brief descriptive text, and
+ * icons should be available in the manifest.
  * @see https://developer.chrome.com/docs/extensions/reference/manifest
  *
  * Clients may `request()` approval to connect. This method may reject if the
@@ -31,34 +38,68 @@ export const PenumbraSymbol = Symbol.for('penumbra');
  *
  */
 export interface PenumbraInjection {
-  /** Call when creating a channel transport to this provider.  Returns a promise
-   * that may resolve with an active `MessagePort`. */
+  /** Should contain a URI at the provider's origin, serving a manifest
+   * describing this provider. */
+  readonly manifest: string;
+
+  /** Call to acquire a `MessagePort` to this provider, subject to approval. */
   readonly connect: () => Promise<MessagePort>;
 
-  /** Call to gain approval to connect.  Returns a `Promise<void>` that may
-   * reject with an enumerated failure reason. */
+  /** Call to gain approval.  May reject with a `PenumbraProviderRequestError`
+   * containing an enumerated `PenumbraRequestFailure` cause. */
   readonly request: () => Promise<void>;
 
-  /** Call to indicate the provider should revoke approval of this origin. */
+  /** Call to indicate the provider should discard approval of this origin. */
   readonly disconnect: () => Promise<void>;
 
   /** Should synchronously return the present connection state.
-   *
    * - `true` indicates active connection.
    * - `false` indicates connection is closed or rejected.
-   * - `undefined` indicates connection may be attempted.
+   * - `undefined` no attempt has resolved. connection may be attempted.
    */
   readonly isConnected: () => boolean | undefined;
 
-  /** Should contain a URI at the provider's origin, which returns a chrome
-   * extension manifest v3 describing this provider. */
-  readonly manifest: string;
+  /** Synchronously return present injection state. */
+  readonly state: () => PenumbraInjectionState;
+
+  /** Emits `PenubraInjectionStateEvent` when state changes. Listen for
+   * `'penumbrastate'` events, and check the `detail` field for a
+   * `PenumbraInjectionState` value. */
+  readonly addEventListener: EventTarget['addEventListener'];
+  readonly removeEventListener: EventTarget['removeEventListener'];
+}
+
+export class PenumbraInjectionStateEvent extends CustomEvent<PenumbraInjectionState> {
+  constructor(override readonly detail: PenumbraInjectionState) {
+    super('penumbrastate', { detail });
+  }
+}
+
+export enum PenumbraInjectionState {
+  /* error is present */
+  'Failed' = 'Failed',
+
+  /* no action has been taken */
+  'Present' = 'Present',
+
+  /* approval request pending */
+  'RequestPending' = 'RequestPending',
+  /* request for approval satisfied */
+  'Requested' = 'Requested',
+
+  /* connection attempt pending */
+  'ConnectPending' = 'ConnectPending',
+  /* connection successful and active */
+  'Connected' = 'Connected',
+
+  /* disconnect was called to release approval */
+  'Disconnected' = 'Disconnected',
 }
 
 declare global {
   interface Window {
-    /** Records upon this global should identify themselves by a field name
-     * matching the origin of the provider. */
+    /** Records injected upon this global should identify themselves by a field
+     * name matching the origin of the provider. */
     readonly [PenumbraSymbol]?: undefined | Readonly<Record<string, PenumbraInjection>>;
   }
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,7 +14,7 @@ export const PenumbraSymbol = Symbol.for('penumbra');
  * - `false`: no connection available. calls to `connect` or `request` will fail
  * - `undefined`: a call may be pending, or no call has been made
  *
- * Each injection may should also track state-changing actions, so calling
+ * Each injection should also track state-changing actions, so calling
  * `.state()` should provide more detail including currently pending state,
  * enumerated by `PenumbraInjectionState`.
  *


### PR DESCRIPTION
Describe interfaces for injection state.

as suggested in https://github.com/penumbra-zone/web/pull/1293#discussion_r1660844191

uses an EventTarget to manage subscribers, and an event type extending CustomEvent 