### PR TITLE
Create SegmentedControl component

### DIFF
--- a/packages/ui/src/SegmentedControl/index.stories.tsx
+++ b/packages/ui/src/SegmentedControl/index.stories.tsx
@@ -12,7 +12,7 @@ const OPTIONS = [
 
 const meta: Meta<typeof SegmentedControl> = {
   component: SegmentedControl,
-  tags: ['autodocs', '!dev'],
+  tags: ['autodocs', '!dev', 'density'],
   argTypes: {
     value: {
       control: 'select',

--- a/packages/ui/src/SegmentedControl/index.stories.tsx
+++ b/packages/ui/src/SegmentedControl/index.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
+
+import { SegmentedControl } from '.';
+
+const OPTIONS = [
+  { label: 'One', value: 'one' },
+  { label: 'Two', value: 'two' },
+  { label: 'Three', value: 'three' },
+  { label: 'Four (disabled)', value: 'four', disabled: true },
+];
+
+const meta: Meta<typeof SegmentedControl> = {
+  component: SegmentedControl,
+  tags: ['autodocs', '!dev'],
+  argTypes: {
+    value: {
+      control: 'select',
+      options: OPTIONS.filter(({ disabled }) => !disabled).map(({ value }) => value),
+    },
+    options: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SegmentedControl>;
+
+export const Basic: Story = {
+  args: {
+    options: OPTIONS,
+    value: 'one',
+  },
+
+  render: function Render({ value, options }) {
+    const [, updateArgs] = useArgs();
+
+    const onChange = (value: { toString: () => string }) => updateArgs({ value });
+
+    return <SegmentedControl value={value} options={options} onChange={onChange} />;
+  },
+};

--- a/packages/ui/src/SegmentedControl/index.test.tsx
+++ b/packages/ui/src/SegmentedControl/index.test.tsx
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { SegmentedControl } from '.';
+import { PenumbraUIProvider } from '../PenumbraUIProvider';
+
+describe('<SegmentedControl />', () => {
+  const onChange = vi.fn();
+  const options = [
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+    { value: 'three', label: 'Three' },
+  ];
+
+  beforeEach(() => {
+    onChange.mockReset();
+  });
+
+  it('renders all passed-in options', () => {
+    const { container } = render(
+      <SegmentedControl value='one' options={options} onChange={onChange} />,
+      { wrapper: PenumbraUIProvider },
+    );
+
+    expect(container).toHaveTextContent('One');
+    expect(container).toHaveTextContent('Two');
+    expect(container).toHaveTextContent('Three');
+  });
+
+  it('calls the `onClick` handler with the value of the clicked option', () => {
+    const { getByText } = render(
+      <SegmentedControl value='one' options={options} onChange={onChange} />,
+      { wrapper: PenumbraUIProvider },
+    );
+    fireEvent.click(getByText('Two', { selector: ':not([aria-hidden])' }));
+
+    expect(onChange).toHaveBeenCalledWith('two');
+  });
+});

--- a/packages/ui/src/SegmentedControl/index.tsx
+++ b/packages/ui/src/SegmentedControl/index.tsx
@@ -1,0 +1,92 @@
+import styled, { DefaultTheme } from 'styled-components';
+import { button } from '../utils/typography';
+import { focusOutline, overlays, buttonBase } from '../utils/button';
+import { Density } from '../types/Density';
+import { useDensity } from '../hooks/useDensity';
+import * as RadixRadioGroup from '@radix-ui/react-radio-group';
+
+const Root = styled.div`
+  display: flex;
+  gap: ${props => props.theme.spacing(2)};
+`;
+
+const Segment = styled.button<{
+  $getFocusOutlineColor: (theme: DefaultTheme) => string;
+  $getBorderRadius: (theme: DefaultTheme) => string;
+  $selected: boolean;
+  $density: Density;
+}>`
+  ${buttonBase}
+  ${button}
+  ${overlays}
+  ${focusOutline}
+
+  color:${props => props.theme.color.base.white};
+  border: 1px solid
+    ${props =>
+      props.$selected ? props.theme.color.neutral.light : props.theme.color.other.tonalStroke};
+  border-radius: ${props => props.theme.borderRadius.full};
+
+  padding-top: ${props => props.theme.spacing(props.$density === 'sparse' ? 2 : 1)};
+  padding-bottom: ${props => props.theme.spacing(props.$density === 'sparse' ? 2 : 1)};
+  padding-left: ${props => props.theme.spacing(props.$density === 'sparse' ? 4 : 2)};
+  padding-right: ${props => props.theme.spacing(props.$density === 'sparse' ? 4 : 2)};
+`;
+
+export interface Option {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SegmentedControlProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: Option[];
+}
+
+/**
+ * Renders a segmented control where only one option can be selected at a time.
+ * Functionally equivalent to a `<select>` element or a set of radio buttons,
+ * but looks nicer when you only have a few options to choose from. (Probably
+ * shouldn't be used with more than 5 options.)
+ *
+ * Fully accessible and keyboard-controllable.
+ *
+ * @example
+ * ```TSX
+ * <SegmentedPicker
+ *   value={value}
+ *   onChange={setValue}
+ *   options={[
+ *     { value: 'one', label: 'One' },
+ *     { value: 'two', label: 'Two' },
+ *     { value: 'three', label: 'Three', disabled: true },
+ *   ]}
+ * />
+ * ```
+ */
+export const SegmentedControl = ({ value, onChange, options }: SegmentedControlProps) => {
+  const density = useDensity();
+
+  return (
+    <RadixRadioGroup.Root asChild value={value} onValueChange={onChange}>
+      <Root>
+        {options.map(option => (
+          <RadixRadioGroup.Item asChild key={option.value} value={option.value}>
+            <Segment
+              onClick={() => onChange(option.value)}
+              $getBorderRadius={theme => theme.borderRadius.full}
+              $getFocusOutlineColor={theme => theme.color.neutral.light}
+              $selected={value === option.value}
+              $density={density}
+              disabled={option.disabled}
+            >
+              {option.label}
+            </Segment>
+          </RadixRadioGroup.Item>
+        ))}
+      </Root>
+    </RadixRadioGroup.Root>
+  );
+};


### PR DESCRIPTION
This PR creates a `<SegmentedControl />` component built on top of Radix's `<RadioGroup />` component, making it fully accessible and keyboard-controllable.

![image](https://github.com/user-attachments/assets/84ba9d04-4353-4932-853a-0c5bfe0c0085)
