### PR TITLE
add abort signalling and controls to transport

### DIFF
--- a/.changeset/rare-hotels-nail.md
+++ b/.changeset/rare-hotels-nail.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/transport-chrome': minor
+'@penumbra-zone/transport-dom': minor
+---
+
+respect transport abort controls

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -233,7 +233,9 @@ export default tseslint.config(
       '**/*.story.@(ts|tsx|js|jsx|mjs|cjs)',
     ],
     rules: {
+      '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/prefer-promise-reject-errors': 'off',
       'react/display-name': 'off',
     },
   },

--- a/packages/transport-chrome/src/session-client.ts
+++ b/packages/transport-chrome/src/session-client.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  isTransportAbort,
   isTransportError,
   isTransportMessage,
   isTransportStream,
@@ -102,10 +103,10 @@ export class CRSessionClient {
     try {
       if (ev.data === false) {
         this.disconnectService();
-      } else if (isTransportMessage(ev.data)) {
+      } else if (isTransportAbort(ev.data) || isTransportMessage(ev.data)) {
         this.servicePort.postMessage(ev.data);
       } else if (isTransportStream(ev.data)) {
-        this.servicePort.postMessage(this.requestChannelStream(ev.data));
+        this.servicePort.postMessage(this.makeChannelStreamRequest(ev.data));
       } else {
         console.warn('Unknown item from client', ev.data);
       }
@@ -135,7 +136,7 @@ export class CRSessionClient {
     return [{ requestId, stream }, [stream]] satisfies [TransportStream, [Transferable]];
   };
 
-  private requestChannelStream = ({ requestId, stream }: TransportStream) => {
+  private makeChannelStreamRequest = ({ requestId, stream }: TransportStream) => {
     const channel = nameConnection(this.prefix, ChannelLabel.STREAM);
     const sinkListener = (p: chrome.runtime.Port) => {
       if (p.name !== channel) {

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -154,7 +154,7 @@ export class CRSessionManager {
    */
   private clientMessageHandler(
     session: CRSession,
-    { requestId, message, timeoutMs }: TransportMessage,
+    { requestId, message }: TransportMessage,
   ): Promise<TransportEvent> {
     if (this.requests.has(requestId)) {
       throw new Error(`Request collision: ${requestId}`);
@@ -162,11 +162,7 @@ export class CRSessionManager {
     const requestController = new AbortController();
     session.signal.addEventListener('abort', () => requestController.abort());
     this.requests.set(requestId, requestController);
-    return this.handler(
-      message,
-      AbortSignal.any([session.signal, requestController.signal]),
-      timeoutMs,
-    )
+    return this.handler(message, AbortSignal.any([session.signal, requestController.signal]))
       .then(response =>
         response instanceof ReadableStream
           ? this.responseChannelStream(requestController.signal, {

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -5,15 +5,15 @@ import { isTransportInitChannel, TransportInitChannel } from './message.js';
 import { PortStreamSink, PortStreamSource } from './stream.js';
 import { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
 import {
+  isTransportAbort,
   isTransportMessage,
   TransportEvent,
   TransportMessage,
   TransportStream,
 } from '@penumbra-zone/transport-dom/messages';
 
-interface CRSession {
+interface CRSession extends AbortController {
   clientId: string;
-  acont: AbortController;
   port: chrome.runtime.Port;
   origin: string;
 }
@@ -43,6 +43,7 @@ interface CRSession {
 export class CRSessionManager {
   private static singleton?: CRSessionManager;
   private sessions = new Map<string, CRSession>();
+  private requests = new Map<string, AbortController>();
 
   private constructor(
     private prefix: string,
@@ -61,6 +62,19 @@ export class CRSessionManager {
    */
   public static init = (prefix: string, handler: ChannelHandlerFn) => {
     CRSessionManager.singleton ??= new CRSessionManager(prefix, handler);
+    return CRSessionManager.singleton.sessions;
+  };
+
+  public static killOrigin = (targetOrigin: string) => {
+    if (CRSessionManager.singleton) {
+      CRSessionManager.singleton.sessions.forEach(session => {
+        if (session.origin === targetOrigin) {
+          session.abort(targetOrigin);
+        }
+      });
+    } else {
+      throw new Error('No session manager');
+    }
   };
 
   /**
@@ -100,29 +114,31 @@ export class CRSessionManager {
     if (this.sessions.has(clientId)) {
       throw new Error(`Session collision: ${clientId}`);
     }
-    const session = {
+
+    const session: CRSession = Object.assign(new AbortController(), {
       clientId,
-      acont: new AbortController(),
       origin: sender.origin,
       port: port,
-    };
+    });
     this.sessions.set(clientId, session);
 
-    session.acont.signal.addEventListener('abort', () => port.disconnect());
-    port.onDisconnect.addListener(() => session.acont.abort('Disconnect'));
+    session.signal.addEventListener('abort', () => port.disconnect());
+    port.onDisconnect.addListener(() => session.abort('Disconnect'));
 
     port.onMessage.addListener((i, p) => {
       void (async () => {
         try {
-          if (isTransportMessage(i)) {
-            p.postMessage(await this.clientMessageHandler(session.acont.signal, i));
+          if (isTransportAbort(i)) {
+            this.requests.get(i.requestId)?.abort();
+          } else if (isTransportMessage(i)) {
+            p.postMessage(await this.clientMessageHandler(session, i));
           } else if (isTransportInitChannel(i)) {
             console.warn('Client streaming unimplemented', this.acceptChannelStreamRequest(i));
           } else {
             console.warn('Unknown item in transport', i);
           }
         } catch (e) {
-          session.acont.abort(e);
+          session.abort(e);
         }
       })();
     });
@@ -137,13 +153,23 @@ export class CRSessionManager {
    * representing an error.
    */
   private clientMessageHandler(
-    signal: AbortSignal,
-    { requestId, message }: TransportMessage,
+    session: CRSession,
+    { requestId, message, timeoutMs }: TransportMessage,
   ): Promise<TransportEvent> {
-    return this.handler(message)
+    if (this.requests.has(requestId)) {
+      throw new Error(`Request collision: ${requestId}`);
+    }
+    const requestController = new AbortController();
+    session.signal.addEventListener('abort', () => requestController.abort());
+    this.requests.set(requestId, requestController);
+    return this.handler(
+      message,
+      AbortSignal.any([session.signal, requestController.signal]),
+      timeoutMs,
+    )
       .then(response =>
         response instanceof ReadableStream
-          ? this.responseChannelStream(signal, {
+          ? this.responseChannelStream(requestController.signal, {
               requestId,
               stream: response as unknown,
             } as TransportStream)
@@ -152,7 +178,8 @@ export class CRSessionManager {
       .catch((error: unknown) => ({
         requestId,
         error: errorToJson(ConnectError.from(error), undefined),
-      }));
+      }))
+      .finally(() => this.requests.delete(requestId));
   }
 
   /**

--- a/packages/transport-dom/src/ReadableStream.from.ts
+++ b/packages/transport-dom/src/ReadableStream.from.ts
@@ -14,8 +14,10 @@ const ReadableStreamWithFrom: typeof ReadableStream & { from: ReadableStreamFrom
   'from' in ReadableStream
     ? (ReadableStream as typeof ReadableStream & { from: ReadableStreamFrom })
     : Object.assign(ReadableStream, {
-        from<T>(iterable: Iterable<T> | AsyncIterable<T>): ReadableStream<T> {
-          if (Symbol.iterator in iterable) {
+        from<T>(iterable: ReadableStream<T> | Iterable<T> | AsyncIterable<T>): ReadableStream<T> {
+          if (iterable instanceof ReadableStream) {
+            return iterable;
+          } else if (Symbol.iterator in iterable) {
             const it = iterable[Symbol.iterator]();
             return new ReadableStream({
               pull(cont) {

--- a/packages/transport-dom/src/create.test.ts
+++ b/packages/transport-dom/src/create.test.ts
@@ -1,46 +1,42 @@
-import { describe, expect, it } from 'vitest';
-
-import { createChannelTransport } from './create.js';
-import { ElizaService } from '@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect.js';
 import {
+  ConverseRequest,
+  ConverseResponse,
   IntroduceRequest,
+  IntroduceResponse,
   SayRequest,
   SayResponse,
 } from '@buf/connectrpc_eliza.bufbuild_es/connectrpc/eliza/v1/eliza_pb.js';
-import { createRegistry } from '@bufbuild/protobuf';
-import { TransportMessage } from './messages.js';
+import { ElizaService } from '@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect.js';
+import { Any, createRegistry, type PlainMessage } from '@bufbuild/protobuf';
+import type { Transport } from '@connectrpc/connect';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type ChannelTransportOptions, createChannelTransport } from './create.js';
+import type { TransportMessage, TransportStream } from './messages.js';
 
 import ReadableStream from './ReadableStream.from.js';
 
+const PRINT_TEST_TIMES = false;
+
 const typeRegistry = createRegistry(ElizaService);
 
-describe('createChannelClient', () => {
-  it('should return a transport', () => {
-    const { port2 } = new MessageChannel();
+describe('message transport', () => {
+  let port1: MessagePort;
+  let port2: MessagePort;
+  let transportOptions: ChannelTransportOptions;
+  let transport: Transport;
 
-    const transportOptions = {
+  beforeEach(() => {
+    ({ port1, port2 } = new MessageChannel());
+    transportOptions = {
       getPort: () => Promise.resolve(port2),
-      defaultTimeoutMs: 5000,
       jsonOptions: { typeRegistry },
     };
-
-    const transport = createChannelTransport(transportOptions);
-
-    expect(transport).toBeDefined();
+    transport = createChannelTransport(transportOptions);
   });
 
   it('should send and receive unary messages', async () => {
-    const { port1, port2 } = new MessageChannel();
-
-    const transportOptions = {
-      getPort: () => Promise.resolve(port2),
-      defaultTimeoutMs: 5000,
-      jsonOptions: { typeRegistry },
-    };
-
-    const transport = createChannelTransport(transportOptions);
-
-    const input = new SayRequest({ sentence: 'hello' });
+    const input: PlainMessage<SayRequest> = { sentence: 'hello' };
+    const response: PlainMessage<SayResponse> = { sentence: 'world' };
 
     const unaryRequest = transport.unary(
       ElizaService,
@@ -48,54 +44,46 @@ describe('createChannelClient', () => {
       undefined,
       undefined,
       undefined,
-      input,
+      new SayRequest(input),
     );
 
-    const otherEnd = new Promise<true>((resolve, reject) => {
+    const otherEnd = new Promise<void>((resolve, reject) => {
       port1.onmessage = (event: MessageEvent<unknown>) => {
         try {
           const { requestId, message } = event.data as TransportMessage;
 
           expect(requestId).toBeTypeOf('string');
           expect(message).toMatchObject({
-            sentence: 'hello',
+            ...input,
             '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayRequest',
           });
 
           port1.postMessage({
             requestId,
             message: {
-              sentence: 'world',
+              ...response,
               '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayResponse',
             },
           });
 
-          resolve(true);
+          resolve();
         } catch (e) {
-          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
           reject(e);
         }
       };
     });
 
-    await expect(otherEnd).resolves.toBe(true);
-
-    await expect(unaryRequest).resolves.toBeTruthy();
-    const { message: unaryResponse } = await unaryRequest;
-    expect(new SayResponse({ sentence: 'world' }).equals(unaryResponse)).toBeTruthy();
+    await expect(otherEnd).resolves.not.toThrow();
+    await expect(unaryRequest.then(({ message }) => message)).resolves.toMatchObject(response);
   });
 
   it('should send and receive streaming requests', async () => {
-    const { port1, port2 } = new MessageChannel();
-    const transportOptions = {
-      getPort: () => Promise.resolve(port2),
-      defaultTimeoutMs: 5000,
-      jsonOptions: { typeRegistry },
-    };
-
-    const transport = createChannelTransport(transportOptions);
-
-    const input = new IntroduceRequest({ name: 'Prax' });
+    const input: PlainMessage<IntroduceRequest> = { name: 'Prax' };
+    const responses: PlainMessage<IntroduceResponse>[] = [
+      { sentence: 'Yo' },
+      { sentence: 'This' },
+      { sentence: 'Streams' },
+    ];
 
     const streamRequest = transport.stream(
       ElizaService,
@@ -103,10 +91,10 @@ describe('createChannelClient', () => {
       undefined,
       undefined,
       undefined,
-      ReadableStream.from([input]),
+      ReadableStream.from([new IntroduceRequest(input)]),
     );
 
-    const otherEnd = new Promise<true>((resolve, reject) => {
+    const otherEnd = new Promise<void>((resolve, reject) => {
       port1.onmessage = (event: MessageEvent<unknown>) => {
         try {
           const { requestId, message } = event.data as TransportMessage;
@@ -117,63 +105,33 @@ describe('createChannelClient', () => {
             '@type': 'type.googleapis.com/connectrpc.eliza.v1.IntroduceRequest',
           });
 
-          const stream = ReadableStream.from([
-            {
-              sentence: 'Yo',
-              '@type': 'type.googleapis.com/connectrpc.eliza.v1.IntroduceResponse',
-            },
-            {
-              sentence: 'This',
-              '@type': 'type.googleapis.com/connectrpc.eliza.v1.IntroduceResponse',
-            },
-            {
-              sentence: 'Streams',
-              '@type': 'type.googleapis.com/connectrpc.eliza.v1.IntroduceResponse',
-            },
-          ]);
-
-          port1.postMessage(
-            {
-              requestId,
-              stream,
-            },
-            [stream],
+          const stream = ReadableStream.from(
+            responses.map(r => Any.pack(new IntroduceResponse(r)).toJson({ typeRegistry })),
           );
 
-          resolve(true);
+          port1.postMessage({ requestId, stream }, [stream]);
+
+          resolve();
         } catch (e) {
-          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
           reject(e);
         }
       };
     });
 
-    await expect(otherEnd).resolves.toBe(true);
-
+    await expect(otherEnd).resolves.not.toThrow();
     await expect(streamRequest).resolves.toMatchObject({ stream: true });
-    const { message: streamResponse } = await streamRequest;
-
-    const res = Array.fromAsync(streamResponse);
-    await expect(res).resolves.toBeTruthy();
+    await expect(
+      streamRequest.then(({ message }) => Array.fromAsync(message)),
+    ).resolves.toMatchObject(responses);
   });
 
   it('should require streaming requests to contain at least one message', async () => {
-    const { port2 } = new MessageChannel();
-    const transportOptions = {
-      getPort: () => Promise.resolve(port2),
-      defaultTimeoutMs: 5000,
-      jsonOptions: { typeRegistry },
-    };
-
-    const transport = createChannelTransport(transportOptions);
-
     const streamRequest = transport.stream(
       ElizaService,
       ElizaService.methods.introduce,
       undefined,
       undefined,
       undefined,
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       (async function* () {})(),
     );
 
@@ -181,16 +139,7 @@ describe('createChannelClient', () => {
   });
 
   it('should require server-streaming requests to contain only one message', async () => {
-    const { port2 } = new MessageChannel();
-    const transportOptions = {
-      getPort: () => Promise.resolve(port2),
-      defaultTimeoutMs: 5000,
-      jsonOptions: { typeRegistry },
-    };
-
-    const transport = createChannelTransport(transportOptions);
-
-    const input = new IntroduceRequest({ name: 'Prax' });
+    const inputs: PlainMessage<IntroduceRequest>[] = [{ name: 'Ananke' }, { name: 'Harpalyke' }];
 
     const streamRequest = transport.stream(
       ElizaService,
@@ -198,9 +147,299 @@ describe('createChannelClient', () => {
       undefined,
       undefined,
       undefined,
-      ReadableStream.from([input, input]),
+      ReadableStream.from(inputs.map(i => new IntroduceRequest(i))),
     );
 
     await expect(streamRequest).rejects.toThrow();
+  });
+
+  it('should handle bidirectional streaming requests', async () => {
+    const { port1, port2 } = new MessageChannel();
+    const transportOptions = {
+      getPort: () => Promise.resolve(port2),
+      jsonOptions: { typeRegistry },
+    };
+
+    const transport = createChannelTransport(transportOptions);
+
+    const inputs: PlainMessage<ConverseRequest>[] = [
+      { sentence: 'homomorphic?' },
+      { sentence: 'gemini double text' },
+    ];
+    const responses: PlainMessage<ConverseResponse>[] = [
+      { sentence: 'no' },
+      { sentence: 'im bi' },
+      { sentence: 'directional' },
+    ];
+
+    const streamRequest = transport.stream(
+      ElizaService,
+      ElizaService.methods.converse,
+      undefined,
+      undefined,
+      undefined,
+      ReadableStream.from(inputs),
+    );
+
+    const otherEnd = new Promise<void>((resolve, reject) => {
+      port1.onmessage = async (event: MessageEvent<unknown>) => {
+        try {
+          const { requestId, stream: inputStream } = event.data as TransportStream;
+
+          expect(requestId).toBeTypeOf('string');
+          await expect(Array.fromAsync(inputStream)).resolves.toMatchObject(inputs);
+
+          const responseStream = ReadableStream.from(
+            responses.map(r => Any.pack(new ConverseResponse(r)).toJson({ typeRegistry })),
+          );
+
+          port1.postMessage({ requestId, stream: responseStream }, [responseStream]);
+
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      };
+    });
+
+    await expect(otherEnd).resolves.not.toThrow();
+    await expect(streamRequest).resolves.toMatchObject({ stream: true });
+    await expect(
+      streamRequest.then(({ message }) => Array.fromAsync(message)),
+    ).resolves.toMatchObject(responses);
+  });
+});
+
+describe('transport options abort and timeout', () => {
+  let port1: MessagePort;
+  let port2: MessagePort;
+  let transportOptions: ChannelTransportOptions;
+  const defaultTimeoutMs = 200;
+  let transport: Transport;
+
+  beforeEach(() => {
+    performance.clearMarks();
+    ({ port1, port2 } = new MessageChannel());
+    transportOptions = {
+      getPort: () => Promise.resolve(port2),
+      jsonOptions: { typeRegistry },
+      defaultTimeoutMs,
+    };
+  });
+
+  it('should time out unary requests', async () => {
+    transport = createChannelTransport(transportOptions);
+
+    const input = { sentence: 'hello' };
+    const response = { sentence: '.........hello' };
+
+    const unaryRequest = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      undefined,
+      undefined,
+      undefined,
+      new SayRequest(input),
+    );
+
+    const otherEnd = new Promise<void>((resolve, reject) => {
+      port1.onmessage = (event: MessageEvent<unknown>) => {
+        try {
+          const { requestId, message } = event.data as TransportMessage;
+
+          expect(requestId).toBeTypeOf('string');
+          expect(message).toMatchObject({
+            ...input,
+            '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayRequest',
+          });
+
+          setTimeout(() => {
+            port1.postMessage({
+              requestId,
+              message: {
+                ...response,
+                '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayResponse',
+              },
+            });
+            resolve();
+          }, defaultTimeoutMs * 2);
+        } catch (e) {
+          reject(e);
+        }
+      };
+    });
+
+    await expect(unaryRequest).rejects.toThrow('[deadline_exceeded]');
+    await expect(otherEnd).resolves.not.toThrow();
+  });
+
+  it('should time out unary requests at a specified custom time', async () => {
+    transport = createChannelTransport(transportOptions);
+    const customTimeoutMs = 100;
+
+    const input: PlainMessage<SayRequest> = { sentence: 'hello' };
+    const response: PlainMessage<SayResponse> = { sentence: '.........hello' };
+
+    const unaryRequest = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      undefined,
+      customTimeoutMs,
+      undefined,
+      new SayRequest(input),
+    );
+
+    const otherEnd = new Promise<void>((resolve, reject) => {
+      port1.onmessage = (event: MessageEvent<unknown>) => {
+        try {
+          const { requestId, message } = event.data as TransportMessage;
+
+          expect(requestId).toBeTypeOf('string');
+          expect(message).toMatchObject({
+            ...input,
+            '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayRequest',
+          });
+
+          setTimeout(() => {
+            port1.postMessage({
+              requestId,
+              message: {
+                ...response,
+                '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayResponse',
+              },
+            });
+            resolve();
+          }, defaultTimeoutMs / 2);
+        } catch (e) {
+          reject(e);
+        }
+      };
+    });
+
+    await expect(unaryRequest).rejects.toThrow('[deadline_exceeded]');
+    await expect(otherEnd).resolves.not.toThrow();
+  });
+
+  it('should time out streaming requests', async () => {
+    transport = createChannelTransport(transportOptions);
+
+    const input: PlainMessage<IntroduceRequest> = { name: 'hello' };
+    const responses: PlainMessage<IntroduceResponse>[] = [
+      { sentence: 'this wont send before timeout' },
+    ];
+
+    const streamRequest = transport.stream(
+      ElizaService,
+      ElizaService.methods.introduce,
+      undefined,
+      undefined,
+      undefined,
+      ReadableStream.from([new IntroduceRequest(input)]),
+    );
+
+    const otherEnd = new Promise<void>((resolve, reject) => {
+      port1.onmessage = (event: MessageEvent<unknown>) => {
+        try {
+          const { requestId, message } = event.data as TransportMessage;
+
+          expect(requestId).toBeTypeOf('string');
+          expect(message).toMatchObject({
+            ...input,
+            '@type': 'type.googleapis.com/connectrpc.eliza.v1.IntroduceRequest',
+          });
+
+          const stream = ReadableStream.from(
+            responses.map(r => Any.pack(new IntroduceResponse(r)).toJson({ typeRegistry })),
+          );
+
+          setTimeout(() => {
+            port1.postMessage({ requestId, stream }, [stream]);
+            resolve();
+          }, defaultTimeoutMs * 2);
+        } catch (e) {
+          reject(e);
+        }
+      };
+    });
+
+    await expect(streamRequest).rejects.toThrow('[deadline_exceeded]');
+    await expect(otherEnd).resolves.not.toThrow();
+  });
+
+  it('should not time out streaming responses that are already streaming', async () => {
+    transport = createChannelTransport(transportOptions);
+
+    const input: PlainMessage<IntroduceRequest> = { name: 'hello' };
+    const responses: PlainMessage<IntroduceResponse>[] = [
+      { sentence: 'thiswillarrivebeforetimeout!!!' },
+      { sentence: 'and so will this,' },
+      { sentence: 'but this one is right on the edge' },
+      { sentence: '.....and this will arrive waaaaaay after timeout' },
+    ];
+
+    const streamRequest = transport.stream(
+      ElizaService,
+      ElizaService.methods.introduce,
+      undefined,
+      undefined,
+      undefined,
+      ReadableStream.from([new IntroduceRequest(input)]),
+    );
+
+    const streamDone = Promise.withResolvers<void>();
+
+    const otherEnd = new Promise<void>((resolve, reject) => {
+      port1.onmessage = (event: MessageEvent<unknown>) => {
+        try {
+          const { requestId, message } = event.data as TransportMessage;
+
+          expect(requestId).toBeTypeOf('string');
+          expect(message).toMatchObject({
+            ...input,
+            '@type': 'type.googleapis.com/connectrpc.eliza.v1.IntroduceRequest',
+          });
+
+          const stream = ReadableStream.from(
+            (async function* (
+              streamFinished: PromiseWithResolvers<void>['resolve'],
+              streamFailed: PromiseWithResolvers<void>['reject'],
+            ) {
+              performance.mark('stream');
+              try {
+                for (const [i, r] of responses.entries()) {
+                  await new Promise(resolve => setTimeout(resolve, defaultTimeoutMs / 3));
+                  performance.measure(`chunk ${i}`, 'stream');
+                  yield Any.pack(new IntroduceResponse(r)).toJson({ typeRegistry });
+                }
+                streamFinished();
+              } catch (e) {
+                streamFailed(e);
+              }
+              performance.measure('end', 'stream');
+            })(streamDone.resolve, streamDone.reject),
+          );
+
+          port1.postMessage({ requestId, stream }, [stream]);
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      };
+    });
+
+    await expect(otherEnd).resolves.not.toThrow();
+    await expect(
+      streamRequest.then(({ message }) => Array.fromAsync(message)),
+    ).resolves.not.toThrow();
+    await expect(streamDone.promise).resolves.not.toThrow();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (PRINT_TEST_TIMES) {
+      console.log('measure', [
+        { defaultTimeoutMs },
+        ...performance
+          .getEntriesByType('measure')
+          .map(({ name, duration }) => ({ name, duration })),
+      ]);
+    }
   });
 });

--- a/packages/transport-dom/src/messages.ts
+++ b/packages/transport-dom/src/messages.ts
@@ -2,7 +2,8 @@ import type { JsonValue } from '@bufbuild/protobuf';
 
 // transport meta
 
-export interface TransportError extends Partial<TransportEvent> {
+export interface TransportError<I extends string | undefined> extends Partial<TransportEvent> {
+  requestId: I extends string ? string : string | undefined;
   error: JsonValue;
   metadata?: HeadersInit;
 }
@@ -35,7 +36,8 @@ export interface TransportStream<I = string> extends TransportEvent<I extends st
 
 const isObj = (o: unknown): o is object => typeof o === 'object' && o !== null;
 
-export const isTransportError = (e: unknown): e is TransportError => isObj(e) && 'error' in e;
+export const isTransportError = <I extends string>(e: unknown, id?: I): e is TransportError<I> =>
+  isObj(e) && 'error' in e && (!id || ('requestId' in e && e.requestId === id));
 
 export const isTransportData = (t: unknown): t is TransportData =>
   isTransportMessage(t) || isTransportStream(t);

--- a/packages/transport-dom/src/messages.ts
+++ b/packages/transport-dom/src/messages.ts
@@ -15,7 +15,6 @@ export interface TransportEvent<I extends string = string> {
   requestId: I;
   header?: HeadersInit;
   trailer?: HeadersInit;
-  timeoutMs?: number;
   //contextValues?: object;
 }
 

--- a/packages/transport-dom/src/messages.ts
+++ b/packages/transport-dom/src/messages.ts
@@ -15,7 +15,12 @@ export interface TransportEvent<I extends string = string> {
   requestId: I;
   header?: HeadersInit;
   trailer?: HeadersInit;
+  timeoutMs?: number;
   //contextValues?: object;
+}
+
+export interface TransportAbort<I = string> extends TransportEvent<I extends string ? I : never> {
+  abort: true;
 }
 
 export interface TransportMessage<I = string> extends TransportEvent<I extends string ? I : never> {
@@ -49,3 +54,6 @@ export const isTransportMessage = <I extends string>(
 
 export const isTransportStream = <I extends string>(s: unknown, id?: I): s is TransportStream<I> =>
   isTransportEvent(s, id) && 'stream' in s && s.stream instanceof ReadableStream;
+
+export const isTransportAbort = <I extends string>(a: unknown, id?: I): a is TransportAbort<I> =>
+  isTransportEvent(a, id) && 'abort' in a && a.abort === true;


### PR DESCRIPTION
this will enable consumers to more gracefully abort pending requests, active streams, and transports as a whole