### PR TITLE
fix: exports default

### DIFF
--- a/.changeset/curly-frogs-grin.md
+++ b/.changeset/curly-frogs-grin.md
@@ -1,0 +1,10 @@
+---
+'@penumbra-zone/transport-chrome': patch
+'@penumbra-zone/services': patch
+'@penumbra-zone/storage': patch
+'@penumbra-zone/crypto-web': patch
+'@penumbra-zone/query': patch
+'@penumbra-zone/types': patch
+---
+
+Move the "default" option in package.json exports field to the last

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -25,8 +25,8 @@
   "publishConfig": {
     "exports": {
       "./*": {
-        "default": "./dist/*.js",
-        "types": "./dist/*.d.ts"
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.js"
       }
     }
   },

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -25,8 +25,8 @@
   "publishConfig": {
     "exports": {
       "./*": {
-        "default": "./dist/*.js",
-        "types": "./dist/*.d.ts"
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.js"
       }
     }
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -25,12 +25,12 @@
   "publishConfig": {
     "exports": {
       "./ctx/*": {
-        "default": "./dist/ctx/*.js",
-        "types": "./dist/ctx/*.d.ts"
+        "types": "./dist/ctx/*.d.ts",
+        "default": "./dist/ctx/*.js"
       },
       "./*": {
-        "default": "./dist/*/index.js",
-        "types": "./dist/*/index.d.ts"
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
       }
     }
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -25,8 +25,8 @@
   "publishConfig": {
     "exports": {
       "./indexed-db": {
-        "default": "./dist/indexed-db/index.js",
-        "types": "./dist/indexed-db/index.d.ts"
+        "types": "./dist/indexed-db/index.d.ts",
+        "default": "./dist/indexed-db/index.js"
       }
     }
   },

--- a/packages/transport-chrome/package.json
+++ b/packages/transport-chrome/package.json
@@ -26,8 +26,8 @@
   "publishConfig": {
     "exports": {
       "./*": {
-        "default": "./dist/*.js",
-        "types": "./dist/*.d.ts"
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.js"
       }
     }
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,18 +19,18 @@
     "dist"
   ],
   "exports": {
-    "./*": "./src/*.ts",
-    "./internal-msg/*": "./src/internal-msg/*.ts"
+    "./internal-msg/*": "./src/internal-msg/*.ts",
+    "./*": "./src/*.ts"
   },
   "publishConfig": {
     "exports": {
       "./*": {
-        "default": "./dist/*.js",
-        "types": "./dist/*.d.ts"
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.js"
       },
       "./internal-msg/*": {
-        "default": "./dist/internal-msg/*.js",
-        "types": "./dist/internal-msg/*.d.ts"
+        "types": "./dist/internal-msg/*.d.ts",
+        "default": "./dist/internal-msg/*.js"
       }
     }
   },


### PR DESCRIPTION
Found a bug while using the `types` package in the Next.js example template saying [`Module not found: Error: Default condition should be last one`](https://stackoverflow.com/questions/76127288/module-not-found-error-default-condition-should-be-last-one). Happens in Next.js and  [microbundle](https://github.com/developit/microbundle) environment.