### PR TITLE
Customize vote symbol

### DIFF
--- a/.changeset/old-rocks-count.md
+++ b/.changeset/old-rocks-count.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': minor
+---
+
+Support customizing symbol for vote receipt tokens

--- a/packages/wasm/crate/src/auction.rs
+++ b/packages/wasm/crate/src/auction.rs
@@ -1,8 +1,9 @@
-use crate::{error::WasmResult, metadata::customize_symbol_inner, utils};
 use penumbra_asset::asset::Metadata;
 use penumbra_auction::auction::{dutch::DutchAuctionDescription, AuctionId, AuctionNft};
 use penumbra_proto::DomainType;
 use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::{error::WasmResult, metadata::customize_symbol_inner, utils};
 
 /// Given a `Uint8Array` encoding of a `DutchAuctionDescription`, returns that
 /// auction's ID.
@@ -64,7 +65,7 @@ mod tests {
         let result = Metadata::decode::<&[u8]>(&result_bytes).unwrap();
         let result_proto = result.to_proto();
 
-        assert!(result_proto.symbol.starts_with("auction("));
+        assert!(result_proto.symbol.starts_with("auction@1234("));
         assert!(result_proto.display.starts_with("auctionnft_1234_pauctid1"));
     }
 }


### PR DESCRIPTION
Vote receipt tokens now have proper symbols:

Before:
<img width="233" alt="Screenshot 2024-07-24 at 7 55 44 PM" src="https://github.com/user-attachments/assets/74c6df89-a4b8-4af5-a622-dd7979e8628b">

After:
<img width="213" alt="Screenshot 2024-07-24 at 7 17 38 PM" src="https://github.com/user-attachments/assets/fc653c82-2385-4c41-a5bb-9d9e8f7bbb02">


Also related to https://github.com/penumbra-zone/web/issues/1546, fixed a bunch of tests