### PR TITLE
fix(minifront): #1590: fix copy button styles

### DIFF
--- a/.changeset/itchy-files-flow.md
+++ b/.changeset/itchy-files-flow.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix copy button styles

--- a/packages/ui/components/ui/copy-to-clipboard/copy-to-clipboard-icon-button.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard/copy-to-clipboard-icon-button.tsx
@@ -14,6 +14,7 @@ export const CopyToClipboardIconButton = ({ text }: { text: string }) => {
           data-testid='CopyToClipboardIconButton__icon'
         />
       }
+      successLabel={<></>}
       className='size-4'
     />
   );

--- a/packages/ui/components/ui/copy-to-clipboard/copy-to-clipboard.tsx
+++ b/packages/ui/components/ui/copy-to-clipboard/copy-to-clipboard.tsx
@@ -21,7 +21,7 @@ const CopyToClipboard = forwardRef<HTMLButtonElement, CopyToClipboardProps>(
         type='button'
         className={cn(
           copied && 'cursor-default text-teal-500 hover:no-underline',
-          'block',
+          'block px-0',
           className,
         )}
         variant='link'
@@ -37,8 +37,8 @@ const CopyToClipboard = forwardRef<HTMLButtonElement, CopyToClipboardProps>(
         {...props}
       >
         {copied ? (
-          <span className={cn(successLabel && 'flex items-center gap-2')}>
-            {successLabel ?? <span>Copied</span>}
+          <span className='flex items-center gap-2'>
+            {successLabel ?? <span className='whitespace-nowrap'>Copied</span>}
             <CheckCircledIcon />
           </span>
         ) : (


### PR DESCRIPTION
Closes #1590 

Simply removes the unnecessary 'Copied' text from the CopyButton in most of the cases. The green checkmark is visually enough to demonstrate the success state of the button.

<img width="486" alt="Screenshot 2024-08-05 at 15 13 28" src="https://github.com/user-attachments/assets/39d9e019-c36b-4ddc-a317-0dba4cc62476">

<img width="866" alt="Screenshot 2024-08-05 at 15 13 18" src="https://github.com/user-attachments/assets/c42fc547-d0f2-4891-80a1-e6be786d4679">
