### PR TITLE
Jailed validators pt 2: block processor + getValidatorInfo endpoint

### DIFF
--- a/.changeset/slow-trees-drum.md
+++ b/.changeset/slow-trees-drum.md
@@ -1,0 +1,9 @@
+---
+'@penumbra-zone/services': minor
+'@penumbra-zone/storage': minor
+'minifront': minor
+'@penumbra-zone/query': minor
+'@penumbra-zone/types': minor
+---
+
+Support viewing fresh state of jailed validators

--- a/apps/minifront/src/components/staking/account/delegation-value-view/validator-info-component.tsx
+++ b/apps/minifront/src/components/staking/account/delegation-value-view/validator-info-component.tsx
@@ -10,10 +10,12 @@ import { useStore } from '../../../../state';
 import {
   getIdentityKeyFromValidatorInfo,
   getValidator,
+  getValidatorState,
 } from '@penumbra-zone/getters/validator-info';
 import { calculateCommissionAsPercentage } from '@penumbra-zone/types/staking';
 import { Metadata } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
 import { AssetIcon } from '@repo/ui/components/ui/asset-icon';
+import { ValidatorStateLabel } from './validator-state-label.tsx';
 
 /**
  * Renders a single `ValidatorInfo`: its name and identity key,
@@ -33,6 +35,7 @@ export const ValidatorInfoComponent = ({
   const showTooltips = useStore(state => !state.staking.loading);
   const validator = getValidator(validatorInfo);
   const identityKey = getIdentityKeyFromValidatorInfo(validatorInfo);
+  const state = getValidatorState.optional()(validatorInfo);
 
   return (
     <TooltipProvider>
@@ -71,6 +74,7 @@ export const ValidatorInfoComponent = ({
               )}
               {!showTooltips && <span>Com:</span>} {calculateCommissionAsPercentage(validatorInfo)}%
             </span>
+            {state && <ValidatorStateLabel state={state} />}
           </div>
         </div>
       </div>

--- a/apps/minifront/src/components/staking/account/delegation-value-view/validator-state-label.tsx
+++ b/apps/minifront/src/components/staking/account/delegation-value-view/validator-state-label.tsx
@@ -1,0 +1,36 @@
+import { ValidatorState_ValidatorStateEnum } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb.js';
+import { cn } from '@repo/ui/lib/utils';
+
+interface LabelInfo {
+  label: string;
+  color: string;
+}
+
+const validatorStateMap = new Map<ValidatorState_ValidatorStateEnum, LabelInfo>([
+  [ValidatorState_ValidatorStateEnum.UNSPECIFIED, { label: 'UNSPECIFIED', color: 'bg-gray-500' }],
+  [ValidatorState_ValidatorStateEnum.DEFINED, { label: 'DEFINED', color: 'bg-blue-500' }],
+  [ValidatorState_ValidatorStateEnum.INACTIVE, { label: 'INACTIVE', color: 'bg-yellow-600' }],
+  [ValidatorState_ValidatorStateEnum.ACTIVE, { label: 'ACTIVE', color: 'bg-green-500' }],
+  [ValidatorState_ValidatorStateEnum.JAILED, { label: 'JAILED', color: 'bg-orange-700' }],
+  [ValidatorState_ValidatorStateEnum.TOMBSTONED, { label: 'TOMBSTONED', color: 'bg-red-800' }],
+  [ValidatorState_ValidatorStateEnum.DISABLED, { label: 'DISABLED', color: 'bg-purple-600' }],
+]);
+
+const getStateLabel = (state: ValidatorState_ValidatorStateEnum) =>
+  validatorStateMap.get(state) ?? {
+    label: 'UNKNOWN',
+    color: 'bg-yellow-600',
+  };
+
+export const ValidatorStateLabel = ({ state }: { state: ValidatorState_ValidatorStateEnum }) => {
+  if (state === ValidatorState_ValidatorStateEnum.ACTIVE) {
+    return <></>;
+  }
+
+  const { label, color } = getStateLabel(state);
+  return (
+    <div className={cn('flex items-center justify-center rounded p-1 font-mono -mt-1', color)}>
+      {label}
+    </div>
+  );
+};

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -8,6 +8,7 @@ import {
 import { AddressIndex } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb.js';
 import { planBuildBroadcast } from '../helpers';
 import {
+  DelegationsByAddressIndexRequest_Filter,
   TransactionPlannerRequest,
   UnbondingTokensByAddressIndexResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/view/v1/view_pb.js';
@@ -231,7 +232,10 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
     };
     const throttledFlushToState = throttle(flushToState, THROTTLE_MS, { trailing: true });
 
-    for await (const response of viewClient.delegationsByAddressIndex({ addressIndex })) {
+    for await (const response of viewClient.delegationsByAddressIndex({
+      addressIndex,
+      filter: DelegationsByAddressIndexRequest_Filter.ALL,
+    })) {
       if (newAbortController.signal.aborted) {
         throttledFlushToState.cancel();
         return;

--- a/packages/getters/src/validator-info.ts
+++ b/packages/getters/src/validator-info.ts
@@ -14,6 +14,10 @@ export const getValidator = createGetter(
   (validatorInfo?: ValidatorInfo) => validatorInfo?.validator,
 );
 
+export const getValidatorState = createGetter(
+  (validatorInfo?: ValidatorInfo) => validatorInfo?.status?.state?.state,
+);
+
 export const getVotingPowerFromValidatorInfo = getStatus.pipe(getVotingPower);
 
 export const getStateEnumFromValidatorInfo = getStatus.pipe(getState).pipe(getValidatorStateEnum);

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -31,7 +31,7 @@ import {
   getIdentityKeyFromValidatorInfoResponse,
 } from '@penumbra-zone/getters/validator-info-response';
 import { toDecimalExchangeRate } from '@penumbra-zone/types/amount';
-import { PRICE_RELEVANCE_THRESHOLDS, assetPatterns } from '@penumbra-zone/types/assets';
+import { assetPatterns, PRICE_RELEVANCE_THRESHOLDS } from '@penumbra-zone/types/assets';
 import type { BlockProcessorInterface } from '@penumbra-zone/types/block-processor';
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 import type { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';
@@ -657,6 +657,9 @@ export class BlockProcessor implements BlockProcessorInterface {
   // TODO: refactor. there is definitely a better way to do this.  batch
   // endpoint issue https://github.com/penumbra-zone/penumbra/issues/4688
   private async updateValidatorInfos(nextEpochStartHeight: bigint): Promise<void> {
+    // It's important to clear the table so any stale (jailed, tombstoned, etc) entries are filtered out.
+    await this.indexedDb.clearValidatorInfos();
+
     for await (const validatorInfoResponse of this.querier.stake.allValidatorInfos()) {
       if (!validatorInfoResponse.validatorInfo) {
         continue;

--- a/packages/query/src/queriers/staking.ts
+++ b/packages/query/src/queriers/staking.ts
@@ -2,6 +2,8 @@ import { PromiseClient } from '@connectrpc/connect';
 import { createClient } from './utils.js';
 import { StakeService } from '@penumbra-zone/protobuf';
 import {
+  GetValidatorInfoRequest,
+  GetValidatorInfoResponse,
   ValidatorInfoResponse,
   ValidatorPenaltyRequest,
   ValidatorPenaltyResponse,
@@ -13,6 +15,10 @@ export class StakeQuerier implements StakeQuerierInterface {
 
   constructor({ grpcEndpoint }: { grpcEndpoint: string }) {
     this.client = createClient(grpcEndpoint, StakeService);
+  }
+
+  validatorInfo(req: GetValidatorInfoRequest): Promise<GetValidatorInfoResponse> {
+    return this.client.getValidatorInfo(req);
   }
 
   allValidatorInfos(): AsyncIterable<ValidatorInfoResponse> {

--- a/packages/services/src/stake-service/get-validator-info.ts
+++ b/packages/services/src/stake-service/get-validator-info.ts
@@ -1,18 +1,31 @@
 import { Impl } from './index.js';
 import { servicesCtx } from '../ctx/prax.js';
 import { Code, ConnectError } from '@connectrpc/connect';
+import {
+  GetValidatorInfoRequest,
+  GetValidatorInfoResponse,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb.js';
 
 export const getValidatorInfo: Impl['getValidatorInfo'] = async (req, ctx) => {
   if (!req.identityKey) {
     throw new ConnectError('Missing identityKey in request', Code.InvalidArgument);
   }
   const services = await ctx.values.get(servicesCtx)();
-  const { indexedDb } = await services.getWalletServices();
+  const { indexedDb, querier } = await services.getWalletServices();
 
-  const validatorInfo = await indexedDb.getValidatorInfo(req.identityKey);
-
-  if (!validatorInfo) {
-    throw new ConnectError('No found validator info', Code.NotFound);
+  // Step 1: Try to find validator info in database
+  const infoInDb = await indexedDb.getValidatorInfo(req.identityKey);
+  if (infoInDb) {
+    return new GetValidatorInfoResponse({ validatorInfo: infoInDb });
   }
-  return { validatorInfo };
+
+  // Step 2: If none locally, query remote node
+  const { validatorInfo: infoFromNode } = await querier.stake.validatorInfo(
+    new GetValidatorInfoRequest({ identityKey: req.identityKey }),
+  );
+  if (infoFromNode) {
+    return new GetValidatorInfoResponse({ validatorInfo: infoFromNode });
+  }
+
+  throw new ConnectError('No found validator info', Code.NotFound);
 };

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -68,8 +68,10 @@ export interface MockQuerier {
 export interface SctMock {
   timestampByHeight?: Mock;
 }
+
 export interface StakeMock {
   validatorPenalty?: Mock;
+  validatorInfo?: Mock;
 }
 
 interface MockServicesInner {

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -689,6 +689,10 @@ export class IndexedDb implements IndexedDbInterface {
     );
   }
 
+  async clearValidatorInfos() {
+    await this.db.clear('VALIDATOR_INFOS');
+  }
+
   async getValidatorInfo(identityKey: IdentityKey): Promise<ValidatorInfo | undefined> {
     // bech32m conversion asserts length
     const key = bech32mIdentityKey(identityKey);

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -109,6 +109,7 @@ export interface IndexedDbInterface {
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
   upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;
   iterateValidatorInfos(): AsyncGenerator<ValidatorInfo, void>;
+  clearValidatorInfos(): Promise<void>;
   getValidatorInfo(identityKey: IdentityKey): Promise<ValidatorInfo | undefined>;
   updatePrice(
     pricedAsset: AssetId,

--- a/packages/types/src/querier.ts
+++ b/packages/types/src/querier.ts
@@ -1,30 +1,32 @@
+import {
+  QueryClientStatesRequest,
+  QueryClientStatesResponse,
+} from '@buf/cosmos_ibc.bufbuild_es/ibc/core/client/v1/query_pb.js';
 import { AppParameters } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/app/v1/app_pb.js';
-import { CompactBlock } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/compact_block/v1/compact_block_pb.js';
 import {
   AssetId,
   Metadata,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb.js';
 import {
-  QueryClientStatesRequest,
-  QueryClientStatesResponse,
-} from '@buf/cosmos_ibc.bufbuild_es/ibc/core/client/v1/query_pb.js';
-import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb.js';
-import { Transaction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb.js';
+  AuctionId,
+  DutchAuction,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb.js';
+import { CompactBlock } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/compact_block/v1/compact_block_pb.js';
 import {
+  TimestampByHeightRequest,
+  TimestampByHeightResponse,
+} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb.js';
+import {
+  GetValidatorInfoRequest,
+  GetValidatorInfoResponse,
   ValidatorInfoRequest,
   ValidatorInfoResponse,
   ValidatorPenaltyRequest,
   ValidatorPenaltyResponse,
 } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/stake/v1/stake_pb.js';
+import { Transaction } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb.js';
+import { TransactionId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/txhash/v1/txhash_pb.js';
 import { MerkleRoot } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/crypto/tct/v1/tct_pb.js';
-import {
-  AuctionId,
-  DutchAuction,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/auction/v1/auction_pb.js';
-import {
-  TimestampByHeightRequest,
-  TimestampByHeightResponse,
-} from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/sct/v1/sct_pb.js';
 
 export interface RootQuerierInterface {
   app: AppQuerierInterface;
@@ -70,6 +72,7 @@ export interface IbcClientQuerierInterface {
 export interface StakeQuerierInterface {
   allValidatorInfos(req: ValidatorInfoRequest): AsyncIterable<ValidatorInfoResponse>;
   validatorPenalty(req: ValidatorPenaltyRequest): Promise<ValidatorPenaltyResponse>;
+  validatorInfo(req: GetValidatorInfoRequest): Promise<GetValidatorInfoResponse>;
 }
 
 export interface CnidariumQuerierInterface {


### PR DESCRIPTION
Follow up from: https://github.com/penumbra-zone/web/pull/1640

Does three things:
- Clears out stale validator info entries in the database anytime we need to refetch
- `getValidatorInfo` view service endpoint has a fallback to the node in the case (like jailed validators) it is not in the db
- Adds a component to prominently display bad statuses of validators

<img width="1470" alt="Screenshot 2024-08-05 at 3 08 03 PM" src="https://github.com/user-attachments/assets/017ec9de-8a31-4348-b3a2-bda36bbbf146">


