### PR TITLE
use inverse candlestick data in chart

### DIFF
--- a/apps/minifront/src/state/swap/helpers.ts
+++ b/apps/minifront/src/state/swap/helpers.ts
@@ -24,7 +24,6 @@ import { fromBaseUnitAmount } from '@penumbra-zone/types/amount';
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
 import { isKnown } from '../helpers';
 import { AbridgedZQueryState } from '@penumbra-zone/zquery/src/types';
-import { toPlainMessage } from '@bufbuild/protobuf';
 
 export const sendSimulateTradeRequest = ({
   assetIn,
@@ -51,6 +50,15 @@ export const sendSimulateTradeRequest = ({
   return simulationClient.simulateTrade(req);
 };
 
+/**
+ * Due to the way price data is recorded, symmetric comparisons do not return
+ * symmetric data. to get the complete picture, a client must combine both
+ * datasets.
+ *  1. query the intended comparison direction (start token -> end token)
+ *  2. query the inverse comparison direction (end token -> start token)
+ *  3. flip the inverse data (reciprocal values, high becomes low)
+ *  4. combine the data (use the highest high, lowest low, sum volumes)
+ */
 export const sendCandlestickDataRequests = async (
   { startMetadata, endMetadata }: Pick<PriceHistorySlice, 'startMetadata' | 'endMetadata'>,
   limit: bigint,
@@ -67,68 +75,72 @@ export const sendCandlestickDataRequests = async (
   }
 
   const suppressAbort = (err: unknown) => {
-    if (signal && !signal.aborted) {
+    if (!signal?.aborted) {
       throw err;
     }
   };
 
   const directReq = dexClient
-    .candlestickData(
-      {
-        pair: { start, end },
-        limit,
-      },
-      { signal },
-    )
+    .candlestickData({ pair: { start, end }, limit }, { signal })
     .catch(suppressAbort);
-
   const inverseReq = dexClient
-    .candlestickData(
-      {
-        pair: { start: end, end: start },
-        limit,
-      },
-      { signal },
-    )
+    .candlestickData({ pair: { start: end, end: start }, limit }, { signal })
     .catch(suppressAbort);
 
-  const candlestickData = (await directReq)?.data ?? [];
+  const directCandles = (await directReq)?.data ?? [];
+  const inverseCandles = (await inverseReq)?.data ?? [];
 
-  const inverseCandlestickData = (await inverseReq)?.data ?? [];
-
-  const collated = Map.groupBy(
+  // collect candles at each height
+  const collatedByHeight = Map.groupBy(
     [
-      ...candlestickData,
-      ...inverseCandlestickData.map(
-        cd =>
-          new CandlestickData({
-            ...toPlainMessage(cd),
-            close: 1 / cd.close,
-            high: 1 / cd.low,
-            low: 1 / cd.high,
-            open: 1 / cd.open,
-          }),
+      ...directCandles,
+      ...inverseCandles.map(
+        // flip inverse data to match orientation of direct data
+        inverseCandle => {
+          const correctedCandle = inverseCandle.clone();
+          // comparative values are reciprocal
+          correctedCandle.open = 1 / inverseCandle.open;
+          correctedCandle.close = 1 / inverseCandle.close;
+          // high and low swap places
+          correctedCandle.high = 1 / inverseCandle.low;
+          correctedCandle.low = 1 / inverseCandle.high;
+          return correctedCandle;
+        },
       ),
     ],
     ({ height }) => height,
   );
 
-  const combined = Array.from(collated.values()).map(([first, extra]) => {
-    if (first && extra) {
-      return new CandlestickData({
-        directVolume: first.directVolume + extra.directVolume,
-        swapVolume: first.swapVolume + extra.swapVolume,
-        height: first.height,
-        open: (first.open + extra.open) / 2,
-        close: (first.close + extra.close) / 2,
-        high: first.high > extra.high ? first.high : extra.high,
-        low: first.low < extra.low ? first.low : extra.low,
-      });
-    }
-    return first!;
-  });
+  // combine data at each height into a single candle
+  const combinedCandles = Array.from(collatedByHeight.entries()).map(
+    ([height, candlesAtHeight]) => {
+      // TODO: open/close don't diverge much, and when they do it seems to be due
+      // to inadequate number precision. it might be better to just pick one, but
+      // it's not clear which one is 'correct'
+      const combinedCandleAtHeight = candlesAtHeight.reduce((acc, cur) => {
+        // sum volumes
+        acc.directVolume += cur.directVolume;
+        acc.swapVolume += cur.swapVolume;
 
-  return combined;
+        // highest high, lowest low
+        acc.high = Math.max(acc.high, cur.high);
+        acc.low = Math.min(acc.low, cur.low);
+
+        // these accumulate to be averaged
+        acc.open += cur.open;
+        acc.close += cur.close;
+        return acc;
+      }, new CandlestickData({ height }));
+
+      // average accumulated open/close
+      combinedCandleAtHeight.open /= candlesAtHeight.length;
+      combinedCandleAtHeight.close /= candlesAtHeight.length;
+
+      return combinedCandleAtHeight;
+    },
+  );
+
+  return combinedCandles;
 };
 
 const byBalanceDescending = (a: BalancesResponse, b: BalancesResponse) => {


### PR DESCRIPTION
fixes https://github.com/penumbra-zone/web/issues/1347 #1183

due to the way price data is recorded, symmetric comparisons do not return symmetric data. to get the complete picture, the client must combine both datasets.

1. query the intended comparison direction (start token -> end token)
2. query the opposite comparison direction (end token -> start token)
3. invert the opposite data (reciprocal values, high becomes low)
4. combine the data (blocks with duplicate records use the highest high, lowest low, sum volumes)

you'll need to run a local devnet and conduct trading activity to view a chart.

