### PR TITLE
NaN bug with simluate selector

### DIFF
--- a/apps/minifront/src/components/swap/swap-form/simulate-swap-result/index.tsx
+++ b/apps/minifront/src/components/swap/swap-form/simulate-swap-result/index.tsx
@@ -24,7 +24,7 @@ const simulateSwapResultSelector = (state: AllSlices) => ({
       case: 'knownAssetId',
       value: {
         amount: toBaseUnit(
-          new BigNumber(state.swap.amount),
+          new BigNumber(state.swap.amount || 0),
           getDisplayDenomExponentFromValueView.optional()(state.swap.assetIn?.balanceView),
         ),
         metadata: getMetadata.optional()(state.swap.assetIn?.balanceView),


### PR DESCRIPTION
After a swap claim is successful, if you have the swap estimate component active, it will throw this error:

<img width="783" alt="Screenshot 2024-07-30 at 11 25 13 PM" src="https://github.com/user-attachments/assets/7afdd65f-3834-4d13-817f-95b9801bbab7">

The reason is because the swap amount in the slice is reset on success and leaves the valueview component with bad inputs (an empty string versus something that can be parsed into a number).
