### PR TITLE
Show 'All' auctions by default

### DIFF
--- a/.changeset/gorgeous-toys-compare.md
+++ b/.changeset/gorgeous-toys-compare.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+show all auctions by default

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -100,7 +100,7 @@ const INITIAL_STATE: State = {
   maxOutput: '',
   txInProgress: false,
   auctionInfos,
-  filter: 'active',
+  filter: 'all',
   estimateLoading: false,
   estimatedOutput: undefined,
 };


### PR DESCRIPTION
fixes #1619 

Users are confused when the 'Auctions' section of the swap page does not show elapsed auctions. As elapsed auctions require user interaction, these should be visible by default.

This PR is a single-line change to this effect.