### PR TITLE
Only process relevant transactions

### DIFF
--- a/.changeset/eight-hounds-compare.md
+++ b/.changeset/eight-hounds-compare.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/storage': patch
+---
+
+Version DB to 47

--- a/.changeset/late-peas-tap.md
+++ b/.changeset/late-peas-tap.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/query': patch
+---
+
+[bug fix] Only process relevant transactions for NFTs

--- a/.changeset/twenty-tomatoes-travel.md
+++ b/.changeset/twenty-tomatoes-travel.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/query': patch
+---
+
+Extract, refactor, and test IdentifyTransactions

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -333,7 +333,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       // TODO: this is the second time we save these records, after "saveScanResult"
       await this.saveRecoveredCommitmentSources(recordsWithSources);
 
-      await this.processTransactions(blockTx);
+      await this.processTransactions(relevantTx);
 
       // at this point txinfo can be generated and saved. this will resolve
       // pending broadcasts, and populate the transaction list.
@@ -591,8 +591,8 @@ export class BlockProcessor implements BlockProcessorInterface {
    * Identify various pieces of data from the transaction that we need to save,
    * such as metadata, liquidity positions, etc.
    */
-  private async processTransactions(txs: Transaction[]) {
-    for (const tx of txs) {
+  private async processTransactions(txs: Map<TransactionId, Transaction>) {
+    for (const [, tx] of txs) {
       for (const { action } of tx.body?.actions ?? []) {
         await Promise.all([this.identifyAuctionNfts(action), this.identifyLpNftPositions(action)]);
       }

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -305,6 +305,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       // this is a network query
       const blockTx = await this.querier.app.txsByHeight(compactBlock.height);
 
+      // Filter down to transactions & note records in block relevant to user
       const { relevantTxs, recoveredSourceRecords } = await identifyTransactions(
         spentNullifiers,
         recordsByCommitment,

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -4,21 +4,13 @@ import {
   PositionState,
   PositionState_PositionStateEnum,
 } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
-import {
-  CommitmentSource,
-  Nullifier,
-} from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
+import { Nullifier } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
 import { ValidatorInfoResponse } from '@penumbra-zone/protobuf/penumbra/core/component/stake/v1/stake_pb';
-import {
-  Action,
-  Transaction,
-} from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
-import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
+import { Action } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import { SpendableNoteRecord, SwapRecord } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { auctionIdFromBech32 } from '@penumbra-zone/bech32m/pauctid';
 import { bech32mIdentityKey } from '@penumbra-zone/bech32m/penumbravalid';
-import { sha256Hash } from '@penumbra-zone/crypto-web/sha256';
 import { getAssetId } from '@penumbra-zone/getters/metadata';
 import {
   getExchangeRateFromValidatorInfoResponse,
@@ -47,6 +39,7 @@ import { getSpendableNoteRecordCommitment } from '@penumbra-zone/getters/spendab
 import { getSwapRecordCommitment } from '@penumbra-zone/getters/swap-record';
 import { CompactBlock } from '@penumbra-zone/protobuf/penumbra/core/component/compact_block/v1/compact_block_pb';
 import { shouldSkipTrialDecrypt } from './helpers/skip-trial-decrypt.js';
+import { identifyTransactions, RelevantTx } from './helpers/identify-txs.js';
 
 declare global {
   // eslint-disable-next-line no-var -- expected globals
@@ -80,10 +73,6 @@ interface ProcessBlockParams {
   latestKnownBlockHeight: bigint;
   skipTrialDecrypt?: boolean;
 }
-
-const BLANK_TX_SOURCE = new CommitmentSource({
-  source: { case: 'transaction', value: { id: new Uint8Array() } },
-});
 
 const POSITION_STATES: PositionState[] = [
   new PositionState({ state: PositionState_PositionStateEnum.OPENED }),
@@ -129,9 +118,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       numOfAttempts: Infinity,
       maxDelay: 20_000, // 20 seconds
       retry: async (e, attemptNumber) => {
-        if (globalThis.__DEV__) {
-          console.debug('Sync failure', attemptNumber, e);
-        }
+        console.error(`Sync failure #${attemptNumber}: `, e);
         await this.viewServer.resetTreeToStored();
         return !this.abortController.signal.aborted;
       },
@@ -318,12 +305,7 @@ export class BlockProcessor implements BlockProcessorInterface {
       // this is a network query
       const blockTx = await this.querier.app.txsByHeight(compactBlock.height);
 
-      // identify tx that involve a new record
-      // - compare nullifiers
-      // - compare state commitments
-      // - collect relevant tx for info generation later
-      // - if matched by commitment, collect record with recovered source
-      const { relevantTx, recordsWithSources } = await this.identifyTransactions(
+      const { relevantTxs, recoveredSourceRecords } = await identifyTransactions(
         spentNullifiers,
         recordsByCommitment,
         blockTx,
@@ -331,15 +313,15 @@ export class BlockProcessor implements BlockProcessorInterface {
 
       // this simply stores the new records with 'rehydrated' sources to idb
       // TODO: this is the second time we save these records, after "saveScanResult"
-      await this.saveRecoveredCommitmentSources(recordsWithSources);
+      await this.saveRecoveredCommitmentSources(recoveredSourceRecords);
 
-      await this.processTransactions(relevantTx);
+      await this.processTransactions(relevantTxs);
 
       // at this point txinfo can be generated and saved. this will resolve
       // pending broadcasts, and populate the transaction list.
       // - calls wasm for each relevant tx
       // - saves to idb
-      await this.saveTransactions(compactBlock.height, relevantTx);
+      await this.saveTransactions(compactBlock.height, relevantTxs);
     }
 
     /**
@@ -450,64 +432,6 @@ export class BlockProcessor implements BlockProcessorInterface {
     }
   }
 
-  private async identifyTransactions(
-    spentNullifiers: Set<Nullifier>,
-    commitmentRecordsByStateCommitment: Map<StateCommitment, SpendableNoteRecord | SwapRecord>,
-    blockTx: Transaction[],
-  ) {
-    const relevantTx = new Map<TransactionId, Transaction>();
-    const recordsWithSources = new Array<SpendableNoteRecord | SwapRecord>();
-    for (const tx of blockTx) {
-      let txId: TransactionId | undefined;
-
-      const txCommitments = (tx.body?.actions ?? []).flatMap(({ action }) => {
-        switch (action.case) {
-          case 'output':
-            return action.value.body?.notePayload?.noteCommitment;
-          case 'swap':
-            return action.value.body?.payload?.commitment;
-          case 'swapClaim':
-            return [action.value.body?.output1Commitment, action.value.body?.output2Commitment];
-          default:
-            return;
-        }
-      });
-
-      const txNullifiers = (tx.body?.actions ?? []).map(({ action }) => {
-        switch (action.case) {
-          case 'spend':
-          case 'swapClaim':
-            return action.value.body?.nullifier;
-          default:
-            return;
-        }
-      });
-
-      for (const spentNullifier of spentNullifiers) {
-        if (txNullifiers.some(txNullifier => spentNullifier.equals(txNullifier))) {
-          txId = new TransactionId({ inner: await sha256Hash(tx.toBinary()) });
-          relevantTx.set(txId, tx);
-          spentNullifiers.delete(spentNullifier);
-        }
-      }
-
-      for (const [stateCommitment, spendableNoteRecord] of commitmentRecordsByStateCommitment) {
-        if (txCommitments.some(txCommitment => stateCommitment.equals(txCommitment))) {
-          txId ??= new TransactionId({ inner: await sha256Hash(tx.toBinary()) });
-          relevantTx.set(txId, tx);
-          if (BLANK_TX_SOURCE.equals(spendableNoteRecord.source)) {
-            spendableNoteRecord.source = new CommitmentSource({
-              source: { case: 'transaction', value: { id: txId.inner } },
-            });
-            recordsWithSources.push(spendableNoteRecord);
-          }
-          commitmentRecordsByStateCommitment.delete(stateCommitment);
-        }
-      }
-    }
-    return { relevantTx, recordsWithSources };
-  }
-
   // TODO: refactor. there is definitely a better way to do this.  batch
   // endpoint issue https://github.com/penumbra-zone/penumbra/issues/4688
   private async saveAndReturnMetadata(assetId: AssetId): Promise<Metadata | undefined> {
@@ -591,9 +515,9 @@ export class BlockProcessor implements BlockProcessorInterface {
    * Identify various pieces of data from the transaction that we need to save,
    * such as metadata, liquidity positions, etc.
    */
-  private async processTransactions(txs: Map<TransactionId, Transaction>) {
-    for (const [, tx] of txs) {
-      for (const { action } of tx.body?.actions ?? []) {
+  private async processTransactions(txs: RelevantTx[]) {
+    for (const { data } of txs) {
+      for (const { action } of data.body?.actions ?? []) {
         await Promise.all([this.identifyAuctionNfts(action), this.identifyLpNftPositions(action)]);
       }
     }
@@ -685,9 +609,9 @@ export class BlockProcessor implements BlockProcessorInterface {
     });
   }
 
-  private async saveTransactions(height: bigint, relevantTx: Map<TransactionId, Transaction>) {
-    for (const [id, transaction] of relevantTx) {
-      await this.indexedDb.saveTransaction(id, height, transaction);
+  private async saveTransactions(height: bigint, relevantTx: RelevantTx[]) {
+    for (const { id, data } of relevantTx) {
+      await this.indexedDb.saveTransaction(id, height, data);
     }
   }
 

--- a/packages/query/src/helpers/identify-txs.test.ts
+++ b/packages/query/src/helpers/identify-txs.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, test } from 'vitest';
+import {
+  CommitmentSource,
+  Nullifier,
+} from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
+import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
+import {
+  Action,
+  Transaction,
+  TransactionBody,
+} from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import {
+  getCommitmentsFromActions,
+  getNullifiersFromActions,
+  identifyTransactions,
+} from './identify-txs.js';
+import {
+  Output,
+  OutputBody,
+  Spend,
+  SpendBody,
+} from '@penumbra-zone/protobuf/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
+import {
+  Swap,
+  SwapBody,
+  SwapClaim,
+  SwapClaimBody,
+} from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { SpendableNoteRecord, SwapRecord } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+
+const BLANK_TX_SOURCE = new CommitmentSource({
+  source: { case: 'transaction', value: { id: new Uint8Array() } },
+});
+
+describe('getCommitmentsFromActions', () => {
+  test('returns empty array when tx.body.actions is undefined', () => {
+    const tx = new Transaction();
+    const commitments = getCommitmentsFromActions(tx);
+    expect(commitments).toEqual([]);
+  });
+
+  test('returns noteCommitment from output actions', () => {
+    const noteCommitment = new StateCommitment({ inner: new Uint8Array([1, 2, 3]) });
+    const outputAction = new Action({
+      action: {
+        case: 'output',
+        value: new Output({
+          body: new OutputBody({
+            notePayload: {
+              noteCommitment,
+            },
+          }),
+        }),
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [outputAction],
+      }),
+    });
+
+    const commitments = getCommitmentsFromActions(tx);
+    expect(commitments).toEqual([noteCommitment]);
+  });
+
+  test('returns commitment from swap actions', () => {
+    const commitment = new StateCommitment({ inner: new Uint8Array([4, 5, 6]) });
+    const swapAction = new Action({
+      action: {
+        case: 'swap',
+        value: new Swap({
+          body: new SwapBody({
+            payload: {
+              commitment,
+            },
+          }),
+        }),
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [swapAction],
+      }),
+    });
+
+    const commitments = getCommitmentsFromActions(tx);
+    expect(commitments).toEqual([commitment]);
+  });
+
+  test('returns output commitments from swapClaim actions', () => {
+    const output1Commitment = new StateCommitment({ inner: new Uint8Array([7, 8, 9]) });
+    const output2Commitment = new StateCommitment({ inner: new Uint8Array([10, 11, 12]) });
+
+    const swapClaimAction = new Action({
+      action: {
+        case: 'swapClaim',
+        value: new SwapClaim({
+          body: new SwapClaimBody({
+            output1Commitment,
+            output2Commitment,
+          }),
+        }),
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [swapClaimAction],
+      }),
+    });
+
+    const commitments = getCommitmentsFromActions(tx);
+    expect(commitments).toEqual([output1Commitment, output2Commitment]);
+  });
+
+  test('ignores actions without commitments', () => {
+    const unknownAction = new Action({
+      action: {
+        case: 'validatorDefinition',
+        value: {},
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [unknownAction],
+      }),
+    });
+
+    const commitments = getCommitmentsFromActions(tx);
+    expect(commitments).toEqual([]);
+  });
+});
+
+describe('getNullifiersFromActions', () => {
+  test('returns empty array when tx.body.actions is undefined', () => {
+    const tx = new Transaction();
+    const nullifiers = getNullifiersFromActions(tx);
+    expect(nullifiers).toEqual([]);
+  });
+
+  test('returns nullifier from spend actions', () => {
+    const nullifier = new Nullifier({ inner: new Uint8Array([1, 2, 3]) });
+    const spendAction = new Action({
+      action: {
+        case: 'spend',
+        value: new Spend({
+          body: new SpendBody({
+            nullifier,
+          }),
+        }),
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [spendAction],
+      }),
+    });
+
+    const nullifiers = getNullifiersFromActions(tx);
+    expect(nullifiers).toEqual([nullifier]);
+  });
+
+  test('returns nullifier from swapClaim actions', () => {
+    const nullifier = new Nullifier({ inner: new Uint8Array([4, 5, 6]) });
+    const swapClaimAction = new Action({
+      action: {
+        case: 'swapClaim',
+        value: new SwapClaim({
+          body: new SwapClaimBody({
+            nullifier,
+          }),
+        }),
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [swapClaimAction],
+      }),
+    });
+
+    const nullifiers = getNullifiersFromActions(tx);
+    expect(nullifiers).toEqual([nullifier]);
+  });
+
+  test('ignores actions without nullifiers', () => {
+    const outputAction = new Action({
+      action: {
+        case: 'output',
+        value: new Output(),
+      },
+    });
+
+    const tx = new Transaction({
+      body: new TransactionBody({
+        actions: [outputAction],
+      }),
+    });
+
+    const nullifiers = getNullifiersFromActions(tx);
+    expect(nullifiers).toEqual([]);
+  });
+});
+
+describe('identifyTransactions', () => {
+  test('returns empty arrays when no relevant transactions are found', async () => {
+    const tx = new Transaction();
+    const blockTx = [tx];
+    const spentNullifiers = new Set<Nullifier>();
+    const commitmentRecords = new Map<StateCommitment, SpendableNoteRecord | SwapRecord>();
+
+    const result = await identifyTransactions(spentNullifiers, commitmentRecords, blockTx);
+
+    expect(result.relevantTxs).toEqual([]);
+    expect(result.recoveredSourceRecords).toEqual([]);
+  });
+
+  test('identifies relevant transactions and recovers sources', async () => {
+    // Transaction 1: Matching nullifier
+    const nullifier = new Nullifier({ inner: new Uint8Array([1, 2, 3]) });
+    const tx1 = new Transaction({
+      body: new TransactionBody({
+        actions: [
+          new Action({
+            action: {
+              case: 'spend',
+              value: new Spend({
+                body: new SpendBody({
+                  nullifier,
+                }),
+              }),
+            },
+          }),
+        ],
+      }),
+    });
+
+    // Transaction 2: Matching commitment
+    const commitment = new StateCommitment({ inner: new Uint8Array([4, 5, 6]) });
+    const tx2 = new Transaction({
+      body: new TransactionBody({
+        actions: [
+          new Action({
+            action: {
+              case: 'output',
+              value: new Output({
+                body: new OutputBody({
+                  notePayload: {
+                    noteCommitment: commitment,
+                  },
+                }),
+              }),
+            },
+          }),
+        ],
+      }),
+    });
+
+    // Transaction 3: Irrelevant commitment
+    const tx3 = new Transaction({
+      body: new TransactionBody({
+        actions: [
+          new Action({
+            action: {
+              case: 'output',
+              value: new Output({
+                body: new OutputBody({
+                  notePayload: {
+                    noteCommitment: new StateCommitment({ inner: new Uint8Array([7, 8, 9]) }),
+                  },
+                }),
+              }),
+            },
+          }),
+        ],
+      }),
+    });
+
+    // Transaction 4: Irrelevant nullifier
+    const tx4 = new Transaction({
+      body: new TransactionBody({
+        actions: [
+          new Action({
+            action: {
+              case: 'spend',
+              value: new Spend({
+                body: new SpendBody({
+                  nullifier: new Nullifier({ inner: new Uint8Array([4, 5, 6]) }),
+                }),
+              }),
+            },
+          }),
+        ],
+      }),
+    });
+
+    const spentNullifiers = new Set<Nullifier>([nullifier]);
+
+    const spendableNoteRecord = new SpendableNoteRecord({
+      source: BLANK_TX_SOURCE,
+    });
+
+    const commitmentRecords = new Map<StateCommitment, SpendableNoteRecord | SwapRecord>([
+      [commitment, spendableNoteRecord], // Expecting match
+      [new StateCommitment({ inner: new Uint8Array([1, 6, 9]) }), new SpendableNoteRecord()], // not expecting match
+    ]);
+
+    const spentNullifiersBeforeSize = spentNullifiers.size;
+    const commitmentRecordsBeforeSize = commitmentRecords.size;
+    const result = await identifyTransactions(spentNullifiers, commitmentRecords, [
+      tx1, // relevant
+      tx2, // relevant
+      tx3, // not
+      tx4, // not
+    ]);
+
+    expect(result.relevantTxs.length).toBe(2);
+    expect(result.recoveredSourceRecords.length).toBe(1);
+
+    // Source was recovered
+    expect(result.recoveredSourceRecords[0]!.source?.equals(BLANK_TX_SOURCE)).toEqual(false);
+
+    // Expect inputs where not mutated
+    expect(spentNullifiersBeforeSize).toEqual(spentNullifiers.size);
+    expect(commitmentRecordsBeforeSize).toEqual(commitmentRecords.size);
+  });
+});

--- a/packages/query/src/helpers/identify-txs.ts
+++ b/packages/query/src/helpers/identify-txs.ts
@@ -1,0 +1,137 @@
+import {
+  CommitmentSource,
+  Nullifier,
+} from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
+import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
+import { SpendableNoteRecord, SwapRecord } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
+import { sha256Hash } from '@penumbra-zone/crypto-web/sha256';
+
+const BLANK_TX_SOURCE = new CommitmentSource({
+  source: { case: 'transaction', value: { id: new Uint8Array() } },
+});
+
+// Used as a type-check helper as .filter(Boolean) still results with undefined as a possible value
+const isDefined = <T>(value: T | null | undefined): value is NonNullable<T> =>
+  value !== null && value !== undefined;
+
+export const getCommitmentsFromActions = (tx: Transaction): StateCommitment[] => {
+  if (!tx.body?.actions) {
+    return [];
+  }
+
+  return tx.body.actions
+    .flatMap(({ action }) => {
+      switch (action.case) {
+        case 'output':
+          return action.value.body?.notePayload?.noteCommitment;
+        case 'swap':
+          return action.value.body?.payload?.commitment;
+        case 'swapClaim':
+          return [action.value.body?.output1Commitment, action.value.body?.output2Commitment];
+        default:
+          return;
+      }
+    })
+    .filter(isDefined);
+};
+
+export const getNullifiersFromActions = (tx: Transaction): Nullifier[] => {
+  if (!tx.body?.actions) {
+    return [];
+  }
+
+  return tx.body.actions
+    .flatMap(({ action }) => {
+      switch (action.case) {
+        case 'spend':
+        case 'swapClaim':
+          return action.value.body?.nullifier;
+        default:
+          return;
+      }
+    })
+    .filter(isDefined);
+};
+
+export interface RelevantTx {
+  id: TransactionId;
+  data: Transaction;
+}
+
+type RecoveredSourceRecords = (SpendableNoteRecord | SwapRecord)[];
+
+const generateTxId = async (tx: Transaction): Promise<TransactionId> => {
+  return new TransactionId({ inner: await sha256Hash(tx.toBinary()) });
+};
+
+const searchRelevant = async (
+  tx: Transaction,
+  spentNullifiers: Set<Nullifier>,
+  commitmentRecords: Map<StateCommitment, SpendableNoteRecord | SwapRecord>,
+): Promise<
+  { relevantTx: RelevantTx; recoveredSourceRecords: RecoveredSourceRecords } | undefined
+> => {
+  let txId: TransactionId | undefined; // If set, that means this tx is relevant and should be returned to the caller
+  const recoveredSourceRecords: RecoveredSourceRecords = [];
+
+  const txNullifiers = getNullifiersFromActions(tx);
+  for (const spentNullifier of spentNullifiers) {
+    if (txNullifiers.some(txNullifier => spentNullifier.equals(txNullifier))) {
+      txId ??= await generateTxId(tx);
+    }
+  }
+
+  const txCommitments = getCommitmentsFromActions(tx);
+  for (const [stateCommitment, spendableNoteRecord] of commitmentRecords) {
+    if (txCommitments.some(txCommitment => stateCommitment.equals(txCommitment))) {
+      txId ??= await generateTxId(tx);
+
+      // Blank sources can be recovered by associating them with the transaction
+      if (BLANK_TX_SOURCE.equals(spendableNoteRecord.source)) {
+        const recovered = spendableNoteRecord.clone();
+        recovered.source = new CommitmentSource({
+          source: { case: 'transaction', value: { id: txId.inner } },
+        });
+        recoveredSourceRecords.push(recovered);
+      }
+    }
+  }
+
+  if (txId) {
+    return {
+      relevantTx: { id: txId, data: tx },
+      recoveredSourceRecords,
+    };
+  }
+
+  return undefined;
+};
+
+// identify transactions that involve a new record by comparing nullifiers and state commitments
+// also returns records with recovered sources
+export const identifyTransactions = async (
+  spentNullifiers: Set<Nullifier>,
+  commitmentRecords: Map<StateCommitment, SpendableNoteRecord | SwapRecord>,
+  blockTx: Transaction[],
+): Promise<{
+  relevantTxs: RelevantTx[];
+  recoveredSourceRecords: RecoveredSourceRecords;
+}> => {
+  const relevantTxs: RelevantTx[] = [];
+  const recoveredSourceRecords: RecoveredSourceRecords = [];
+
+  const searchPromises = blockTx.map(tx => searchRelevant(tx, spentNullifiers, commitmentRecords));
+  const results = await Promise.all(searchPromises);
+
+  for (const result of results) {
+    if (result?.relevantTx) {
+      relevantTxs.push(result.relevantTx);
+    }
+    if (result?.recoveredSourceRecords.length) {
+      recoveredSourceRecords.push(...result.recoveredSourceRecords);
+    }
+  }
+  return { relevantTxs, recoveredSourceRecords };
+};

--- a/packages/storage/src/indexed-db/config.ts
+++ b/packages/storage/src/indexed-db/config.ts
@@ -2,4 +2,4 @@
  * The version number for the IndexedDB schema. This version number is used to manage
  * database upgrades and ensure that the correct schema version is applied.
  */
-export const IDB_VERSION = 46;
+export const IDB_VERSION = 47;


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/web/issues/1792

We should only be processing transactions that have nullifiers, spends, or swaps we recognize. At the moment, if there is a relevant tx in a block, we later process the entire block. This caused the original issue of an LP position misattributed to the owner when it was external.

Note, we need to version the DB given users may have in their db's LP NFTs and Auction NFTs that happened to be in the same block as another person's. 