### PR TITLE
Enable the syncing dialog; make it dismissible

### DIFF
--- a/apps/minifront/src/components/layout.tsx
+++ b/apps/minifront/src/components/layout.tsx
@@ -3,13 +3,8 @@ import { HeadTag } from './metadata/head-tag';
 import { Header } from './header/header';
 import { Toaster } from '@repo/ui/components/ui/toaster';
 import { Footer } from './footer/footer';
+import { SyncingDialog } from './syncing-dialog';
 import '@repo/ui/styles/globals.css';
-
-/**
- * @todo: add back the SyncingDialog once we've determined whether it can be
- * dismissed.
- */
-// import { SyncingDialog } from './syncing-dialog';
 
 export const Layout = () => {
   return (
@@ -25,7 +20,7 @@ export const Layout = () => {
       </div>
 
       <Toaster />
-      {/* <SyncingDialog /> */}
+      <SyncingDialog />
     </>
   );
 };

--- a/apps/minifront/src/components/syncing-dialog/index.tsx
+++ b/apps/minifront/src/components/syncing-dialog/index.tsx
@@ -3,6 +3,7 @@ import { Status, useStatus } from '../../state/status';
 import { AbridgedZQueryState } from '@penumbra-zone/zquery/src/types';
 import { SyncAnimation } from './sync-animation';
 import { Text } from '@repo/ui/Text';
+import { useEffect, useState } from 'react';
 
 type StatusSelector =
   | {
@@ -40,23 +41,30 @@ export const SyncingDialog = () => {
     select: statusSelector,
   });
 
-  if (!status?.isCatchingUp) {
-    return null;
-  }
+  const [isOpen, setIsOpen] = useState(false);
 
-  const { fullSyncHeight, latestKnownBlockHeight, percentSynced } = status;
+  useEffect(() => {
+    if (status?.isCatchingUp) {
+      setIsOpen(true);
+    } else {
+      setIsOpen(false);
+    }
+  }, [status?.isCatchingUp]);
 
   return (
-    <Dialog isOpen>
+    <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)}>
       <Dialog.Content title='Your client is syncing...'>
         <SyncAnimation />
 
         <div className='text-center'>
           <Text p>Updating your local state with public state.</Text>
-          <Text technical>
-            {!!percentSynced && `${percentSynced} Synced – `} Block {fullSyncHeight.toString()}{' '}
-            {!!latestKnownBlockHeight && `of ${latestKnownBlockHeight.toString()}`}
-          </Text>
+          {!!status?.isCatchingUp && (
+            <Text technical>
+              {!!status.percentSynced && `${status.percentSynced} Synced – `} Block{' '}
+              {status.fullSyncHeight.toString()}{' '}
+              {!!status.latestKnownBlockHeight && `of ${status.latestKnownBlockHeight.toString()}`}
+            </Text>
+          )}
         </div>
       </Dialog.Content>
     </Dialog>


### PR DESCRIPTION
Follow-up to my previous PR that created (but disabled) the syncing dialog. This also makes the dialog dismissible, hence the extra logic.

![image](https://github.com/user-attachments/assets/c19b9e67-c6f3-4f3b-a216-c4854741fad8)
