### PR TITLE
feat(minifront): #1139: decimals validation

### DIFF
--- a/.changeset/shiny-eggs-do.md
+++ b/.changeset/shiny-eggs-do.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Add decimal part validation (its length cannot exeed the exponent of a selected token)

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -64,6 +64,11 @@ export const IbcOutForm = () => {
             issue: 'insufficient funds',
             checkFn: () => validationErrors.amountErr,
           },
+          {
+            type: 'error',
+            issue: 'invalid decimal length',
+            checkFn: () => validationErrors.exponentErr,
+          },
         ]}
         balances={filteredBalances}
       />

--- a/apps/minifront/src/components/send/send-form/index.tsx
+++ b/apps/minifront/src/components/send/send-form/index.tsx
@@ -83,6 +83,11 @@ export const SendForm = () => {
             issue: 'insufficient funds',
             checkFn: () => validationErrors.amountErr,
           },
+          {
+            type: 'error',
+            issue: 'invalid decimal length',
+            checkFn: () => validationErrors.exponentErr,
+          },
         ]}
         balances={transferableBalancesResponses?.data ?? []}
         loading={transferableBalancesResponses?.loading}

--- a/apps/minifront/src/components/shared/input-token.tsx
+++ b/apps/minifront/src/components/shared/input-token.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from 'react';
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
+import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
+import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import { BalanceValueView } from '@repo/ui/components/ui/balance-value-view';
 import { cn } from '@repo/ui/lib/utils';
 import BalanceSelector from './selectors/balance-selector';
 import { Validation } from './validation-result';
 import { InputBlock } from './input-block';
-import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
-import { BalanceValueView } from '@repo/ui/components/ui/balance-value-view';
 import { getFormattedAmtFromValueView } from '@penumbra-zone/types/value-view';
 import { NumberInput } from './number-input';
 
