### PR TITLE
Fix tabs' border radius on hover

### DIFF
--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -133,7 +133,9 @@ export const Tabs = ({ value, onChange, options, actionType = 'default' }: TabsP
                 $getFocusOutlineColor={theme =>
                   theme.color.action[outlineColorByActionType[actionType]]
                 }
-                $getBorderRadius={theme => theme.borderRadius.none}
+                $getBorderRadius={theme =>
+                  `${theme.borderRadius.xs} ${theme.borderRadius.xs} ${theme.borderRadius.none} ${theme.borderRadius.none}`
+                }
               >
                 {value === option.value && (
                   <SelectedIndicator layout layoutId={layoutId} $actionType={actionType} />


### PR DESCRIPTION
They're supposed to have rounded top left and right corners, but they were previously square. This PR fixes that.

![image](https://github.com/user-attachments/assets/8dd56080-d731-4002-a4dd-63d117467bf9)

See @VanishMax 's first bullet point [here](https://github.com/penumbra-zone/web/pull/1607#discussion_r1709221930)