### PR TITLE
improve manifest type

### DIFF
--- a/.changeset/unlucky-cows-rush.md
+++ b/.changeset/unlucky-cows-rush.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/client': minor
+---
+
+improve manifest type

--- a/apps/minifront/src/components/header/menu/provider.tsx
+++ b/apps/minifront/src/components/header/menu/provider.tsx
@@ -33,7 +33,7 @@ export const ProviderMenu = () => {
             id='provider-icon'
             className={cn('w-[1.5em]', 'max-w-none', 'h-[1.5em]')}
             src={URL.createObjectURL(penumbra.manifest.icons['128'])}
-            alt={`${penumbra.manifest['name']} Icon`}
+            alt={`${penumbra.manifest.name} Icon`}
           />
           {chainId}
         </NavigationMenu.Trigger>
@@ -43,9 +43,9 @@ export const ProviderMenu = () => {
               <NavigationMenu.Link className={cn(...linkStyle, 'p-0', 'leading-normal')}>
                 <div className='ml-4 text-muted-foreground'>
                   <span className='font-headline text-muted'>
-                    {penumbra.manifest['name']} {penumbra.manifest['version']}
+                    {penumbra.manifest.name} {penumbra.manifest.version}
                   </span>
-                  <p>{penumbra.manifest['description']}</p>
+                  <p>{penumbra.manifest.description}</p>
                 </div>
               </NavigationMenu.Link>
             </NavigationMenu.Item>

--- a/packages/client/src/manifest.ts
+++ b/packages/client/src/manifest.ts
@@ -17,11 +17,14 @@
  *
  * @see https://web.archive.org/web/20120606044635/http://supercollider.dk/2010/01/calculating-chrome-extension-id-from-your-private-key-233
  */
-export type PenumbraManifestJson = Partial<chrome.runtime.ManifestV3> &
-  Required<Pick<chrome.runtime.ManifestV3, 'name' | 'version' | 'description' | 'icons'>>;
+export type PenumbraManifestJson = chrome.runtime.ManifestV3 & {
+  [k in 'name' | 'version' | 'description' | 'icons']-?: NonNullable<chrome.runtime.ManifestV3[k]>;
+};
 
-export type PenumbraManifest = Omit<PenumbraManifestJson, 'icons'> & {
-  ['icons']: { '128': Blob } & Record<`${number}`, Blob>;
+type IconBlobs = { [size in `${number}`]?: Blob } & { [size128 in `${128}`]-?: NonNullable<Blob> };
+
+export type PenumbraManifest = {
+  [k in keyof PenumbraManifestJson]: k extends 'icons' ? IconBlobs : PenumbraManifestJson[k];
 };
 
 export const isPenumbraManifestJson = (mf: unknown): mf is PenumbraManifestJson =>


### PR DESCRIPTION
manifest access was slightly awkward in #1734 so this change improves the manifest type to provide more consistent access (fields no longer use index access, allow dot notation, don't optionalize existing required fields)