@@ -36,6 +39,10 @@ export default function InputToken({
   onInputChange,
   loading,
 }: InputTokenProps) {
+  const tokenExponent = useMemo(() => {
+    return getDisplayDenomExponent.optional()(getMetadataFromBalancesResponseOptional(selection));
+  }, [selection]);
+
   const setInputToBalanceMax = () => {
     const match = balances.find(b => b.balanceView?.equals(selection?.balanceView));
     if (match?.balanceView) {
@@ -52,6 +59,7 @@ export default function InputToken({
         <NumberInput
           variant='transparent'
           placeholder={placeholder}
+          maxExponent={tokenExponent}
           className={cn(
             'md:h-8 xl:h-10 md:w-[calc(100%-80px)] xl:w-[calc(100%-160px)] md:text-xl xl:text-3xl font-bold leading-10',
             inputClassName,

--- a/apps/minifront/src/components/shared/number-input/index.tsx
+++ b/apps/minifront/src/components/shared/number-input/index.tsx
@@ -1,8 +1,30 @@
+import type { FC, KeyboardEventHandler } from 'react';
 import { Input, InputProps } from '@repo/ui/components/ui/input';
 import { useWheelPrevent } from './use-wheel-prevent';
 
-export const NumberInput = (props: InputProps) => {
+export interface NumberInputProps extends InputProps {
+  /** If present, prevents users from entering the fractional number part longer than `maxExponent` */
+  maxExponent?: number;
+}
+
+export const NumberInput: FC<NumberInputProps> = ({ maxExponent, ...props }) => {
   const inputRef = useWheelPrevent();
 
-  return <Input ref={inputRef} type='number' {...props} />;
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (maxExponent === 0 && (event.key === '.' || event.key === ',')) {
+      event.preventDefault();
+      return;
+    }
+
+    if (typeof maxExponent !== 'undefined' && typeof props.value === 'string' && !Number.isNaN(Number(event.key))) {
+      const fraction = `${props.value}${event.key}`.split('.')[1]?.length;
+      if (fraction && fraction > maxExponent) {
+        event.preventDefault();
+        return;
+      }
+    }
+    props.onKeyDown?.(event);
+  };
+
+  return <Input ref={inputRef} {...props} type='number' onKeyDown={onKeyDown} />;
 };

--- a/apps/minifront/src/components/shared/number-input/index.tsx
+++ b/apps/minifront/src/components/shared/number-input/index.tsx
@@ -10,13 +10,17 @@ export interface NumberInputProps extends InputProps {
 export const NumberInput: FC<NumberInputProps> = ({ maxExponent, ...props }) => {
   const inputRef = useWheelPrevent();
 
-  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = event => {
     if (maxExponent === 0 && (event.key === '.' || event.key === ',')) {
       event.preventDefault();
       return;
     }
 
-    if (typeof maxExponent !== 'undefined' && typeof props.value === 'string' && !Number.isNaN(Number(event.key))) {
+    if (
+      typeof maxExponent !== 'undefined' &&
+      typeof props.value === 'string' &&
+      !Number.isNaN(Number(event.key))
+    ) {
       const fraction = `${props.value}${event.key}`.split('.')[1]?.length;
       if (fraction && fraction > maxExponent) {
         event.preventDefault();

--- a/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
+++ b/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
@@ -4,7 +4,11 @@ import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { Box } from '@repo/ui/components/ui/box';
 import { CandlestickPlot } from '@repo/ui/components/ui/candlestick-plot';
 import { joinLoHiAmount } from '@penumbra-zone/types/amount';
-import { getAmount, getBalanceView, getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import {
+  getAmount,
+  getBalanceView,
+  getMetadataFromBalancesResponseOptional,
+} from '@penumbra-zone/getters/balances-response';
 import { ArrowRight } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { getBlockDate } from '../../../fetchers/block-date';

--- a/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
+++ b/apps/minifront/src/components/swap/swap-form/token-swap-input.tsx
@@ -4,9 +4,9 @@ import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/
 import { Box } from '@repo/ui/components/ui/box';
 import { CandlestickPlot } from '@repo/ui/components/ui/candlestick-plot';
 import { joinLoHiAmount } from '@penumbra-zone/types/amount';
-import { getAmount, getBalanceView } from '@penumbra-zone/getters/balances-response';
+import { getAmount, getBalanceView, getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
 import { ArrowRight } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { getBlockDate } from '../../../fetchers/block-date';
 import { AllSlices } from '../../../state';
 import { useStoreShallow } from '../../../utils/use-store-shallow';
@@ -26,6 +26,7 @@ import {
   swappableAssetsSelector,
   swappableBalancesResponsesSelector,
 } from '../../../state/swap/helpers';
+import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 
 const getAssetOutBalance = (
   balancesResponses: BalancesResponse[] = [],
@@ -70,6 +71,9 @@ export const TokenSwapInput = () => {
   const { amount, setAmount, assetIn, setAssetIn, assetOut, setAssetOut, priceHistory, reverse } =
     useStoreShallow(tokenSwapInputSelector);
   const assetOutBalance = getAssetOutBalance(balancesResponses?.data, assetIn, assetOut);
+  const assetInExponent = useMemo(() => {
+    return getDisplayDenomExponent.optional()(getMetadataFromBalancesResponseOptional(assetIn));
+  }, [assetIn]);
 
   useEffect(() => {
     if (!assetIn || !assetOut) {
@@ -108,6 +112,7 @@ export const TokenSwapInput = () => {
           variant='transparent'
           placeholder='Enter an amount...'
           max={maxAmountAsString}
+          maxExponent={assetInExponent}
           step='any'
           className={'font-bold leading-10 md:h-8 md:text-xl xl:h-10 xl:text-3xl'}
           onChange={e => {

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -21,7 +21,8 @@ import { TransactionClassification } from '@penumbra-zone/perspective/transactio
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 import { fromValueView } from '@penumbra-zone/types/amount';
 import { BigNumber } from 'bignumber.js';
-import { getValueViewCaseFromBalancesResponse } from '@penumbra-zone/getters/balances-response';
+import { getMetadataFromBalancesResponseOptional, getValueViewCaseFromBalancesResponse } from '@penumbra-zone/getters/balances-response';
+import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 
 /**
  * Handles the common use case of planning, building, and broadcasting a
@@ -185,8 +186,29 @@ export const amountMoreThanBalance = (
   return Boolean(amountInDisplayDenom) && BigNumber(amountInDisplayDenom).gt(balanceAmt);
 };
 
+/**
+ * Checks if the entered amount fraction part is longer than the asset's exponent
+ */
+export const isIncorrectDecimal = (
+  asset: BalancesResponse,
+  /**
+   * The amount that a user types into the interface will always be in the
+   * display denomination -- e.g., in `penumbra`, not in `upenumbra`.
+   */
+  amountInDisplayDenom: string,
+): boolean => {
+  if (!asset.balanceView) {
+    throw new Error('Missing balanceView');
+  }
+
+  const exponent = getDisplayDenomExponent.optional()(getMetadataFromBalancesResponseOptional(asset));
+  const fraction = amountInDisplayDenom.split('.')[1]?.length;
+  return typeof exponent !== 'undefined' && typeof fraction !== 'undefined' && fraction > exponent;
+
+};
+
 export const isValidAmount = (amount: string, assetIn?: BalancesResponse) =>
-  Number(amount) >= 0 && (!assetIn || !amountMoreThanBalance(assetIn, amount));
+  Number(amount) >= 0 && (!assetIn || !amountMoreThanBalance(assetIn, amount)) && (!assetIn || !isIncorrectDecimal(assetIn, amount));
 
 export const isKnown = (balancesResponse: BalancesResponse) =>
   getValueViewCaseFromBalancesResponse.optional()(balancesResponse) === 'knownAssetId';

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -21,7 +21,10 @@ import { TransactionClassification } from '@penumbra-zone/perspective/transactio
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 import { fromValueView } from '@penumbra-zone/types/amount';
 import { BigNumber } from 'bignumber.js';
-import { getMetadataFromBalancesResponseOptional, getValueViewCaseFromBalancesResponse } from '@penumbra-zone/getters/balances-response';
+import {
+  getMetadataFromBalancesResponseOptional,
+  getValueViewCaseFromBalancesResponse,
+} from '@penumbra-zone/getters/balances-response';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 
 /**
@@ -201,14 +204,17 @@ export const isIncorrectDecimal = (
     throw new Error('Missing balanceView');
   }
 
-  const exponent = getDisplayDenomExponent.optional()(getMetadataFromBalancesResponseOptional(asset));
+  const exponent = getDisplayDenomExponent.optional()(
+    getMetadataFromBalancesResponseOptional(asset),
+  );
   const fraction = amountInDisplayDenom.split('.')[1]?.length;
   return typeof exponent !== 'undefined' && typeof fraction !== 'undefined' && fraction > exponent;
-
 };
 
 export const isValidAmount = (amount: string, assetIn?: BalancesResponse) =>
-  Number(amount) >= 0 && (!assetIn || !amountMoreThanBalance(assetIn, amount)) && (!assetIn || !isIncorrectDecimal(assetIn, amount));
+  Number(amount) >= 0 &&
+  (!assetIn || !amountMoreThanBalance(assetIn, amount)) &&
+  (!assetIn || !isIncorrectDecimal(assetIn, amount));
 
 export const isKnown = (balancesResponse: BalancesResponse) =>
   getValueViewCaseFromBalancesResponse.optional()(balancesResponse) === 'knownAssetId';

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -233,7 +233,9 @@ export const ibcValidationErrors = (state: AllSlices) => {
     amountErr: !state.ibcOut.selection
       ? false
       : amountMoreThanBalance(state.ibcOut.selection, state.ibcOut.amount),
-    exponentErr: !state.ibcOut.selection ? false : isIncorrectDecimal(state.ibcOut.selection, state.ibcOut.amount),
+    exponentErr: !state.ibcOut.selection
+      ? false
+      : isIncorrectDecimal(state.ibcOut.selection, state.ibcOut.amount),
   };
 };
 

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -14,7 +14,7 @@ import {
 } from '@penumbra-zone/getters/value-view';
 import { getAddressIndex } from '@penumbra-zone/getters/address-view';
 import { toBaseUnit } from '@penumbra-zone/types/lo-hi';
-import { amountMoreThanBalance, planBuildBroadcast } from './helpers';
+import { amountMoreThanBalance, isIncorrectDecimal, planBuildBroadcast } from './helpers';
 import { getAssetId } from '@penumbra-zone/getters/metadata';
 import { assetPatterns } from '@penumbra-zone/types/assets';
 import { bech32, bech32m } from 'bech32';
@@ -233,6 +233,7 @@ export const ibcValidationErrors = (state: AllSlices) => {
     amountErr: !state.ibcOut.selection
       ? false
       : amountMoreThanBalance(state.ibcOut.selection, state.ibcOut.amount),
+    exponentErr: !state.ibcOut.selection ? false : isIncorrectDecimal(state.ibcOut.selection, state.ibcOut.amount),
   };
 };
 

--- a/apps/minifront/src/state/send/index.ts
+++ b/apps/minifront/src/state/send/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
 import { BigNumber } from 'bignumber.js';
 import { MemoPlaintext } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb';
-import { amountMoreThanBalance, plan, planBuildBroadcast } from '../helpers';
+import { amountMoreThanBalance, isIncorrectDecimal, plan, planBuildBroadcast } from '../helpers';
 
 import {
   Fee,
@@ -177,6 +177,7 @@ const assembleRequest = ({
 export interface SendValidationFields {
   recipientErr: boolean;
   amountErr: boolean;
+  exponentErr: boolean;
   memoErr: boolean;
 }
 
@@ -189,6 +190,7 @@ export const sendValidationErrors = (
   return {
     recipientErr: Boolean(recipient) && !isAddress(recipient),
     amountErr: !asset ? false : amountMoreThanBalance(asset, amount),
+    exponentErr: !asset ? false : isIncorrectDecimal(asset, amount),
     // The memo cannot exceed 512 bytes
     // return address uses 80 bytes
     // so 512-80=432 bytes for memo text


### PR DESCRIPTION
Closes #1139 

Does two things:
- Prohibits entering the number with fractional part length greater than the exponent of a selected token
- Displays a validation error in case this amount was entered, extends the `isValidAmount` function. It can happen when, for example, user first enters the amount in 'UM' token, then changes to a token with different exponent

<img width="402" alt="image" src="https://github.com/user-attachments/assets/ee163b4b-7520-40aa-af89-367d394dee86">

See how the 'Send' button is disabled. Previously, entering the incorrect decimal amount was considered ok