### PR TITLE
Fix exponential string bug

### DIFF
--- a/apps/minifront/src/components/ibc/ibc-in/asset-utils.tsx
+++ b/apps/minifront/src/components/ibc/ibc-in/asset-utils.tsx
@@ -5,6 +5,7 @@ import { BigNumber } from 'bignumber.js';
 import { AssetDenomUnit } from '@chain-registry/types/assets';
 import { CosmosAssetBalance } from './hooks.ts';
 import { ChainRegistryClient } from '@penumbra-labs/registry';
+import { bigNumConfig } from '@penumbra-zone/types/lo-hi';
 
 // Searches for corresponding denom in asset registry and returns the metadata
 export const augmentToAsset = (denom: string, chainName: string): Asset => {
@@ -52,7 +53,11 @@ export const fromDisplayAmount = (
   const baseExponent = getExponent(asset.denom_units, asset.base) ?? 0;
 
   const exponentDifference = displayExponent - baseExponent;
-  const amount = new BigNumber(displayAmount).shiftedBy(exponentDifference).toString();
+
+  // Overriding repo default and setting a very high threshold to avoid exponential notation
+  const CustomBigNumber = BigNumber.clone({ ...bigNumConfig, EXPONENTIAL_AT: [-1e9, 1e9] });
+
+  const amount = new CustomBigNumber(displayAmount).shiftedBy(exponentDifference).toString();
   return { denom: asset.base, amount };
 };
 

--- a/packages/types/src/lo-hi.ts
+++ b/packages/types/src/lo-hi.ts
@@ -2,13 +2,15 @@
 
 import { BigNumber } from 'bignumber.js';
 
-BigNumber.config({
+export const bigNumConfig: BigNumber.Config = {
   EXPONENTIAL_AT: [-20, 20],
   FORMAT: {
     decimalSeparator: '.',
     groupSeparator: '',
   },
-});
+};
+
+BigNumber.config(bigNumConfig);
 
 /**
  * In protobufs, it's common to split a single u128 into two u64's.


### PR DESCRIPTION
When we are doing an IBC-in, if the user selects a number sufficiently big, the notation will convert to the exponential form: `1.12e+20`. This, however, is not a valid input as a coin amount for a ibc transfer message. It needs to be the full form.

This PR fixes this bug by overriding the default exponential config when performing the IBC-in to ensure it does not go to the exponential form. 

Related: https://github.com/noble-assets/noble/issues/404