### PR TITLE
fix(minifront): #1593: sort asset groups by account index

### DIFF
--- a/.changeset/odd-cheetahs-help.md
+++ b/.changeset/odd-cheetahs-help.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+sort asset groups by account index

--- a/apps/minifront/src/components/dashboard/assets-table/index.tsx
+++ b/apps/minifront/src/components/dashboard/assets-table/index.tsx
@@ -28,11 +28,18 @@ const getTradeLink = (balance: BalancesResponse): string => {
   return metadata ? `${PagePath.SWAP}?from=${metadata.symbol}${accountQuery}` : PagePath.SWAP;
 };
 
+const byAccountIndex = (a: BalancesByAccount, b: BalancesByAccount) => {
+  return a.account - b.account;
+};
+
 const filteredBalancesByAccountSelector = (
   zQueryState: AbridgedZQueryState<BalancesResponse[]>,
 ): BalancesByAccount[] =>
-  zQueryState.data?.filter(shouldDisplay).sort(sortByPriorityScore).reduce(groupByAccount, []) ??
-  [];
+  zQueryState.data
+    ?.filter(shouldDisplay)
+    .sort(sortByPriorityScore)
+    .reduce(groupByAccount, [])
+    .sort(byAccountIndex) ?? [];
 
 export default function AssetsTable() {
   const balancesByAccount = useBalancesResponses({


### PR DESCRIPTION
Closes #1593 

Sorts asset groups by account index on the dashboard of minifront in ascending order