### PR TITLE
Use the new `<Density />` component in place of the `size` prop throughout the new UI components

### DIFF
--- a/packages/ui/.storybook/preview.jsx
+++ b/packages/ui/.storybook/preview.jsx
@@ -17,7 +17,7 @@ const Column = styled.div`
   gap: ${props => props.theme.spacing(8)};
 `;
 
-const DensityWrapper = ({ children, includeDensityControl }) => {
+const DensityWrapper = ({ children, showDensityControl }) => {
   const [density, setDensity] = useState('sparse');
 
   return (
@@ -27,7 +27,7 @@ const DensityWrapper = ({ children, includeDensityControl }) => {
       else={children => <Density compact>{children}</Density>}
     >
       <Column>
-        {includeDensityControl && (
+        {showDensityControl && (
           <Tabs
             options={[
               { label: 'Sparse', value: 'sparse' },
@@ -61,7 +61,7 @@ const preview = {
 
       return (
         <ThemeProvider>
-          <DensityWrapper includeDensityControl={tags.includes('density')}>
+          <DensityWrapper showDensityControl={tags.includes('density')}>
             <WhiteTextWrapper>
               <Story />
             </WhiteTextWrapper>

--- a/packages/ui/.storybook/preview.jsx
+++ b/packages/ui/.storybook/preview.jsx
@@ -17,6 +17,10 @@ const Column = styled.div`
   gap: ${props => props.theme.spacing(8)};
 `;
 
+/**
+ * Utility component to let users control the density, for components whose
+ * stories include the `density` tag.
+ */
 const DensityWrapper = ({ children, showDensityControl }) => {
   const [density, setDensity] = useState('sparse');
 

--- a/packages/ui/.storybook/preview.jsx
+++ b/packages/ui/.storybook/preview.jsx
@@ -1,17 +1,53 @@
-import React from 'react';
+import React, { useState } from 'react';
 import globalsCssUrl from '../styles/globals.css?url';
 import penumbraTheme from './penumbraTheme';
+import { ConditionalWrap } from '../src/utils/ConditionalWrap';
 import { ThemeProvider } from '../src/ThemeProvider';
+import { Density } from '../src/Density';
+import { Tabs } from '../src/Tabs';
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
+const WhiteTextWrapper = styled.div`
   color: ${props => props.theme.color.text.primary};
 `;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(8)};
+`;
+
+const DensityWrapper = ({ children, includeDensityControl }) => {
+  const [density, setDensity] = useState('sparse');
+
+  return (
+    <ConditionalWrap
+      if={density === 'sparse'}
+      then={children => <Density sparse>{children}</Density>}
+      else={children => <Density compact>{children}</Density>}
+    >
+      <Column>
+        {includeDensityControl && (
+          <Tabs
+            options={[
+              { label: 'Sparse', value: 'sparse' },
+              { label: 'Compact', value: 'compact' },
+            ]}
+            value={density}
+            onChange={setDensity}
+          />
+        )}
+
+        {children}
+      </Column>
+    </ConditionalWrap>
+  );
+};
 
 /** @type { import('@storybook/react').Preview } */
 const preview = {
   decorators: [
-    (Story, { title }) => {
+    (Story, { title, tags }) => {
       const isDeprecatedComponent = title.startsWith('Deprecated/');
 
       if (isDeprecatedComponent) {
@@ -25,9 +61,11 @@ const preview = {
 
       return (
         <ThemeProvider>
-          <Wrapper>
-            <Story />
-          </Wrapper>
+          <DensityWrapper includeDensityControl={tags.includes('density')}>
+            <WhiteTextWrapper>
+              <Story />
+            </WhiteTextWrapper>
+          </DensityWrapper>
         </ThemeProvider>
       );
     },

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -322,3 +322,17 @@ Note that we do not use unit tests to test the visual appearance of components; 
 ### Use the `useDensity()` hook to control component density.
 
 Components should never accept a `density` prop to control their density. This ensures that all components in a given density context will be rendered with the same density.
+
+#### Using density with Storybook
+
+If you're creating a component that has density variants, use the `density` tag for your Storybook stories:
+
+```ts
+const meta: Meta<typeof MyComponent> = {
+  component: MyComponent,
+  tags: ['density'],
+  // ...
+};
+```
+
+Storybook will then add a control for density, so that density can be controlled via context.

--- a/packages/ui/src/Button/index.stories.tsx
+++ b/packages/ui/src/Button/index.stories.tsx
@@ -5,7 +5,7 @@ import { ArrowLeftRight, Check } from 'lucide-react';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  tags: ['autodocs', '!dev'],
+  tags: ['autodocs', '!dev', 'density'],
   argTypes: {
     icon: {
       control: 'select',
@@ -21,7 +21,6 @@ type Story = StoryObj<typeof Button>;
 
 export const Basic: Story = {
   args: {
-    size: 'sparse',
     children: 'Save',
     actionType: 'default',
     disabled: false,

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -9,20 +9,20 @@ import { ButtonPriorityContext } from '../utils/ButtonPriorityContext';
 import { Density } from '../types/Density';
 import { useDensity } from '../hooks/useDensity';
 
-const dense = css<StyledButtonProps>`
-  border-radius: ${props => props.theme.borderRadius.full};
-  padding-left: ${props => props.theme.spacing(props.$iconOnly ? 2 : 4)};
-  padding-right: ${props => props.theme.spacing(props.$iconOnly ? 2 : 4)};
-  height: 32px;
-  min-width: 32px;
-`;
-
 const sparse = css<StyledButtonProps>`
   border-radius: ${props => props.theme.borderRadius.sm};
   padding-left: ${props => props.theme.spacing(4)};
   padding-right: ${props => props.theme.spacing(4)};
   height: 48px;
   width: ${props => (props.$iconOnly ? '48px' : '100%')};
+`;
+
+const compact = css<StyledButtonProps>`
+  border-radius: ${props => props.theme.borderRadius.full};
+  padding-left: ${props => props.theme.spacing(props.$iconOnly ? 2 : 4)};
+  padding-right: ${props => props.theme.spacing(props.$iconOnly ? 2 : 4)};
+  height: 32px;
+  min-width: 32px;
 `;
 
 const outlineColorByActionType: Record<ActionType, keyof DefaultTheme['color']['action']> = {
@@ -70,7 +70,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   overflow: hidden;
   position: relative;
 
-  ${props => (props.$density === 'compact' ? dense : sparse)}
+  ${props => (props.$density === 'sparse' ? sparse : compact)}
 
   ${buttonInteractions}
 

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -1,11 +1,13 @@
 import { MouseEventHandler, useContext } from 'react';
 import styled, { css, DefaultTheme } from 'styled-components';
 import { asTransientProps } from '../utils/asTransientProps';
-import { Size, Priority, ActionType, buttonInteractions } from '../utils/button';
+import { Priority, ActionType, buttonInteractions } from '../utils/button';
 import { getBackgroundColor } from './helpers';
 import { button } from '../utils/typography';
 import { LucideIcon } from 'lucide-react';
 import { ButtonPriorityContext } from '../utils/ButtonPriorityContext';
+import { Density } from '../types/Density';
+import { useDensity } from '../hooks/useDensity';
 
 const dense = css<StyledButtonProps>`
   border-radius: ${props => props.theme.borderRadius.full};
@@ -44,7 +46,7 @@ interface StyledButtonProps {
   $iconOnly?: boolean;
   $actionType: ActionType;
   $priority: Priority;
-  $size: Size;
+  $density: Density;
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;
 }
@@ -68,7 +70,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   overflow: hidden;
   position: relative;
 
-  ${props => (props.$size === 'dense' ? dense : sparse)}
+  ${props => (props.$density === 'compact' ? dense : sparse)}
 
   ${buttonInteractions}
 
@@ -84,14 +86,6 @@ interface BaseButtonProps {
    * `aria-label` attribute.
    */
   children: string;
-  /**
-   * Set to `sparse` for more loosely arranged layouts, such as when this is the
-   * submit button for a form. Use `dense` when, e.g., this button appears next
-   * to every item in a dense list of data.
-   *
-   * Default: `sparse`.
-   */
-  size?: Size;
   /**
    * What type of action is this button related to? Leave as `default` for most
    * buttons, set to `accent` for the single most important action on a given
@@ -154,15 +148,15 @@ export const Button = ({
   onClick,
   icon: IconComponent,
   iconOnly,
-  size = 'sparse',
   actionType = 'default',
   type = 'button',
 }: ButtonProps) => {
   const priority = useContext(ButtonPriorityContext);
+  const density = useDensity();
 
   return (
     <StyledButton
-      {...asTransientProps({ iconOnly, size, actionType, priority })}
+      {...asTransientProps({ iconOnly, density, actionType, priority })}
       type={type}
       disabled={disabled}
       onClick={onClick}
@@ -170,10 +164,10 @@ export const Button = ({
       title={iconOnly ? children : undefined}
       $getFocusOutlineColor={theme => theme.color.action[outlineColorByActionType[actionType]]}
       $getBorderRadius={theme =>
-        size === 'sparse' ? theme.borderRadius.sm : theme.borderRadius.full
+        density === 'sparse' ? theme.borderRadius.sm : theme.borderRadius.full
       }
     >
-      {IconComponent && <IconComponent size={size === 'sparse' && iconOnly ? 24 : 16} />}
+      {IconComponent && <IconComponent size={density === 'sparse' && iconOnly ? 24 : 16} />}
 
       {!iconOnly && children}
     </StyledButton>

--- a/packages/ui/src/ButtonGroup/index.stories.tsx
+++ b/packages/ui/src/ButtonGroup/index.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof ButtonGroup>;
 export const Basic: Story = {
   args: {
     actionType: 'default',
-    size: 'sparse',
+    density: 'sparse',
     iconOnly: false,
     buttons: [
       {

--- a/packages/ui/src/ButtonGroup/index.stories.tsx
+++ b/packages/ui/src/ButtonGroup/index.stories.tsx
@@ -5,7 +5,7 @@ import { Ban, HandCoins, Send } from 'lucide-react';
 
 const meta: Meta<typeof ButtonGroup> = {
   component: ButtonGroup,
-  tags: ['autodocs', '!dev'],
+  tags: ['autodocs', '!dev', 'density'],
   argTypes: {
     buttons: { control: false },
   },
@@ -17,7 +17,6 @@ type Story = StoryObj<typeof ButtonGroup>;
 export const Basic: Story = {
   args: {
     actionType: 'default',
-    density: 'sparse',
     iconOnly: false,
     buttons: [
       {

--- a/packages/ui/src/ButtonGroup/index.tsx
+++ b/packages/ui/src/ButtonGroup/index.tsx
@@ -55,7 +55,7 @@ const isIconOnly = (props: ButtonGroupProps<boolean>): props is ButtonGroupProps
 
 /**
  * Use a `<ButtonGroup />` to render multiple buttons in a group with the same
- * `actionType` and `size`.
+ * `actionType`.
  *
  * When rendering multiple Penumbra UI buttons together, always use a
  * `<ButtonGroup />` rather than individual `<Button />`s. This ensures that

--- a/packages/ui/src/ButtonGroup/index.tsx
+++ b/packages/ui/src/ButtonGroup/index.tsx
@@ -1,25 +1,27 @@
 import { LucideIcon } from 'lucide-react';
 import { MouseEventHandler } from 'react';
-import { ActionType, Size } from '../utils/button';
+import { ActionType } from '../utils/button';
 import { Button } from '../Button';
 import styled from 'styled-components';
 import { media } from '../utils/media';
 import { ButtonPriorityContext } from '../utils/ButtonPriorityContext';
+import { Density } from '../types/Density';
+import { useDensity } from '../hooks/useDensity';
 
-const Root = styled.div<{ $size: Size }>`
+const Root = styled.div<{ $density: Density }>`
   display: flex;
-  flex-direction: ${props => (props.$size === 'sparse' ? 'column' : 'row')};
+  flex-direction: ${props => (props.$density === 'sparse' ? 'column' : 'row')};
   gap: ${props => props.theme.spacing(2)};
 
   ${props => media.tablet`
     flex-direction: row;
-    gap: ${props.theme.spacing(props.$size === 'sparse' ? 4 : 2)};
+    gap: ${props.theme.spacing(props.$density === 'sparse' ? 4 : 2)};
   `}
 `;
 
-const ButtonWrapper = styled.div<{ $size: Size; $iconOnly?: boolean }>`
-  flex-grow: ${props => (props.$size === 'sparse' && !props.$iconOnly ? 1 : 0)};
-  flex-shrink: ${props => (props.$size === 'sparse' && !props.$iconOnly ? 1 : 0)};
+const ButtonWrapper = styled.div<{ $density: Density; $iconOnly?: boolean }>`
+  flex-grow: ${props => (props.$density === 'sparse' && !props.$iconOnly ? 1 : 0)};
+  flex-shrink: ${props => (props.$density === 'sparse' && !props.$iconOnly ? 1 : 0)};
 `;
 
 type ButtonDescription<IconOnly extends boolean> = {
@@ -39,8 +41,6 @@ export interface ButtonGroupProps<IconOnly extends boolean> {
    * group.
    */
   actionType?: ActionType;
-  /** Will be used for all buttons in the group. */
-  size?: Size;
   /**
    * When `true`, will render just icon buttons. The label for each button will
    * be used as the `aria-label`.
@@ -64,43 +64,37 @@ const isIconOnly = (props: ButtonGroupProps<boolean>): props is ButtonGroupProps
  * the `primary` priority, while subsequent buttons are the `secondary`
  * priority.)
  */
-export const ButtonGroup = ({
-  actionType = 'default',
-  size = 'sparse',
-  ...props
-}: ButtonGroupProps<boolean>) => (
-  <Root $size={size}>
-    {/* Annoying TypeScript workaround — we need to explicitly delineate the
+export const ButtonGroup = ({ actionType = 'default', ...props }: ButtonGroupProps<boolean>) => {
+  const density = useDensity();
+
+  return (
+    <Root $density={density}>
+      {/* Annoying TypeScript workaround — we need to explicitly delineate the
       `isIconOnly` and `!isIconOnly` cases, since TypeScript won't resolve the
       compatibility of the icon-only and non-icon-only types otherwise. If
       someone comes up with a better way to do this, feel free to revisit this.
       */}
-    {isIconOnly(props) &&
-      props.buttons.map((button, index) => (
-        <ButtonPriorityContext.Provider key={index} value={index === 0 ? 'primary' : 'secondary'}>
-          <ButtonWrapper $size={size} $iconOnly>
-            <Button
-              icon={button.icon}
-              actionType={actionType}
-              onClick={button.onClick}
-              size={size}
-              iconOnly
-            >
-              {button.label}
-            </Button>
-          </ButtonWrapper>
-        </ButtonPriorityContext.Provider>
-      ))}
+      {isIconOnly(props) &&
+        props.buttons.map((button, index) => (
+          <ButtonPriorityContext.Provider key={index} value={index === 0 ? 'primary' : 'secondary'}>
+            <ButtonWrapper $density={density} $iconOnly>
+              <Button icon={button.icon} actionType={actionType} onClick={button.onClick} iconOnly>
+                {button.label}
+              </Button>
+            </ButtonWrapper>
+          </ButtonPriorityContext.Provider>
+        ))}
 
-    {!isIconOnly(props) &&
-      props.buttons.map((button, index) => (
-        <ButtonPriorityContext.Provider key={index} value={index === 0 ? 'primary' : 'secondary'}>
-          <ButtonWrapper $size={size}>
-            <Button icon={button.icon} actionType={actionType} onClick={button.onClick} size={size}>
-              {button.label}
-            </Button>
-          </ButtonWrapper>
-        </ButtonPriorityContext.Provider>
-      ))}
-  </Root>
-);
+      {!isIconOnly(props) &&
+        props.buttons.map((button, index) => (
+          <ButtonPriorityContext.Provider key={index} value={index === 0 ? 'primary' : 'secondary'}>
+            <ButtonWrapper $density={density}>
+              <Button icon={button.icon} actionType={actionType} onClick={button.onClick}>
+                {button.label}
+              </Button>
+            </ButtonWrapper>
+          </ButtonPriorityContext.Provider>
+        ))}
+    </Root>
+  );
+};

--- a/packages/ui/src/Pill/index.stories.tsx
+++ b/packages/ui/src/Pill/index.stories.tsx
@@ -4,7 +4,7 @@ import { Pill } from '.';
 
 const meta: Meta<typeof Pill> = {
   component: Pill,
-  tags: ['autodocs', '!dev'],
+  tags: ['autodocs', '!dev', 'density'],
 };
 export default meta;
 
@@ -13,7 +13,6 @@ type Story = StoryObj<typeof Pill>;
 export const Basic: Story = {
   args: {
     children: 'Pill',
-    size: 'sparse',
     priority: 'primary',
   },
 };

--- a/packages/ui/src/Pill/index.tsx
+++ b/packages/ui/src/Pill/index.tsx
@@ -2,13 +2,14 @@ import styled from 'styled-components';
 import { asTransientProps } from '../utils/asTransientProps';
 import { ReactNode } from 'react';
 import { button } from '../utils/typography';
+import { Density } from '../types/Density';
+import { useDensity } from '../hooks/useDensity';
 
-type Size = 'sparse' | 'dense';
 type Priority = 'primary' | 'secondary';
 
 const TEN_PERCENT_OPACITY_IN_HEX = '1a';
 
-const Root = styled.span<{ $size: Size; $priority: Priority }>`
+const Root = styled.span<{ $density: Density; $priority: Priority }>`
   ${button}
 
   box-sizing: border-box;
@@ -20,11 +21,11 @@ const Root = styled.span<{ $size: Size; $priority: Priority }>`
   display: inline-block;
   max-width: 100%;
 
-  padding-top: ${props => props.theme.spacing(props.$size === 'sparse' ? 2 : 1)};
-  padding-bottom: ${props => props.theme.spacing(props.$size === 'sparse' ? 2 : 1)};
+  padding-top: ${props => props.theme.spacing(props.$density === 'sparse' ? 2 : 1)};
+  padding-bottom: ${props => props.theme.spacing(props.$density === 'sparse' ? 2 : 1)};
 
-  padding-left: ${props => props.theme.spacing(props.$size === 'sparse' ? 4 : 2)};
-  padding-right: ${props => props.theme.spacing(props.$size === 'sparse' ? 4 : 2)};
+  padding-left: ${props => props.theme.spacing(props.$density === 'sparse' ? 4 : 2)};
+  padding-right: ${props => props.theme.spacing(props.$density === 'sparse' ? 4 : 2)};
 
   background-color: ${props =>
     props.$priority === 'primary'
@@ -34,10 +35,11 @@ const Root = styled.span<{ $size: Size; $priority: Priority }>`
 
 export interface PillProps {
   children: ReactNode;
-  size?: Size;
   priority?: Priority;
 }
 
-export const Pill = ({ children, size = 'sparse', priority = 'primary' }: PillProps) => (
-  <Root {...asTransientProps({ size, priority })}>{children}</Root>
-);
+export const Pill = ({ children, priority = 'primary' }: PillProps) => {
+  const density = useDensity();
+
+  return <Root {...asTransientProps({ density, priority })}>{children}</Root>;
+};

--- a/packages/ui/src/Table/index.stories.tsx
+++ b/packages/ui/src/Table/index.stories.tsx
@@ -2,15 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Table } from '.';
 import { Text } from '../Text';
-import { ComponentType, PropsWithChildren, useState } from 'react';
-import { Density } from '../Density';
-import { ConditionalWrap } from '../utils/ConditionalWrap';
-import { Tabs } from '../Tabs';
-import styled from 'styled-components';
+import { ComponentType } from 'react';
 
 const meta: Meta<typeof Table> = {
   component: Table,
-  tags: ['autodocs', '!dev'],
+  tags: ['autodocs', '!dev', 'density'],
   subcomponents: {
     // Re: type coercion, see
     // https://github.com/storybookjs/storybook/issues/23170#issuecomment-2241802787
@@ -34,46 +30,7 @@ const DATA = [
   [1024, 'Delegate', '9d80ffa9113f7eed74ddeff8eddfda6a89106c6cdf336565f9cbaf90810396bf'],
 ];
 
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${props => props.theme.spacing(4)};
-`;
-
-const DensityWrapper = ({ children }: PropsWithChildren) => {
-  const [density, setDensity] = useState('sparse');
-
-  return (
-    <ConditionalWrap
-      if={density === 'sparse'}
-      then={children => <Density sparse>{children}</Density>}
-      else={children => <Density compact>{children}</Density>}
-    >
-      <Column>
-        <Tabs
-          options={[
-            { label: 'Sparse', value: 'sparse' },
-            { label: 'Compact', value: 'compact' },
-          ]}
-          value={density}
-          onChange={setDensity}
-        />
-
-        {children}
-      </Column>
-    </ConditionalWrap>
-  );
-};
-
 export const Basic: Story = {
-  decorators: [
-    Story => (
-      <DensityWrapper>
-        <Story />
-      </DensityWrapper>
-    ),
-  ],
-
   render: function Render() {
     return (
       <Table>

--- a/packages/ui/src/ValueViewComponent/AssetIcon/index.tsx
+++ b/packages/ui/src/ValueViewComponent/AssetIcon/index.tsx
@@ -15,7 +15,6 @@ const IconImg = styled.img`
 
 export interface AssetIcon {
   metadata?: Metadata;
-  size?: 'sparse' | 'dense';
 }
 
 export const AssetIcon = ({ metadata }: AssetIcon) => {

--- a/packages/ui/src/ValueViewComponent/index.stories.tsx
+++ b/packages/ui/src/ValueViewComponent/index.stories.tsx
@@ -10,7 +10,7 @@ import {
 
 const meta: Meta<typeof ValueViewComponent> = {
   component: ValueViewComponent,
-  tags: ['autodocs', '!dev'],
+  tags: ['autodocs', '!dev', 'density'],
   argTypes: {
     valueView: {
       options: [
@@ -38,7 +38,6 @@ export const Basic: Story = {
   args: {
     valueView: PENUMBRA_VALUE_VIEW,
     context: 'default',
-    size: 'sparse',
     priority: 'primary',
   },
 };

--- a/packages/ui/src/ValueViewComponent/index.tsx
+++ b/packages/ui/src/ValueViewComponent/index.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { AssetIcon } from './AssetIcon';
 import { getMetadata } from '@penumbra-zone/getters/value-view';
 import { getFormattedAmtFromValueView } from '@penumbra-zone/types/value-view';
+import { Density } from '../types/Density';
+import { useDensity } from '../hooks/useDensity';
 
 type Context = 'default' | 'table';
 
@@ -30,9 +32,9 @@ const AssetIconWrapper = styled.div`
   flex-shrink: 0;
 `;
 
-const PillMarginOffsets = styled.div<{ $size: 'dense' | 'sparse' }>`
-  margin-left: ${props => props.theme.spacing(props.$size === 'sparse' ? -2 : -1)};
-  margin-right: ${props => props.theme.spacing(props.$size === 'sparse' ? -1 : 0)};
+const PillMarginOffsets = styled.div<{ $density: Density }>`
+  margin-left: ${props => props.theme.spacing(props.$density === 'sparse' ? -2 : -1)};
+  margin-right: ${props => props.theme.spacing(props.$density === 'sparse' ? -1 : 0)};
 `;
 
 const Content = styled.div`
@@ -64,11 +66,6 @@ export interface ValueViewComponentProps<SelectedContext extends Context> {
    */
   context?: SelectedContext;
   /**
-   * Can only be set when the `context` is `default`. For the `table` context,
-   * there is only one size (`sparse`).
-   */
-  size?: SelectedContext extends 'table' ? 'sparse' : 'dense' | 'sparse';
-  /**
    * Use `primary` in most cases, or `secondary` when this value view
    * represents a secondary value, such as when it's an equivalent value of a
    * numeraire.
@@ -79,13 +76,16 @@ export interface ValueViewComponentProps<SelectedContext extends Context> {
 /**
  * `ValueViewComponent` renders a `ValueView` — its amount, icon, and symbol.
  * Use this anywhere you would like to render a `ValueView`.
+ *
+ * Note that `ValueViewComponent` only has density variants when the `context`
+ * is `default`. For the `table` context, there is only one density.
  */
 export const ValueViewComponent = <SelectedContext extends Context = 'default'>({
   valueView,
   context,
-  size = 'sparse',
   priority = 'primary',
 }: ValueViewComponentProps<SelectedContext>) => {
+  const density = useDensity();
   const formattedAmount = getFormattedAmtFromValueView(valueView, true);
   const metadata = getMetadata.optional()(valueView);
   // Symbol default is "" and thus cannot do nullish coalescing
@@ -96,14 +96,14 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
     <ConditionalWrap
       if={!context || context === 'default'}
       then={children => (
-        <Pill size={size} priority={priority}>
-          <PillMarginOffsets $size={size}>{children}</PillMarginOffsets>
+        <Pill priority={priority}>
+          <PillMarginOffsets $density={density}>{children}</PillMarginOffsets>
         </Pill>
       )}
     >
       <Row $context={context ?? 'default'} $priority={priority}>
         <AssetIconWrapper>
-          <AssetIcon metadata={metadata} size={size} />
+          <AssetIcon metadata={metadata} />
         </AssetIconWrapper>
 
         <Content>

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -4,8 +4,6 @@ export type ActionType = 'default' | 'accent' | 'unshield' | 'destructive';
 
 export type Priority = 'primary' | 'secondary';
 
-export type Size = 'dense' | 'sparse';
-
 const focusOutline = css<{
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;


### PR DESCRIPTION
After my previous PR for [introducing the `<Density />` component](https://github.com/penumbra-zone/web/pull/1545) was merged, we now have a `<Density />` component that sets a context variable for components to use to determine whether to render with `compact` or `sparse` density.

Previously, a bunch of the new UI library components were using a `size` prop to control density. In that previous PR, I mentioned that I would create a follow-up PR to remove their `size` props and instead use the new `useDensity()` hook, which uses the context value set by the `<Density />` component.

This PR is that follow-up PR. It makes that change for the `<Button />`, `<ButtonGroup />`, `<Pill />`, and `<ValueViewComponent />` components.

It also introduces a `density` tag for Storybook stories, which adds a density control to stories of components that have density variants.