### PR TITLE
Initialize reduce w/ zero

### DIFF
--- a/packages/types/src/staking.ts
+++ b/packages/types/src/staking.ts
@@ -57,7 +57,7 @@ export const isDelegationTokenForValidator = (
  */
 export const calculateCommissionAsPercentage = (validatorInfo: ValidatorInfo): number => {
   const fundingStreams = getFundingStreamsFromValidatorInfo(validatorInfo);
-  const totalBps = fundingStreams.map(getRateBpsFromFundingStream).reduce(toSum);
+  const totalBps = fundingStreams.map(getRateBpsFromFundingStream).reduce(toSum, 0);
 
   return totalBps / 100;
 };


### PR DESCRIPTION
Found on testnet. If a validator has zero staking commission, the array reduce will error out. Initializing w/ zero to prevent an error on this edge case.

<img width="850" alt="Screenshot 2024-09-12 at 1 14 55 PM" src="https://github.com/user-attachments/assets/b3a65304-14a6-4c4a-b4ab-ab60a304f61c">
