### PR TITLE
don't error ibc page if no connections available

### DIFF
--- a/apps/minifront/src/components/ibc/ibc-in/hooks.ts
+++ b/apps/minifront/src/components/ibc/ibc-in/hooks.ts
@@ -21,8 +21,11 @@ BigInt.prototype.toJSON = function () {
 export const useChainConnector = () => {
   const { selectedChain } = useStore(ibcInSelector);
   const { chainRecords } = useManager();
-  const defaultChain = chainRecords[0]!.name;
-  return useChain(selectedChain?.chainName ?? defaultChain);
+  const selectedOrDefaultChain = selectedChain?.chainName ?? chainRecords[0]?.name;
+  if (!selectedOrDefaultChain) {
+    throw new Error('No chain available');
+  }
+  return useChain(selectedOrDefaultChain);
 };
 
 const useCosmosQueryHooks = () => {

--- a/apps/minifront/src/components/ibc/ibc-in/interchain-ui.tsx
+++ b/apps/minifront/src/components/ibc/ibc-in/interchain-ui.tsx
@@ -14,6 +14,9 @@ export const InterchainUi = () => {
   if (!data) {
     return <></>;
   }
+  if (!data.ibcConnections.length) {
+    return <div>No known IBC connections available for {data.chainId}</div>;
+  }
 
   return (
     <IbcChainProvider registry={data}>


### PR DESCRIPTION
fixes #1449 

ibc page no longer errors, but the page is still not usable because no ibc connections are known to the registry.