### PR TITLE
Fix idb account contains asset, fix wasm gas prices

### DIFF
--- a/.changeset/cuddly-monkeys-end.md
+++ b/.changeset/cuddly-monkeys-end.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/getters': minor
+---
+
+add getAmountFromNote

--- a/.changeset/itchy-planets-return.md
+++ b/.changeset/itchy-planets-return.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/storage': major
+'@penumbra-zone/types': major
+---
+
+implement accountHasSpendableAsset correctly

--- a/.changeset/rotten-apes-raise.md
+++ b/.changeset/rotten-apes-raise.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': minor
+---
+
+do not fail planning upon undefined gas

--- a/packages/getters/src/note.ts
+++ b/packages/getters/src/note.ts
@@ -1,0 +1,4 @@
+import { Note } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb.js';
+import { createGetter } from './utils/create-getter.js';
+
+export const getAmountFromNote = createGetter((note?: Note) => note?.value?.amount);

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -35,7 +35,7 @@ export interface IndexedDbMock {
   getAuctionOutstandingReserves?: Mock;
   stakingTokenAssetId?: Mock;
   upsertAuction?: Mock;
-  hasTokenBalance?: Mock;
+  accountHasSpendableAsset?: Mock;
   saveGasPrices?: Mock;
 }
 

--- a/packages/services/src/view-service/fees.test.ts
+++ b/packages/services/src/view-service/fees.test.ts
@@ -34,7 +34,7 @@ describe('extractAltFee', () => {
       getAuction: vi.fn(),
       saveGasPrices: vi.fn(),
       getAltGasPrices: vi.fn(),
-      hasTokenBalance: vi.fn(),
+      accountHasSpendableAsset: vi.fn(),
     };
   });
 
