### PR TITLE
fix(monorepo): #1591: refetch balancesResponses after successful swap and send

### DIFF
--- a/.changeset/grumpy-swans-look.md
+++ b/.changeset/grumpy-swans-look.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Refetch BalancesResponse query after successful swap and send

--- a/apps/minifront/src/components/shared/selectors/balance-selector.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-selector.tsx
@@ -9,7 +9,12 @@ import { motion } from 'framer-motion';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
 import { emptyBalanceResponse } from '../../../utils/empty-balance-response';
 import { bySearch } from './search-filters';
-import { BalanceOrMetadata, isMetadata, mergeBalancesAndAssets } from './helpers';
+import {
+  BalanceOrMetadata,
+  isMetadata,
+  mergeBalancesAndAssets,
+  useSyncSelectedBalance,
+} from './helpers';
 import { BalanceItem } from './balance-item';
 import { cn } from '@repo/ui/lib/utils';
 import { LoadingIndicator } from './loading-indicator';
@@ -44,6 +49,7 @@ export default function BalanceSelector({
 
   const allAssets = mergeBalancesAndAssets(balances, assets);
   const filteredBalances = search ? allAssets.filter(bySearch(search)) : allAssets;
+  useSyncSelectedBalance({ balances, value, onChange });
 
   const onSelect = (asset: BalanceOrMetadata) => {
     if (!isMetadata(asset)) {

--- a/apps/minifront/src/components/shared/selectors/helpers.ts
+++ b/apps/minifront/src/components/shared/selectors/helpers.ts
@@ -1,6 +1,10 @@
 import { BalancesResponse } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
-import { getMetadataFromBalancesResponseOptional } from '@penumbra-zone/getters/balances-response';
+import {
+  getAddressIndex,
+  getMetadataFromBalancesResponseOptional,
+} from '@penumbra-zone/getters/balances-response';
+import { useEffect } from 'react';
 
 export type BalanceOrMetadata = BalancesResponse | Metadata;
 
@@ -23,4 +27,33 @@ export const mergeBalancesAndAssets = (
     });
   });
   return [...balances, ...filteredAssets];
+};
+
+// When `balances` change, emit new value of the selected balance: match by address index and asset metadata
+export const useSyncSelectedBalance = ({
+  balances,
+  onChange,
+  value,
+}: {
+  balances?: BalancesResponse[];
+  value?: BalancesResponse;
+  onChange: (selection: BalancesResponse) => void;
+}) => {
+  useEffect(() => {
+    if (value) {
+      const matchedValue = balances?.find(balance => {
+        return (
+          getAddressIndex.optional()(balance)?.equals(getAddressIndex.optional()(value)) &&
+          getMetadataFromBalancesResponseOptional(balance)?.equals(
+            getMetadataFromBalancesResponseOptional(value),
+          )
+        );
+      });
+      if (matchedValue && !matchedValue.equals(value)) {
+        onChange(matchedValue);
+      }
+    }
+    // we only want to run this on new balances from ZQuery, so don't include `value` as dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [balances]);
 };

--- a/apps/minifront/src/state/send/index.ts
+++ b/apps/minifront/src/state/send/index.ts
@@ -118,6 +118,7 @@ export const createSendSlice = (): SliceCreator<SendSlice> => (set, get) => {
         set(state => {
           state.send.amount = '';
         });
+        get().shared.balancesResponses.revalidate();
       } finally {
         set(state => {
           state.send.txInProgress = false;

--- a/apps/minifront/src/state/swap/dutch-auction/index.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/index.ts
@@ -172,6 +172,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
 
       get().swap.setAmount('');
       get().swap.dutchAuction.auctionInfos.revalidate();
+      get().shared.balancesResponses.revalidate();
     } finally {
       set(state => {
         state.swap.dutchAuction.txInProgress = false;
@@ -186,6 +187,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     });
     await planBuildBroadcast('dutchAuctionEnd', req);
     get().swap.dutchAuction.auctionInfos.revalidate();
+    get().shared.balancesResponses.revalidate();
   },
 
   withdraw: async (auctionId, currentSeqNum, addressIndex) => {
@@ -195,6 +197,7 @@ export const createDutchAuctionSlice = (): SliceCreator<DutchAuctionSlice> => (s
     });
     await planBuildBroadcast('dutchAuctionWithdraw', req);
     get().swap.dutchAuction.auctionInfos.revalidate();
+    get().shared.balancesResponses.revalidate();
   },
 
   reset: () =>

--- a/apps/minifront/src/state/swap/instant-swap.ts
+++ b/apps/minifront/src/state/swap/instant-swap.ts
@@ -149,6 +149,7 @@ export const createInstantSwapSlice = (): SliceCreator<InstantSwapSlice> => (set
         set(state => {
           state.swap.amount = '';
         });
+        get().shared.balancesResponses.revalidate();
       } finally {
         set(state => {
           state.swap.instantSwap.txInProgress = false;


### PR DESCRIPTION
Closes #1591 

- Refetches BalancesResponse query after successful swap and send
- Updates the BalancesSelector with new value

Demo 1: Send


https://github.com/user-attachments/assets/c8cef95b-b68b-4efa-b12a-207e82fd7efc

Demo 2: Swap


https://github.com/user-attachments/assets/63345360-cf11-46bc-97d6-bb19f19ae168

