### PR TITLE
feat(minifront): #1225: reverse swap button

### DIFF
--- a/.changeset/cool-coats-complain.md
+++ b/.changeset/cool-coats-complain.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Minifront: add reverse swap assets button

--- a/apps/minifront/src/state/swap/getters.ts
+++ b/apps/minifront/src/state/swap/getters.ts
@@ -1,0 +1,48 @@
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
+import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import { getAddressIndex } from '@penumbra-zone/getters/address-view';
+import { getMetadata } from '@penumbra-zone/getters/value-view';
+
+export const balancesResponseAndMetadataAreSameAsset = (
+  balancesResponse?: BalancesResponse,
+  metadata?: Metadata,
+) => getMetadata.optional()(balancesResponse?.balanceView)?.equals(metadata);
+
+export const getFirstBalancesResponseNotMatchingMetadata = (
+  balancesResponses: BalancesResponse[],
+  metadata?: Metadata,
+) =>
+  balancesResponses.find(
+    balancesResponse => !balancesResponseAndMetadataAreSameAsset(balancesResponse, metadata),
+  );
+
+export const getFirstBalancesResponseMatchingMetadata = (
+  balancesResponses: BalancesResponse[],
+  metadata?: Metadata,
+) =>
+  balancesResponses.find(balancesResponse =>
+    balancesResponseAndMetadataAreSameAsset(balancesResponse, metadata),
+  );
+
+export const getFirstMetadataNotMatchingBalancesResponse = (
+  metadatas: Metadata[],
+  balancesResponse: BalancesResponse,
+) =>
+  metadatas.find(metadata => !balancesResponseAndMetadataAreSameAsset(balancesResponse, metadata));
+
+export const getBalanceByMatchingMetadataAndAddressIndex = (
+  balances: BalancesResponse[],
+  addressIndex: AddressIndex,
+  metadata: Metadata,
+) => {
+  return balances.find(balance => {
+    const balanceViewMetadata = getMetadataFromBalancesResponseOptional(balance);
+
+    return (
+      getAddressIndex(balance.accountAddress).account === addressIndex.account &&
+      metadata.penumbraAssetId?.equals(balanceViewMetadata?.penumbraAssetId)
+    );
+  });
+};


### PR DESCRIPTION
Closes #1225 

Made the arrow button clickable. Reverse actions preserve the account index selected for the assetIn