### PR TITLE
Create Toggle and AccountSelector components

### DIFF
--- a/packages/ui/src/AccountSelector/AccountSelectorAddress.tsx
+++ b/packages/ui/src/AccountSelector/AccountSelectorAddress.tsx
@@ -1,0 +1,61 @@
+import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { bech32mAddress } from '@penumbra-zone/bech32m/penumbra';
+import styled from 'styled-components';
+import { useDensity } from '../hooks/useDensity';
+import { Density } from '../types/Density';
+import { CopyToClipboardButton } from '../CopyToClipboardButton';
+import { Shrink0 } from '../utils/Shrink0';
+import { technical, truncate } from '../utils/typography';
+
+const Root = styled.div<{ $ephemeral: boolean; $loading: boolean; $density: Density }>`
+  border: 1px solid ${props => props.theme.color.other.tonalStroke};
+  padding: ${props => props.theme.spacing(2)} ${props => props.theme.spacing(3)};
+
+  display: flex;
+  gap: ${props => props.theme.spacing(2)};
+
+  color: ${props =>
+    props.$loading
+      ? props.theme.color.text.muted
+      : props.$ephemeral
+        ? props.theme.color.text.special
+        : props.theme.color.text.primary};
+
+  ${props => props.$density === 'sparse' && 'word-break: break-all;'}
+`;
+
+const TextWrapper = styled.div<{ $density: Density }>`
+  flex-grow: 1;
+
+  ${props => props.$density === 'compact' && truncate}
+  ${technical}
+`;
+
+export interface AccountSelectorAddressProps {
+  address?: Address;
+  ephemeral: boolean;
+  loading: boolean;
+}
+
+export const AccountSelectorAddress = ({
+  address,
+  ephemeral,
+  loading,
+}: AccountSelectorAddressProps) => {
+  const density = useDensity();
+
+  return (
+    <Root $ephemeral={ephemeral} $loading={loading} $density={density}>
+      <TextWrapper $density={density}>
+        {address ? bech32mAddress(address) : `penumbra1...`}
+      </TextWrapper>
+
+      <Shrink0>
+        <CopyToClipboardButton
+          text={address ? bech32mAddress(address) : ''}
+          disabled={!address || loading}
+        />
+      </Shrink0>
+    </Root>
+  );
+};

--- a/packages/ui/src/AccountSelector/IbcDepositToggle.tsx
+++ b/packages/ui/src/AccountSelector/IbcDepositToggle.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import { Toggle } from '../Toggle';
+import { Text } from '../Text';
+
+const Root = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export interface IbcDepositToggleProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+export const IbcDepositToggle = ({ value, onChange }: IbcDepositToggleProps) => {
+  return (
+    <Root>
+      <Text detail>IBC Deposit</Text>
+      <Toggle value={value} onChange={onChange} label='IBC Deposit' />
+    </Root>
+  );
+};

