### PR TITLE
Build out the `<FormField />` and `<TextInput />` components, and add other features in preparation for new v2 pages

### DIFF
--- a/.changeset/wise-buses-switch.md
+++ b/.changeset/wise-buses-switch.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': minor
+---
+
+Create <Card />'s subcomponents; create <FormField /> and <TextInput />; add some features re: disabled fields

--- a/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/assets-page/index.tsx
@@ -37,7 +37,7 @@ export const AssetsPage = () => {
   });
 
   return (
-    <div className='flex flex-col gap-1'>
+    <>
       {balancesByAccount?.map(account => (
         <Table key={account.account} layout='fixed' title={<TableTitle account={account} />}>
           <Table.Thead>
@@ -71,6 +71,6 @@ export const AssetsPage = () => {
           </Table.Tbody>
         </Table>
       ))}
-    </div>
+    </>
   );
 };

--- a/apps/minifront/src/components/v2/dashboard-layout/index.tsx
+++ b/apps/minifront/src/components/v2/dashboard-layout/index.tsx
@@ -30,16 +30,14 @@ export const DashboardLayout = () => {
 
       <Grid tablet={8} desktop={6} xl={4}>
         <Card title={CARD_TITLE_BY_PATH[v2PathPrefix(pagePath)]}>
-          <div className='flex flex-col gap-4'>
-            <Tabs
-              value={v2PathPrefix(pagePath)}
-              onChange={value => navigate(value)}
-              options={TABS_OPTIONS}
-              actionType='accent'
-            />
+          <Tabs
+            value={v2PathPrefix(pagePath)}
+            onChange={value => navigate(value)}
+            options={TABS_OPTIONS}
+            actionType='accent'
+          />
 
-            <Outlet />
-          </div>
+          <Outlet />
         </Card>
       </Grid>
 

--- a/packages/ui/src/Button/helpers.ts
+++ b/packages/ui/src/Button/helpers.ts
@@ -1,5 +1,6 @@
 import { DefaultTheme } from 'styled-components';
-import { Priority, ActionType } from '../utils/button';
+import { Priority } from '../utils/button';
+import { ActionType } from '../utils/ActionType';
 
 export const getBackgroundColor = (
   actionType: ActionType,

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -1,12 +1,13 @@
 import { MouseEventHandler } from 'react';
 import styled, { css, DefaultTheme } from 'styled-components';
 import { asTransientProps } from '../utils/asTransientProps';
-import { Priority, ActionType, focusOutline, overlays, buttonBase } from '../utils/button';
+import { Priority, focusOutline, overlays, buttonBase } from '../utils/button';
 import { getBackgroundColor } from './helpers';
 import { button } from '../utils/typography';
 import { LucideIcon } from 'lucide-react';
 import { Density } from '../types/Density';
 import { useDensity } from '../hooks/useDensity';
+import { ActionType } from '../utils/ActionType';
 
 const iconOnlyAdornment = css<StyledButtonProps>`
   border-radius: ${props => props.theme.borderRadius.full};

--- a/packages/ui/src/ButtonGroup/index.tsx
+++ b/packages/ui/src/ButtonGroup/index.tsx
@@ -1,6 +1,6 @@
 import { LucideIcon } from 'lucide-react';
 import { MouseEventHandler } from 'react';
-import { ActionType } from '../utils/button';
+import { ActionType } from '../utils/ActionType';
 import { Button } from '../Button';
 import styled from 'styled-components';
 import { media } from '../utils/media';

--- a/packages/ui/src/Card/index.stories.tsx
+++ b/packages/ui/src/Card/index.stories.tsx
@@ -5,6 +5,12 @@ import { Card } from '.';
 import storiesBg from './storiesBg.jpg';
 import styled from 'styled-components';
 import { Text } from '../Text';
+import { FormField } from '../FormField';
+import { TextInput } from '../TextInput';
+import { useState } from 'react';
+import { Button } from '../Button';
+import { Tabs } from '../Tabs';
+import { Send } from 'lucide-react';
 
 const BgWrapper = styled.div`
   padding: ${props => props.theme.spacing(20)};
@@ -48,10 +54,58 @@ export const Basic: Story = {
   },
 
   render: function Render({ as, title }) {
+    const [tab, setTab] = useState('one');
+    const [textInput, setTextInput] = useState('');
+
     return (
       <Card as={as} title={title}>
-        <Text p>This is the card content.</Text>
-        <Text p>Here is some more content.</Text>
+        <Tabs
+          value={tab}
+          onChange={setTab}
+          options={[
+            { label: 'One', value: 'one' },
+            { label: 'Two', value: 'two' },
+          ]}
+        />
+
+        <div>
+          <Text p>
+            This is the card content. Note that each top-level item inside the card is spaced apart
+            with a spacing of <Text technical>4</Text>. Hence the distance between the tabs and this
+            paragraph, and the distance between this paragraph and the stack below.
+          </Text>
+        </div>
+
+        <Card.Stack>
+          <Card.Section>
+            <Text>
+              This is a <Text technical>&lt;Card.Stack /&gt;</Text> comprised of several{' '}
+              <Text technical>&lt;Card.Section /&gt;</Text>s. Note that the top and bottom of the
+              entire stack have rounded corners.
+            </Text>
+          </Card.Section>
+          <Card.Section>
+            <Text>
+              Card sections in a stack are useful for forms: each field of the form can be wrapped
+              in a <Text technical>&lt;Card.Section /&gt;</Text>.
+            </Text>
+          </Card.Section>
+          <Card.Section>
+            <FormField
+              label='Sample form field'
+              helperText="Here's an example of a form field inside a card section."
+            >
+              <TextInput
+                value={textInput}
+                onChange={setTextInput}
+                placeholder='Type something...'
+              />
+            </FormField>
+          </Card.Section>
+        </Card.Stack>
+        <Button actionType='accent' icon={Send}>
+          Send
+        </Button>
       </Card>
     );
   },

--- a/packages/ui/src/Card/index.tsx
+++ b/packages/ui/src/Card/index.tsx
@@ -46,7 +46,25 @@ export interface CardProps {
  * page by a background and an optional title. They're useful for presenting
  * data, or for wrapping a form.
  *
- * You can use `<Card.Stack />` and `<Card.Section />` to create a stack of
+ * A `<Card />` wraps its children in a flex column with a spacing of `4`
+ * between each top-level HTML element. This results in a standard card layout
+ * no matter what its contents are.
+ *
+ * If you wish to pass children to `<Card />` that should not be spaced apart in
+ * that way, simply pass a single HTML element as the root of the `<Card />`'s
+ * children. That way, the built-in flex column will have no effect:
+ *
+ * ```tsx
+ * <Card title="This is the card title">
+ *   <div>
+ *     <span>These two elements...</span>
+ *     <span>...will not appear in a flex column, but rather inline beside each
+ *     other.</span>
+ *   </div>
+ * </Card>
+ * ```
+ *
+ * You can also use `<Card.Stack />` and `<Card.Section />` to create a stack of
  * sections, which are useful for wrapping individual form fields.
  *
  * ```tsx

--- a/packages/ui/src/Card/index.tsx
+++ b/packages/ui/src/Card/index.tsx
@@ -21,6 +21,10 @@ const Content = styled.div`
   backdrop-filter: blur(${props => props.theme.blur.lg});
   border-radius: ${props => props.theme.borderRadius.xl};
   padding: ${props => props.theme.spacing(3)};
+
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(4)};
 `;
 
 export interface CardProps {
@@ -30,13 +34,30 @@ export interface CardProps {
    *
    * @example
    * ```tsx
-   * <Card as='section'>This is a section element with card styling</Card>
+   * <Card as='main'>This is a main element with card styling</Card>
    * ```
    */
   as?: WebTarget;
   title?: ReactNode;
 }
 
+/**
+ * `<Card />`s are rectangular sections of a page set off from the rest of the
+ * page by a background and an optional title. They're useful for presenting
+ * data, or for wrapping a form.
+ *
+ * You can use `<Card.Stack />` and `<Card.Section />` to create a stack of
+ * sections, which are useful for wrapping individual form fields.
+ *
+ * ```tsx
+ * <Card title="This is the card title">
+ *   <Card.Stack>
+ *     <Card.Section><Text>Section one</Text></Card.Section>
+ *     <Card.Section><Text>Section two</Text></Card.Section>
+ *   </Card.Stack>
+ * </Card>
+ * ```
+ */
 export const Card = ({ children, as = 'section', title }: CardProps) => {
   return (
     <Root as={as}>
@@ -46,3 +67,25 @@ export const Card = ({ children, as = 'section', title }: CardProps) => {
     </Root>
   );
 };
+
+const StyledStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(1)};
+
+  border-radius: ${props => props.theme.borderRadius.sm};
+  overflow: hidden; /** To enforce the border-radius */
+`;
+const Stack = ({ children }: { children?: ReactNode }) => {
+  return <StyledStack>{children}</StyledStack>;
+};
+Card.Stack = Stack;
+
+const StyledSection = styled.div`
+  background-color: ${props => props.theme.color.other.tonalFill5};
+  padding: ${props => props.theme.spacing(3)};
+`;
+const Section = ({ children }: { children?: ReactNode }) => (
+  <StyledSection>{children}</StyledSection>
+);
+Card.Section = Section;

--- a/packages/ui/src/Colors.stories.tsx
+++ b/packages/ui/src/Colors.stories.tsx
@@ -71,7 +71,7 @@ const Color = <T extends Exclude<TColor, 'action' | 'other' | 'base'>>({ color }
     <Grid mobile={6} tablet={10}>
       <Variants>
         {color === 'text'
-          ? (['primary', 'secondary', 'disabled', 'special'] as const).map(variant => (
+          ? (['primary', 'secondary', 'muted', 'special'] as const).map(variant => (
               <Variant key={variant} $color={color} $colorVariant={variant}>
                 <Text technical>{variant}</Text>
               </Variant>

--- a/packages/ui/src/FormField/index.stories.tsx
+++ b/packages/ui/src/FormField/index.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FormField } from '.';
+import { TextInput } from '../TextInput';
+import { useState } from 'react';
+import { SegmentedControl } from '../SegmentedControl';
+
+const meta: Meta<typeof FormField> = {
+  component: FormField,
+  tags: ['autodocs', '!dev'],
+  argTypes: {
+    children: { control: false },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FormField>;
+
+export const TextInputExample: Story = {
+  args: {
+    label: "Recipient's address",
+    helperText: 'The recipient can find their address via the Receive tab.',
+    disabled: false,
+  },
+
+  render: function Render(props) {
+    const [recipient, setRecipient] = useState('');
+
+    return (
+      <FormField {...props}>
+        <TextInput value={recipient} onChange={setRecipient} placeholder='penumbra1abc123...' />
+      </FormField>
+    );
+  },
+};
+
+export const SegmentedControlExample: Story = {
+  args: {
+    label: 'Fee Tier',
+    disabled: false,
+  },
+
+  render: function Render(props) {
+    const [feeTier, setFeeTier] = useState('low');
+
+    return (
+      <FormField {...props}>
+        <SegmentedControl
+          value={feeTier}
+          options={[
+            { label: 'Low', value: 'low' },
+            { label: 'Medium', value: 'medium' },
+            { label: 'High', value: 'high' },
+          ]}
+          onChange={setFeeTier}
+        />
+      </FormField>
+    );
+  },
+};

--- a/packages/ui/src/FormField/index.tsx
+++ b/packages/ui/src/FormField/index.tsx
@@ -26,6 +26,14 @@ const LabelText = styled.div<{ $disabled: boolean }>`
 
 export interface FormFieldProps {
   label: string;
+  /**
+   * Setting this to `true` will render the `<FormField />` as disabled, and
+   * will also disable whatever input component you pass as children (if that
+   * component uses the `useDisabled()` hook).
+   *
+   * Thus, you can simply set `disabled` on the `<FormField />`, and don't need
+   * to _also_ set it on the child input component.
+   */
   disabled?: boolean;
   helperText?: string;
   /**
@@ -35,6 +43,25 @@ export interface FormFieldProps {
   children: ReactNode;
 }
 
+/**
+ * A wrapper around a field in a form. Provides a standardized presentation for
+ * any inputs, such as `<TextInput />`, `<SegmentedControl />`, etc.
+ *
+ * ```tsx
+ * <FormField
+ *   label="Field label"
+ *   helperText="This is the helper text."
+ *   disabled={disabled}
+ * >
+ *   <TextInput value={value} onChange={onChange} />
+ * </FormField>
+ * ```
+ *
+ * Note that, in the example above, you can simply pass the `disabled` prop to
+ * `<FormField />`, and it will take care of disabling its child input component
+ * via context (assuming the child input component uses the `useDisabled()`
+ * hook).
+ */
 export const FormField = ({ label, disabled = false, helperText, children }: FormFieldProps) => (
   <Root>
     <LabelText $disabled={disabled}>{label}</LabelText>

--- a/packages/ui/src/FormField/index.tsx
+++ b/packages/ui/src/FormField/index.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { small, strong } from '../utils/typography';
+import { ReactNode } from 'react';
+import { DisabledContext } from '../utils/DisabledContext';
+
+const Root = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(2)};
+  position: relative;
+`;
+
+const HelperText = styled.div<{ $disabled: boolean }>`
+  color: ${props =>
+    props.$disabled ? props.theme.color.text.muted : props.theme.color.text.secondary};
+
+  ${small}
+`;
+
+const LabelText = styled.div<{ $disabled: boolean }>`
+  ${strong}
+
+  color: ${props =>
+    props.$disabled ? props.theme.color.text.muted : props.theme.color.text.primary};
+`;
+
+export interface FormFieldProps {
+  label: string;
+  disabled?: boolean;
+  helperText?: string;
+  /**
+   * The form control to render for this field, whether a `<TextInput />`,
+   * `<SegmentedControl />`, etc.
+   */
+  children: ReactNode;
+}
+
+export const FormField = ({ label, disabled = false, helperText, children }: FormFieldProps) => (
+  <Root>
+    <LabelText $disabled={disabled}>{label}</LabelText>
+
+    <DisabledContext.Provider value={disabled}>{children}</DisabledContext.Provider>
+
+    {helperText && <HelperText $disabled={disabled}>{helperText}</HelperText>}
+  </Root>
+);

--- a/packages/ui/src/Input/index.stories.tsx
+++ b/packages/ui/src/Input/index.stories.tsx
@@ -13,16 +13,20 @@ type Story = StoryObj<typeof Input>;
 
 export const Basic: Story = {
   args: {
-    label: 'Label',
-    placeholder: 'Enter text here...',
+    actionType: 'default',
+    label: "Recipient's address",
+    placeholder: 'penumbra1abc123...',
     value: '',
+    disabled: false,
+    helperText: 'The recipient can find their address via the Receive tab above.',
+    type: 'text',
   },
 
-  render: function Render({ label, value, placeholder }) {
+  render: function Render(props) {
     const [, updateArgs] = useArgs();
 
     const onChange = (value: string) => updateArgs({ value });
 
-    return <Input label={label} value={value} onChange={onChange} placeholder={placeholder} />;
+    return <Input {...props} onChange={onChange} />;
   },
 };

--- a/packages/ui/src/Input/index.stories.tsx
+++ b/packages/ui/src/Input/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
+
+import { Input } from '.';
+
+const meta: Meta<typeof Input> = {
+  component: Input,
+  tags: ['autodocs', '!dev'],
+};
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Basic: Story = {
+  args: {
+    label: 'Label',
+    placeholder: 'Enter text here...',
+    value: '',
+  },
+
+  render: function Render({ label, value, placeholder }) {
+    const [, updateArgs] = useArgs();
+
+    const onChange = (value: string) => updateArgs({ value });
+
+    return <Input label={label} value={value} onChange={onChange} placeholder={placeholder} />;
+  },
+};

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import { Text } from '../Text';
+import { small } from '../utils/typography';
+
+const Root = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(2)};
+`;
+
+const BORDER_BOTTOM_WIDTH = '2px';
+
+const StyledInput = styled.input`
+  appearance: none;
+  border: none;
+  background-color: ${props => props.theme.color.other.tonalFill5};
+  color: ${props => props.theme.color.text.primary};
+
+  padding-left: ${props => props.theme.spacing(3)};
+  padding-right: ${props => props.theme.spacing(3)};
+  padding-top: ${props => props.theme.spacing(2)};
+  padding-bottom: calc(${props => props.theme.spacing(2)} - ${BORDER_BOTTOM_WIDTH});
+  border-bottom: ${BORDER_BOTTOM_WIDTH} solid ${props => props.theme.color.base.transparent};
+  transition: border-color 0.15s;
+
+  ${small}
+
+  &::placeholder {
+    color: ${props => props.theme.color.text.secondary};
+  }
+
+  &:focus {
+    border-bottom-color: ${props => props.theme.color.action.neutralFocusOutline};
+    outline: none;
+  }
+`;
+
+export interface InputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export const Input = ({ label, value, onChange, placeholder }: InputProps) => {
+  return (
+    <Root>
+      <Text strong>{label}</Text>
+      <StyledInput
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </Root>
+  );
+};

--- a/packages/ui/src/Input/index.tsx
+++ b/packages/ui/src/Input/index.tsx
@@ -1,16 +1,53 @@
-import styled from 'styled-components';
+import styled, { DefaultTheme } from 'styled-components';
 import { Text } from '../Text';
 import { small } from '../utils/typography';
+import { ActionType } from '../utils/ActionType';
 
-const Root = styled.label`
+const Root = styled.label<{ $disabled?: boolean }>`
   display: flex;
   flex-direction: column;
   gap: ${props => props.theme.spacing(2)};
+  position: relative;
+
+  ${props =>
+    props.$disabled &&
+    `
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: ${props.theme.color.action.disabledOverlay};
+        cursor: not-allowed;
+      }
+    `}
 `;
 
 const BORDER_BOTTOM_WIDTH = '2px';
 
-const StyledInput = styled.input`
+const borderColorByActionType: Record<ActionType, keyof DefaultTheme['color']['action']> = {
+  default: 'neutralFocusOutline',
+  accent: 'primaryFocusOutline',
+  unshield: 'unshieldFocusOutline',
+  destructive: 'destructiveFocusOutline',
+};
+
+const InputWrapper = styled.div<{ $disabled?: boolean }>`
+  position: relative;
+  width: 100%;
+
+  ${props =>
+    !props.$disabled &&
+    `
+      &:hover::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: ${props.theme.color.action.hoverOverlay};
+      }
+    `}
+`;
+
+const StyledInput = styled.input<{ $actionType: ActionType }>`
   appearance: none;
   border: none;
   background-color: ${props => props.theme.color.other.tonalFill5};
@@ -23,6 +60,9 @@ const StyledInput = styled.input`
   border-bottom: ${BORDER_BOTTOM_WIDTH} solid ${props => props.theme.color.base.transparent};
   transition: border-color 0.15s;
 
+  box-sizing: border-box;
+  width: 100%;
+
   ${small}
 
   &::placeholder {
@@ -30,9 +70,16 @@ const StyledInput = styled.input`
   }
 
   &:focus {
-    border-bottom-color: ${props => props.theme.color.action.neutralFocusOutline};
+    border-bottom-color: ${props =>
+      props.theme.color.action[borderColorByActionType[props.$actionType]]};
     outline: none;
   }
+`;
+
+const HelperText = styled.div`
+  color: ${props => props.theme.color.text.secondary};
+
+  ${small}
 `;
 
 export interface InputProps {
@@ -40,17 +87,38 @@ export interface InputProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  actionType?: ActionType;
+  disabled?: boolean;
+  helperText?: string;
+  type?: 'email' | 'number' | 'password' | 'tel' | 'text' | 'url';
 }
 
-export const Input = ({ label, value, onChange, placeholder }: InputProps) => {
+export const Input = ({
+  label,
+  value,
+  onChange,
+  placeholder,
+  actionType = 'default',
+  disabled,
+  helperText,
+  type = 'text',
+}: InputProps) => {
   return (
-    <Root>
+    <Root $disabled={disabled}>
       <Text strong>{label}</Text>
-      <StyledInput
-        value={value}
-        onChange={e => onChange(e.target.value)}
-        placeholder={placeholder}
-      />
+
+      <InputWrapper>
+        <StyledInput
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          type={type}
+          $actionType={actionType}
+        />
+      </InputWrapper>
+
+      {helperText && <HelperText>{helperText}</HelperText>}
     </Root>
   );
 };

--- a/packages/ui/src/PenumbraUIProvider/theme.ts
+++ b/packages/ui/src/PenumbraUIProvider/theme.ts
@@ -181,7 +181,7 @@ export const theme = {
     text: {
       primary: PALETTE.neutral['50'],
       secondary: PALETTE.neutral['400'],
-      disabled: PALETTE.neutral['500'],
+      muted: PALETTE.neutral['700'],
       special: PALETTE.orange['400'],
     },
     action: {
@@ -240,6 +240,7 @@ export const theme = {
   },
   spacing: (spacingUnits: number) => `${spacingUnits * 4}px`,
   zIndex: {
+    disabledOverlay: 10,
     dialogOverlay: 1000,
     dialogContent: 1001,
   },

--- a/packages/ui/src/PenumbraUIProvider/theme.ts
+++ b/packages/ui/src/PenumbraUIProvider/theme.ts
@@ -180,7 +180,7 @@ export const theme = {
     },
     text: {
       primary: PALETTE.neutral['50'],
-      secondary: PALETTE.neutral['300'],
+      secondary: PALETTE.neutral['400'],
       disabled: PALETTE.neutral['500'],
       special: PALETTE.orange['400'],
     },

--- a/packages/ui/src/SegmentedControl/index.stories.tsx
+++ b/packages/ui/src/SegmentedControl/index.stories.tsx
@@ -29,13 +29,14 @@ export const Basic: Story = {
   args: {
     options: OPTIONS,
     value: 'one',
+    disabled: false,
   },
 
-  render: function Render({ value, options }) {
+  render: function Render(props) {
     const [, updateArgs] = useArgs();
 
     const onChange = (value: { toString: () => string }) => updateArgs({ value });
 
-    return <SegmentedControl value={value} options={options} onChange={onChange} />;
+    return <SegmentedControl {...props} onChange={onChange} />;
   },
 };

--- a/packages/ui/src/SegmentedControl/index.tsx
+++ b/packages/ui/src/SegmentedControl/index.tsx
@@ -4,6 +4,7 @@ import { focusOutline, overlays, buttonBase } from '../utils/button';
 import { Density } from '../types/Density';
 import { useDensity } from '../hooks/useDensity';
 import * as RadixRadioGroup from '@radix-ui/react-radio-group';
+import { useDisabled } from '../hooks/useDisabled';
 
 const Root = styled.div`
   display: flex;
@@ -36,6 +37,7 @@ const Segment = styled.button<{
 export interface Option {
   value: string;
   label: string;
+  /** Whether this individual option should be disabled. */
   disabled?: boolean;
 }
 
@@ -43,6 +45,12 @@ export interface SegmentedControlProps {
   value: string;
   onChange: (value: string) => void;
   options: Option[];
+  /**
+   * Whether this entire control should be disabled. Note that single options
+   * can be disabled individually by setting the `disabled` property for that
+   * given option.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -66,8 +74,9 @@ export interface SegmentedControlProps {
  * />
  * ```
  */
-export const SegmentedControl = ({ value, onChange, options }: SegmentedControlProps) => {
+export const SegmentedControl = ({ value, onChange, options, disabled }: SegmentedControlProps) => {
   const density = useDensity();
+  disabled = useDisabled(disabled);
 
   return (
     <RadixRadioGroup.Root asChild value={value} onValueChange={onChange}>
@@ -80,7 +89,7 @@ export const SegmentedControl = ({ value, onChange, options }: SegmentedControlP
               $getFocusOutlineColor={theme => theme.color.neutral.light}
               $selected={value === option.value}
               $density={density}
-              disabled={option.disabled}
+              disabled={disabled || option.disabled}
             >
               {option.label}
             </Segment>

--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { useId } from 'react';
 import { buttonBase, overlays } from '../utils/button';
 import * as RadixTabs from '@radix-ui/react-tabs';
+import { ActionType } from '../utils/ActionType';
 
 const Root = styled.div`
   height: 52px;
@@ -14,22 +15,22 @@ const Root = styled.div`
   box-sizing: border-box;
 `;
 
-type ActionType = 'default' | 'accent' | 'unshield';
+type LimitedActionType = Exclude<ActionType, 'destructive'>;
 
-const outlineColorByActionType: Record<ActionType, keyof DefaultTheme['color']['action']> = {
+const outlineColorByActionType: Record<LimitedActionType, keyof DefaultTheme['color']['action']> = {
   default: 'neutralFocusOutline',
   accent: 'primaryFocusOutline',
   unshield: 'unshieldFocusOutline',
 };
 
-const gradientColorByActionType: Record<ActionType, 'neutral' | 'primary' | 'unshield'> = {
+const gradientColorByActionType: Record<LimitedActionType, 'neutral' | 'primary' | 'unshield'> = {
   default: 'neutral',
   accent: 'primary',
   unshield: 'unshield',
 };
 
 const Tab = styled.button<{
-  $actionType: ActionType;
+  $actionType: LimitedActionType;
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
   $getBorderRadius: (theme: DefaultTheme) => string;
 }>`
@@ -65,7 +66,7 @@ const Tab = styled.button<{
 `;
 
 const THIRTY_FIVE_PERCENT_OPACITY_IN_HEX = '59';
-const SelectedIndicator = styled(motion.div)<{ $actionType: ActionType }>`
+const SelectedIndicator = styled(motion.div)<{ $actionType: LimitedActionType }>`
   background: radial-gradient(
     at 50% 100%,
     ${props =>
@@ -91,7 +92,7 @@ export interface TabsProps {
   value: string;
   onChange: (value: string) => void;
   options: TabsTab[];
-  actionType?: ActionType;
+  actionType?: LimitedActionType;
 }
 
 /**

--- a/packages/ui/src/TextInput/index.stories.tsx
+++ b/packages/ui/src/TextInput/index.stories.tsx
@@ -1,24 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from '@storybook/preview-api';
 
-import { Input } from '.';
+import { TextInput } from '.';
 
-const meta: Meta<typeof Input> = {
-  component: Input,
+const meta: Meta<typeof TextInput> = {
+  component: TextInput,
   tags: ['autodocs', '!dev'],
 };
 export default meta;
 
-type Story = StoryObj<typeof Input>;
+type Story = StoryObj<typeof TextInput>;
 
 export const Basic: Story = {
   args: {
     actionType: 'default',
-    label: "Recipient's address",
     placeholder: 'penumbra1abc123...',
     value: '',
     disabled: false,
-    helperText: 'The recipient can find their address via the Receive tab above.',
     type: 'text',
   },
 
@@ -27,6 +25,6 @@ export const Basic: Story = {
 
     const onChange = (value: string) => updateArgs({ value });
 
-    return <Input {...props} onChange={onChange} />;
+    return <TextInput {...props} onChange={onChange} />;
   },
 };

--- a/packages/ui/src/TextInput/index.tsx
+++ b/packages/ui/src/TextInput/index.tsx
@@ -59,6 +59,7 @@ export interface TextInputProps {
   type?: 'email' | 'number' | 'password' | 'tel' | 'text' | 'url';
 }
 
+/** A simple text field. */
 export const TextInput = ({
   value,
   onChange,

--- a/packages/ui/src/TextInput/index.tsx
+++ b/packages/ui/src/TextInput/index.tsx
@@ -1,26 +1,7 @@
 import styled, { DefaultTheme } from 'styled-components';
-import { Text } from '../Text';
 import { small } from '../utils/typography';
 import { ActionType } from '../utils/ActionType';
-
-const Root = styled.label<{ $disabled?: boolean }>`
-  display: flex;
-  flex-direction: column;
-  gap: ${props => props.theme.spacing(2)};
-  position: relative;
-
-  ${props =>
-    props.$disabled &&
-    `
-      &::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background-color: ${props.theme.color.action.disabledOverlay};
-        cursor: not-allowed;
-      }
-    `}
-`;
+import { useDisabled } from '../hooks/useDisabled';
 
 const BORDER_BOTTOM_WIDTH = '2px';
 
@@ -31,27 +12,12 @@ const borderColorByActionType: Record<ActionType, keyof DefaultTheme['color']['a
   destructive: 'destructiveFocusOutline',
 };
 
-const InputWrapper = styled.div<{ $disabled?: boolean }>`
-  position: relative;
-  width: 100%;
-
-  ${props =>
-    !props.$disabled &&
-    `
-      &:hover::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background-color: ${props.theme.color.action.hoverOverlay};
-      }
-    `}
-`;
-
 const StyledInput = styled.input<{ $actionType: ActionType }>`
   appearance: none;
   border: none;
   background-color: ${props => props.theme.color.other.tonalFill5};
-  color: ${props => props.theme.color.text.primary};
+  color: ${props =>
+    props.disabled ? props.theme.color.text.muted : props.theme.color.text.primary};
 
   padding-left: ${props => props.theme.spacing(3)};
   padding-right: ${props => props.theme.spacing(3)};
@@ -69,6 +35,14 @@ const StyledInput = styled.input<{ $actionType: ActionType }>`
     color: ${props => props.theme.color.text.secondary};
   }
 
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  &:disabled::placeholder {
+    color: ${props => props.theme.color.text.muted};
+  }
+
   &:focus {
     border-bottom-color: ${props =>
       props.theme.color.action[borderColorByActionType[props.$actionType]]};
@@ -76,49 +50,33 @@ const StyledInput = styled.input<{ $actionType: ActionType }>`
   }
 `;
 
-const HelperText = styled.div`
-  color: ${props => props.theme.color.text.secondary};
-
-  ${small}
-`;
-
-export interface InputProps {
-  label: string;
+export interface TextInputProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
   actionType?: ActionType;
   disabled?: boolean;
-  helperText?: string;
   type?: 'email' | 'number' | 'password' | 'tel' | 'text' | 'url';
 }
 
-export const Input = ({
-  label,
+export const TextInput = ({
   value,
   onChange,
   placeholder,
   actionType = 'default',
   disabled,
-  helperText,
   type = 'text',
-}: InputProps) => {
+}: TextInputProps) => {
+  disabled = useDisabled(disabled);
+
   return (
-    <Root $disabled={disabled}>
-      <Text strong>{label}</Text>
-
-      <InputWrapper>
-        <StyledInput
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          placeholder={placeholder}
-          disabled={disabled}
-          type={type}
-          $actionType={actionType}
-        />
-      </InputWrapper>
-
-      {helperText && <HelperText>{helperText}</HelperText>}
-    </Root>
+    <StyledInput
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      placeholder={placeholder}
+      disabled={disabled}
+      type={type}
+      $actionType={actionType}
+    />
   );
 };

--- a/packages/ui/src/hooks/useDisabled/index.test.tsx
+++ b/packages/ui/src/hooks/useDisabled/index.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { useDisabled } from '.';
+import { render } from '@testing-library/react';
+import { DisabledContext } from '../../utils/DisabledContext';
+
+const MockUseDisabledComponent = ({ disabled }: { disabled?: boolean }) => {
+  disabled = useDisabled(disabled);
+
+  return <>{disabled.toString()}</>;
+};
+
+describe('useDisabled()', () => {
+  it('is disabled when passed `disabled`', () => {
+    const { container } = render(<MockUseDisabledComponent disabled />);
+
+    expect(container).toHaveTextContent('true');
+  });
+
+  it('is disabled when `disabled` is `false` but there is a `<DisabledContext />` wrapper', () => {
+    const { container } = render(
+      <DisabledContext.Provider value={true}>
+        <MockUseDisabledComponent disabled={false} />
+      </DisabledContext.Provider>,
+    );
+
+    expect(container).toHaveTextContent('true');
+  });
+
+  it('is disabled when `disabled` is undefined but there is a `<DisabledContext />` wrapper', () => {
+    const { container } = render(
+      <DisabledContext.Provider value={true}>
+        <MockUseDisabledComponent />
+      </DisabledContext.Provider>,
+    );
+
+    expect(container).toHaveTextContent('true');
+  });
+
+  it('is disabled when `disabled` is `true` and the `<DisabledContext />` wrapper is set to `false`', () => {
+    const { container } = render(
+      <DisabledContext.Provider value={false}>
+        <MockUseDisabledComponent disabled={true} />
+      </DisabledContext.Provider>,
+    );
+
+    expect(container).toHaveTextContent('true');
+  });
+
+  it("is not disabled when `disabled` is undefined and there's no `<DisabledContext />` wrapper", () => {
+    const { container } = render(<MockUseDisabledComponent />);
+
+    expect(container).toHaveTextContent('false');
+  });
+
+  it('is not disabled when `disabled` is undefined and the `<DisabledContext />` wrapper is set to `false`', () => {
+    const { container } = render(
+      <DisabledContext.Provider value={false}>
+        <MockUseDisabledComponent />
+      </DisabledContext.Provider>,
+    );
+
+    expect(container).toHaveTextContent('false');
+  });
+
+  it('is not disabled when `disabled` is false and the `<DisabledContext />` wrapper is set to `false`', () => {
+    const { container } = render(
+      <DisabledContext.Provider value={false}>
+        <MockUseDisabledComponent disabled={false} />
+      </DisabledContext.Provider>,
+    );
+
+    expect(container).toHaveTextContent('false');
+  });
+});

--- a/packages/ui/src/hooks/useDisabled/index.ts
+++ b/packages/ui/src/hooks/useDisabled/index.ts
@@ -1,0 +1,38 @@
+import { useContext } from 'react';
+import { DisabledContext } from '../../utils/DisabledContext';
+
+/**
+ * Internal use only.
+ *
+ * Returns the passed-in `disabled` prop if it's `true`, or the value from
+ * `DisabledContext` otherwise.
+ *
+ * Used by input components to determine whether they should be `disabled`, even
+ * when their `disabled` prop is not explicitly set. This is useful for
+ * `<FormField />`s which will set this context on behalf of their `children`.
+ *
+ * @example
+ * ```tsx
+ * const MyInputComponent = ({ disabled }: { disabled?: boolean }) => {
+ *   // Note the lack of `const` -- we're reassigning the value of `disabled`.
+ *   disabled = useDisabled(disabled);
+ *
+ *   return <input type="text" disabled={disabled} />
+ * }
+ * ```
+ *
+ * In the above example, consumers can then use `<MyInputComponent />` inside an
+ * `<FormField />` without having to explicitly set `disabled` on both:
+ *
+ * @example
+ * ```tsx
+ * <FormField label="Some field" disabled>
+ *   <MyInputComponent /> -- will be disabled because the `<FormField />` is
+ * </FormField>
+ * ```
+ */
+export const useDisabled = (disabledProp?: boolean): boolean => {
+  const disabledContext = useContext(DisabledContext);
+
+  return !!disabledProp || disabledContext;
+};

--- a/packages/ui/src/utils/ActionType.ts
+++ b/packages/ui/src/utils/ActionType.ts
@@ -1,0 +1,1 @@
+export type ActionType = 'default' | 'accent' | 'unshield' | 'destructive';

--- a/packages/ui/src/utils/DisabledContext.ts
+++ b/packages/ui/src/utils/DisabledContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+/**
+ * Used by `<FormField />` to set its `children` as `disabled`, so that
+ * consumers of `<FormField />` don't need to set `disabled` on _both_
+ * `<FormField />` and the child component(s).
+ */
+export const DisabledContext = createContext<boolean>(false);

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -1,7 +1,5 @@
 import { css, DefaultTheme } from 'styled-components';
 
-export type ActionType = 'default' | 'accent' | 'unshield' | 'destructive';
-
 export type Priority = 'primary' | 'secondary';
 
 /** Shared styles to use for any `<button />` */


### PR DESCRIPTION
This is another PR where I was planning on making some new v2 pages, but then realized how many more components still had to be built before I could create the pages.

## In this PR
- Build out the `<Card />` component further with `<Card.Stack />` and `<Card.Section />` sub-components.
- Update a few theme values.
- Create `<FormField />` and `<TextInput />` components.
- Make it possible to disable an entire `<SegmentedControl />` (rather than just one of its options).
- Create a new `DisabledContext` and `useDisabled()` hook.
  - This allows users to pass `disabled` to `<FormField />` without having to _also_ pass it to whatever input component is the `<FormField />`'s children. `<FormField />` then sets the disabled context to `true`, which is then read by the child input component.
- Extract `ActionType` into a shared type used by multiple files.