### PR TITLE
eslint rule no-non-null-assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "turbo format",
     "format:prettier": "prettier --write .",
     "format:syncpack": "syncpack format",
-    "lint": "turbo lint -- --max-warnings 0",
+    "lint": "turbo lint",
     "lint:fix": "turbo lint -- --fix",
     "lint:prettier": "prettier --check .",
     "lint:rust": "turbo lint:rust",

--- a/packages/eslint-config/eslint.config.mjs
+++ b/packages/eslint-config/eslint.config.mjs
@@ -70,6 +70,7 @@ export const penumbraEslintConfig = {
     '@typescript-eslint/no-unnecessary-condition': ['error', { allowConstantLoopConditions: true }],
     '@typescript-eslint/no-invalid-void-type': 'off',
     '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+    '@typescript-eslint/no-non-null-assertion': 'warn',
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     // Catches untyped let declarations


### PR DESCRIPTION
relevant #1449

```
@repo/ui:lint: ✖ 23 problems (0 errors, 23 warnings)
@penumbra-zone/perspective:lint: ✖ 12 problems (0 errors, 12 warnings)
@penumbra-zone/query:lint: ✖ 2 problems (0 errors, 2 warnings)
@penumbra-zone/transport-chrome:lint: ✖ 2 problems (0 errors, 2 warnings)
@penumbra-zone/services:lint: ✖ 22 problems (0 errors, 22 warnings)
@penumbra-zone/crypto-web:lint: ✖ 4 problems (0 errors, 4 warnings)
minifront:lint: ✖ 23 problems (0 errors, 23 warnings)
@penumbra-zone/bech32m:lint: ✖ 2 problems (0 errors, 2 warnings)
@penumbra-zone/types:lint: ✖ 2 problems (0 errors, 2 warnings)
@penumbra-zone/storage:lint: ✖ 19 problems (0 errors, 19 warnings)
```

a lot of that is probably tests