### PR TITLE
fix storybook CI

### DIFF
--- a/.github/workflows/deploy-ui-preview-main.yml
+++ b/.github/workflows/deploy-ui-preview-main.yml
@@ -16,7 +16,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-        working-directory: packages/ui
+
+      - name: Protobuf codegen
+        run: pnpm proto
 
       - name: Build static site
         run: pnpm build-storybook

--- a/.github/workflows/deploy-ui-preview-pr.yml
+++ b/.github/workflows/deploy-ui-preview-pr.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-        working-directory: packages/ui
+
+      - name: Protobuf codegen
+        run: pnpm proto
 
       - name: Build static site
         run: pnpm build-storybook

--- a/.github/workflows/deploy-ui-release.yml
+++ b/.github/workflows/deploy-ui-release.yml
@@ -18,7 +18,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-        working-directory: packages/ui
+
+      - name: Protobuf codegen
+        run: pnpm proto
 
       - name: Build static site
         run: pnpm build-storybook


### PR DESCRIPTION
this changes storybook CI to run proto codegen before trying to build storybooks.

changing `install` to not use the ui working directory has no effect, because `pnpm install` always runs at workspace level.