### PR TITLE
adr 006 changes

### DIFF
--- a/docs/adrs/006-web-apis.md
+++ b/docs/adrs/006-web-apis.md
@@ -41,9 +41,19 @@ Creating the `client` should be the starting point for any application working w
 ```ts
 import { PenumbraClient } from '@penumbra-zone/client';
 
-export const providerManifests: Record<string, PenumbraManifest> = await PenumbraClient.manifests();
-const providerOrigin: keyof providerManifests = '....';
-export const client = new PenumbraClient(providerOrigin);
+const providerManifests: Record<
+  string,
+  Promise<PenumbraManifest>
+> = PenumbraClient.providerManifests();
+const someProviderOrigin: keyof providerManifests = '....';
+
+// connect will fetch and verify manifest before initiating connection, then return an active client
+const someProviderClient = await PenumbraClient.connect(someProviderOrigin);
+
+// or, a caller could do it independently
+const someProviderManifest = await providerManifests[someProviderOrigin];
+const createdProviderClient = new PenumbraClient(someProviderOrigin);
+void createdProviderClient.connect();
 ```
 
 The flow of work with the `client` would be as follows:

--- a/docs/adrs/006-web-apis.md
+++ b/docs/adrs/006-web-apis.md
@@ -100,15 +100,15 @@ import type { PromiseClient } from '@connectrpc/connect';
 interface PenumbraClient {
 
   // static methods
-  public static manifests: () => Record<string, Promise<PenumbraManifest>>;
+  public static providerManifests: () => Record<string, Promise<PenumbraManifest>>;
 
   // provider-specific static methods
-  public static manifest: (providerOrigin?: string) =>  Promise<PenumbraManifest>;
-  public static isConnected: (providerOrigin?: string) => boolean;
-  public static state: (providerOrigin?: string) => PenumbraState;
+  public static providerManifest: (providerOrigin?: string) =>  Promise<PenumbraManifest>;
+  public static providerIsConnected: (providerOrigin?: string) => boolean;
+  public static providerState: (providerOrigin?: string) => PenumbraState;
 
   /** Initiates initiates connection, returns a client instance. */
-  public static connect: (providerOrigin?: string) => Promise<PenumbraClient>;
+  public static providerConnect: (providerOrigin?: string) => Promise<PenumbraClient>;
 
   // instance features
 

--- a/docs/adrs/006-web-apis.md
+++ b/docs/adrs/006-web-apis.md
@@ -39,9 +39,11 @@ that manages the injected connections and provides methods for interacting with 
 Creating the `client` should be the starting point for any application working with Penumbra:
 
 ```ts
-import { createPenumbraClient } from '@penumbra-zone/client';
+import { PenumbraClient } from '@penumbra-zone/client';
 
-export const client = createPenumbraClient();
+export const providerManifests: Record<string, PenumbraManifest> = await PenumbraClient.manifests();
+const providerOrigin: keyof providerManifests = '....';
+export const client = new PenumbraClient(providerOrigin);
 ```
 
 The flow of work with the `client` would be as follows:
@@ -61,43 +63,28 @@ The idea of a single shared `client` is inspired by these popular TypeScript lib
 The `client` must be able to connect to injected wallets. To make the API possible, the interface injected into the `window` object must be standardized:
 
 ```ts
-/** The callback type for the `penumbrastate` event */
-export type PenumbraStateEventHandler = (
-  value: CustomEvent<{ origin: string; connected: boolean; state: PenumbraState }>,
-) => void;
-
-/**
- * Describes the type of `addListener` and `removeListener` functions.
- * If there will more event types in the future, this function should be overloaded
- */
-export type PenumbraListener = (type: 'penumbrastate', value: PenumbraStateListener) => void;
-
 export interface PenumbraProvider extends Readonly<PenumbraStateEventTarget> {
-  /** Should contain a URI at the provider's origin,
-   * serving a manifest describing this provider */
-  readonly manifest: string;
+  /** Should contain a URI at the provider's origin, serving a manifest
+   * describing this provider */
+  manifest: string;
 
-  /** Call to gain approval. Returns `MessagePort` to this provider.
-   * Might throw descriptive errors if user denies the connection */
-  readonly connect: () => Promise<MessagePort>;
+  /** Call to acquire a `MessagePort` to this provider, subject to approval. */
+  connect: () => Promise<MessagePort>;
 
-  /** Call to indicate the provider should discard approval of this origin.
-   * Successfull if doesn't throw errors */
-  readonly disconnect: () => Promise<void>;
+  /** Call to indicate the provider should discard approval of this origin. */
+  disconnect: () => Promise<void>;
 
   /** Should synchronously return the present connection state.
    * - `true` indicates active connection.
-   * - `false` indicates connection is closed, rejected, or not attempted.
-   */
-  readonly isConnected: () => boolean;
+   * - `false` indicates connection is inactive. */
+  isConnected: () => boolean;
 
   /** Synchronously return present injection state */
-  readonly state: () => PenumbraState;
+  state: () => PenumbraState;
 
-  /** Fires a callback with CustomEvent each time the state changes */
-  readonly addEventListener: PenumbraListener;
-  /** Unsubscribes from the state change events. Provide the same callback as in `addListener` */
-  readonly removeEventListener: PenumbraListener;
+  /** Standard EventTarget methods emitting PenumbraStateEvent upon state changes */
+  addEventListener: EventTarget['addEventListener'];
+  removeEventListener: EventTarget['removeEvenListener'];
 }
 ```
 
@@ -111,80 +98,61 @@ import type { PenumbraService } from '@penumbra-zone/protobuf';
 import type { PromiseClient } from '@connectrpc/connect';
 
 interface PenumbraClient {
-  /**
-   * Asks users to approve the connection to a specific browser manifest URL.
-   * If `manifest` argument is not provided, tries to connect to the first injected provider.
-   * Returns the manifest URL of the connected provider or error otherwise
-   */
-  readonly connect: (providerUrl?: string) => Promise<string>;
 
-  /** Reexports the `disconnect` function from injected provider */
-  readonly disconnect: () => Promise<void>;
-  /** Reexports the `isConnected` function from injected provider  */
-  readonly isConnected: () => boolean | undefined;
-  /** Reexports the `state` function from injected provider */
-  readonly getState: () => PenumbraState;
-  /** Reexports the `onConnectionChange` listener from injected provider*/
-  readonly onConnectionChange: (
-    cb: (connection: { origin: string; connected: boolean; state: PenumbraState }) => void,
-  ) => void;
+  // static methods
+  public static manifests: () => Record<string, Promise<PenumbraManifest>>;
 
-  /**
-   * Needed for custom service connections if `getService` is not enough.
-   * For example, might be useful for React wrapper of the `client` package
-   */
-  readonly getMessagePort: () => MessagePort;
+  // provider-specific static methods
+  public static manifest: (providerOrigin?: string) =>  Promise<PenumbraManifest>;
+  public static isConnected: (providerOrigin?: string) => boolean;
+  public static state: (providerOrigin?: string) => PenumbraState;
+
+  /** Initiates initiates connection, returns a client instance. */
+  public static connect: (providerOrigin?: string) => Promise<PenumbraClient>;
+
+  // instance features
+
+  /** Creates a client instance for a provider origin but does not take any action. */
+  constructor(providerOrigin?: string) => PenumbraClient
+
+  // constructor input
+  public readonly providerOrigin: string;
+
+  // populated when client is in appropriate state.
+  public readonly transport?: Transport;
+  public readonly port?: MessagePort;
+
+  /** Direct re-exports the from appropriate provider */
+  public readonly disconnect: () => Promise<void>;
+  public readonly isConnected: () => boolean | undefined;
+  public readonly state: () => PenumbraState;
+  public readonly addEventListener: EventTarget['addEventListener'];
+  public readonly removeEventListener: EventTarget['removeEvenListener'];
+
+  /** Initiates connection request and then connection. A transport is
+   * constructed, maintained internally and also returned to the caller. */
+  public readonly connect: () => Promise<Transport>;
+
+  /** Fetches manifest for the provider of this instance */
+  public readonly manifest: () =>  Promise<PenumbraManifest>;
+
+
+  /** Returns a new or re-used `PromiseClient<T>` for a specific
+   * `PenumbraService` using this client's transport. */
+  public service = <T extends PenumbraService>(service: T): PromiseClient<T>;
 }
 ```
-
-Moreover, the `client` package might export but not limited to the following useful functions and types:
-
-```ts
-export type PenumbraManifest = Partial<chrome.runtime.ManifestV3> &
-  Required<Pick<chrome.runtime.ManifestV3, 'name' | 'version' | 'description' | 'icons'>>;
-
-export type getInjectedProvider = (penumbraOrigin: string) => Promise<PenumbraProvider>;
-
-export type getAllInjectedProviders = () => string[];
-
-export type getPenumbraManifest = (
-  penumbraOrigin: string,
-  signal?: AbortSignal,
-) => Promise<PenumbraManifest>;
-
-export type getAllPenumbraManifests = () => Record<
-  keyof (typeof window)[typeof PenumbraSymbol],
-  Promise<PenumbraManifest>
->;
-```
-
-## Requests
-
-The client library should separately export the creation of service clients. It is not going to be integrated into the `client` instance to save the initial bundle size. Instead, it should be exported from `@penumbra-zone/client/service`:
-
-```ts
-/** Synchronously creates a connectrpc `PromiseClient` instance to a given Penumbra service */
-export type createServiceClient = <T extends ServiceType>(
-  client: PenumbraClient,
-  service: T,
-) => PromiseClient<T>;
-```
-
-Under the hood, `createServiceClient` might save the resulting PromiseClient in the `client` instance to avoid creating multiple instances of the same service.
 
 Requesting data example:
 
 ```ts
-import { createPenumbraClient } from '@penumbra-zone/client';
-import { createServiceClient } from '@penumbra-zone/client/servce';
+import { PenumbraClient } from '@penumbra-zone/client';
 import { ViewService } from '@penumbra-zone/protobuf';
 
-export const client = createPenumbraClient();
+const penumbraClient = new PenumbraClient.connect('some origin');
 
-const viewService = createServiceClient(client, ViewService);
+const viewClient = penumbraClient.service(ViewService);
 
-const address = await viewService.getAddressByIndex({ account: 0 });
-const balances = await viewService.getBalances({ account: 0 });
+const address = await viewClient.getAddressByIndex({ account: 0 });
+const balances = await viewClient.getBalances({ account: 0 });
 ```
-
-Each call of the services function should check for a connection and throw an error if the connection is not established.


### PR DESCRIPTION
static and instance methods on `PenumbraClient`

- client static methods allow consumers to inspect available providers
- client instance is created to interact with a specific provider

implementation following soon