### PR TITLE
Implement the v2 assets/transactions pages using PenumbraUI

### DIFF
--- a/apps/minifront/src/components/root-router.tsx
+++ b/apps/minifront/src/components/root-router.tsx
@@ -14,8 +14,10 @@ import { StakingLayout } from './staking/layout';
 import { IbcLayout } from './ibc/layout';
 import { abortLoader } from '../abort-loader';
 import type { Router } from '@remix-run/router';
+import { routes as v2Routes } from './v2/root-router';
 
 export const rootRouter: Router = createHashRouter([
+  ...v2Routes,
   {
     path: '/',
     element: <Layout />,

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-card-title.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-card-title.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@repo/ui/Button';
+import { Dialog } from '@repo/ui/Dialog';
+import { Text } from '@repo/ui/Text';
+import { Info } from 'lucide-react';
+
+export const AssetsCardTitle = () => (
+  <div className='flex items-center gap-2'>
+    Asset Balances
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button icon={Info} iconOnly='adornment'>
+          Info
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content title='Asset Balances'>
+        <Text>
+          Your balances are shielded, and are known only to you. They are not visible on chain. Each
+          Penumbra wallet controls many numbered accounts, each with its own balance. Account
+          information is never revealed on-chain.
+        </Text>
+      </Dialog.Content>
+    </Dialog>
+  </div>
+);

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-page/equivalent-values.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-page/equivalent-values.tsx
@@ -1,0 +1,23 @@
+import { ValueView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
+import { asValueView } from '@penumbra-zone/getters/equivalent-value';
+import { getDisplayDenomFromView, getEquivalentValues } from '@penumbra-zone/getters/value-view';
+import { ValueViewComponent } from '@repo/ui/ValueViewComponent';
+
+export const EquivalentValues = ({ valueView }: { valueView?: ValueView }) => {
+  const equivalentValuesAsValueViews = (getEquivalentValues.optional()(valueView) ?? []).map(
+    asValueView,
+  );
+
+  return (
+    <div className='flex flex-wrap gap-2'>
+      {equivalentValuesAsValueViews.map(equivalentValueAsValueView => (
+        <ValueViewComponent
+          key={getDisplayDenomFromView(equivalentValueAsValueView)}
+          valueView={equivalentValueAsValueView}
+          priority='secondary'
+          context='table'
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
@@ -1,20 +1,72 @@
 import { Table } from '@repo/ui/Table';
+import { BalancesByAccount, groupByAccount, useBalancesResponses } from '../../../../state/shared';
+import { shouldDisplay } from '../../../../fetchers/balances/should-display';
+import { sortByPriorityScore } from '../../../../fetchers/balances/by-priority-score';
+import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb';
+import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import { PagePath } from '../../../metadata/paths';
+import { getAddressIndex } from '@penumbra-zone/getters/address-view';
+import { AbridgedZQueryState } from '@penumbra-zone/zquery/src/types';
+import { ValueViewComponent } from '@repo/ui/ValueViewComponent';
+import { EquivalentValues } from './equivalent-values';
+import { TableTitle } from './table-title';
+import { Link } from 'react-router-dom';
 
-export const AssetsPage = () => (
-  <div className='flex flex-col gap-1'>
-    <Table title={<div>Account #1</div>}>
-      <Table.Thead>
-        <Table.Tr>
-          <Table.Th>Asset</Table.Th>
-          <Table.Th>Estimate</Table.Th>
-        </Table.Tr>
-      </Table.Thead>
-      <Table.Tbody>
-        <Table.Tr>
-          <Table.Td>test</Table.Td>
-          <Table.Td>test</Table.Td>
-        </Table.Tr>
-      </Table.Tbody>
-    </Table>
-  </div>
-);
+const getTradeLink = (balance: BalancesResponse): string => {
+  const metadata = getMetadataFromBalancesResponseOptional(balance);
+  const accountIndex = getAddressIndex(balance.accountAddress).account;
+  const accountQuery = accountIndex ? `&account=${accountIndex}` : '';
+  return metadata ? `${PagePath.SWAP}?from=${metadata.symbol}${accountQuery}` : PagePath.SWAP;
+};
+
+const filteredBalancesByAccountSelector = (
+  zQueryState: AbridgedZQueryState<BalancesResponse[]>,
+): BalancesByAccount[] =>
+  zQueryState.data?.filter(shouldDisplay).sort(sortByPriorityScore).reduce(groupByAccount, []) ??
+  [];
+
+const BUTTON_WIDTH_PX = 100;
+
+export const AssetsPage = () => {
+  const balancesByAccount = useBalancesResponses({
+    select: filteredBalancesByAccountSelector,
+    shouldReselect: (before, after) => before?.data !== after.data,
+  });
+
+  return (
+    <div className='flex flex-col gap-1'>
+      {balancesByAccount?.map(account => (
+        <Table key={account.account} layout='fixed' title={<TableTitle account={account} />}>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th width={`calc(50% - ${BUTTON_WIDTH_PX / 2}px)`}>Asset</Table.Th>
+              <Table.Th width={`calc(50% - ${BUTTON_WIDTH_PX / 2}px)`}>Estimate</Table.Th>
+              <Table.Th width={`${BUTTON_WIDTH_PX}px`} />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {account.balances.map((balance, index) => (
+              <Table.Tr key={index}>
+                <Table.Td vAlign='top'>
+                  <ValueViewComponent valueView={balance.balanceView} context='table' />
+                </Table.Td>
+                <Table.Td vAlign='top'>
+                  <EquivalentValues valueView={balance.balanceView} />
+                </Table.Td>
+
+                <Table.Td>
+                  <Link
+                    className='opacity-0 transition [tr:hover>td>&]:opacity-100'
+                    to={getTradeLink(balance)}
+                  >
+                    Trade
+                  </Link>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      ))}
+    </div>
+  );
+};

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
@@ -1,0 +1,20 @@
+import { Table } from '@repo/ui/Table';
+
+export const AssetsPage = () => (
+  <div className='flex flex-col gap-1'>
+    <Table title={<div>Account #1</div>}>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Asset</Table.Th>
+          <Table.Th>Estimate</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        <Table.Tr>
+          <Table.Td>test</Table.Td>
+          <Table.Td>test</Table.Td>
+        </Table.Tr>
+      </Table.Tbody>
+    </Table>
+  </div>
+);

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
@@ -1,3 +1,4 @@
+import { Density } from '@repo/ui/Density';
 import { Table } from '@repo/ui/Table';
 import { BalancesByAccount, groupByAccount, useBalancesResponses } from '../../../../state/shared';
 import { shouldDisplay } from '../../../../fetchers/balances/should-display';
@@ -11,6 +12,8 @@ import { ValueViewComponent } from '@repo/ui/ValueViewComponent';
 import { EquivalentValues } from './equivalent-values';
 import { TableTitle } from './table-title';
 import { Link } from 'react-router-dom';
+import { Button } from '@repo/ui/Button';
+import { ArrowRightLeft } from 'lucide-react';
 
 const getTradeLink = (balance: BalancesResponse): string => {
   const metadata = getMetadataFromBalancesResponseOptional(balance);
@@ -25,7 +28,7 @@ const filteredBalancesByAccountSelector = (
   zQueryState.data?.filter(shouldDisplay).sort(sortByPriorityScore).reduce(groupByAccount, []) ??
   [];
 
-const BUTTON_WIDTH_PX = 100;
+const BUTTON_CELL_WIDTH_PX = '56px';
 
 export const AssetsPage = () => {
   const balancesByAccount = useBalancesResponses({
@@ -39,9 +42,9 @@ export const AssetsPage = () => {
         <Table key={account.account} layout='fixed' title={<TableTitle account={account} />}>
           <Table.Thead>
             <Table.Tr>
-              <Table.Th width={`calc(50% - ${BUTTON_WIDTH_PX / 2}px)`}>Asset</Table.Th>
-              <Table.Th width={`calc(50% - ${BUTTON_WIDTH_PX / 2}px)`}>Estimate</Table.Th>
-              <Table.Th width={`${BUTTON_WIDTH_PX}px`} />
+              <Table.Th width={`calc(50% - (${BUTTON_CELL_WIDTH_PX} / 2))`}>Asset</Table.Th>
+              <Table.Th width={`calc(50% - (${BUTTON_CELL_WIDTH_PX} / 2))`}>Estimate</Table.Th>
+              <Table.Th width={BUTTON_CELL_WIDTH_PX} />
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
@@ -55,11 +58,12 @@ export const AssetsPage = () => {
                 </Table.Td>
 
                 <Table.Td>
-                  <Link
-                    className='opacity-0 transition [tr:hover>td>&]:opacity-100'
-                    to={getTradeLink(balance)}
-                  >
-                    Trade
+                  <Link to={getTradeLink(balance)}>
+                    <Density compact>
+                      <Button icon={ArrowRightLeft} iconOnly>
+                        Trade
+                      </Button>
+                    </Density>
                   </Link>
                 </Table.Td>
               </Table.Tr>

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-page/table-title.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-page/table-title.tsx
@@ -1,0 +1,22 @@
+import { AddressViewComponent } from '@repo/ui/AddressViewComponent';
+import { BalancesByAccount } from '../../../../state/shared';
+import { AddressView } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { useMemo } from 'react';
+
+export const TableTitle = ({ account }: { account: BalancesByAccount }) => {
+  const addressView = useMemo(
+    () =>
+      new AddressView({
+        addressView: {
+          case: 'decoded',
+          value: {
+            address: account.address,
+            index: { account: account.account },
+          },
+        },
+      }),
+    [account.address, account.account],
+  );
+
+  return <AddressViewComponent addressView={addressView} />;
+};

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -4,13 +4,15 @@ import { Grid } from '@repo/ui/Grid';
 import { Tabs } from '@repo/ui/Tabs';
 import { usePagePath } from '../../../fetchers/page-path';
 import { PagePath } from '../../metadata/paths';
+import { AssetsCardTitle } from './assets-card-title';
+import { TransactionsCardTitle } from './transactions-card-title';
 
 /** @todo: Remove this function and its uses after we switch to v2 layout */
 const v2PathPrefix = (path: string) => `/v2${path}`;
 
 const CARD_TITLE_BY_PATH = {
-  [v2PathPrefix(PagePath.DASHBOARD)]: 'Asset Balances',
-  [v2PathPrefix(PagePath.TRANSACTIONS)]: 'Transaction List',
+  [v2PathPrefix(PagePath.DASHBOARD)]: <AssetsCardTitle />,
+  [v2PathPrefix(PagePath.TRANSACTIONS)]: <TransactionsCardTitle />,
 };
 
 export const DashboardLayout = () => {

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -23,17 +23,19 @@ export const DashboardLayout = () => {
 
       <Grid tablet={8} desktop={6} xl={4}>
         <Card title={CARD_TITLE_BY_PATH[v2PathPrefix(pagePath)]}>
-          <Tabs
-            value={v2PathPrefix(pagePath)}
-            onChange={value => navigate(value)}
-            options={[
-              { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
-              { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
-            ]}
-            actionType='accent'
-          />
+          <div className='flex flex-col gap-4'>
+            <Tabs
+              value={v2PathPrefix(pagePath)}
+              onChange={value => navigate(value)}
+              options={[
+                { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
+                { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
+              ]}
+              actionType='accent'
+            />
 
-          <Outlet />
+            <Outlet />
+          </div>
         </Card>
       </Grid>
 

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -1,0 +1,28 @@
+import { Card } from '@repo/ui/Card';
+import { Outlet, useNavigate } from 'react-router-dom';
+import { Tabs } from '@repo/ui/Tabs';
+import { usePagePath } from '../../../fetchers/page-path';
+import { PagePath } from '../../metadata/paths';
+
+/** @todo: Remove this function and its uses after we switch to v2 layout */
+const v2PathPrefix = (path: string) => `/v2${path}`;
+
+export const DashboardLayout = () => {
+  const pagePath = usePagePath();
+  const navigate = useNavigate();
+
+  return (
+    <Card title='Asset Balances'>
+      <Tabs
+        value={v2PathPrefix(pagePath)}
+        onChange={value => navigate(value)}
+        options={[
+          { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
+          { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
+        ]}
+      />
+
+      <Outlet />
+    </Card>
+  );
+};

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -15,6 +15,11 @@ const CARD_TITLE_BY_PATH = {
   [v2PathPrefix(PagePath.TRANSACTIONS)]: <TransactionsCardTitle />,
 };
 
+const TABS_OPTIONS = [
+  { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
+  { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
+];
+
 export const DashboardLayout = () => {
   const pagePath = usePagePath();
   const navigate = useNavigate();
@@ -29,10 +34,7 @@ export const DashboardLayout = () => {
             <Tabs
               value={v2PathPrefix(pagePath)}
               onChange={value => navigate(value)}
-              options={[
-                { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
-                { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
-              ]}
+              options={TABS_OPTIONS}
               actionType='accent'
             />
 

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@repo/ui/Card';
 import { Outlet, useNavigate } from 'react-router-dom';
+import { Grid } from '@repo/ui/Grid';
 import { Tabs } from '@repo/ui/Tabs';
 import { usePagePath } from '../../../fetchers/page-path';
 import { PagePath } from '../../metadata/paths';
@@ -12,18 +13,26 @@ export const DashboardLayout = () => {
   const navigate = useNavigate();
 
   return (
-    <Card title='Asset Balances'>
-      <Tabs
-        value={v2PathPrefix(pagePath)}
-        onChange={value => navigate(value)}
-        options={[
-          { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
-          { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
-        ]}
-        actionType='accent'
-      />
+    <Grid container>
+      <Grid mobile={0} tablet={2} desktop={3} xl={4} />
 
-      <Outlet />
-    </Card>
+      <Grid tablet={8} desktop={6} xl={4}>
+        <Card title='Asset Balances'>
+          <Tabs
+            value={v2PathPrefix(pagePath)}
+            onChange={value => navigate(value)}
+            options={[
+              { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
+              { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
+            ]}
+            actionType='accent'
+          />
+
+          <Outlet />
+        </Card>
+      </Grid>
+
+      <Grid mobile={0} tablet={2} desktop={3} xl={4} />
+    </Grid>
   );
 };

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -8,6 +8,11 @@ import { PagePath } from '../../metadata/paths';
 /** @todo: Remove this function and its uses after we switch to v2 layout */
 const v2PathPrefix = (path: string) => `/v2${path}`;
 
+const CARD_TITLE_BY_PATH = {
+  [v2PathPrefix(PagePath.DASHBOARD)]: 'Asset Balances',
+  [v2PathPrefix(PagePath.TRANSACTIONS)]: 'Transaction List',
+};
+
 export const DashboardLayout = () => {
   const pagePath = usePagePath();
   const navigate = useNavigate();
@@ -17,7 +22,7 @@ export const DashboardLayout = () => {
       <Grid mobile={0} tablet={2} desktop={3} xl={4} />
 
       <Grid tablet={8} desktop={6} xl={4}>
-        <Card title='Asset Balances'>
+        <Card title={CARD_TITLE_BY_PATH[v2PathPrefix(pagePath)]}>
           <Tabs
             value={v2PathPrefix(pagePath)}
             onChange={value => navigate(value)}

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -20,6 +20,7 @@ export const DashboardLayout = () => {
           { label: 'Assets', value: v2PathPrefix(PagePath.DASHBOARD) },
           { label: 'Transactions', value: v2PathPrefix(PagePath.TRANSACTIONS) },
         ]}
+        actionType='accent'
       />
 
       <Outlet />

--- a/apps/minifront/src/components/v2/dashboard-layout/transactions-card-title.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/transactions-card-title.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@repo/ui/Button';
+import { Dialog } from '@repo/ui/Dialog';
+import { Text } from '@repo/ui/Text';
+import { Info } from 'lucide-react';
+
+export const TransactionsCardTitle = () => (
+  <div className='flex items-center gap-2'>
+    Transactions List
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button icon={Info} iconOnly='adornment'>
+          Info
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content title='Transactions List'>
+        <Text>
+          Your wallet scans shielded chain data locally and indexes all relevant transactions it
+          detects, both incoming and outgoing.
+        </Text>
+      </Dialog.Content>
+    </Dialog>
+  </div>
+);

--- a/apps/minifront/src/components/v2/dashboard-layout/transactions-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/transactions-page/index.tsx
@@ -12,7 +12,7 @@ export const TransactionsPage = () => {
     <Table layout='fixed'>
       <Table.Thead>
         <Table.Tr>
-          <Table.Th>Block Height</Table.Th>
+          <Table.Th width='150px'>Block Height</Table.Th>
           <Table.Th>Description</Table.Th>
           <Table.Th width='125px'>Hash</Table.Th>
         </Table.Tr>
@@ -28,7 +28,11 @@ export const TransactionsPage = () => {
             </Table.Td>
             <Table.Td>
               <div className='flex gap-1'>
-                <Link to={`/tx/${summary.hash}`} className='shrink overflow-hidden'>
+                <Link
+                  to={`/tx/${summary.hash}`}
+                  className='shrink overflow-hidden'
+                  title={summary.hash}
+                >
                   <Text truncate as='div'>
                     {summary.hash}
                   </Text>

--- a/apps/minifront/src/components/v2/dashboard-layout/transactions-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/transactions-page/index.tsx
@@ -1,0 +1,1 @@
+export const TransactionsPage = () => <div>Transactions page</div>;

--- a/apps/minifront/src/components/v2/dashboard-layout/transactions-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/transactions-page/index.tsx
@@ -1,1 +1,48 @@
-export const TransactionsPage = () => <div>Transactions page</div>;
+import { Table } from '@repo/ui/Table';
+import { useSummaries } from '../../../../state/transactions';
+import { Text } from '@repo/ui/Text';
+import { Link } from 'react-router-dom';
+import { SquareArrowOutUpRight } from 'lucide-react';
+import { Button } from '@repo/ui/Button';
+
+export const TransactionsPage = () => {
+  const summaries = useSummaries();
+
+  return (
+    <Table layout='fixed'>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Block Height</Table.Th>
+          <Table.Th>Description</Table.Th>
+          <Table.Th width='125px'>Hash</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {summaries.data?.map(summary => (
+          <Table.Tr key={summary.hash}>
+            <Table.Td>
+              <Text>{summary.height}</Text>
+            </Table.Td>
+            <Table.Td>
+              <Text>{summary.description}</Text>
+            </Table.Td>
+            <Table.Td>
+              <div className='flex gap-1'>
+                <Link to={`/tx/${summary.hash}`} className='shrink overflow-hidden'>
+                  <Text truncate as='div'>
+                    {summary.hash}
+                  </Text>
+                </Link>
+                <Link to={`/tx/${summary.hash}`}>
+                  <Button icon={SquareArrowOutUpRight} iconOnly='adornment'>
+                    View transaction
+                  </Button>
+                </Link>
+              </div>
+            </Table.Td>
+          </Table.Tr>
+        ))}
+      </Table.Tbody>
+    </Table>
+  );
+};

--- a/apps/minifront/src/components/v2/layout.tsx
+++ b/apps/minifront/src/components/v2/layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import { HeadTag } from '../metadata/head-tag';
+import { Toaster } from '@repo/ui/components/ui/toaster';
+import { SyncingDialog } from '../syncing-dialog';
+
+export const Layout = () => (
+  <div>
+    <HeadTag />
+    <Outlet />
+    <Toaster />
+    <SyncingDialog />
+  </div>
+);

--- a/apps/minifront/src/components/v2/layout.tsx
+++ b/apps/minifront/src/components/v2/layout.tsx
@@ -1,13 +1,14 @@
-import { Outlet } from 'react-router-dom';
+import { Display } from '@repo/ui/Display';
 import { HeadTag } from '../metadata/head-tag';
+import { Outlet } from 'react-router-dom';
 import { Toaster } from '@repo/ui/components/ui/toaster';
 import { SyncingDialog } from '../syncing-dialog';
 
 export const Layout = () => (
-  <div>
+  <Display>
     <HeadTag />
     <Outlet />
     <Toaster />
     <SyncingDialog />
-  </div>
+  </Display>
 );

--- a/apps/minifront/src/components/v2/root-router.tsx
+++ b/apps/minifront/src/components/v2/root-router.tsx
@@ -1,0 +1,52 @@
+import { redirect, RouteObject } from 'react-router-dom';
+import { Layout } from './layout';
+import { abortLoader } from '../../abort-loader';
+import { PagePath } from '../metadata/paths';
+import { DashboardLayout } from './dashboard-layout';
+import { AssetsPage } from './dashboard-layout/assets-page';
+import { TransactionsPage } from './dashboard-layout/transactions-page';
+
+/** @todo: Delete this helper once we switch over to the v2 layout. */
+const temporarilyPrefixPathsWithV2 = (routes: RouteObject[]): RouteObject[] =>
+  routes.map(route => {
+    if (route.index) {
+      return route;
+    }
+
+    return {
+      ...route,
+      path: `/v2${route.path === '/' ? '' : route.path}`,
+      ...(route.children ? { children: temporarilyPrefixPathsWithV2(route.children) } : {}),
+    };
+  });
+
+/**
+ * @todo: Once we switch over to the v2 layout, we need to:
+ * 1) pass these routes to `createHashRouter()` and export the returned router,
+ * like in `../root-router.tsx`.
+ * 2) remove the call to `temporarilyPrefixPathsWithV2()`.
+ */
+export const routes: RouteObject[] = temporarilyPrefixPathsWithV2([
+  {
+    path: '/',
+    element: <Layout />,
+    loader: abortLoader,
+    children: [
+      { index: true, loader: () => redirect(`/v2${PagePath.DASHBOARD}`) },
+      {
+        path: PagePath.DASHBOARD,
+        element: <DashboardLayout />,
+        children: [
+          {
+            index: true,
+            element: <AssetsPage />,
+          },
+          {
+            path: PagePath.TRANSACTIONS,
+            element: <TransactionsPage />,
+          },
+        ],
+      },
+    ],
+  },
+]);

--- a/apps/minifront/src/fetchers/page-path.ts
+++ b/apps/minifront/src/fetchers/page-path.ts
@@ -13,6 +13,8 @@ export const usePagePath = <T extends PagePath>() => {
 };
 
 export const matchPagePath = (str: string): PagePath => {
+  /** @todo: Remove next line after we switch to v2 layout */
+  str = str.replace('/v2', '');
   const pathValues = Object.values(PagePath);
 
   if (pathValues.includes(str as PagePath)) {

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -163,8 +163,8 @@ export type ButtonProps = BaseButtonProps & (IconOnlyProps | RegularProps);
  *
  * See individual props for how to use `<Button />` in various forms.
  *
- * Note that, to use `<Button />` as a link, you can simple wrap it in an `<a
- * />` (or `<Link />`, if you're using e.g., React Router) tag and leave
+ * Note that, to use `<Button />` as a link, you can simply wrap it in an anchor
+ * (`<a />`) tag (or `<Link />`, if you're using e.g., React Router) and leave
  * `onClick` undefined.
  */
 export const Button = ({

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -158,7 +158,15 @@ interface RegularProps {
 
 export type ButtonProps = BaseButtonProps & (IconOnlyProps | RegularProps);
 
-/** A component for all your button needs! */
+/**
+ * A component for all your button needs!
+ *
+ * See individual props for how to use `<Button />` in various forms.
+ *
+ * Note that, to use `<Button />` as a link, you can simple wrap it in an `<a
+ * />` (or `<Link />`, if you're using e.g., React Router) tag and leave
+ * `onClick` undefined.
+ */
 export const Button = ({
   children,
   disabled = false,

--- a/packages/ui/src/Card/index.tsx
+++ b/packages/ui/src/Card/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import styled, { WebTarget } from 'styled-components';
 import { large } from '../utils/typography';
+import { hexOpacity } from '../utils/hexOpacity';
 
 const Root = styled.section``;
 
@@ -11,13 +12,11 @@ const Title = styled.h2`
   padding: ${props => props.theme.spacing(3)};
 `;
 
-const TEN_PERCENT_OPACITY_IN_HEX = '1a';
-const ONE_PERCENT_OPACITY_IN_HEX = '03';
 const Content = styled.div`
   background: linear-gradient(
     136deg,
-    ${props => props.theme.color.neutral.contrast + TEN_PERCENT_OPACITY_IN_HEX} 6.32%,
-    ${props => props.theme.color.neutral.contrast + ONE_PERCENT_OPACITY_IN_HEX} 75.55%
+    ${props => props.theme.color.neutral.contrast + hexOpacity(0.1)} 6.32%,
+    ${props => props.theme.color.neutral.contrast + hexOpacity(0.01)} 75.55%
   );
   backdrop-filter: blur(${props => props.theme.blur.lg});
   border-radius: ${props => props.theme.borderRadius.xl};

--- a/packages/ui/src/Card/index.tsx
+++ b/packages/ui/src/Card/index.tsx
@@ -11,7 +11,14 @@ const Title = styled.h1`
   padding: ${props => props.theme.spacing(3)};
 `;
 
+const TEN_PERCENT_OPACITY_IN_HEX = '1a';
+const ONE_PERCENT_OPACITY_IN_HEX = '03';
 const Content = styled.div`
+  background: linear-gradient(
+    136deg,
+    ${props => props.theme.color.neutral.contrast + TEN_PERCENT_OPACITY_IN_HEX} 6.32%,
+    ${props => props.theme.color.neutral.contrast + ONE_PERCENT_OPACITY_IN_HEX} 75.55%
+  );
   backdrop-filter: blur(${props => props.theme.blur.lg});
   border-radius: ${props => props.theme.borderRadius.xl};
   padding: ${props => props.theme.spacing(3)};

--- a/packages/ui/src/Card/index.tsx
+++ b/packages/ui/src/Card/index.tsx
@@ -4,7 +4,7 @@ import { large } from '../utils/typography';
 
 const Root = styled.section``;
 
-const Title = styled.h1`
+const Title = styled.h2`
   ${large};
 
   color: ${props => props.theme.color.base.white};
@@ -35,7 +35,7 @@ export interface CardProps {
    * ```
    */
   as?: WebTarget;
-  title?: string;
+  title?: ReactNode;
 }
 
 export const Card = ({ children, as = 'section', title }: CardProps) => {

--- a/packages/ui/src/Dialog/index.tsx
+++ b/packages/ui/src/Dialog/index.tsx
@@ -1,60 +1,44 @@
 import { createContext, ReactNode, useContext } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import * as RadixDialog from '@radix-ui/react-dialog';
 import { Text } from '../Text';
 import { X } from 'lucide-react';
 import { ButtonGroup, ButtonGroupProps } from '../ButtonGroup';
 import { Button } from '../Button';
 import { Density } from '../Density';
-
-const gradualBlur = (blur: string) => keyframes`
-  from {
-    backdrop-filter: blur(0);
-  }
-
-  to {
-    backdrop-filter: blur(${blur});
-  }
-`;
+import { Display } from '../Display';
+import { Grid } from '../Grid';
 
 const Overlay = styled(RadixDialog.Overlay)`
-  animation: ${props => gradualBlur(props.theme.blur.xs)} 0.15s forwards;
-  /* animation: name duration timing-function delay iteration-count direction fill-mode; */
+  backdrop-filter: blur(${props => props.theme.blur.xs});
+  background-color: ${props => props.theme.color.other.overlay};
   position: fixed;
   inset: 0;
   z-index: ${props => props.theme.zIndex.dialogOverlay};
 `;
 
-const fadeIn = keyframes`
-  from {
-    opacity: 0;
-  }
+const FullHeightWrapper = styled.div`
+  height: 100%;
+  min-height: 100svh;
+  max-height: 100lvh;
+  position: relative;
 
-  to {
-    opacity: 1;
-  };
+  display: flex;
+  align-items: center;
 `;
 
-const TEN_PERCENT_OPACITY_IN_HEX = '1a';
-const ONE_PERCENT_OPACITY_IN_HEX = '03';
-const DialogContent = styled(RadixDialog.Content)`
-  animation: ${fadeIn} 0.15s forwards;
-
+const DialogContent = styled.div`
   position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  inset: 0;
   z-index: ${props => props.theme.zIndex.dialogContent};
+  pointer-events: none;
+`;
 
-  width: 472px;
-  max-width: 100%;
+const DialogContentCard = styled.div`
+  width: 100%;
   box-sizing: border-box;
 
-  background: linear-gradient(
-    136deg,
-    ${props => props.theme.color.neutral.contrast + TEN_PERCENT_OPACITY_IN_HEX},
-    ${props => props.theme.color.neutral.contrast + ONE_PERCENT_OPACITY_IN_HEX}
-  );
+  background: ${props => props.theme.color.other.dialogBackground};
   border: 1px solid ${props => props.theme.color.other.tonalStroke};
   border-radius: ${props => props.theme.borderRadius.xl};
   backdrop-filter: blur(${props => props.theme.blur.xl});
@@ -67,6 +51,8 @@ const DialogContent = styled(RadixDialog.Content)`
   display: flex;
   flex-direction: column;
   gap: ${props => props.theme.spacing(6)};
+
+  pointer-events: auto;
 `;
 
 const TitleAndCloseButton = styled.header`
@@ -211,29 +197,45 @@ const Content = <IconOnlyButtonGroupProps extends boolean | undefined>({
     <RadixDialog.Portal>
       <Overlay />
 
-      <DialogContent>
-        <TitleAndCloseButton>
-          <RadixDialog.Title asChild>
-            <Text xxl as='h2'>
-              {title}
-            </Text>
-          </RadixDialog.Title>
+      <RadixDialog.Content>
+        <DialogContent>
+          <Display>
+            <Grid container>
+              <Grid mobile={0} tablet={2} desktop={3} xl={4} />
 
-          {showCloseButton && (
-            <Density compact>
-              <RadixDialog.Close asChild>
-                <Button icon={X} iconOnly priority='secondary'>
-                  Close
-                </Button>
-              </RadixDialog.Close>
-            </Density>
-          )}
-        </TitleAndCloseButton>
+              <Grid mobile={12} tablet={8} desktop={6} xl={4}>
+                <FullHeightWrapper>
+                  <DialogContentCard>
+                    <TitleAndCloseButton>
+                      <RadixDialog.Title asChild>
+                        <Text xxl as='h2'>
+                          {title}
+                        </Text>
+                      </RadixDialog.Title>
 
-        {children}
+                      {showCloseButton && (
+                        <Density compact>
+                          <RadixDialog.Close asChild>
+                            <Button icon={X} iconOnly priority='secondary'>
+                              Close
+                            </Button>
+                          </RadixDialog.Close>
+                        </Density>
+                      )}
+                    </TitleAndCloseButton>
 
-        {buttonGroupProps && <ButtonGroup {...buttonGroupProps} column />}
-      </DialogContent>
+                    {children}
+
+                    {buttonGroupProps && <ButtonGroup {...buttonGroupProps} column />}
+                  </DialogContentCard>
+                </FullHeightWrapper>
+              </Grid>
+
+              <Grid mobile={0} tablet={2} desktop={3} xl={4} />
+            </Grid>
+          </Display>
+        </DialogContent>
+      </RadixDialog.Content>
     </RadixDialog.Portal>
   );
 };

--- a/packages/ui/src/Dialog/index.tsx
+++ b/packages/ui/src/Dialog/index.tsx
@@ -27,6 +27,17 @@ const FullHeightWrapper = styled.div`
   align-items: center;
 `;
 
+/**
+ * We make a full-screen wrapper around the dialog's content so that we can
+ * correctly position it using the same `<Display />`/`<Grid />` as the
+ * underlying page uses. Note that we use a `styled.div` here, rather than
+ * `styled(RadixDialog.Content)`, because Radix adds an inline `pointer-events:
+ * auto` style to that element. We need to make sure there _aren't_ pointer
+ * events on the dialog content, because of the aforementioned full-screen
+ * wrapper that appears over the `<Overlay />`. We want to make sure that clicks
+ * on the full-screen wrapper pass through to the underlying `<Overlay />`, so
+ * that the dialog closes when the user clicks there.
+ */
 const DialogContent = styled.div`
   position: fixed;
   inset: 0;
@@ -52,6 +63,11 @@ const DialogContentCard = styled.div`
   flex-direction: column;
   gap: ${props => props.theme.spacing(6)};
 
+  /**
+   * We add 'pointer-events: auto' here so that clicks _inside_ the content card
+   * work, even though the _outside_ clicks pass through to the underlying
+   * '<Overlay />'.
+   */
   pointer-events: auto;
 `;
 

--- a/packages/ui/src/Display/index.stories.tsx
+++ b/packages/ui/src/Display/index.stories.tsx
@@ -48,8 +48,8 @@ export const FullWidth: Story = {
           the size of the browser window.
         </Text>
         <Text p>
-          To view the <Text technical>&lt;Display /&gt;</Text> at full width, click the &quot;Full
-          Width&quot; item in the left sidebar.
+          To test <Text technical>&lt;Display /&gt;</Text> at full width, click the &quot;Full
+          Width&quot; item in the left sidebar, and try resizing your browser.
         </Text>
       </InnerWidthIndicator>
     ),

--- a/packages/ui/src/Display/index.stories.tsx
+++ b/packages/ui/src/Display/index.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Display } from '.';
+import styled from 'styled-components';
+import { Text } from '../Text';
+
+const meta: Meta<typeof Display> = {
+  component: Display,
+  tags: ['autodocs'],
+  argTypes: {
+    children: { control: false },
+  },
+  decorators: [
+    Story => (
+      <OuterWidthIndicator>
+        <Story />
+      </OuterWidthIndicator>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Display>;
+
+const OuterWidthIndicator = styled.div`
+  border: 1px solid ${props => props.theme.color.base.white};
+`;
+
+const InnerWidthIndicator = styled.div`
+  background: ${props => props.theme.color.base.white};
+  color: ${props => props.theme.color.base.black};
+  padding: ${props => props.theme.spacing(2)};
+`;
+
+export const FullWidth: Story = {
+  args: {
+    children: (
+      <>
+        <InnerWidthIndicator>
+          <Text p>
+            The white background that this text sits inside of indicates the width of whatever you
+            put <Text strong>inside</Text> the <Text technical>&lt;Display /&gt;</Text> component.
+            The white border to the left and right of this white bar represent the{' '}
+            <Text technical>&lt;Display /&gt;</Text> component&apos;s boundaries itself.
+          </Text>
+          <Text p>
+            You can resize your window to see how the margins at left and right change depending on
+            the size of the browser window.
+          </Text>
+          <Text p>
+            To view the <Text technical>&lt;Display /&gt;</Text> at full width, click the &quot;Full
+            Width&quot; item in the left sidebar.
+          </Text>
+        </InnerWidthIndicator>
+      </>
+    ),
+  },
+};

--- a/packages/ui/src/Display/index.stories.tsx
+++ b/packages/ui/src/Display/index.stories.tsx
@@ -35,24 +35,23 @@ const InnerWidthIndicator = styled.div`
 export const FullWidth: Story = {
   args: {
     children: (
-      <>
-        <InnerWidthIndicator>
-          <Text p>
-            The white background that this text sits inside of indicates the width of whatever you
-            put <Text strong>inside</Text> the <Text technical>&lt;Display /&gt;</Text> component.
-            The white border to the left and right of this white bar represent the{' '}
-            <Text technical>&lt;Display /&gt;</Text> component&apos;s boundaries itself.
-          </Text>
-          <Text p>
-            You can resize your window to see how the margins at left and right change depending on
-            the size of the browser window.
-          </Text>
-          <Text p>
-            To view the <Text technical>&lt;Display /&gt;</Text> at full width, click the &quot;Full
-            Width&quot; item in the left sidebar.
-          </Text>
-        </InnerWidthIndicator>
-      </>
+      <InnerWidthIndicator>
+        <Text p>
+          The white background that this text sits inside of represents the{' '}
+          <Text strong>inside</Text> width of the <Text technical>&lt;Display /&gt;</Text>{' '}
+          component. The white border to the left and right of this white bar represent the{' '}
+          <Text strong>outside</Text> width of the <Text technical>&lt;Display /&gt;</Text>{' '}
+          component.
+        </Text>
+        <Text p>
+          You can resize your window to see how the margins at left and right change depending on
+          the size of the browser window.
+        </Text>
+        <Text p>
+          To view the <Text technical>&lt;Display /&gt;</Text> at full width, click the &quot;Full
+          Width&quot; item in the left sidebar.
+        </Text>
+      </InnerWidthIndicator>
     ),
   },
 };

--- a/packages/ui/src/Display/index.tsx
+++ b/packages/ui/src/Display/index.tsx
@@ -1,0 +1,42 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+import { media } from '../utils/media';
+
+const Root = styled.section`
+  padding: 0 ${props => props.theme.spacing(4)};
+
+  ${props => media.desktop`
+    padding: 0 ${props.theme.spacing(8)};
+  `}
+`;
+
+const ContentsWrapper = styled.div`
+  max-width: 1600px;
+  margin: 0 auto;
+`;
+
+export interface DisplayProps {
+  children?: ReactNode;
+}
+
+/**
+ * Wrap your top-level component for a given page (usually a `<Grid />`) in
+ * `<Diplay />` to adhere to PenumbraUI guidelines regarding maximum layouts
+ * widths, horizontal margins, etc.
+ *
+ * ```tsx
+ * <Display>
+ *   <Grid container>
+ *     <Grid tablet={6}>Column one</Grid>
+ *     <Grid tablet={6}>Column two</Grid>
+ *   </Grid>
+ * </Display>
+ * ```
+ */
+export const Display = ({ children }: DisplayProps) => {
+  return (
+    <Root>
+      <ContentsWrapper>{children}</ContentsWrapper>
+    </Root>
+  );
+};

--- a/packages/ui/src/Grid/index.tsx
+++ b/packages/ui/src/Grid/index.tsx
@@ -32,19 +32,19 @@ interface GridItemProps extends BaseGridProps {
    * The mobile grid layout can only be split in half, so you can only set a
    * grid item to 6 or 12 columns on mobile.
    */
-  mobile?: 6 | 12;
+  mobile?: 0 | 6 | 12;
   /**
    * The number of columns this grid item should span on tablet.
    *
    * The tablet grid layout can only be split into six columns.
    */
-  tablet?: 2 | 4 | 6 | 8 | 10 | 12;
+  tablet?: 0 | 2 | 4 | 6 | 8 | 10 | 12;
   /** The number of columns this grid item should span on desktop. */
-  desktop?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  desktop?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
   /** The number of columns this grid item should span on large screens. */
-  lg?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  lg?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
   /** The number of columns this grid item should span on XL screens. */
-  xl?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  xl?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 }
 
 export type GridProps = PropsWithChildren<GridContainerProps | GridItemProps>;

--- a/packages/ui/src/PenumbraUIProvider/theme.ts
+++ b/packages/ui/src/PenumbraUIProvider/theme.ts
@@ -1,3 +1,5 @@
+import { hexOpacity } from '../utils/hexOpacity';
+
 /**
  * Used for reference in the `theme` object below. Not intended to be used
  * directly by consumers, but rather as a semantic reference for building the
@@ -102,19 +104,6 @@ const PALETTE = {
   },
 };
 
-/**
- * Given a decimal opacity (between 0 and 1), returns a two-character string
- * that can be appended to an RGB value for the alpha channel.
- *
- * ```ts
- * `#000000${opacityInHex(0.5)}` // #00000080 -- i.e., black at 50% opacity
- * ```
- */
-const opacityInHex = (opacity: number) =>
-  Math.round(opacity * 255)
-    .toString(16)
-    .padStart(2, '0');
-
 export const theme = {
   blur: {
     none: '0px',
@@ -196,9 +185,9 @@ export const theme = {
       special: PALETTE.orange['400'],
     },
     action: {
-      hoverOverlay: PALETTE.teal['400'] + opacityInHex(0.15),
-      activeOverlay: PALETTE.neutral['950'] + opacityInHex(0.15),
-      disabledOverlay: PALETTE.neutral['950'] + opacityInHex(0.8),
+      hoverOverlay: PALETTE.teal['400'] + hexOpacity(0.15),
+      activeOverlay: PALETTE.neutral['950'] + hexOpacity(0.15),
+      disabledOverlay: PALETTE.neutral['950'] + hexOpacity(0.8),
       primaryFocusOutline: PALETTE.orange['400'],
       secondaryFocusOutline: PALETTE.teal['400'],
       unshieldFocusOutline: PALETTE.purple['400'],
@@ -206,12 +195,12 @@ export const theme = {
       destructiveFocusOutline: PALETTE.red['400'],
     },
     other: {
-      tonalStroke: PALETTE.neutral['50'] + opacityInHex(0.15),
-      tonalFill5: PALETTE.neutral['50'] + opacityInHex(0.05),
-      tonalFill10: PALETTE.neutral['50'] + opacityInHex(0.1),
+      tonalStroke: PALETTE.neutral['50'] + hexOpacity(0.15),
+      tonalFill5: PALETTE.neutral['50'] + hexOpacity(0.05),
+      tonalFill10: PALETTE.neutral['50'] + hexOpacity(0.1),
       solidStroke: PALETTE.neutral['700'],
-      dialogBackground: PALETTE.teal['700'] + opacityInHex(0.1),
-      overlay: PALETTE.base.black + opacityInHex(0.5),
+      dialogBackground: PALETTE.teal['700'] + hexOpacity(0.1),
+      overlay: PALETTE.base.black + hexOpacity(0.5),
     },
   },
   font: {

--- a/packages/ui/src/PenumbraUIProvider/theme.ts
+++ b/packages/ui/src/PenumbraUIProvider/theme.ts
@@ -95,10 +95,25 @@ const PALETTE = {
     900: '#6B3F18',
     950: '#201004',
   },
+  base: {
+    black: '#000000',
+    white: '#ffffff',
+    transparent: 'transparent',
+  },
 };
 
-const FIFTEEN_PERCENT_OPACITY_IN_HEX = '26';
-const EIGHTY_PERCENT_OPACITY_IN_HEX = 'cc';
+/**
+ * Given a decimal opacity (between 0 and 1), returns a two-character string
+ * that can be appended to an RGB value for the alpha channel.
+ *
+ * ```ts
+ * `#000000${opacityInHex(0.5)}` // #00000080 -- i.e., black at 50% opacity
+ * ```
+ */
+const opacityInHex = (opacity: number) =>
+  Math.round(opacity * 255)
+    .toString(16)
+    .padStart(2, '0');
 
 export const theme = {
   blur: {
@@ -170,9 +185,9 @@ export const theme = {
       contrast: PALETTE.green['50'],
     },
     base: {
-      black: '#000',
-      white: '#fff',
-      transparent: 'transparent',
+      black: PALETTE.base.black,
+      white: PALETTE.base.white,
+      transparent: PALETTE.base.transparent,
     },
     text: {
       primary: PALETTE.neutral['50'],
@@ -181,9 +196,9 @@ export const theme = {
       special: PALETTE.orange['400'],
     },
     action: {
-      hoverOverlay: PALETTE.teal['400'] + FIFTEEN_PERCENT_OPACITY_IN_HEX,
-      activeOverlay: PALETTE.neutral['950'] + FIFTEEN_PERCENT_OPACITY_IN_HEX,
-      disabledOverlay: PALETTE.neutral['950'] + EIGHTY_PERCENT_OPACITY_IN_HEX,
+      hoverOverlay: PALETTE.teal['400'] + opacityInHex(0.15),
+      activeOverlay: PALETTE.neutral['950'] + opacityInHex(0.15),
+      disabledOverlay: PALETTE.neutral['950'] + opacityInHex(0.8),
       primaryFocusOutline: PALETTE.orange['400'],
       secondaryFocusOutline: PALETTE.teal['400'],
       unshieldFocusOutline: PALETTE.purple['400'],
@@ -191,8 +206,12 @@ export const theme = {
       destructiveFocusOutline: PALETTE.red['400'],
     },
     other: {
-      tonalStroke: PALETTE.neutral['50'] + FIFTEEN_PERCENT_OPACITY_IN_HEX,
+      tonalStroke: PALETTE.neutral['50'] + opacityInHex(0.15),
+      tonalFill5: PALETTE.neutral['50'] + opacityInHex(0.05),
+      tonalFill10: PALETTE.neutral['50'] + opacityInHex(0.1),
       solidStroke: PALETTE.neutral['700'],
+      dialogBackground: PALETTE.teal['700'] + opacityInHex(0.1),
+      overlay: PALETTE.base.black + opacityInHex(0.5),
     },
   },
   font: {

--- a/packages/ui/src/Table/index.tsx
+++ b/packages/ui/src/Table/index.tsx
@@ -8,12 +8,13 @@ import { ConditionalWrap } from '../utils/ConditionalWrap';
 const FIVE_PERCENT_OPACITY_IN_HEX = '0d';
 
 // So named to avoid naming conflicts with `<Table />`
-const StyledTable = styled.table`
+const StyledTable = styled.table<{ $layout?: 'fixed' | 'auto' }>`
   width: 100%;
   background-color: ${props => props.theme.color.neutral.contrast + FIVE_PERCENT_OPACITY_IN_HEX};
   padding-left: ${props => props.theme.spacing(3)};
   padding-right: ${props => props.theme.spacing(3)};
   border-radius: ${props => props.theme.borderRadius.lg};
+  table-layout: ${props => props.$layout ?? 'auto'};
 `;
 
 const TitleAndTableWrapper = styled.div`
@@ -29,6 +30,8 @@ export interface TableProps {
   /** Content that will appear above the table. */
   title?: ReactNode;
   children: ReactNode;
+  /** Which CSS `table-layout` property to use. */
+  layout?: 'fixed' | 'auto';
 }
 
 /**
@@ -72,7 +75,7 @@ export interface TableProps {
  * </Table>
  * ```
  */
-export const Table = ({ title, ...props }: TableProps) => (
+export const Table = ({ title, children, layout }: TableProps) => (
   <ConditionalWrap
     if={!!title}
     then={children => (
@@ -82,7 +85,9 @@ export const Table = ({ title, ...props }: TableProps) => (
       </TitleAndTableWrapper>
     )}
   >
-    <StyledTable cellSpacing={0} cellPadding={0} {...props} />
+    <StyledTable cellSpacing={0} cellPadding={0} $layout={layout}>
+      {children}
+    </StyledTable>
   </ConditionalWrap>
 );
 

--- a/packages/ui/src/Table/index.tsx
+++ b/packages/ui/src/Table/index.tsx
@@ -154,7 +154,6 @@ Table.Th = Th;
 const StyledTd = styled.td<CellStyledProps>`
   border-bottom: 1px solid ${props => props.theme.color.other.tonalStroke};
   color: ${props => props.theme.color.text.primary};
-  ${props => props.$width && `width: ${props.$width};`}
 
   ${StyledTbody} > ${StyledTr}:last-child > & {
     border-bottom: none;

--- a/packages/ui/src/Table/index.tsx
+++ b/packages/ui/src/Table/index.tsx
@@ -107,6 +107,8 @@ interface CellStyledProps {
 }
 
 const cell = css<CellStyledProps>`
+  box-sizing: border-box;
+
   padding-left: ${props => props.theme.spacing(3)};
   padding-right: ${props => props.theme.spacing(3)};
 

--- a/packages/ui/src/ValueViewComponent/index.tsx
+++ b/packages/ui/src/ValueViewComponent/index.tsx
@@ -15,7 +15,7 @@ const Row = styled.span<{ $context: Context; $priority: 'primary' | 'secondary' 
   display: flex;
   gap: ${props => props.theme.spacing(2)};
   align-items: center;
-  width: min-content;
+  width: max-content;
   max-width: 100%;
   text-overflow: ellipsis;
 

--- a/packages/ui/src/ValueViewComponent/index.tsx
+++ b/packages/ui/src/ValueViewComponent/index.tsx
@@ -58,7 +58,7 @@ const SymbolWrapper = styled.div`
 `;
 
 export interface ValueViewComponentProps<SelectedContext extends Context> {
-  valueView: ValueView;
+  valueView?: ValueView;
   /**
    * A `ValueViewComponent` will be rendered differently depending on which
    * context it's rendered in. By default, it'll be rendered in a pill. But in a
@@ -86,6 +86,11 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
   priority = 'primary',
 }: ValueViewComponentProps<SelectedContext>) => {
   const density = useDensity();
+
+  if (!valueView) {
+    return null;
+  }
+
   const formattedAmount = getFormattedAmtFromValueView(valueView, true);
   const metadata = getMetadata.optional()(valueView);
   // Symbol default is "" and thus cannot do nullish coalescing

--- a/packages/ui/src/ValueViewComponent/index.tsx
+++ b/packages/ui/src/ValueViewComponent/index.tsx
@@ -11,21 +11,13 @@ import { useDensity } from '../hooks/useDensity';
 
 type Context = 'default' | 'table';
 
-const Row = styled.span<{ $context: Context; $priority: 'primary' | 'secondary' }>`
+const Row = styled.span`
   display: flex;
   gap: ${props => props.theme.spacing(2)};
   align-items: center;
   width: max-content;
   max-width: 100%;
   text-overflow: ellipsis;
-
-  ${props =>
-    props.$context === 'table' && props.$priority === 'secondary'
-      ? `
-        border-bottom: 2px dashed ${props.theme.color.other.tonalStroke};
-        padding-bottom: ${props.theme.spacing(2)};
-      `
-      : ''};
 `;
 
 const AssetIconWrapper = styled.div`
@@ -37,7 +29,7 @@ const PillMarginOffsets = styled.div<{ $density: Density }>`
   margin-right: ${props => props.theme.spacing(props.$density === 'sparse' ? -1 : 0)};
 `;
 
-const Content = styled.div`
+const Content = styled.div<{ $context: Context; $priority: 'primary' | 'secondary' }>`
   flex-grow: 1;
   flex-shrink: 1;
 
@@ -46,6 +38,11 @@ const Content = styled.div`
   align-items: center;
 
   overflow: hidden;
+
+  ${props =>
+    props.$context === 'table' &&
+    props.$priority === 'secondary' &&
+    `border-bottom: 2px dashed ${props.theme.color.other.tonalStroke};`};
 `;
 
 const SymbolWrapper = styled.div`
@@ -106,12 +103,12 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
         </Pill>
       )}
     >
-      <Row $context={context ?? 'default'} $priority={priority}>
+      <Row>
         <AssetIconWrapper>
           <AssetIcon metadata={metadata} />
         </AssetIconWrapper>
 
-        <Content>
+        <Content $context={context ?? 'default'} $priority={priority}>
           <Text>{formattedAmount} </Text>
           <SymbolWrapper title={symbol}>
             <Text technical>{symbol}</Text>

--- a/packages/ui/src/utils/hexOpacity.ts
+++ b/packages/ui/src/utils/hexOpacity.ts
@@ -1,0 +1,12 @@
+/**
+ * Given a decimal opacity (between 0 and 1), returns a two-character string
+ * that can be appended to an RGB value for the alpha channel.
+ *
+ * ```ts
+ * `#000000${opacityInHex(0.5)}` // #00000080 -- i.e., black at 50% opacity
+ * ```
+ */
+export const hexOpacity = (opacity: number) =>
+  Math.round(opacity * 255)
+    .toString(16)
+    .padStart(2, '0');


### PR DESCRIPTION
This PR creates the first two v2 pages! I started with the simplest ones (assets/transactions) even though they're not 100% ready yet in Figma, because I wanted to just get something shipped.

Note that the layouts are a bit narrow at the moment. But I'm just following Figma designs, so please direct design feedback to Sam 😆 That said, these can be merged as a work in progress, because we're still building out the v2 layouts.


https://github.com/user-attachments/assets/bea9a89b-85fd-4d7f-aec5-21327ba47f77



## In this PR
- Create [v2-prefixed routes](https://github.com/penumbra-zone/web/pull/1607/files#diff-d76fa2d1aa95b7c0191339695bee2306207d3bc5fa8bd2eabcf208b2094f8e64) for the new pages, and [add them to the main router](https://github.com/penumbra-zone/web/pull/1607/files#diff-7a5d45039c54d2c203035a013c7d6d2047140884a074b0956de167a3dbd11399).
- Implement the assets and transactions pages.
- Create a `hexOpacity()` helper so I can stop making `TEN_PERCENT_OPACITY_IN_HEX` consts.
- Create a`<Display />` component that handles page max widths and horizontal margins.
- Fix some sizing issues with `<Dialog />`
  - Sam pointed out the the sizing of the `<Dialog />` component should be based on a grid, just like the sizing of regular components on the page. So I had to rework the `<Dialog />` component a bit so that the dialog is wrapped in a `<Display />` and a `<Grid />` and fits the specs in Figma.
- Add some missing values to the theme, and update some others, per Figma.
- Make it possible to use a fixed-layout table.