--- a/packages/ui/src/AccountSelector/index.stories.tsx
+++ b/packages/ui/src/AccountSelector/index.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { AccountSelector } from '.';
+import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { Text } from '../Text';
+import styled from 'styled-components';
+
+const u8 = (length: number) => Uint8Array.from({ length }, () => Math.floor(Math.random() * 256));
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(4)};
+`;
+
+const mockGetAddressByIndex = (): Promise<Address> =>
+  new Promise(resolve => setTimeout(() => resolve(new Address({ inner: u8(80) })), 1000));
+
+const meta: Meta<typeof AccountSelector> = {
+  component: AccountSelector,
+  tags: ['autodocs', '!dev'],
+  argTypes: {
+    filter: { control: false },
+    value: { control: false }, // For Storybook, we're leaving this uncontrolled
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof AccountSelector>;
+
+export const WithAddress: Story = {
+  tags: ['density'],
+  args: {
+    /**
+     * Storybook automatically adds handlers for `on*` handlers. That has a
+     * material effect on `<AccountSelector />`, since it can be either a
+     * controlled or uncontrolled component, based on whether `onChange` is
+     * defined. So we'll explicitly set `onChange` to `undefined` here to leave
+     * it uncontrolled in Storybook.
+     */
+    onChange: undefined,
+    getAddressByIndex: mockGetAddressByIndex,
+    filter: [0, 1, 2, 3, 4],
+  },
+  decorators: [
+    Story => (
+      <Column>
+        <Text>
+          Note that, for the sake of this Storybook story, a random series of bytes is generated for
+          the addresses. Thus, they are non-deterministic: if you select account #0, then #1, then
+          back to #0, the 0th address will be different the second time around than it was the first
+          time. In a real-world scenario, they <Text strong>are</Text> deterministic: for the same
+          address index, the (non-ephemeral) address will always be the same.
+        </Text>
+        <Text>
+          Also, note that, to simulate loading times, there is a one-second delay on calculating the
+          address for a given address index. Real-world loading times will likely be faster, but
+          this allows users to see the loading state.
+        </Text>
+        <Text>
+          Lastly, for the sake of this Storybook story, a filter has been applied that limits the
+          user to selecting the first 5 accounts (indexes 0-4).
+        </Text>
+
+        <Story />
+      </Column>
+    ),
+  ],
+};
+
+export const WithoutAddress: Story = {
+  args: {
+    onChange: undefined,
+  },
+};

--- a/packages/ui/src/AccountSelector/index.tsx
+++ b/packages/ui/src/AccountSelector/index.tsx
@@ -1,0 +1,156 @@
+import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+import { TextInput } from '../TextInput';
+import styled from 'styled-components';
+import { body } from '../utils/typography';
+import { Density } from '../Density';
+import { Button } from '../Button';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { AccountSelectorAddress } from './AccountSelectorAddress';
+import { IbcDepositToggle } from './IbcDepositToggle';
+import { useAccountSelector } from './useAccountSelector';
+
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacing(2)};
+`;
+
+const StartAdornment = styled.div`
+  ${body}
+
+  color: ${props => props.theme.color.text.secondary};
+`;
+
+const EndAdornment = styled.div`
+  display: flex;
+  gap: ${props => props.theme.spacing(2)};
+  padding: ${props => props.theme.spacing(2)} 0;
+`;
+
+const MAX_INDEX = 2 ** 32;
+
+interface ControlledProps {
+  /**
+   * The current account index.
+   *
+   * Leave this undefined if you want to use `<AccountSelector />` as an
+   * uncontrolled component.
+   */
+  value: number;
+  /**
+   * The account index the user is changing to.
+   *
+   * Leave this undefined if you want to use `<AccountSelector />` as an
+   * uncontrolled component.
+   */
+  onChange: (index: number) => void;
+}
+
+interface UncontrolledProps {
+  value?: undefined;
+  onChange?: undefined;
+}
+
+export type AccountSelectorProps = {
+  /**
+   * A possibly async function that, when given an address index (and a boolean
+   * indicating whether the address should be ephemeral), returns an `Address`.
+   *
+   * If left undefined, no address will be rendered.
+   */
+  getAddressByIndex?: (index: number, ephemeral: boolean) => Promise<Address> | Address;
+  /**
+   * An array of address indexes to switch between, if you want to limit the
+   * options. No need to sort them, as the component will do that for you.
+   */
+  filter?: number[];
+} & (ControlledProps | UncontrolledProps);
+
+/**
+ * Allows users to navigate between their accounts, either for viewing their
+ * addresses, or for toggling between accounts to control an account-based view.
+ *
+ * Can be used as either a controlled or uncontrolled component. To use as a
+ * controlled component, pass the `value` and `onChange` props. To use as an
+ * uncontrolled component (for when, e.g., you just want to enable a user to
+ * page through their account addresses, but doing so won't affect anything else
+ * on the page), leave those props undefined.
+ */
+export const AccountSelector = (props: AccountSelectorProps) => {
+  const {
+    index,
+    handleChange,
+    handleClickPrevious,
+    previousButtonEnabled,
+    handleClickNext,
+    nextButtonEnabled,
+    address,
+    ephemeral,
+    setEphemeral,
+    loading,
+  } = useAccountSelector(props);
+
+  return (
+    <Root>
+      <TextInput
+        type='number'
+        value={index.toString()}
+        min={0}
+        max={MAX_INDEX}
+        onChange={value => {
+          /**
+           * Don't allow manual account number entry when there's a
+           * filter.
+           *
+           * @todo: Change this to only call `handleChange()` when the
+           * user presses Enter? Then it could validate that the entered
+           * account index is in the filter.
+           */
+          if (props.filter) {
+            return;
+          }
+          const valueAsNumber = Number(value);
+          const valueLength = value.replace(/^0+/, '').length;
+
+          if (valueAsNumber > MAX_INDEX || valueLength > MAX_INDEX.toString().length) {
+            return;
+          }
+
+          handleChange(valueAsNumber);
+        }}
+        startAdornment={<StartAdornment>Account #</StartAdornment>}
+        endAdornment={
+          <EndAdornment>
+            <Density compact>
+              <Button
+                icon={ArrowLeft}
+                iconOnly
+                priority='secondary'
+                onClick={handleClickPrevious}
+                disabled={!previousButtonEnabled}
+              >
+                Previous
+              </Button>
+              <Button
+                icon={ArrowRight}
+                iconOnly
+                priority='secondary'
+                onClick={handleClickNext}
+                disabled={!nextButtonEnabled}
+              >
+                Next
+              </Button>
+            </Density>
+          </EndAdornment>
+        }
+      />
+
+      {props.getAddressByIndex && (
+        <>
+          <AccountSelectorAddress address={address} ephemeral={ephemeral} loading={loading} />
+          <IbcDepositToggle value={ephemeral} onChange={setEphemeral} />
+        </>
+      )}
+    </Root>
+  );
+};

--- a/packages/ui/src/AccountSelector/index.tsx
+++ b/packages/ui/src/AccountSelector/index.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { AccountSelectorAddress } from './AccountSelectorAddress';
 import { IbcDepositToggle } from './IbcDepositToggle';
 import { useAccountSelector } from './useAccountSelector';
+import { useRef } from 'react';
 
 const Root = styled.div`
   display: flex;
@@ -19,6 +20,7 @@ const StartAdornment = styled.div`
   ${body}
 
   color: ${props => props.theme.color.text.secondary};
+  cursor: pointer;
 `;
 
 const EndAdornment = styled.div`
@@ -90,6 +92,9 @@ export const AccountSelector = (props: AccountSelectorProps) => {
     loading,
   } = useAccountSelector(props);
 
+  const textInputRef = useRef<HTMLInputElement>(null);
+  const onClickStartAdornment = () => textInputRef.current?.focus();
+
   return (
     <Root>
       <TextInput
@@ -97,6 +102,7 @@ export const AccountSelector = (props: AccountSelectorProps) => {
         value={index.toString()}
         min={0}
         max={MAX_INDEX}
+        ref={textInputRef}
         onChange={value => {
           /**
            * Don't allow manual account number entry when there's a
@@ -118,7 +124,15 @@ export const AccountSelector = (props: AccountSelectorProps) => {
 
           handleChange(valueAsNumber);
         }}
-        startAdornment={<StartAdornment>Account #</StartAdornment>}
+        startAdornment={
+          <StartAdornment
+            role='button'
+            aria-label='Focus on the account number input'
+            onClick={onClickStartAdornment}
+          >
+            Account #
+          </StartAdornment>
+        }
         endAdornment={
           <EndAdornment>
             <Density compact>

--- a/packages/ui/src/AccountSelector/useAccountSelector.ts
+++ b/packages/ui/src/AccountSelector/useAccountSelector.ts
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { AccountSelectorProps } from '.';
+import { Address } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb';
+
+const MAX_INDEX = 2 ** 32;
+
+/**
+ * A hook that encapsulates the business logic of the `<AccountSelector />`
+ * component.
+ */
+export const useAccountSelector = ({
+  getAddressByIndex,
+  filter,
+  value,
+  onChange,
+}: AccountSelectorProps) => {
+  const [uncontrolledIndex, setUncontrolledIndex] = useState<number>(0);
+  const [ephemeral, setEphemeral] = useState<boolean>(false);
+  const [address, setAddress] = useState<Address>();
+  const [loading, setLoading] = useState(false);
+  const sortedFilter = useMemo(() => (filter ? [...filter].sort() : undefined), [filter]);
+
+  const isControlled = onChange !== undefined;
+
+  const index = isControlled ? value : uncontrolledIndex;
+
+  const handleChange = (newValue: number) => {
+    if (isControlled) {
+      onChange(newValue);
+    } else {
+      setUncontrolledIndex(newValue);
+    }
+  };
+
+  const abortController = useRef(new AbortController());
+
+  useEffect(() => {
+    abortController.current.abort();
+
+    if (!getAddressByIndex) {
+      return;
+    }
+
+    const newAbortController = new AbortController();
+    abortController.current = newAbortController;
+    setLoading(true);
+
+    void (async () => {
+      const address = await getAddressByIndex(uncontrolledIndex, ephemeral);
+
+      if (!newAbortController.signal.aborted) {
+        setAddress(address);
+        setLoading(false);
+      }
+    })();
+  }, [uncontrolledIndex, ephemeral, getAddressByIndex]);
+
+  const handleClickPrevious = () => {
+    if (sortedFilter) {
+      const previousAccount = sortedFilter[sortedFilter.indexOf(index) - 1];
+      if (previousAccount !== undefined) {
+        handleChange(previousAccount);
+      }
+    } else {
+      handleChange(index - 1);
+    }
+  };
+
+  const handleClickNext = () => {
+    if (sortedFilter) {
+      const nextAccount = sortedFilter[sortedFilter.indexOf(index) + 1];
+      if (nextAccount !== undefined) {
+        handleChange(nextAccount);
+      }
+    } else {
+      handleChange(index + 1);
+    }
+  };
+
+  const previousButtonEnabled = index !== 0 && (!sortedFilter || sortedFilter.indexOf(index) > 0);
+  const nextButtonEnabled =
+    index !== MAX_INDEX && (!sortedFilter || sortedFilter.indexOf(index) < sortedFilter.length - 1);
+
+  return {
+    index,
+    handleChange,
+    handleClickPrevious,
+    previousButtonEnabled,
+    handleClickNext,
+    nextButtonEnabled,
+    address,
+    ephemeral,
+    setEphemeral,
+    loading,
+  };
+};

--- a/packages/ui/src/CopyToClipboardButton/index.stories.tsx
+++ b/packages/ui/src/CopyToClipboardButton/index.stories.tsx
@@ -13,5 +13,6 @@ type Story = StoryObj<typeof CopyToClipboardButton>;
 export const Basic: Story = {
   args: {
     text: 'This is sample text copied by the PenumbraUI <CopyToClipboardButton /> component.',
+    disabled: false,
   },
 };

--- a/packages/ui/src/CopyToClipboardButton/index.tsx
+++ b/packages/ui/src/CopyToClipboardButton/index.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes, useState } from 'react';
+import { useState } from 'react';
 import { Copy, Check, LucideIcon } from 'lucide-react';
 import { Button } from '../Button';
 
@@ -19,23 +19,24 @@ const useClipboardButton = (text: string) => {
   return { onClick, icon, label };
 };
 
-export interface CopyToClipboardButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface CopyToClipboardButtonProps {
   /**
    * The text that should be copied to the clipboard when the user presses this
    * button.
    */
   text: string;
+  disabled?: boolean;
 }
 
 /**
  * A simple icon button for copying some text to the clipboard. Use it alongside
  * text that the user may want to copy.
  */
-export const CopyToClipboardButton = ({ text }: CopyToClipboardButtonProps) => {
+export const CopyToClipboardButton = ({ text, disabled = false }: CopyToClipboardButtonProps) => {
   const { onClick, icon, label } = useClipboardButton(text);
 
   return (
-    <Button type='button' iconOnly='adornment' icon={icon} onClick={onClick}>
+    <Button type='button' iconOnly='adornment' icon={icon} onClick={onClick} disabled={disabled}>
       {label}
     </Button>
   );

--- a/packages/ui/src/Text/index.tsx
+++ b/packages/ui/src/Text/index.tsx
@@ -10,6 +10,7 @@ import {
   small,
   strong,
   technical,
+  truncate,
   xxl,
 } from '../utils/typography';
 import { ReactNode } from 'react';
@@ -19,13 +20,7 @@ interface StyledProps {
 }
 
 const maybeTruncate = css<StyledProps>`
-  ${props =>
-    props.$truncate &&
-    `
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  `}
+  ${props => props.$truncate && truncate}
 `;
 
 const H1 = styled.h1<StyledProps>`

--- a/packages/ui/src/TextInput/index.stories.tsx
+++ b/packages/ui/src/TextInput/index.stories.tsx
@@ -2,10 +2,38 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from '@storybook/preview-api';
 
 import { TextInput } from '.';
+import { Icon } from '../Icon';
+import { BookUser, Send } from 'lucide-react';
+import { Button } from '../Button';
+import { Density } from '../Density';
+
+const SampleButton = () => (
+  <Density compact>
+    <Button icon={Send} iconOnly>
+      Validate
+    </Button>
+  </Density>
+);
 
 const meta: Meta<typeof TextInput> = {
   component: TextInput,
   tags: ['autodocs', '!dev'],
+  argTypes: {
+    startAdornment: {
+      options: ['Address book icon', 'None'],
+      mapping: {
+        'Address book icon': <Icon IconComponent={BookUser} size='sm' />,
+        None: undefined,
+      },
+    },
+    endAdornment: {
+      options: ['Sample button', 'None'],
+      mapping: {
+        'Sample button': <SampleButton />,
+        None: undefined,
+      },
+    },
+  },
 };
 export default meta;
 
@@ -18,6 +46,8 @@ export const Basic: Story = {
     value: '',
     disabled: false,
     type: 'text',
+    startAdornment: <Icon IconComponent={BookUser} size='sm' />,
+    endAdornment: <SampleButton />,
   },
 
   render: function Render(props) {

--- a/packages/ui/src/TextInput/index.test.tsx
+++ b/packages/ui/src/TextInput/index.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { TextInput } from '.';
+import { render } from '@testing-library/react';
+import { PenumbraUIProvider } from '../PenumbraUIProvider';
+
+describe('<TextInput />', () => {
+  it('renders the passed-in `startAdornment`', () => {
+    const { container } = render(
+      <TextInput value='' onChange={() => {}} startAdornment='Start adornment' />,
+      { wrapper: PenumbraUIProvider },
+    );
+
+    expect(container).toHaveTextContent('Start adornment');
+  });
+
+  it('renders the passed-in `endAdornment`', () => {
+    const { container } = render(
+      <TextInput value='' onChange={() => {}} endAdornment='End adornment' />,
+      { wrapper: PenumbraUIProvider },
+    );
+
+    expect(container).toHaveTextContent('End adornment');
+  });
+});

--- a/packages/ui/src/TextInput/index.tsx
+++ b/packages/ui/src/TextInput/index.tsx
@@ -2,6 +2,7 @@ import styled, { DefaultTheme } from 'styled-components';
 import { small } from '../utils/typography';
 import { ActionType } from '../utils/ActionType';
 import { useDisabled } from '../hooks/useDisabled';
+import { ReactNode } from 'react';
 
 const BORDER_BOTTOM_WIDTH = '2px';
 
@@ -12,22 +13,36 @@ const borderColorByActionType: Record<ActionType, keyof DefaultTheme['color']['a
   destructive: 'destructiveFocusOutline',
 };
 
-const StyledInput = styled.input<{ $actionType: ActionType }>`
+const Wrapper = styled.div<{ $hasStartAdornment: boolean; $hasEndAdornment: boolean }>`
+  background-color: ${props => props.theme.color.other.tonalFill5};
+  display: flex;
+  align-items: center;
+  gap: ${props => props.theme.spacing(2)};
+
+  ${props => props.$hasStartAdornment && `padding-left: ${props.theme.spacing(3)};`}
+  ${props => props.$hasEndAdornment && `padding-right: ${props.theme.spacing(3)};`}
+`;
+
+const StyledInput = styled.input<{
+  $actionType: ActionType;
+  $hasStartAdornment: boolean;
+  $hasEndAdornment: boolean;
+}>`
   appearance: none;
   border: none;
-  background-color: ${props => props.theme.color.other.tonalFill5};
   color: ${props =>
     props.disabled ? props.theme.color.text.muted : props.theme.color.text.primary};
+  background-color: ${props => props.theme.color.base.transparent};
 
-  padding-left: ${props => props.theme.spacing(3)};
-  padding-right: ${props => props.theme.spacing(3)};
+  padding-left: ${props => (props.$hasStartAdornment ? '0' : props.theme.spacing(3))};
+  padding-right: ${props => (props.$hasEndAdornment ? '0' : props.theme.spacing(3))};
   padding-top: ${props => props.theme.spacing(2)};
   padding-bottom: calc(${props => props.theme.spacing(2)} - ${BORDER_BOTTOM_WIDTH});
   border-bottom: ${BORDER_BOTTOM_WIDTH} solid ${props => props.theme.color.base.transparent};
   transition: border-color 0.15s;
 
   box-sizing: border-box;
-  width: 100%;
+  flex-grow: 1;
 
   ${small}
 
@@ -57,9 +72,26 @@ export interface TextInputProps {
   actionType?: ActionType;
   disabled?: boolean;
   type?: 'email' | 'number' | 'password' | 'tel' | 'text' | 'url';
+  /**
+   * Markup to render inside the text input's visual frame, before the text
+   * input itself.
+   */
+  startAdornment?: ReactNode;
+  /**
+   * Markup to render inside the text input's visual frame, after the text input
+   * itself.
+   */
+  endAdornment?: ReactNode;
+  max?: string | number;
+  min?: string | number;
 }
 
-/** A simple text field. */
+/**
+ * A simple text field.
+ *
+ * Can be enriched with start and end adornments, which are markup that render
+ * inside the text input's visual frame.
+ */
 export const TextInput = ({
   value,
   onChange,
@@ -67,17 +99,31 @@ export const TextInput = ({
   actionType = 'default',
   disabled,
   type = 'text',
+  startAdornment = null,
+  endAdornment = null,
+  max,
+  min,
 }: TextInputProps) => {
   disabled = useDisabled(disabled);
 
   return (
-    <StyledInput
-      value={value}
-      onChange={e => onChange(e.target.value)}
-      placeholder={placeholder}
-      disabled={disabled}
-      type={type}
-      $actionType={actionType}
-    />
+    <Wrapper $hasStartAdornment={!!startAdornment} $hasEndAdornment={!!endAdornment}>
+      {startAdornment}
+
+      <StyledInput
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        type={type}
+        max={max}
+        min={min}
+        $actionType={actionType}
+        $hasStartAdornment={!!startAdornment}
+        $hasEndAdornment={!!endAdornment}
+      />
+
+      {endAdornment}
+    </Wrapper>
   );
 };

--- a/packages/ui/src/TextInput/index.tsx
+++ b/packages/ui/src/TextInput/index.tsx
@@ -2,7 +2,7 @@ import styled, { DefaultTheme } from 'styled-components';
 import { small } from '../utils/typography';
 import { ActionType } from '../utils/ActionType';
 import { useDisabled } from '../hooks/useDisabled';
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 
 const BORDER_BOTTOM_WIDTH = '2px';
 
@@ -92,38 +92,44 @@ export interface TextInputProps {
  * Can be enriched with start and end adornments, which are markup that render
  * inside the text input's visual frame.
  */
-export const TextInput = ({
-  value,
-  onChange,
-  placeholder,
-  actionType = 'default',
-  disabled,
-  type = 'text',
-  startAdornment = null,
-  endAdornment = null,
-  max,
-  min,
-}: TextInputProps) => {
-  disabled = useDisabled(disabled);
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  (
+    {
+      value,
+      onChange,
+      placeholder,
+      actionType = 'default',
+      disabled,
+      type = 'text',
+      startAdornment = null,
+      endAdornment = null,
+      max,
+      min,
+    }: TextInputProps,
+    ref,
+  ) => {
+    disabled = useDisabled(disabled);
 
-  return (
-    <Wrapper $hasStartAdornment={!!startAdornment} $hasEndAdornment={!!endAdornment}>
-      {startAdornment}
+    return (
+      <Wrapper $hasStartAdornment={!!startAdornment} $hasEndAdornment={!!endAdornment}>
+        {startAdornment}
 
-      <StyledInput
-        value={value}
-        onChange={e => onChange(e.target.value)}
-        placeholder={placeholder}
-        disabled={disabled}
-        type={type}
-        max={max}
-        min={min}
-        $actionType={actionType}
-        $hasStartAdornment={!!startAdornment}
-        $hasEndAdornment={!!endAdornment}
-      />
+        <StyledInput
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          type={type}
+          max={max}
+          min={min}
+          ref={ref}
+          $actionType={actionType}
+          $hasStartAdornment={!!startAdornment}
+          $hasEndAdornment={!!endAdornment}
+        />
 
-      {endAdornment}
-    </Wrapper>
-  );
-};
+        {endAdornment}
+      </Wrapper>
+    );
+  },
+);

--- a/packages/ui/src/Toggle/index.stories.tsx
+++ b/packages/ui/src/Toggle/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
+
+import { Toggle } from '.';
+
+const meta: Meta<typeof Toggle> = {
+  component: Toggle,
+  tags: ['autodocs', '!dev', 'density'],
+};
+export default meta;
+
+type Story = StoryObj<typeof Toggle>;
+
+export const Basic: Story = {
+  args: {
+    value: false,
+    label: 'Label',
+    disabled: false,
+  },
+
+  render: function Render(props) {
+    const [, updateArgs] = useArgs();
+
+    const onChange = (value: boolean) => updateArgs({ value });
+
+    return <Toggle {...props} onChange={onChange} />;
+  },
+};

--- a/packages/ui/src/Toggle/index.test.tsx
+++ b/packages/ui/src/Toggle/index.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Toggle } from '.';
+import { fireEvent, render } from '@testing-library/react';
+import { PenumbraUIProvider } from '../PenumbraUIProvider';
+
+describe('<Toggle />', () => {
+  it('toggles from false to true', () => {
+    const onChange = vi.fn();
+
+    const { getByLabelText } = render(<Toggle label='Toggle' value={false} onChange={onChange} />, {
+      wrapper: PenumbraUIProvider,
+    });
+
+    fireEvent.click(getByLabelText('Toggle'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('toggles from true to false', () => {
+    const onChange = vi.fn();
+
+    const { getByLabelText } = render(<Toggle label='Toggle' value={true} onChange={onChange} />, {
+      wrapper: PenumbraUIProvider,
+    });
+
+    fireEvent.click(getByLabelText('Toggle'));
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/ui/src/Toggle/index.tsx
+++ b/packages/ui/src/Toggle/index.tsx
@@ -1,0 +1,65 @@
+import * as RadixToggle from '@radix-ui/react-toggle';
+import { useDisabled } from '../hooks/useDisabled';
+import styled from 'styled-components';
+import { buttonBase } from '../utils/button';
+import { useDensity } from '../hooks/useDensity';
+import { Density } from '../types/Density';
+
+const SPARSE_INDICATOR_SIZE = 24;
+const COMPACT_INDICATOR_SIZE = 16;
+
+const Root = styled(RadixToggle.Root)<{ $density: Density }>`
+  ${buttonBase}
+
+  border: 1px solid ${props => props.theme.color.other.tonalStroke};
+  border-radius: ${props => props.theme.borderRadius.full};
+
+  width: ${props =>
+    props.$density === 'sparse' ? SPARSE_INDICATOR_SIZE * 2 : COMPACT_INDICATOR_SIZE * 2}px;
+
+  background-color: ${props =>
+    props.pressed ? props.theme.color.primary.main : props.theme.color.base.transparent};
+  transition: background-color 0.15s;
+`;
+
+const Indicator = styled.div<{ $value: boolean; $density: Density }>`
+  background-color: ${props =>
+    props.$value ? props.theme.color.primary.contrast : props.theme.color.neutral.light};
+  border-radius: ${props => props.theme.borderRadius.full};
+
+  width: ${props =>
+    props.$density === 'sparse' ? SPARSE_INDICATOR_SIZE : COMPACT_INDICATOR_SIZE}px;
+  height: ${props =>
+    props.$density === 'sparse' ? SPARSE_INDICATOR_SIZE : COMPACT_INDICATOR_SIZE}px;
+
+  transition:
+    transform 0.15s,
+    background-color 0.15s;
+  transform: translateX(${props => (props.$value ? '100%' : '0')});
+`;
+
+export interface ToggleProps {
+  /** An accessibility label. */
+  label: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  /** @todo: Implement disabled state visually. */
+  disabled?: boolean;
+}
+
+export const Toggle = ({ label, value, onChange, disabled }: ToggleProps) => {
+  disabled = useDisabled(disabled);
+  const density = useDensity();
+
+  return (
+    <Root
+      aria-label={label}
+      pressed={value}
+      onPressedChange={onChange}
+      disabled={disabled}
+      $density={density}
+    >
+      <Indicator $value={value} $density={density} />
+    </Root>
+  );
+};

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -8,6 +8,7 @@ export const buttonBase = css`
   background: transparent;
   border: none;
   cursor: pointer;
+  padding: 0;
 `;
 
 /** Adds a focus outline to a button using the `:focus-within` pseudoclass. */

--- a/packages/ui/src/utils/typography.ts
+++ b/packages/ui/src/utils/typography.ts
@@ -142,3 +142,9 @@ export const button = css`
   font-weight: 500;
   line-height: ${props => props.theme.lineHeight.textBase};
 `;
+
+export const truncate = `
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -20,8 +20,8 @@
     "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",
     "postcompile": "touch ./wasm/.npmignore",
     "test": "vitest run",
-    "test:wasm": "cd crate && wasm-pack test --headless --firefox -- --target wasm32-unknown-unknown --release --features 'mock-database'",
-    "test:cargo": "cd crate && cargo test --release"
+    "test:cargo": "cd crate && cargo test --release",
+    "test:wasm": "cd crate && wasm-pack test --headless --firefox -- --target wasm32-unknown-unknown --release --features 'mock-database'"
   },
   "files": [
     "wasm",


### PR DESCRIPTION
Creating more components for the v2 send/receive pages

## In this PR
- Create the v2 `<AccountSelector />` component
    ![image](https://github.com/user-attachments/assets/0d01b333-f37a-4fc9-986a-3a247ae2cd5c)
- Create a v2 `<Toggle />` component
  - Note that this component is incomplete, as it doesn't yet visually support disabled and focused states. But those are coming soon in mockups.
- Add `disabled` prop to `<CopyToClipboardButton />`.
- Extract a `truncate` CSS mixin.
- Add support for `startAdornment` and `endAdornment` props in `<TextInput />`, as these are needed for `<AccountSelector />`. Also, add `max`/`min` prop support.