### PR TITLE
Display UM fallback if not in registry

### DIFF
--- a/apps/minifront/src/components/ibc/ibc-in/assets-table.tsx
+++ b/apps/minifront/src/components/ibc/ibc-in/assets-table.tsx
@@ -12,6 +12,7 @@ import {
 import { Avatar, AvatarImage } from '@penumbra-zone/ui/components/ui/avatar';
 import { Identicon } from '@penumbra-zone/ui/components/ui/identicon';
 import { LineWave } from 'react-loader-spinner';
+import { getIconWithUmFallback } from './asset-utils.tsx';
 
 export const AssetsTable = () => {
   const { address } = useChainConnector();
@@ -55,7 +56,7 @@ export const AssetsTable = () => {
               <TableRow key={b.displayDenom}>
                 <TableCell className='flex gap-2'>
                   <Avatar className='size-6'>
-                    <AvatarImage src={b.icon} />
+                    <AvatarImage src={getIconWithUmFallback(b)} />
                     <Identicon uniqueIdentifier={b.displayDenom} type='gradient' size={22} />
                   </Avatar>
                   <span className='max-w-[200px] truncate'>{b.displayDenom}</span>

--- a/apps/minifront/src/components/ibc/ibc-in/ibc-in-request.tsx
+++ b/apps/minifront/src/components/ibc/ibc-in/ibc-in-request.tsx
@@ -14,6 +14,7 @@ import { DestinationAddr } from './destination-addr';
 import { Button } from '@penumbra-zone/ui/components/ui/button';
 import { LockClosedIcon } from '@radix-ui/react-icons';
 import { NumberInput } from '../../shared/number-input';
+import { getIconWithUmFallback } from './asset-utils.tsx';
 
 const isReadySelector = (state: AllSlices) => {
   const { amount, coin, selectedChain } = state.ibcIn;
@@ -55,7 +56,7 @@ export const IbcInRequest = () => {
                 <SelectItem value={b.displayDenom} key={b.displayDenom} className='p-2'>
                   <div className='flex gap-2 text-stone-700'>
                     <Avatar className='size-6'>
-                      <AvatarImage src={b.icon} />
+                      <AvatarImage src={getIconWithUmFallback(b)} />
                       <Identicon uniqueIdentifier={b.displayDenom} type='gradient' size={22} />
                     </Avatar>
                     <span className=''>{b.displayDenom}</span>


### PR DESCRIPTION
If UM is not in the counterparty chain registry, it will not show an icon but display an identicon gradient (like other unidentified assets). This has caused some confusion for users that IBC to a chain and then can't find it. 

This PR adds an icon for ibc UM if they do not have an entry in the counterparty chain's registry. We already have the code that can identify UM from the IBC hash. This just looks for the `isPenumbra` field.

<img width="555" alt="Screenshot 2024-08-28 at 11 43 32 AM" src="https://github.com/user-attachments/assets/f66240dd-5b76-42d3-8eb4-259e2379cf02">
