### PR TITLE
`<SegmentedPicker />`: Use Radix UI's Tabs component under the hood, and rename to `<Tabs />`

### DIFF
--- a/packages/ui/src/SegmentedPicker/index.tsx
+++ b/packages/ui/src/SegmentedPicker/index.tsx
@@ -69,25 +69,16 @@ const SelectedIndicator = styled(motion.div)`
   z-index: -1;
 `;
 
-export interface SegmentedPickerOption<ValueType> {
-  /**
-   * The value to pass to the `onChange` handler when clicked. Must be unique
-   * across all segments, and must be either a string, number, or an object with
-   * a `.toString()` method so that it can be used as a React key.
-   */
-  value: ValueType;
+export interface SegmentedPickerOption {
+  value: string;
   label: string;
   disabled?: boolean;
 }
 
-export interface SegmentedPickerProps<ValueType extends { toString: () => string }> {
-  /**
-   * The currently selected value. Will be compared to the `options`' `value`
-   * property using `===` to determine which segment is selected.
-   */
-  value: ValueType;
-  onChange: (value: ValueType) => void;
-  options: SegmentedPickerOption<ValueType>[];
+export interface SegmentedPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: SegmentedPickerOption[];
   actionType?: ActionType;
 }
 
@@ -110,12 +101,12 @@ export interface SegmentedPickerProps<ValueType extends { toString: () => string
  * />
  * ```
  */
-export const SegmentedPicker = <ValueType extends { toString: () => string }>({
+export const SegmentedPicker = ({
   value,
   onChange,
   options,
   actionType = 'default',
-}: SegmentedPickerProps<ValueType>) => {
+}: SegmentedPickerProps) => {
   const layoutId = useId();
 
   return (

--- a/packages/ui/src/SegmentedPicker/index.tsx
+++ b/packages/ui/src/SegmentedPicker/index.tsx
@@ -3,6 +3,7 @@ import { tab } from '../utils/typography';
 import { motion } from 'framer-motion';
 import { useId } from 'react';
 import { buttonInteractions } from '../utils/button';
+import * as Tabs from '@radix-ui/react-tabs';
 
 const TEN_PERCENT_OPACITY_IN_HEX = '1a';
 
@@ -118,20 +119,32 @@ export const SegmentedPicker = <ValueType extends { toString: () => string }>({
   const layoutId = useId();
 
   return (
-    <Root>
-      {options.map(option => (
-        <SegmentButton
-          key={option.value.toString()}
-          onClick={() => onChange(option.value)}
-          $actionType={actionType}
-          disabled={option.disabled}
-          $getFocusOutlineColor={theme => theme.color.action[outlineColorByActionType[actionType]]}
-          $getBorderRadius={theme => theme.borderRadius.xs}
-        >
-          {value === option.value && <SelectedIndicator layout layoutId={layoutId} />}
-          {option.label}
-        </SegmentButton>
-      ))}
-    </Root>
+    <Tabs.Root value={value} onValueChange={onChange}>
+      <Tabs.List asChild>
+        <Root>
+          {options.map(option => (
+            <Tabs.Trigger
+              value={option.value}
+              key={option.value.toString()}
+              disabled={option.disabled}
+              asChild
+            >
+              <SegmentButton
+                onClick={() => onChange(option.value)}
+                disabled={option.disabled}
+                $actionType={actionType}
+                $getFocusOutlineColor={theme =>
+                  theme.color.action[outlineColorByActionType[actionType]]
+                }
+                $getBorderRadius={theme => theme.borderRadius.xs}
+              >
+                {value === option.value && <SelectedIndicator layout layoutId={layoutId} />}
+                {option.label}
+              </SegmentButton>
+            </Tabs.Trigger>
+          ))}
+        </Root>
+      </Tabs.List>
+    </Tabs.Root>
   );
 };

--- a/packages/ui/src/Tabs/index.stories.tsx
+++ b/packages/ui/src/Tabs/index.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from '@storybook/preview-api';
 
-import { SegmentedPicker } from '.';
+import { Tabs } from '.';
 
-const meta: Meta<typeof SegmentedPicker> = {
-  component: SegmentedPicker,
-  title: 'SegmentedPicker',
+const meta: Meta<typeof Tabs> = {
+  component: Tabs,
   tags: ['autodocs', '!dev'],
   argTypes: {
     value: { control: false },
@@ -15,7 +14,7 @@ const meta: Meta<typeof SegmentedPicker> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof SegmentedPicker>;
+type Story = StoryObj<typeof Tabs>;
 
 export const Basic: Story = {
   args: {
@@ -34,6 +33,6 @@ export const Basic: Story = {
 
     const onChange = (value: { toString: () => string }) => updateArgs({ value });
 
-    return <SegmentedPicker {...props} onChange={onChange} />;
+    return <Tabs {...props} onChange={onChange} />;
   },
 };

--- a/packages/ui/src/Tabs/index.test.tsx
+++ b/packages/ui/src/Tabs/index.test.tsx
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
-import { SegmentedPicker } from '.';
+import { Tabs } from '.';
 import { fireEvent, render } from '@testing-library/react';
 import { ThemeProvider } from '../ThemeProvider';
 
-describe('<SegmentedPicker />', () => {
+describe('<Tabs />', () => {
   it('renders a button for each of the `options`', () => {
     const { queryByText } = render(
-      <SegmentedPicker
+      <Tabs
         value='one'
         options={[
           { label: 'One', value: 'one' },
@@ -24,7 +24,7 @@ describe('<SegmentedPicker />', () => {
   it("calls the `onChange` handler with the clicked option's value when clicked", () => {
     const onChange = vi.fn();
     const { getByText } = render(
-      <SegmentedPicker
+      <Tabs
         value='one'
         options={[
           { label: 'One', value: 'one' },

--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -3,7 +3,7 @@ import { tab } from '../utils/typography';
 import { motion } from 'framer-motion';
 import { useId } from 'react';
 import { buttonInteractions } from '../utils/button';
-import * as Tabs from '@radix-ui/react-tabs';
+import * as RadixTabs from '@radix-ui/react-tabs';
 
 const TEN_PERCENT_OPACITY_IN_HEX = '1a';
 
@@ -26,7 +26,7 @@ const outlineColorByActionType: Record<ActionType, keyof DefaultTheme['color']['
   unshield: 'unshieldFocusOutline',
 };
 
-const SegmentButton = styled.button<{
+const Tab = styled.button<{
   $actionType: ActionType;
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;
@@ -69,28 +69,27 @@ const SelectedIndicator = styled(motion.div)`
   z-index: -1;
 `;
 
-export interface SegmentedPickerOption {
+export interface TabsTab {
   value: string;
   label: string;
   disabled?: boolean;
 }
 
-export interface SegmentedPickerProps {
+export interface TabsProps {
   value: string;
   onChange: (value: string) => void;
-  options: SegmentedPickerOption[];
+  options: TabsTab[];
   actionType?: ActionType;
 }
 
 /**
- * Renders a segmented picker where only one option can be selected at a time.
- * Functionally equivalent to a `<select>` element or a set of radio buttons,
- * but looks nicer when you only have a few options to choose from. (Probably
- * shouldn't be used with more than 5 options.)
+ * Use tabs for switching between related pages or views.
  *
- * @example
+ * Built atop Radix UI's `<Tabs />` component, so it's fully accessible and
+ * supports keyboard navigation.
+ *
  * ```TSX
- * <SegmentedPicker
+ * <Tabs
  *   value={value}
  *   onChange={setValue}
  *   options={[
@@ -101,26 +100,21 @@ export interface SegmentedPickerProps {
  * />
  * ```
  */
-export const SegmentedPicker = ({
-  value,
-  onChange,
-  options,
-  actionType = 'default',
-}: SegmentedPickerProps) => {
+export const Tabs = ({ value, onChange, options, actionType = 'default' }: TabsProps) => {
   const layoutId = useId();
 
   return (
-    <Tabs.Root value={value} onValueChange={onChange}>
-      <Tabs.List asChild>
+    <RadixTabs.Root value={value} onValueChange={onChange}>
+      <RadixTabs.List asChild>
         <Root>
           {options.map(option => (
-            <Tabs.Trigger
+            <RadixTabs.Trigger
               value={option.value}
               key={option.value.toString()}
               disabled={option.disabled}
               asChild
             >
-              <SegmentButton
+              <Tab
                 onClick={() => onChange(option.value)}
                 disabled={option.disabled}
                 $actionType={actionType}
@@ -131,11 +125,11 @@ export const SegmentedPicker = ({
               >
                 {value === option.value && <SelectedIndicator layout layoutId={layoutId} />}
                 {option.label}
-              </SegmentButton>
-            </Tabs.Trigger>
+              </Tab>
+            </RadixTabs.Trigger>
           ))}
         </Root>
-      </Tabs.List>
-    </Tabs.Root>
+      </RadixTabs.List>
+    </RadixTabs.Root>
   );
 };

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -9,6 +9,11 @@ export type Size = 'dense' | 'sparse';
 const focusOutline = css<{
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;
+  /**
+   * Allows styling of a non-button component (such as a link, which doesn't
+   * support the `disabled` attribute) as disabled.
+   */
+  $disabled?: boolean;
 }>`
   &::after {
     content: '';
@@ -31,17 +36,29 @@ const focusOutline = css<{
    * disabled button, the overlay of the disabled button would be above the
    * outline, making the outline appear to be partly cut off.
    */
-  &:focus::after {
+  &:focus-within {
+    outline: none;
+  }
+
+  &:focus-within::after {
     outline-color: ${props => props.$getFocusOutlineColor(props.theme)};
   }
 
+  &:disabled,
   &:disabled::after {
     pointer-events: none;
   }
+
+  ${props => props.$disabled && `pointer-events: none;`}
 `;
 
 const overlays = css<{
   $getBorderRadius: (theme: DefaultTheme) => string;
+  /**
+   * Allows styling of a non-button component (such as a link, which doesn't
+   * support the `disabled` attribute) as disabled.
+   */
+  $disabled?: boolean;
 }>`
   &::before {
     border-radius: ${props => props.$getBorderRadius(props.theme)};
@@ -65,6 +82,15 @@ const overlays = css<{
     background-color: ${props => props.theme.color.action.disabledOverlay};
     cursor: not-allowed;
   }
+
+  ${props =>
+    props.$disabled &&
+    `
+      &::before {
+        background-color: ${props.theme.color.action.disabledOverlay};
+        cursor: not-allowed;
+      }
+    `}
 `;
 
 /**

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -9,11 +9,6 @@ export type Size = 'dense' | 'sparse';
 const focusOutline = css<{
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;
-  /**
-   * Allows styling of a non-button component (such as a link, which doesn't
-   * support the `disabled` attribute) as disabled.
-   */
-  $disabled?: boolean;
 }>`
   &::after {
     content: '';
@@ -48,17 +43,10 @@ const focusOutline = css<{
   &:disabled::after {
     pointer-events: none;
   }
-
-  ${props => props.$disabled && `pointer-events: none;`}
 `;
 
 const overlays = css<{
   $getBorderRadius: (theme: DefaultTheme) => string;
-  /**
-   * Allows styling of a non-button component (such as a link, which doesn't
-   * support the `disabled` attribute) as disabled.
-   */
-  $disabled?: boolean;
 }>`
   &::before {
     border-radius: ${props => props.$getBorderRadius(props.theme)};
@@ -82,15 +70,6 @@ const overlays = css<{
     background-color: ${props => props.theme.color.action.disabledOverlay};
     cursor: not-allowed;
   }
-
-  ${props =>
-    props.$disabled &&
-    `
-      &::before {
-        background-color: ${props.theme.color.action.disabledOverlay};
-        cursor: not-allowed;
-      }
-    `}
 `;
 
 /**


### PR DESCRIPTION
This PR addresses @VanishMax 's [comment](https://github.com/penumbra-zone/web/pull/1516#discussion_r1687901787) about accessibility issues with the `<SegmentedPicker />` component. To address the issues, I refactored `<SegmentedPicker />` to use Radix UI's fully accessible `<Tabs />` component under the hood. Per Sam's agreement, I also renamed this component to `<Tabs />`.

This component may be modified further once it's being used in actual pages, so this is just a gradual improvement for now.