### PR TITLE
Fix icon adornment outline

### DIFF
--- a/packages/ui/src/Button/index.stories.tsx
+++ b/packages/ui/src/Button/index.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '.';
-import { ArrowLeftRight, Check } from 'lucide-react';
+import { ArrowLeftRight, Check, Copy } from 'lucide-react';
 
 const meta: Meta<typeof Button> = {
   component: Button,
@@ -9,8 +9,8 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     icon: {
       control: 'select',
-      options: ['None', 'Check', 'ArrowLeftRight'],
-      mapping: { None: undefined, Check, ArrowLeftRight },
+      options: ['None', 'Copy', 'Check', 'ArrowLeftRight'],
+      mapping: { None: undefined, Copy, Check, ArrowLeftRight },
     },
     iconOnly: {
       options: ['true', 'false', 'adornment'],
@@ -28,7 +28,7 @@ export const Basic: Story = {
     children: 'Save',
     actionType: 'default',
     disabled: false,
-    icon: Check,
+    icon: Copy,
     iconOnly: false,
     type: 'button',
   },

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -52,6 +52,7 @@ interface StyledButtonProps {
   $priority: Priority;
   $density: Density;
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
+  $getFocusOutlineOffset?: (theme: DefaultTheme) => string | undefined;
   $getBorderRadius: (theme: DefaultTheme) => string;
 }
 
@@ -71,7 +72,6 @@ const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   justify-content: center;
   color: ${props => props.theme.color.neutral.contrast};
-  overflow: hidden;
   position: relative;
 
   ${props =>
@@ -81,12 +81,12 @@ const StyledButton = styled.button<StyledButtonProps>`
         ? sparse
         : compact}
 
-  ${focusOutline}
-  ${overlays}
-
   &::after {
     outline-offset: -2px;
   }
+
+  ${focusOutline}
+  ${overlays}
 `;
 
 interface BaseButtonProps {
@@ -187,11 +187,8 @@ export const Button = ({
       onClick={onClick}
       aria-label={iconOnly ? children : undefined}
       title={iconOnly ? children : undefined}
-      $getFocusOutlineColor={theme =>
-        iconOnly === 'adornment'
-          ? theme.color.base.transparent
-          : theme.color.action[outlineColorByActionType[actionType]]
-      }
+      $getFocusOutlineColor={theme => theme.color.action[outlineColorByActionType[actionType]]}
+      $getFocusOutlineOffset={() => (iconOnly === 'adornment' ? '0px' : undefined)}
       $getBorderRadius={theme =>
         density === 'sparse' && iconOnly !== 'adornment'
           ? theme.borderRadius.sm

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -15,6 +15,7 @@ export const buttonBase = css`
 /** Adds a focus outline to a button using the `:focus-within` pseudoclass. */
 export const focusOutline = css<{
   $getFocusOutlineColor: (theme: DefaultTheme) => string;
+  $getFocusOutlineOffset?: (theme: DefaultTheme) => string | undefined;
   $getBorderRadius: (theme: DefaultTheme) => string;
 }>`
   position: relative;
@@ -28,6 +29,9 @@ export const focusOutline = css<{
     outline-width: 2px;
     outline-style: solid;
     outline-color: transparent;
+    ${props =>
+      props.$getFocusOutlineOffset?.(props.theme) &&
+      `outline-offset: ${props.$getFocusOutlineOffset(props.theme)};`}
     border-radius: ${props => props.$getBorderRadius(props.theme)};
 
     transition: outline-color 0.15s;


### PR DESCRIPTION
Previously, it was too tight around the icon, so we removed it entirely. That causes accessibility issues, though, so this PR adds it back and adds an offset so that it doesn't look cramped.

![image](https://github.com/user-attachments/assets/0caf8f62-3333-4efe-b5cf-21ea429e7dbe)

In situ ^ (see third row of the table)

This addresses @VanishMax 's bullet points 2-3 [here](https://github.com/penumbra-zone/web/pull/1607#discussion_r1709221930)