### PR TITLE
Redesign `<Tabs />` per Figma

### DIFF
--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -1,7 +1,7 @@
 import { MouseEventHandler, useContext } from 'react';
 import styled, { css, DefaultTheme } from 'styled-components';
 import { asTransientProps } from '../utils/asTransientProps';
-import { Priority, ActionType, buttonInteractions } from '../utils/button';
+import { Priority, ActionType, focusOutline, overlays } from '../utils/button';
 import { getBackgroundColor } from './helpers';
 import { button } from '../utils/typography';
 import { LucideIcon } from 'lucide-react';
@@ -72,7 +72,8 @@ const StyledButton = styled.button<StyledButtonProps>`
 
   ${props => (props.$density === 'sparse' ? sparse : compact)}
 
-  ${buttonInteractions}
+  ${focusOutline}
+  ${overlays}
 
   &::after {
     outline-offset: -2px;

--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -2,14 +2,10 @@ import styled, { DefaultTheme } from 'styled-components';
 import { tab } from '../utils/typography';
 import { motion } from 'framer-motion';
 import { useId } from 'react';
-import { buttonInteractions } from '../utils/button';
+import { overlays } from '../utils/button';
 import * as RadixTabs from '@radix-ui/react-tabs';
 
-const TEN_PERCENT_OPACITY_IN_HEX = '1a';
-
 const Root = styled.div`
-  border: 1px solid ${props => props.theme.color.other.tonalStroke};
-  border-radius: ${props => props.theme.borderRadius.sm};
   height: 52px;
   padding: ${props => props.theme.spacing(1)};
 
@@ -26,6 +22,12 @@ const outlineColorByActionType: Record<ActionType, keyof DefaultTheme['color']['
   unshield: 'unshieldFocusOutline',
 };
 
+const gradientColorByActionType: Record<ActionType, 'neutral' | 'primary' | 'unshield'> = {
+  default: 'neutral',
+  accent: 'primary',
+  unshield: 'unshield',
+};
+
 const Tab = styled.button<{
   $actionType: ActionType;
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
@@ -38,7 +40,6 @@ const Tab = styled.button<{
   appearance: none;
   background-color: transparent;
   border: none;
-  border-radius: ${props => props.theme.borderRadius.xs};
   color: ${props => {
     switch (props.$actionType) {
       case 'accent':
@@ -54,16 +55,29 @@ const Tab = styled.button<{
   cursor: pointer;
 
   ${tab}
-  ${buttonInteractions}
+  ${overlays}
+
+  &:focus-within {
+    outline: none;
+  }
 
   &::after {
     inset: ${props => props.theme.spacing(0.5)};
   }
 `;
 
-const SelectedIndicator = styled(motion.div)`
-  background-color: ${props => props.theme.color.text.primary + TEN_PERCENT_OPACITY_IN_HEX};
-  border-radius: ${props => props.theme.borderRadius.xs};
+const THIRTY_FIVE_PERCENT_OPACITY_IN_HEX = '59';
+const SelectedIndicator = styled(motion.div)<{ $actionType: ActionType }>`
+  background: radial-gradient(
+    at 50% 100%,
+    ${props =>
+        props.theme.color[gradientColorByActionType[props.$actionType]].light +
+        THIRTY_FIVE_PERCENT_OPACITY_IN_HEX}
+      0%,
+    transparent 50%
+  );
+  border-bottom: 2px solid
+    ${props => props.theme.color.action[outlineColorByActionType[props.$actionType]]};
   position: absolute;
   inset: 0;
   z-index: -1;
@@ -121,9 +135,11 @@ export const Tabs = ({ value, onChange, options, actionType = 'default' }: TabsP
                 $getFocusOutlineColor={theme =>
                   theme.color.action[outlineColorByActionType[actionType]]
                 }
-                $getBorderRadius={theme => theme.borderRadius.xs}
+                $getBorderRadius={theme => theme.borderRadius.none}
               >
-                {value === option.value && <SelectedIndicator layout layoutId={layoutId} />}
+                {value === option.value && (
+                  <SelectedIndicator layout layoutId={layoutId} $actionType={actionType} />
+                )}
                 {option.label}
               </Tab>
             </RadixTabs.Trigger>

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -4,7 +4,8 @@ export type ActionType = 'default' | 'accent' | 'unshield' | 'destructive';
 
 export type Priority = 'primary' | 'secondary';
 
-const focusOutline = css<{
+/** Adds a focus outline to a button using the `:focus-within` pseudoclass. */
+export const focusOutline = css<{
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;
 }>`
@@ -43,7 +44,8 @@ const focusOutline = css<{
   }
 `;
 
-const overlays = css<{
+/** Adds overlays to a button for when it's hovered, active, or disabled. */
+export const overlays = css<{
   $getBorderRadius: (theme: DefaultTheme) => string;
 }>`
   &::before {
@@ -68,20 +70,4 @@ const overlays = css<{
     background-color: ${props => props.theme.color.action.disabledOverlay};
     cursor: not-allowed;
   }
-`;
-
-/**
- * A set of shared styles for buttons that handle `:hover`, `:active`,
- * `:disabled`, etc. states.
- *
- * Requires a few props to get rendering parameters, which means that any styled
- * components that use this utility will need to have those props defined as
- * well.
- */
-export const buttonInteractions = css<{
-  $getFocusOutlineColor: (theme: DefaultTheme) => string;
-  $getBorderRadius: (theme: DefaultTheme) => string;
-}>`
-  ${overlays}
-  ${focusOutline}
 `;


### PR DESCRIPTION
The `<Tabs />` component was recently redesigned in Figma, so this PR updates how they look. Demo [here](https://penumbra-ui-preview--pr1597-jessepinho-tabs-segm-szcywjtq.web.app/?path=/docs/ui-library-tabs--docs).