### PR TITLE
forbid um ibc out to celestia

### DIFF
--- a/.changeset/polite-otters-cheer.md
+++ b/.changeset/polite-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+forbid um ibc out to celestia

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -5,6 +5,7 @@ import { useStore } from '../../../state';
 import {
   filteredIbcBalancesSelector,
   ibcOutSelector,
+  ibcPlaceholderSelector,
   ibcValidationErrors,
 } from '../../../state/ibc-out';
 import InputToken from '../../shared/input-token';
@@ -34,6 +35,7 @@ export const IbcOutForm = () => {
     setSelection,
   } = useStore(ibcOutSelector);
   const validationErrors = useStore(ibcValidationErrors);
+  const placeholder = useStore(ibcPlaceholderSelector);
 
   return (
     <form
@@ -46,7 +48,7 @@ export const IbcOutForm = () => {
       <ChainSelector />
       <InputToken
         label='Amount to send'
-        placeholder={filteredBalances.length > 0 ? 'Enter an amount' : 'No balances to transfer'}
+        placeholder={placeholder}
         className='mb-1'
         selection={selection}
         setSelection={setSelection}

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -75,7 +75,7 @@ export const IbcOutForm = () => {
           if (chain?.chainId && FORBID_UM_IBC_OUT.includes(chain.chainId)) {
             const um = stakingTokenMetadata.data?.penumbraAssetId;
             const balanceAsset = getAssetIdFromBalancesResponseOptional(b);
-            const notUm = !um?.equals(balanceAsset);
+            const notUm = !balanceAsset?.equals(um);
             return notUm;
           }
           return true;

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -75,8 +75,8 @@ export const IbcOutForm = () => {
           if (chain?.chainId && FORBID_UM_IBC_OUT.includes(chain.chainId)) {
             const um = stakingTokenMetadata.data?.penumbraAssetId;
             const balanceAsset = getAssetIdFromBalancesResponseOptional(b);
-            const filter = !um?.equals(balanceAsset);
-            return filter;
+            const notUm = !um?.equals(balanceAsset);
+            return notUm;
           }
           return true;
         })}

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -13,6 +13,8 @@ import { LockOpen2Icon } from '@radix-ui/react-icons';
 import { useAssets, useBalancesResponses, useStakingTokenMetadata } from '../../../state/shared';
 import { getAssetIdFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
 
+const FORBID_UM_IBC_OUT = ['celestia'];
+
 export const IbcOutForm = () => {
   const stakingTokenMetadata = useStakingTokenMetadata();
   const assets = useAssets();
@@ -69,13 +71,15 @@ export const IbcOutForm = () => {
             checkFn: () => validationErrors.exponentErr,
           },
         ]}
-        balances={filteredBalances.filter(
-          b =>
-            chain?.chainId !== 'celestia' ||
-            !stakingTokenMetadata.data?.penumbraAssetId?.equals(
-              getAssetIdFromBalancesResponseOptional(b),
-            ),
-        )}
+        balances={filteredBalances.filter(b => {
+          if (chain?.chainId && FORBID_UM_IBC_OUT.includes(chain.chainId)) {
+            const um = stakingTokenMetadata.data?.penumbraAssetId;
+            const balanceAsset = getAssetIdFromBalancesResponseOptional(b);
+            const filter = !um?.equals(balanceAsset);
+            return filter;
+          }
+          return true;
+        })}
       />
       <InputBlock
         label='Recipient on destination chain'

--- a/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
+++ b/apps/minifront/src/components/ibc/ibc-out/ibc-out-form.tsx
@@ -11,6 +11,7 @@ import InputToken from '../../shared/input-token';
 import { InputBlock } from '../../shared/input-block';
 import { LockOpen2Icon } from '@radix-ui/react-icons';
 import { useAssets, useBalancesResponses, useStakingTokenMetadata } from '../../../state/shared';
+import { getAssetIdFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
 
 export const IbcOutForm = () => {
   const stakingTokenMetadata = useStakingTokenMetadata();
@@ -68,7 +69,13 @@ export const IbcOutForm = () => {
             checkFn: () => validationErrors.exponentErr,
           },
         ]}
-        balances={filteredBalances}
+        balances={filteredBalances.filter(
+          b =>
+            chain?.chainId !== 'celestia' ||
+            !stakingTokenMetadata.data?.penumbraAssetId?.equals(
+              getAssetIdFromBalancesResponseOptional(b),
+            ),
+        )}
       />
       <InputBlock
         label='Recipient on destination chain'

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -26,6 +26,8 @@ import { BLOCKS_PER_HOUR } from './constants';
 import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
 import { getChains } from '../fetchers/registry';
 
+const FORBID_UM_IBC_OUT = ['celestia'];
+
 export const { chains, useChains } = createZQuery({
   name: 'chains',
   fetch: getChains,
@@ -272,10 +274,14 @@ export const filterBalancesPerChain = (
     })
     .map(m => m.penumbraAssetId!);
 
-  const assetIdsToCheck = [penumbraAssetId, ...assetsWithMatchingChannel];
+  const assetIdsToCheck = [...assetsWithMatchingChannel];
+
+  if (!FORBID_UM_IBC_OUT.includes(chain!.chainId)) {
+    assetIdsToCheck.push(penumbraAssetId!);
+  }
 
   return allBalances.filter(({ balanceView }) => {
-    return assetIdsToCheck.some(assetId => assetId?.equals(getAssetIdFromValueView(balanceView)));
+    return assetIdsToCheck.some(assetId => assetId.equals(getAssetIdFromValueView(balanceView)));
   });
 };
 

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -304,3 +304,14 @@ export const filteredIbcBalancesSelector = (state: AllSlices): BalancesResponse[
     state.shared.stakingTokenMetadata.data,
   );
 };