@@ -66,7 +66,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -101,7 +101,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -155,7 +155,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(outputAssetId)).toBeTruthy();
@@ -191,7 +191,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -227,7 +227,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -313,7 +313,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -339,7 +339,7 @@ describe('extractAltFee', () => {
       seqNum: 0n,
     });
 
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValueOnce(true);
 
     const request = new TransactionPlannerRequest({
       dutchAuctionEndActions: [
@@ -362,7 +362,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -406,9 +406,9 @@ describe('extractAltFee', () => {
     mockIndexedDb.saveGasPrices?.mockResolvedValue(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
 
-    // Mock hasTokenBalance twice to control its behavior in the function
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(false); // For the specificAssetId check
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true); // For the altGasPrices check
+    // Mock accountHasSpendableAsset twice to control its behavior in the function
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValueOnce(false); // For the specificAssetId check
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValueOnce(true); // For the altGasPrices check
 
     const request = new TransactionPlannerRequest({
       dutchAuctionEndActions: [
@@ -455,7 +455,7 @@ describe('extractAltFee', () => {
 
     mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValue(true);
 
     const request = new TransactionPlannerRequest({
       dutchAuctionWithdrawActions: [
@@ -508,9 +508,9 @@ describe('extractAltFee', () => {
     mockIndexedDb.saveGasPrices?.mockResolvedValue(gasPrices);
     mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
 
-    // Mock hasTokenBalance twice to control its behavior in the function
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(false); // For the specificAssetId check
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true); // For the altGasPrices check
+    // Mock accountHasSpendableAsset twice to control its behavior in the function
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValueOnce(false); // For the specificAssetId check
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValueOnce(true); // For the altGasPrices check
 
     const request = new TransactionPlannerRequest({
       dutchAuctionWithdrawActions: [

--- a/packages/services/src/view-service/fees.test.ts
+++ b/packages/services/src/view-service/fees.test.ts
@@ -108,11 +108,27 @@ describe('extractAltFee', () => {
   });
 
   it('prioritizes outputs over all else', async () => {
-    const outputAssetId = new AssetId({ altBaseDenom: 'output' });
+    const outputAssetId = new AssetId({
+      inner: new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+      ]),
+      altBaseDenom: 'output',
+    });
     const swapAssetId = new AssetId({ altBaseDenom: 'swap' });
     const auctionScheduleAssetId = new AssetId({ altBaseDenom: 'auction-schedule' });
-    const auctionEndAuctionId = new AuctionId({ inner: new Uint8Array([3, 2, 5, 2]) });
-    const auctionWithdrawAuctiontId = new AuctionId({ inner: new Uint8Array([9, 9, 6, 3]) });
+    const auctionEndAuctionId = new AuctionId({
+      inner: new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+      ]),
+    });
+    const auctionWithdrawAuctiontId = new AuctionId({
+      inner: new Uint8Array([
+        32, 31, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9,
+        8, 7, 6, 5, 4, 3, 2, 1,
+      ]),
+    });
 
     const request = new TransactionPlannerRequest({
       outputs: [
@@ -390,7 +406,10 @@ describe('extractAltFee', () => {
 
     // Retrieve a different asset ID than the original scheduled auction.
     const anotherAssetId = new AssetId({
-      inner: new Uint8Array([0, 1, 2, 3]),
+      inner: new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+      ]),
     });
 
     const gasPrices = [
@@ -492,7 +511,10 @@ describe('extractAltFee', () => {
 
     // Retrieve a different asset ID than the original scheduled auction.
     const anotherAssetId = new AssetId({
-      inner: new Uint8Array([0, 1, 2, 3]),
+      inner: new Uint8Array([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+      ]),
     });
 
     const gasPrices = [

--- a/packages/services/src/view-service/gas-prices.test.ts
+++ b/packages/services/src/view-service/gas-prices.test.ts
@@ -48,9 +48,9 @@ describe('GasPrices request handler', () => {
     expect(gasPricesResponse.gasPrices?.equals(testData)).toBeTruthy();
   });
 
-  test('should fail to get gas prices when idb has none', async () => {
+  test('should return undefined gas prices when idb has none', async () => {
     mockIndexedDb.getNativeGasPrices?.mockResolvedValue(undefined);
-    await expect(gasPrices(new GasPricesRequest(), mockCtx)).rejects.toThrow(
+    await expect(gasPrices(new GasPricesRequest(), mockCtx)).resolves.not.toThrow(
       'Gas prices is not available',
     );
   });

--- a/packages/services/src/view-service/gas-prices.ts
+++ b/packages/services/src/view-service/gas-prices.ts
@@ -1,6 +1,5 @@
 import type { Impl } from './index.js';
 import { servicesCtx } from '../ctx/prax.js';
-import { Code, ConnectError } from '@connectrpc/connect';
 
 /**
  * Gas prices are published within the 'CompactBlock' whenever they change. The specific block
@@ -25,9 +24,6 @@ export const gasPrices: Impl['gasPrices'] = async (_, ctx) => {
   const { indexedDb } = await services.getWalletServices();
   const gasPrices = await indexedDb.getNativeGasPrices();
   const altGasPRices = await indexedDb.getAltGasPrices();
-  if (!gasPrices) {
-    throw new ConnectError('Gas prices is not available', Code.NotFound);
-  }
 
   return {
     gasPrices,

--- a/packages/services/src/view-service/transaction-planner/index.test.ts
+++ b/packages/services/src/view-service/transaction-planner/index.test.ts
@@ -38,7 +38,7 @@ describe('TransactionPlanner request handler', () => {
       getAppParams: vi.fn(),
       getNativeGasPrices: vi.fn(),
       constants: vi.fn(),
-      hasTokenBalance: vi.fn(),
+      accountHasSpendableAsset: vi.fn(),
     };
 
     mockServices = {
@@ -104,7 +104,7 @@ describe('TransactionPlanner request handler', () => {
     );
 
     mockIndexedDb.stakingTokenAssetId?.mockResolvedValueOnce(true);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true);
+    mockIndexedDb.accountHasSpendableAsset?.mockResolvedValueOnce(true);
 
     await transactionPlanner(req, mockCtx);
 

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -48,7 +48,7 @@ import {
   SwapRecord,
   TransactionInfo,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
-import { PartialMessage } from '@bufbuild/protobuf';
+import { PartialMessage, PlainMessage } from '@bufbuild/protobuf';
 import type { Jsonified } from './jsonified.js';
 
 export interface IdbUpdate<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>> {
@@ -150,7 +150,10 @@ export interface IndexedDbInterface {
     auctionId: AuctionId,
   ): Promise<{ input: Value; output: Value } | undefined>;
 
-  hasTokenBalance(addressIndex: AddressIndex, assetId: AssetId): Promise<boolean>;
+  accountHasSpendableAsset(
+    addressIndex: PlainMessage<AddressIndex>,
+    assetId: PlainMessage<AssetId>,
+  ): Promise<boolean>;
 }
 
 export interface PenumbraDb extends DBSchema {

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -205,7 +205,7 @@ pub async fn plan_transaction_inner<Db: Database>(
     let gas_prices = storage
         .get_gas_prices_by_asset_id(&fee_asset_id)
         .await?
-        .ok_or_else(|| anyhow!("GasPrices not available"))?;
+        .unwrap_or_default();
 
     let fee_tier = match request.fee_mode {
         None => FeeTier::default(),


### PR DESCRIPTION
fixes #1601
fixes #1602 

this PR corrects idb method used to identify tokens present in an account by correctly comparing address index and asset id. the method will assert the validity of incoming arguments.

this PR corrects wasm planner to use default-zero gas fees if none are present in idb query.

some minifront ui may still be submitting plans with asset id that are not valid.

it should be decided if:

1. incoming rpc with asset id that do not contain a proper inner binary field should be accepted
2. incoming rpc with asset id that do not contain a proper inner binary field should be rejected

tested on deimos (zero chain gas fees) successfully with ibc-osmo gda to um and ibc-osmo out.

tested on phobos (chain gas fees) successfully with ibc-osmo gda to um and ibc-osmo out.

## ci is failing because tests are using incorrect data.