### PR TITLE
transport timeouts

### DIFF
--- a/.changeset/silly-buckets-dream.md
+++ b/.changeset/silly-buckets-dream.md
@@ -1,0 +1,9 @@
+---
+'@penumbra-zone/transport-chrome': minor
+'@penumbra-zone/transport-dom': minor
+'@penumbra-zone/services': minor
+'@penumbra-zone/client': minor
+'@penumbra-zone/react': minor
+---
+
+Update default timeouts to better support build times

--- a/packages/client/src/create.ts
+++ b/packages/client/src/create.ts
@@ -77,7 +77,12 @@ export const createPenumbraChannelTransport = async (
 export const createPenumbraClientSync = <P extends PenumbraService>(
   service: P,
   requireProvider?: string,
-) => createPromiseClient(service, createPenumbraChannelTransportSync(requireProvider));
+  transportOptions?: Omit<ChannelTransportOptions, 'getPort'>,
+) =>
+  createPromiseClient(
+    service,
+    createPenumbraChannelTransportSync(requireProvider, transportOptions),
+  );
 
 /**
  * Asynchronously create a client for `service` from the specified provider, or

--- a/packages/react/src/hooks/use-penumbra-transport.ts
+++ b/packages/react/src/hooks/use-penumbra-transport.ts
@@ -11,7 +11,7 @@ export const usePenumbraTransport = () => usePenumbra().transport;
 /** This method immediately returns a new, unshared Transport to the surrounding
  * Penumbra context. This transport will always create synchronously, but may
  * time out and reject all requests if the Penumbra context does not provide a
- * port within your configured defaultTimeoutMs (defaults to 10 seconds). */
+ * port within your configured defaultTimeoutMs (defaults to 60 seconds). */
 export const usePenumbraTransportSync = (opts?: Omit<ChannelTransportOptions, 'getPort'>) => {
   const penumbra = usePenumbra();
   const { port, failure, state } = penumbra;

--- a/packages/services/src/view-service/util/custody-authorize.ts
+++ b/packages/services/src/view-service/util/custody-authorize.ts
@@ -13,7 +13,8 @@ export const custodyAuthorize = async (
   if (!custodyClient) {
     throw new ConnectError('Cannot access custody service', Code.FailedPrecondition);
   }
-  const { data } = await custodyClient.authorize({ plan });
+  // authorization awaits user interaction, so timeout is disabled
+  const { data } = await custodyClient.authorize({ plan }, { timeoutMs: 0 });
   if (!data) {
     throw new ConnectError('No authorization data', Code.PermissionDenied);
   }

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -126,21 +126,19 @@ export class CRSessionManager {
     port.onDisconnect.addListener(() => session.abort('Disconnect'));
 
     port.onMessage.addListener((i, p) => {
-      void (async () => {
-        try {
-          if (isTransportAbort(i)) {
-            this.requests.get(i.requestId)?.abort();
-          } else if (isTransportMessage(i)) {
-            p.postMessage(await this.clientMessageHandler(session, i));
-          } else if (isTransportInitChannel(i)) {
-            console.warn('Client streaming unimplemented', this.acceptChannelStreamRequest(i));
-          } else {
-            console.warn('Unknown item in transport', i);
-          }
-        } catch (e) {
-          session.abort(e);
+      try {
+        if (isTransportAbort(i)) {
+          this.requests.get(i.requestId)?.abort();
+        } else if (isTransportMessage(i)) {
+          void this.clientMessageHandler(session, i).then(res => p.postMessage(res));
+        } else if (isTransportInitChannel(i)) {
+          console.warn('Client streaming unimplemented', this.acceptChannelStreamRequest(i));
+        } else {
+          console.warn('Unknown item in transport', i);
         }
-      })();
+      } catch (e) {
+        session.abort(e);
+      }
     });
   };
 


### PR DESCRIPTION
- increased to 60 by default
- options applied to one helper that was missing them
- authorization request explicitly disabled timeout
- correctly respect 0-value timeouts in options (like connectrpc)