### PR TITLE
remove last window reference from `@penumbra-zone/react`

### DIFF
--- a/.changeset/hungry-flowers-worry.md
+++ b/.changeset/hungry-flowers-worry.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/react': patch
+---
+
+remove reference to window

--- a/packages/react/src/penumbra-context.ts
+++ b/packages/react/src/penumbra-context.ts
@@ -1,17 +1,10 @@
 import type { Transport } from '@connectrpc/connect';
-import {
-  PenumbraProvider,
-  PenumbraSymbol,
-  type PenumbraManifest,
-  type PenumbraState,
-} from '@penumbra-zone/client';
+import { PenumbraProvider, type PenumbraManifest, type PenumbraState } from '@penumbra-zone/client';
 import type { ChannelTransportOptions } from '@penumbra-zone/transport-dom/create';
 import { createContext } from 'react';
 
-const penumbraGlobal = window[PenumbraSymbol];
-
 export type PenumbraContext = Partial<Omit<PenumbraProvider, 'manifest' | 'state'>> & {
-  origin?: keyof NonNullable<typeof penumbraGlobal>;
+  origin?: string;
   manifest?: PenumbraManifest;
   port?: MessagePort | false;
   failure?: Error;


### PR DESCRIPTION
missed one lingering reference in a type definition - this should now generally be safe for use without special client/server config