### PR TITLE
fix(minifront): #1120: sort the balances by priority score, fix styles

### DIFF
--- a/.changeset/young-mice-drive.md
+++ b/.changeset/young-mice-drive.md
@@ -1,0 +1,5 @@
+---
+'minifront': patch
+---
+
+Sort the balances by priority in the swap and send pages

--- a/apps/minifront/src/components/shared/selectors/asset-selector.tsx
+++ b/apps/minifront/src/components/shared/selectors/asset-selector.tsx
@@ -142,16 +142,18 @@ export const AssetSelector = ({ assets, loading, onChange, value, filter }: Asse
           <div className='flex max-h-[90dvh] flex-col'>
             <DialogHeader>Select asset</DialogHeader>
 
-            <div className='flex flex-col gap-2 overflow-auto p-4'>
-              <Box spacing='compact'>
-                <IconInput
-                  icon={<MagnifyingGlassIcon className='size-5 text-muted-foreground' />}
-                  value={search}
-                  onChange={setSearch}
-                  autoFocus
-                  placeholder='Search assets...'
-                />
-              </Box>
+            <div className='flex flex-col gap-2 overflow-auto'>
+              <div className='px-4 pt-4'>
+                <Box spacing='compact'>
+                  <IconInput
+                    icon={<MagnifyingGlassIcon className='size-5 text-muted-foreground' />}
+                    value={search}
+                    onChange={setSearch}
+                    autoFocus
+                    placeholder='Search assets...'
+                  />
+                </Box>
+              </div>
 
               <Table>
                 <TableBody>
@@ -165,7 +167,7 @@ export const AssetSelector = ({ assets, loading, onChange, value, filter }: Asse
                         <TableCell className='p-0'>
                           <div
                             className={cn(
-                              '-mx-4 flex h-full gap-[6px] p-4 hover:bg-light-brown',
+                              'flex h-full gap-[6px] p-4 hover:bg-light-brown',
                               isSelected(metadata) && 'bg-light-brown',
                             )}
                           >

--- a/apps/minifront/src/components/shared/selectors/balance-item.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-item.tsx
@@ -46,7 +46,7 @@ export const BalanceItem = ({ asset, value, onSelect }: BalanceItemProps) => {
           isSelected && 'bg-light-brown',
         )}
       >
-        <TableCell>{account}</TableCell>
+        <TableCell className='pl-4'>{account}</TableCell>
 
         <TableCell>
           <div className='col-span-2 flex items-center justify-start gap-1'>
@@ -60,7 +60,7 @@ export const BalanceItem = ({ asset, value, onSelect }: BalanceItemProps) => {
           </div>
         </TableCell>
 
-        <TableCell>
+        <TableCell className='pr-4'>
           <div className='col-span-2 flex justify-end'>
             {isBalance(asset) && (
               <ValueViewComponent showIcon={false} showDenom={false} view={asset.balanceView} />

--- a/apps/minifront/src/components/shared/selectors/balance-selector.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-selector.tsx
@@ -115,7 +115,7 @@ export default function BalanceSelector({
                   <TableRow>
                     <TableHead className='pl-4'>Account</TableHead>
                     <TableHead>Asset</TableHead>
-                    <TableHead className='text-right pr-4'>Balance</TableHead>
+                    <TableHead className='pr-4 text-right'>Balance</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/apps/minifront/src/components/shared/selectors/balance-selector.tsx
+++ b/apps/minifront/src/components/shared/selectors/balance-selector.tsx
@@ -98,22 +98,24 @@ export default function BalanceSelector({
         <DialogContent layoutId={layoutId}>
           <div className='flex max-h-[90dvh] flex-col'>
             <DialogHeader>Select asset</DialogHeader>
-            <div className='flex shrink flex-col gap-4 overflow-auto p-4'>
-              <Box spacing='compact'>
-                <IconInput
-                  icon={<MagnifyingGlassIcon className='size-5 text-muted-foreground' />}
-                  value={search}
-                  onChange={setSearch}
-                  autoFocus
-                  placeholder='Search assets...'
-                />
-              </Box>
+            <div className='flex shrink flex-col gap-4 overflow-auto'>
+              <div className='px-4 pt-4'>
+                <Box spacing='compact'>
+                  <IconInput
+                    icon={<MagnifyingGlassIcon className='size-5 text-muted-foreground' />}
+                    value={search}
+                    onChange={setSearch}
+                    autoFocus
+                    placeholder='Search assets...'
+                  />
+                </Box>
+              </div>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Account</TableHead>
+                    <TableHead className='pl-4'>Account</TableHead>
                     <TableHead>Asset</TableHead>
-                    <TableHead className='text-right'>Balance</TableHead>
+                    <TableHead className='text-right pr-4'>Balance</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/apps/minifront/src/fetchers/balances/by-priority-score.ts
+++ b/apps/minifront/src/fetchers/balances/by-priority-score.ts
@@ -2,6 +2,7 @@ import { BalancesResponse } from '@penumbra-zone/protobuf/penumbra/view/v1/view_
 import {
   getMetadataFromBalancesResponseOptional,
   getAmount,
+  getAddressIndex,
 } from '@penumbra-zone/getters/balances-response';
 import { multiplyAmountByNumber, joinLoHiAmount } from '@penumbra-zone/types/amount';
 
@@ -20,4 +21,15 @@ export const sortByPriorityScore = (a: BalancesResponse, b: BalancesResponse) =>
     : bScore;
 
   return Number(bPriority - aPriority);
+};
+
+export const sortByPriorityScoreAndAccountIndex = (a: BalancesResponse, b: BalancesResponse) => {
+  const aIndex = getAddressIndex.optional()(a)?.account ?? Infinity;
+  const bIndex = getAddressIndex.optional()(b)?.account ?? Infinity;
+
+  if (aIndex === bIndex) {
+    return sortByPriorityScore(a, b);
+  }
+
+  return aIndex - bIndex;
 };

--- a/apps/minifront/src/state/swap/helpers.ts
+++ b/apps/minifront/src/state/swap/helpers.ts
@@ -20,7 +20,7 @@ import { isKnown } from '../helpers';
 import { AbridgedZQueryState } from '@penumbra-zone/zquery/src/types';
 import { penumbra } from '../../prax';
 import { DexService, SimulationService } from '@penumbra-zone/protobuf';
-import { sortByPriorityScore } from '../../fetchers/balances/by-priority-score.ts';
+import { sortByPriorityScoreAndAccountIndex } from '../../fetchers/balances/by-priority-score.ts';
 
 export const sendSimulateTradeRequest = ({
   assetIn,
@@ -173,7 +173,7 @@ export const swappableBalancesResponsesSelector = (
   data: zQueryState.data
     ?.filter(isKnown)
     .filter(balance => isSwappable(getMetadata(balance.balanceView)))
-    .sort(sortByPriorityScore),
+    .sort(sortByPriorityScoreAndAccountIndex),
 });
 
 export const swappableAssetsSelector = (zQueryState: AbridgedZQueryState<Metadata[]>) => ({

--- a/apps/minifront/src/state/swap/helpers.ts
+++ b/apps/minifront/src/state/swap/helpers.ts
@@ -9,19 +9,18 @@ import { getAssetId, getDisplay } from '@penumbra-zone/getters/metadata';
 import {
   getAssetIdFromValueView,
   getDisplayDenomExponentFromValueView,
-  getAmount,
   getMetadata,
 } from '@penumbra-zone/getters/value-view';
 import { toBaseUnit } from '@penumbra-zone/types/lo-hi';
 import { BigNumber } from 'bignumber.js';
 import { SwapSlice } from '.';
 import { assetPatterns } from '@penumbra-zone/types/assets';
-import { fromBaseUnitAmount } from '@penumbra-zone/types/amount';
 import { BalancesResponse } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { isKnown } from '../helpers';
 import { AbridgedZQueryState } from '@penumbra-zone/zquery/src/types';
 import { penumbra } from '../../prax';
 import { DexService, SimulationService } from '@penumbra-zone/protobuf';
+import { sortByPriorityScore } from '../../fetchers/balances/by-priority-score.ts';
 
 export const sendSimulateTradeRequest = ({
   assetIn,
@@ -151,15 +150,6 @@ export const combinedCandlestickDataSelector = (
   }
 };
 
-const byBalanceDescending = (a: BalancesResponse, b: BalancesResponse) => {
-  const aExponent = getDisplayDenomExponentFromValueView(a.balanceView);
-  const bExponent = getDisplayDenomExponentFromValueView(b.balanceView);
-  const aAmount = fromBaseUnitAmount(getAmount(a.balanceView), aExponent);
-  const bAmount = fromBaseUnitAmount(getAmount(b.balanceView), bExponent);
-
-  return bAmount.comparedTo(aAmount);
-};
-
 const nonSwappableAssetPatterns = [
   assetPatterns.lpNft,
   assetPatterns.proposalNft,
@@ -183,7 +173,7 @@ export const swappableBalancesResponsesSelector = (
   data: zQueryState.data
     ?.filter(isKnown)
     .filter(balance => isSwappable(getMetadata(balance.balanceView)))
-    .sort(byBalanceDescending),
+    .sort(sortByPriorityScore),
 });
 
 export const swappableAssetsSelector = (zQueryState: AbridgedZQueryState<Metadata[]>) => ({


### PR DESCRIPTION
Closes #1120 

- Added the sorting "by priority score" for balances in the swap asset selector
- Fixed the paddings in the asset selectors

Might look a little unexpected first but it is designed for better UX – users will see their top-valued assets first

<img width="656" alt="image" src="https://github.com/user-attachments/assets/10305e1e-cf3f-49a3-b8d7-0c095c52d72a">
