### PR TITLE
Only deploy an ephemeral Storybook preview for PRs that make changes to the UI package

### DIFF
--- a/.github/workflows/deploy-ui-preview-pr.yml
+++ b/.github/workflows/deploy-ui-preview-pr.yml
@@ -4,6 +4,10 @@ name: Deploy UI to temporary URL
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      # Only deploy an ephemeral Storybook preview for PRs that make changes to
+      # the UI package.
+      - 'packages/ui/src/**'
 permissions:
   checks: write
   contents: read


### PR DESCRIPTION
Manual testing:
- I pushed up [b598f3a](https://github.com/penumbra-zone/web/pull/1515/commits/b598f3ae1c02bfb5b10060f6a3c627eed0916fad) (the Github workflow change) and observed that this PR [did not deploy an ephemeral Storybook preview URL](https://github.com/penumbra-zone/web/actions/runs/9997927541).
- I then pushed up [0872ecb](https://github.com/penumbra-zone/web/commit/0872ecbc4d537129b5e8fd8e96e80fb74abe9592) (a temporary change to a file inside `packages/ui/src`) and observed that this PR [_did_ deploy an ephemeral Storybook preview URL](https://github.com/penumbra-zone/web/actions/runs/9997999327).
- I then `git reset --hard b598f3a` to go back to the first commit. Note that the `github-actions` comment for the ephemeral Storybook URL is still there — it doesn't get auto-deleted.

Closes https://github.com/prax-wallet/web/issues/113