### PR TITLE
fix: #1371: candelesticks and the rest

### DIFF
--- a/.changeset/tasty-emus-worry.md
+++ b/.changeset/tasty-emus-worry.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/services': patch
+'minifront': patch
+---
+
+Services: add priority scores to the `assets` service. Minifront: fix rendering issues

--- a/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
+++ b/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
@@ -37,15 +37,13 @@ const getAssetOutBalance = (
 ) => {
   if (!assetIn || !assetOut) return zeroValueView();
 
-  const assetOutMetadata = new Metadata(assetOut);
-
   const match = balancesResponses.find(balance => {
     const balanceViewMetadata = getMetadataFromBalancesResponse(balance);
 
     return (
       getAddressIndex(balance.accountAddress).account ===
         getAddressIndex(assetIn.accountAddress).account &&
-      assetOutMetadata.penumbraAssetId?.equals(balanceViewMetadata.penumbraAssetId)
+      assetOut.penumbraAssetId?.equals(balanceViewMetadata.penumbraAssetId)
     );
   });
   const matchedBalance = getBalanceView.optional()(match);

--- a/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
+++ b/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
@@ -37,12 +37,15 @@ const getAssetOutBalance = (
 ) => {
   if (!assetIn || !assetOut) return zeroValueView();
 
+  const assetOutMetadata = new Metadata(assetOut);
+
   const match = balancesResponses.find(balance => {
     const balanceViewMetadata = getMetadataFromBalancesResponse(balance);
 
     return (
-      getAddressIndex(balance.accountAddress).equals(getAddressIndex(assetIn.accountAddress)) &&
-      assetOut.equals(balanceViewMetadata)
+      getAddressIndex(balance.accountAddress).account ===
+        getAddressIndex(assetIn.accountAddress).account &&
+      assetOutMetadata.penumbraAssetId?.equals(balanceViewMetadata.penumbraAssetId)
     );
   });
   const matchedBalance = getBalanceView.optional()(match);
@@ -161,6 +164,9 @@ export const TokenSwapInput = () => {
             </div>
           </div>
         </div>
+      </div>
+
+      <div className='pt-2'>
         {priceHistory.startMetadata && priceHistory.endMetadata && priceHistory.candles.length ? (
           <CandlestickPlot
             className='h-[480px] w-full bg-charcoal'

--- a/packages/services/src/view-service/assets.ts
+++ b/packages/services/src/view-service/assets.ts
@@ -1,6 +1,7 @@
 import type { Impl } from '.';
 import { servicesCtx } from '../ctx/prax';
 import { assetPatterns, RegexMatcher } from '@penumbra-zone/types/assets';
+import { getAssetPriorityScore } from './util/asset-priority-score';
 
 export const assets: Impl['assets'] = async function* (req, ctx) {
   const services = await ctx.values.get(servicesCtx)();
@@ -48,6 +49,9 @@ export const assets: Impl['assets'] = async function* (req, ctx) {
 
   for await (const metadata of indexedDb.iterateAssetsMetadata()) {
     if (filtered && !patterns.find(p => p.pattern.matches(metadata.display))) continue;
+    if (!metadata.priorityScore) {
+      metadata.priorityScore = getAssetPriorityScore(metadata, indexedDb.stakingTokenAssetId);
+    }
     yield { denomMetadata: metadata };
   }
 };


### PR DESCRIPTION
fixes #1371

also fixes the asset out balance issue + priority scores issue in the `assets` service that caused the problem with metadata comparison