### PR TITLE
remove react-refresh lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,6 @@ import * as import_ from 'eslint-plugin-import';
 import prettier from 'eslint-config-prettier';
 import react from 'eslint-plugin-react';
 import react_hooks from 'eslint-plugin-react-hooks';
-import react_refresh from 'eslint-plugin-react-refresh';
 import storybook from 'eslint-plugin-storybook';
 import tailwindcss from 'eslint-plugin-tailwindcss';
 import turbo from 'eslint-plugin-turbo';
@@ -87,7 +86,6 @@ export default tseslint.config(
       react: fixupPluginRules(react),
       // @ts-expect-error - react_hooks is incorrectly typed
       'react-hooks': fixupPluginRules(react_hooks),
-      'react-refresh': react_refresh,
     },
     // @ts-expect-error - rules are incorrectly typed
     rules: {
@@ -101,7 +99,6 @@ export default tseslint.config(
           allowExpressions: true,
         },
       ],
-      'react-refresh/only-export-components': 'off',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "5.1.0-rc-c3cdbec0a7-20240708",
-    "eslint-plugin-react-refresh": "^0.4.8",
     "eslint-plugin-storybook": "0.9.0--canary.156.ed236ca.0",
     "eslint-plugin-tailwindcss": "^3.17.4",
     "eslint-plugin-turbo": "^2.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 5.1.0-rc-c3cdbec0a7-20240708
         version: 5.1.0-rc-c3cdbec0a7-20240708(eslint@9.6.0)
-      eslint-plugin-react-refresh:
-        specifier: ^0.4.8
-        version: 0.4.8(eslint@9.6.0)
       eslint-plugin-storybook:
         specifier: 0.9.0--canary.156.ed236ca.0
         version: 0.9.0--canary.156.ed236ca.0(eslint@9.6.0)(typescript@5.5.3)
@@ -6839,11 +6836,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-
-  eslint-plugin-react-refresh@0.4.8:
-    resolution: {integrity: sha512-MIKAclwaDFIiYtVBLzDdm16E+Ty4GwhB6wZlCAG1R3Ur+F9Qbo6PRxpA5DK7XtDgm+WlCoAY2WxAwqhmIDHg6Q==}
-    peerDependencies:
-      eslint: '>=7'
 
   eslint-plugin-react@7.35.0:
     resolution: {integrity: sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==}
@@ -20009,10 +20001,6 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@9.6.0)
 
   eslint-plugin-react-hooks@5.1.0-rc-c3cdbec0a7-20240708(eslint@9.6.0):
-    dependencies:
-      eslint: 9.6.0
-
-  eslint-plugin-react-refresh@0.4.8(eslint@9.6.0):
     dependencies:
       eslint: 9.6.0
 


### PR DESCRIPTION
react fast refresh is an acceleration to HMR, and it doesn't affect production code.

it is supported by vite and enabled by `@vitejs/plugin-react-swc`, so technically it is used in this repository. https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports

the lint rule was included in eslint config at some point, but its use was unclear. the eslint rules from the eslint plugin aren't actually enabled, so the eslint plugin is unused.

work in #1721 did not re-enable this rule that was provisionally disabled.

the rule should be enabled or deleted.

many components do not respect the requirements of react-fast-refresh, so enabling it would require many changes, including breaking changes to exports.

this PR deletes the eslint plugin and the disabled rule.