### PR TITLE
Add Poppins font to the Penumbra Storybook head

### DIFF
--- a/.changeset/hungry-jobs-teach.md
+++ b/.changeset/hungry-jobs-teach.md
@@ -1,0 +1,5 @@
+---
+'@repo/ui': patch
+---
+
+Fix sidebar font

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -1,5 +1,11 @@
 import { join, dirname } from 'path';
 
+const poppinsFontCss = `
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+`;
+
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
@@ -39,5 +45,9 @@ const config = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
   },
+  managerHead: head => `
+    ${head}
+    ${poppinsFontCss}
+  `,
 };
 export default config;


### PR DESCRIPTION
@hdevalence noticed that the Penumbra sidebar was rendering incorrectly, because the Poppins font wasn't loaded in Storybook:

![image](https://github.com/user-attachments/assets/86014d4e-5bc2-47c9-9890-0fa4cc720587)

This PR fixes that by adding the Google font CSS for Poppins to the Storybook head.