### PR TITLE
`@penumbra-zone/react` tsconfig corrected

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -4,7 +4,9 @@
     "composite": true,
     "jsx": "react-jsx",
     "module": "Node16",
-    "noEmit": true,
+    "outDir": "dist",
+    "preserveWatchOutput": true,
+    "rootDir": "src",
     "target": "ESNext"
   },
   "extends": "@tsconfig/strictest/tsconfig.json",


### PR DESCRIPTION
this corrects the `@penumbra-zone/react` build which was producing an empty package, due to a rebase mistake