+
+export const ibcPlaceholderSelector = (state: AllSlices): string => {
+  const filteredBalances = filteredIbcBalancesSelector(state);
+  if (!state.ibcOut.chain) {
+    return 'Select a chain';
+  }
+  if (filteredBalances.length === 0) {
+    return 'No balances to transfer';
+  }
+  return 'Enter an amount';
+};

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -1,4 +1,4 @@
-import { AllSlices, Middleware, SliceCreator, useStore } from '.';
+import { AllSlices, SliceCreator, useStore } from '.';
 import {
   BalancesResponse,
   TransactionPlannerRequest,
@@ -23,7 +23,7 @@ import { Chain } from '@penumbra-labs/registry';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
 import { Channel } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/channel/v1/channel_pb.js';
 import { BLOCKS_PER_HOUR } from './constants';
-import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
+import { createZQuery, ZQueryState } from '@penumbra-zone/zquery';
 import { getChains } from '../fetchers/registry';
 
 export const { chains, useChains } = createZQuery({
@@ -74,6 +74,12 @@ export const createIbcOutSlice = (): SliceCreator<IbcOutSlice> => (set, get) => 
     setChain: chain => {
       set(state => {
         state.ibcOut.chain = chain;
+      });
+
+      // After new chain is selected, the asset selection should also be updated separately
+      const initialSelection = filteredIbcBalancesSelector(get())[0];
+      set(state => {
+        state.ibcOut.selection = initialSelection;
       });
     },
     setDestinationChainAddress: addr => {
@@ -248,6 +254,9 @@ const unknownAddrIsValid = (chain: Chain | undefined, address: string): boolean 
   return !!words && prefix === chain.addressPrefix;
 };
 
+// These chains do not allow IBC-in transfers unless the token is native to the chain
+export const NATIVE_TRANSFERS_ONLY_CHAIN_IDS = ['celestia'];
+
 /**
  * Filters the given IBC loader response balances by checking if any of the assets
  * in the balance view match the staking token's asset ID or are of the same ibc channel.
@@ -272,58 +281,26 @@ export const filterBalancesPerChain = (
     })
     .map(m => m.penumbraAssetId!);
 
-  const assetIdsToCheck = [penumbraAssetId, ...assetsWithMatchingChannel];
+  const assetIdsToCheck = [...assetsWithMatchingChannel];
+
+  if (
+    chain?.chainId &&
+    penumbraAssetId &&
+    !NATIVE_TRANSFERS_ONLY_CHAIN_IDS.includes(chain.chainId)
+  ) {
+    assetIdsToCheck.push(penumbraAssetId);
+  }
 
   return allBalances.filter(({ balanceView }) => {
-    return assetIdsToCheck.some(assetId => assetId?.equals(getAssetIdFromValueView(balanceView)));
+    return assetIdsToCheck.some(assetId => assetId.equals(getAssetIdFromValueView(balanceView)));
   });
 };
 
-export const ibcOutMiddleware: Middleware = f => (set, get, store) => {
-  const modifiedSetter: typeof set = (...args) => {
-    set(...args);
-
-    const initialChain = get().ibcOut.chains.data?.[0];
-    const shouldSetInitialChain = !!initialChain && !get().ibcOut.chain;
-    if (shouldSetInitialChain) {
-      set(state => ({
-        ...state,
-        ibcOut: {
-          ...state.ibcOut,
-          chain: initialChain,
-        },
-      }));
-    }
-
-    const assets = get().shared.assets.data;
-    const balancesResponses = get().shared.balancesResponses.data;
-    const stakingTokenMetadata = get().shared.stakingTokenMetadata.data;
-    const shouldSetInitialSelection =
-      initialChain &&
-      assets?.length &&
-      balancesResponses?.length &&
-      stakingTokenMetadata &&
-      !get().ibcOut.selection;
-
-    if (shouldSetInitialSelection) {
-      const initialSelection = filterBalancesPerChain(
-        balancesResponses,
-        initialChain,
-        assets,
-        stakingTokenMetadata,
-      )[0];
-
-      set(state => ({
-        ...state,
-        ibcOut: {
-          ...state.ibcOut,
-          selection: initialSelection,
-        },
-      }));
-    }
-  };
-
-  store.setState = modifiedSetter;
-
-  return f(modifiedSetter, get, store);
+export const filteredIbcBalancesSelector = (state: AllSlices): BalancesResponse[] => {
+  return filterBalancesPerChain(
+    state.shared.balancesResponses.data ?? [],
+    state.ibcOut.chain,
+    state.shared.assets.data ?? [],
+    state.shared.stakingTokenMetadata.data,
+  );
 };

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -26,8 +26,6 @@ import { BLOCKS_PER_HOUR } from './constants';
 import { ZQueryState, createZQuery } from '@penumbra-zone/zquery';
 import { getChains } from '../fetchers/registry';
 
-const FORBID_UM_IBC_OUT = ['celestia'];
-
 export const { chains, useChains } = createZQuery({
   name: 'chains',
   fetch: getChains,
@@ -274,14 +272,10 @@ export const filterBalancesPerChain = (
     })
     .map(m => m.penumbraAssetId!);
 
-  const assetIdsToCheck = [...assetsWithMatchingChannel];
-
-  if (!FORBID_UM_IBC_OUT.includes(chain!.chainId)) {
-    assetIdsToCheck.push(penumbraAssetId!);
-  }
+  const assetIdsToCheck = [penumbraAssetId, ...assetsWithMatchingChannel];
 
   return allBalances.filter(({ balanceView }) => {
-    return assetIdsToCheck.some(assetId => assetId.equals(getAssetIdFromValueView(balanceView)));
+    return assetIdsToCheck.some(assetId => assetId?.equals(getAssetIdFromValueView(balanceView)));
   });
 };
 

--- a/apps/minifront/src/state/index.ts
+++ b/apps/minifront/src/state/index.ts
@@ -2,7 +2,7 @@ import { create, StateCreator } from 'zustand';
 import { enableMapSet } from 'immer';
 import { immer } from 'zustand/middleware/immer';
 import { createSwapSlice, SwapSlice } from './swap';
-import { createIbcOutSlice, ibcOutMiddleware, IbcOutSlice } from './ibc-out';
+import { createIbcOutSlice, IbcOutSlice } from './ibc-out';
 import { createSendSlice, sendSelectionMiddleware, SendSlice } from './send';
 import { createStakingSlice, StakingSlice } from './staking';
 import { createStatusSlice, StatusSlice } from './status';
@@ -51,20 +51,18 @@ export const initializeStore = () => {
   // middleware call. Thus, all other middlewares can't use immer's syntax in
   // their setters.
   return immer(
-    ibcOutMiddleware(
-      sendSelectionMiddleware(
-        swapBalancesMiddleware((setState, getState: () => AllSlices, store) => ({
-          ibcIn: createIbcInSlice()(setState, getState, store),
-          ibcOut: createIbcOutSlice()(setState, getState, store),
-          send: createSendSlice()(setState, getState, store),
-          shared: createSharedSlice()(setState, getState, store),
-          staking: createStakingSlice()(setState, getState, store),
-          status: createStatusSlice()(setState, getState, store),
-          swap: createSwapSlice()(setState, getState, store),
-          transactions: createTransactionsSlice()(setState, getState, store),
-          unclaimedSwaps: createUnclaimedSwapsSlice()(setState, getState, store),
-        })),
-      ),
+    sendSelectionMiddleware(
+      swapBalancesMiddleware((setState, getState: () => AllSlices, store) => ({
+        ibcIn: createIbcInSlice()(setState, getState, store),
+        ibcOut: createIbcOutSlice()(setState, getState, store),
+        send: createSendSlice()(setState, getState, store),
+        shared: createSharedSlice()(setState, getState, store),
+        staking: createStakingSlice()(setState, getState, store),
+        status: createStatusSlice()(setState, getState, store),
+        swap: createSwapSlice()(setState, getState, store),
+        transactions: createTransactionsSlice()(setState, getState, store),
+        unclaimedSwaps: createUnclaimedSwapsSlice()(setState, getState, store),
+      })),
     ),
   );
 };

--- a/packages/getters/src/balances-response.ts
+++ b/packages/getters/src/balances-response.ts
@@ -7,8 +7,6 @@ export const getBalanceView = createGetter(
   (balancesResponse?: BalancesResponse) => balancesResponse?.balanceView,
 );
 
-export const getAssetIdFromBalancesResponse = getBalanceView.pipe(getMetadata).pipe(getAssetId);
-
 export const getAssetIdFromBalancesResponseOptional = getBalanceView
   .optional()
   .pipe(getMetadata)

--- a/packages/getters/src/balances-response.ts
+++ b/packages/getters/src/balances-response.ts
@@ -7,6 +7,8 @@ export const getBalanceView = createGetter(
   (balancesResponse?: BalancesResponse) => balancesResponse?.balanceView,
 );
 
+export const getAssetIdFromBalancesResponse = getBalanceView.pipe(getMetadata).pipe(getAssetId);
+
 export const getAssetIdFromBalancesResponseOptional = getBalanceView
   .optional()
   .pipe(getMetadata)


### PR DESCRIPTION
~~this PR will conditionally filter um tokens within the ibc out state slice, before they reach the UI asset picker~~

when celestia is selected, filter um tokens from the token picker, when passed into the component prop.

this was easier to confirm behavior than filtering in the state slice.

currently the ibc form will have a pre-filtered set of balances that are already restricted to a chain's native tokens plus um. so, on celestia chain id condition, um is filtered.