### PR TITLE
Delegator voting action view

### DIFF
--- a/.changeset/late-dancers-check.md
+++ b/.changeset/late-dancers-check.md
@@ -1,0 +1,7 @@
+---
+'@penumbra-zone/perspective': minor
+'@penumbra-zone/getters': minor
+'@repo/ui': minor
+---
+
+Add support for delegate vote action views

--- a/packages/getters/src/delegator-vote-view.ts
+++ b/packages/getters/src/delegator-vote-view.ts
@@ -1,0 +1,14 @@
+import { createGetter } from './utils/create-getter.js';
+import {
+  DelegatorVoteBody,
+  DelegatorVoteView,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb.js';
+
+export const getDelegatorVoteBody = createGetter(
+  (view?: DelegatorVoteView) => view?.delegatorVote.value?.delegatorVote?.body,
+);
+
+const getProposal = createGetter((body?: DelegatorVoteBody) => body?.proposal);
+const getStartPosition = createGetter((body?: DelegatorVoteBody) => body?.startPosition);
+const getVote = createGetter((body?: DelegatorVoteBody) => body?.vote?.vote);
+const getUnbonded = createGetter((body?: DelegatorVoteBody) => body?.unbondedAmount);

--- a/packages/getters/src/delegator-vote-view.ts
+++ b/packages/getters/src/delegator-vote-view.ts
@@ -1,14 +1,6 @@
 import { createGetter } from './utils/create-getter.js';
-import {
-  DelegatorVoteBody,
-  DelegatorVoteView,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb.js';
+import { DelegatorVoteView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb.js';
 
 export const getDelegatorVoteBody = createGetter(
   (view?: DelegatorVoteView) => view?.delegatorVote.value?.delegatorVote?.body,
 );
-
-const getProposal = createGetter((body?: DelegatorVoteBody) => body?.proposal);
-const getStartPosition = createGetter((body?: DelegatorVoteBody) => body?.startPosition);
-const getVote = createGetter((body?: DelegatorVoteBody) => body?.vote?.vote);
-const getUnbonded = createGetter((body?: DelegatorVoteBody) => body?.unbondedAmount);

--- a/packages/perspective/src/translators/action-view.ts
+++ b/packages/perspective/src/translators/action-view.ts
@@ -5,6 +5,7 @@ import { asOpaqueOutputView, asReceiverOutputView } from './output-view.js';
 import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb.js';
 import { asOpaqueSwapView } from './swap-view.js';
 import { asOpaqueSwapClaimView } from './swap-claim-view.js';
+import { asOpaqueDelegatorVoteView } from './delegator-vote-view.js';
 
 export const asPublicActionView: Translator<ActionView> = actionView => {
   switch (actionView?.actionView.case) {
@@ -37,6 +38,14 @@ export const asPublicActionView: Translator<ActionView> = actionView => {
         actionView: {
           case: 'swapClaim',
           value: asOpaqueSwapClaimView(actionView.actionView.value),
+        },
+      });
+
+    case 'delegatorVote':
+      return new ActionView({
+        actionView: {
+          case: 'delegatorVote',
+          value: asOpaqueDelegatorVoteView(actionView.actionView.value),
         },
       });
 

--- a/packages/perspective/src/translators/delegator-vote-view.test.ts
+++ b/packages/perspective/src/translators/delegator-vote-view.test.ts
@@ -1,0 +1,60 @@
+import { asOpaqueDelegatorVoteView } from './delegator-vote-view.js';
+import { describe, expect, test } from 'vitest';
+import {
+  DelegatorVote,
+  DelegatorVoteView,
+  DelegatorVoteView_Opaque,
+  DelegatorVoteView_Visible,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb.js';
+import { NoteView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb.js';
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
+
+describe('asOpaqueDelegatorVoteView', () => {
+  test('when passed `undefined` returns an empty, opaque delegator vote view', () => {
+    const expected = new DelegatorVoteView({
+      delegatorVote: {
+        case: 'opaque',
+        value: new DelegatorVoteView_Opaque({
+          delegatorVote: undefined,
+        }),
+      },
+    });
+
+    expect(asOpaqueDelegatorVoteView(undefined)).toEqual(expected);
+  });
+
+  test('when passed an already-opaque delegator vote view returns the delegator vote view as-is', () => {
+    const opaqueDelegatorVoteView = new DelegatorVoteView({
+      delegatorVote: {
+        case: 'opaque',
+        value: new DelegatorVoteView_Opaque({
+          delegatorVote: new DelegatorVote({ body: { proposal: 123n } }),
+        }),
+      },
+    });
+    expect(
+      asOpaqueDelegatorVoteView(opaqueDelegatorVoteView).equals(opaqueDelegatorVoteView),
+    ).toBeTruthy();
+  });
+
+  test('returns an opaque version of the delegator vote view', () => {
+    const visibleDelegatorVoteView = new DelegatorVoteView({
+      delegatorVote: {
+        case: 'visible',
+        value: new DelegatorVoteView_Visible({
+          delegatorVote: new DelegatorVote({ body: { proposal: 123n } }),
+          note: new NoteView({ value: new ValueView() }),
+        }),
+      },
+    });
+
+    const result = asOpaqueDelegatorVoteView(visibleDelegatorVoteView);
+
+    expect(result.delegatorVote.case).toBe('opaque');
+    expect(
+      result.delegatorVote.value?.delegatorVote?.equals(
+        visibleDelegatorVoteView.delegatorVote.value?.delegatorVote,
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/packages/perspective/src/translators/delegator-vote-view.ts
+++ b/packages/perspective/src/translators/delegator-vote-view.ts
@@ -1,0 +1,20 @@
+import { Translator } from './types.js';
+import {
+  DelegatorVoteView,
+  DelegatorVoteView_Opaque,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb.js';
+
+export const asOpaqueDelegatorVoteView: Translator<DelegatorVoteView> = delegatorVoteView => {
+  if (delegatorVoteView?.delegatorVote.case === 'opaque') {
+    return delegatorVoteView;
+  }
+
+  return new DelegatorVoteView({
+    delegatorVote: {
+      case: 'opaque',
+      value: new DelegatorVoteView_Opaque({
+        delegatorVote: delegatorVoteView?.delegatorVote.value?.delegatorVote,
+      }),
+    },
+  });
+};

--- a/packages/ui/components/ui/tx/action-view.tsx
+++ b/packages/ui/components/ui/tx/action-view.tsx
@@ -12,6 +12,7 @@ import { ActionDutchAuctionScheduleViewComponent } from './actions-views/action-
 import { ActionDutchAuctionEndComponent } from './actions-views/action-dutch-auction-end';
 import { ActionDutchAuctionWithdrawViewComponent } from './actions-views/action-dutch-auction-withdraw-view';
 import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
+import { DelegatorVoteComponent } from './actions-views/delegator-vote.tsx';
 
 const CASE_TO_LABEL: Record<string, string> = {
   daoDeposit: 'DAO Deposit',
@@ -106,7 +107,7 @@ export const ActionViewComponent = ({
       return <UnimplementedView label='Validator Vote' />;
 
     case 'delegatorVote':
-      return <UnimplementedView label='Delegator Vote' />;
+      return <DelegatorVoteComponent value={actionView.value} />;
 
     case 'proposalDepositClaim':
       return <UnimplementedView label='Proposal Deposit Claim' />;

--- a/packages/ui/components/ui/tx/actions-views/delegator-vote.tsx
+++ b/packages/ui/components/ui/tx/actions-views/delegator-vote.tsx
@@ -1,0 +1,101 @@
+import { ViewBox } from '../viewbox';
+import { ValueWithAddress } from './value-with-address';
+import { ValueViewComponent } from '../../value';
+import { getAddress } from '@penumbra-zone/getters/note-view';
+import { ActionDetails } from './action-details';
+import {
+  DelegatorVoteBody,
+  DelegatorVoteView,
+  Vote,
+  Vote_Vote,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb';
+import { joinLoHiAmount } from '@penumbra-zone/types/amount';
+import { getDelegatorVoteBody } from '@penumbra-zone/getters/delegator-vote-view';
+import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
+
+export const DelegatorVoteComponent = ({ value }: { value: DelegatorVoteView }) => {
+  const body = getDelegatorVoteBody.optional()(value);
+
+  if (value.delegatorVote.case === 'visible') {
+    const note = value.delegatorVote.value.note;
+    const address = getAddress.optional()(note);
+
+    return (
+      <ViewBox
+        label='Delegator Vote'
+        visibleContent={
+          <>
+            <ValueWithAddress addressView={address} label='from'>
+              <ValueViewComponent view={note?.value} />
+            </ValueWithAddress>
+            <VoteBodyDetails body={body} />
+          </>
+        }
+      />
+    );
+  }
+
+  if (value.delegatorVote.case === 'opaque') {
+    return (
+      <ViewBox
+        label='Delegator Vote'
+        isOpaque={true}
+        visibleContent={<VoteBodyDetails body={body} />}
+      />
+    );
+  }
+
+  return <div>Invalid DelegatorVoteView</div>;
+};
+
+const VoteToString = (vote: Vote): string => {
+  switch (vote.vote) {
+    case Vote_Vote.UNSPECIFIED:
+      return 'UNSPECIFIED';
+    case Vote_Vote.ABSTAIN:
+      return 'ABSTAIN';
+    case Vote_Vote.YES:
+      return 'YES';
+    case Vote_Vote.NO:
+      return 'NO';
+  }
+};
+
+const VoteBodyDetails = ({ body }: { body?: DelegatorVoteBody }) => {
+  return (
+    <ActionDetails>
+      {!!body?.proposal && (
+        <ActionDetails.Row label='Proposal'>{Number(body.proposal)}</ActionDetails.Row>
+      )}
+
+      {!!body?.startPosition && (
+        <ActionDetails.Row label='Start Position'>{Number(body.startPosition)}</ActionDetails.Row>
+      )}
+
+      {!!body?.vote && (
+        <ActionDetails.Row label='Vote'>{VoteToString(body.vote)}</ActionDetails.Row>
+      )}
+
+      {!!body?.value && (
+        <>
+          {body.value.assetId && (
+            <ActionDetails.Row label='Asset id'>
+              {bech32mAssetId({ inner: body.value.assetId.inner })}
+            </ActionDetails.Row>
+          )}
+          {body.value.amount && (
+            <ActionDetails.Row label='Amount'>
+              {joinLoHiAmount(body.value.amount).toString()}
+            </ActionDetails.Row>
+          )}
+        </>
+      )}
+
+      {!!body?.unbondedAmount && (
+        <ActionDetails.Row label='Unbonded Amount'>
+          {joinLoHiAmount(body.unbondedAmount).toString()}
+        </ActionDetails.Row>
+      )}
+    </ActionDetails>
+  );
+};


### PR DESCRIPTION
Adds action view support to the tx-details page. Paired w/ @plaidfinch to get current design.

Visible:

<img width="896" alt="Screenshot 2024-07-23 at 10 07 43 PM" src="https://github.com/user-attachments/assets/cb065a2e-eb79-4f89-9d4d-f7ac1f641d56">

Opaque:
<img width="903" alt="Screenshot 2024-07-23 at 10 07 48 PM" src="https://github.com/user-attachments/assets/6aa6d00b-ab00-41c4-8074-dd33d62674aa">
