### PR TITLE
fix(ui): dialog content z-index

### DIFF
--- a/.changeset/tame-llamas-remain.md
+++ b/.changeset/tame-llamas-remain.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Fix z-index of dialog content

--- a/packages/ui/src/Dialog/index.tsx
+++ b/packages/ui/src/Dialog/index.tsx
@@ -44,7 +44,7 @@ const DialogContent = styled.div`
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: auto;
+  z-index: 9999;
 `;
 
 const DialogContentCard = styled(motion.div)`


### PR DESCRIPTION
This fixed the issues with z-index for v1 of minifront. However, it introduces even more problems for v2. We will have to tackle them separately in #1756 