### PR TITLE
update decaf377 deps

### DIFF
--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1.0.86"
 ark-ff = { version = "0.4.2", features = ["std"] }
 base64 = "0.22.1"
 console_error_panic_hook = { version = "0.1.7", optional = true }
-decaf377 = { version = "0.5.0", features = ["r1cs"] }
+decaf377 = { version = "0.10.1", features = ["r1cs"] }
 hex = "0.4.3"
 indexed_db_futures = "0.4.1"
 prost = "0.12.6"


### PR DESCRIPTION
references https://github.com/penumbra-zone/web/issues/1481

@redshiftzero why does bumping decaf377 dep to `0.10.1` fail?

<img width="1728" alt="Screenshot 2024-07-17 at 12 28 01 AM" src="https://github.com/user-attachments/assets/df43ec8e-3d29-4780-b1f8-4eec1e53de92">

I was only able to get it working by adding the `arkworks` feature in the penumbra workspace https://github.com/penumbra-zone/penumbra/commit/48e2e4d18910f41e345e97d00d478227949d0b03