### PR TITLE
Lower batch limit (auctions)

### DIFF
--- a/apps/minifront/src/components/swap/auction-list/end-or-withdraw-all-button.tsx
+++ b/apps/minifront/src/components/swap/auction-list/end-or-withdraw-all-button.tsx
@@ -44,6 +44,14 @@ export const assembleAuctionBatch = (
   return { auctions: filteredBySeqAndAddressIndexAuctions, source: firstFoundAddressIndex! };
 };
 
+// Chain has a transaction size limit, so we can add at most a batch of 48 auctions in a single transaction
+// see https://github.com/penumbra-zone/web/issues/1166#issuecomment-2263550249
+// However, due to wasm memory limits, making the max lower until resolved:
+// https://github.com/penumbra-zone/web/issues/1702
+const BATCH_LIMIT = 24;
+const endTooltipContent = `End a batch of open auctions, with a limit of ${BATCH_LIMIT} auctions per transaction`;
+const withdrawTooltipContent = `Withdraw a batch of ended auctions, with a limit of ${BATCH_LIMIT} auctions per transaction`;
+
 export const EndOrWithdrawAllButton = () => {
   const { endAllAuctions, withdrawAllAuctions } = useStoreShallow(endOrWithdrawAllButtonSelector);
   const { data } = useAuctionInfos();
@@ -57,9 +65,7 @@ export const EndOrWithdrawAllButton = () => {
         <Tooltip>
           <TooltipTrigger
             onClick={() => {
-              // Chain has a transaction size limit, so we can add at most a batch of 48 auctions in a single transaction
-              // see https://github.com/penumbra-zone/web/issues/1166#issuecomment-2263550249
-              const auctionBatch = assembleAuctionBatch(data, 0n, 48);
+              const auctionBatch = assembleAuctionBatch(data, 0n, BATCH_LIMIT);
 
               void endAllAuctions(
                 auctionBatch.auctions,
@@ -67,17 +73,15 @@ export const EndOrWithdrawAllButton = () => {
                 auctionBatch.source,
               );
             }}
-            aria-label='End all open auctions, with a limit of 48 auctions per transaction'
+            aria-label={endTooltipContent}
           >
-            <div className='w-[85px] shrink-0'>
+            <div className='w-[120px] shrink-0'>
               <Button size='sm' variant='secondary' className='w-full'>
-                End all
+                End batch
               </Button>
             </div>
           </TooltipTrigger>
-          <TooltipContent>
-            End all open auctions, with a limit of 48 auctions per transaction
-          </TooltipContent>
+          <TooltipContent>{endTooltipContent}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     );
@@ -89,26 +93,22 @@ export const EndOrWithdrawAllButton = () => {
         <Tooltip>
           <TooltipTrigger
             onClick={() => {
-              // Chain has a transaction size limit, so we can add at most a batch of 48 auctions in a single transaction
-              // see https://github.com/penumbra-zone/web/issues/1166#issuecomment-2263550249
-              const auctionBatch = assembleAuctionBatch(data, 1n, 48);
+              const auctionBatch = assembleAuctionBatch(data, 1n, BATCH_LIMIT);
               void withdrawAllAuctions(
                 auctionBatch.auctions,
                 // TODO Should use the index of the selected account after the account selector for the auction is implemented
                 auctionBatch.source,
               );
             }}
-            aria-label='Withdraw all ended auctions, with a limit of 48 auctions per transaction'
+            aria-label={withdrawTooltipContent}
           >
-            <div className='w-[95px] shrink-0'>
+            <div className='w-[120px] shrink-0'>
               <Button size='sm' variant='secondary' className='w-full'>
-                Withdraw all
+                Withdraw batch
               </Button>
             </div>
           </TooltipTrigger>
-          <TooltipContent>
-            Withdraw all ended auctions, with a limit of 48 auctions per transaction
-          </TooltipContent>
+          <TooltipContent>{withdrawTooltipContent}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     );


### PR DESCRIPTION
Temporary mitigation for: https://github.com/penumbra-zone/web/issues/1702

A full 24 action auction batch takes ~2mins on my computer (m1 max). I wonder if this is a good setting just generally. 