### PR TITLE
swap: estimation error messages

### DIFF
--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -190,3 +190,13 @@ export const isValidAmount = (amount: string, assetIn?: BalancesResponse) =>
 
 export const isKnown = (balancesResponse: BalancesResponse) =>
   getValueViewCaseFromBalancesResponse.optional()(balancesResponse) === 'knownAssetId';
+
+// Utility function to extract status code from error message.
+export const getStatusCodeFromError = (errorMessage: string): number | undefined => {
+  if (errorMessage.includes('HTTP 404')) {
+    return 404;
+  } else if (errorMessage.includes('HTTP 412')) {
+    return 412;
+  }
+  return undefined;
+};

--- a/apps/minifront/src/state/swap/instant-swap.ts
+++ b/apps/minifront/src/state/swap/instant-swap.ts
@@ -1,6 +1,6 @@
 import { AllSlices, SliceCreator } from '..';
 import { TransactionPlannerRequest } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
-import { isValidAmount, planBuildBroadcast , getStatusCodeFromError } from '../helpers';
+import { isValidAmount, planBuildBroadcast, getStatusCodeFromError } from '../helpers';
 import {
   AssetId,
   Metadata,


### PR DESCRIPTION
references https://github.com/penumbra-zone/web/issues/1423 and https://github.com/penumbra-zone/web/issues/936

handles specific error handling for different HTTP error codes, such as 412 (Precondition Failed) and 408 (Request Timeout), to provide better context to the user. The error messages can probably be improved.

**412** error: 
<img width="339" alt="Screenshot 2024-07-17 at 6 55 16 AM" src="https://github.com/user-attachments/assets/c25cecf4-dbed-4315-8b58-957818976a61">

**404** error:
<img width="339" alt="Screenshot 2024-07-17 at 6 56 14 AM" src="https://github.com/user-attachments/assets/1c442cb2-c9e1-46a2-ab8a-751a045cc601">
