### PR TITLE
wasm: handle spend transaction planner requests in planner

### DIFF
--- a/.changeset/blue-onions-return.md
+++ b/.changeset/blue-onions-return.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': minor
+---
+
+add support for spend transaction planner requests in wasm

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -801,8 +801,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -815,8 +815,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -1806,12 +1806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,8 +2081,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2125,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2170,8 +2164,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2200,8 +2194,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2231,8 +2225,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2284,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2300,8 +2294,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2324,8 +2318,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2373,8 +2367,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2408,8 +2402,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "aes",
  "anyhow",
@@ -2452,8 +2446,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2488,8 +2482,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2502,7 +2496,6 @@ dependencies = [
  "ark-std",
  "bech32",
  "decaf377",
- "lazy_static",
  "num-bigint",
  "once_cell",
  "rand",
@@ -2514,8 +2507,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2541,8 +2534,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2574,8 +2567,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2625,8 +2618,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2666,8 +2659,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2694,8 +2687,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2745,8 +2738,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.80.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.0#f8fd4b41c875e395bac4051be0c0cc4cc45e24bc"
+version = "0.80.5"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.5#43f6e9375354b4684d4232e89270244e803175f6"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -14,21 +14,21 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.0", package = "penumbra-transaction", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.5", package = "penumbra-transaction", default-features = false }
 
 anyhow = "1.0.86"
 ark-ff = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -553,7 +553,7 @@ pub async fn plan_transaction_inner<Db: Database>(
         // Safety: check if the requested spend amount is equal to the accumulated note balance.
         if accumulated_note_amounts.to_proto() != value.amount.unwrap() {
             let error_message =
-                format!("Invalid transaction: The transaction was constructed improperly.");
+                "Invalid transaction: The transaction was constructed improperly.".to_string();
             return Err(WasmError::Anyhow(anyhow!(error_message)));
         }
 
@@ -571,7 +571,8 @@ pub async fn plan_transaction_inner<Db: Database>(
             if let ActionPlan::Spend(spend_plan) = action {
                 if spend_plan.note.asset_id() != fee_asset_id {
                     let error_message =
-                        format!("Invalid transaction: The transaction was constructed improperly.");
+                        "Invalid transaction: The transaction was constructed improperly."
+                            .to_string();
                     return Err(WasmError::Anyhow(anyhow!(error_message)));
                 }
             }

--- a/packages/wasm/crate/src/storage.rs
+++ b/packages/wasm/crate/src/storage.rs
@@ -59,6 +59,15 @@ pub struct Storage<Db: Database> {
     tables: Tables,
 }
 
+impl<Db: Database + Clone> Clone for Storage<Db> {
+    fn clone(&self) -> Self {
+        Self {
+            db: self.db.clone(),
+            tables: self.tables.clone(),
+        }
+    }
+}
+
 impl<Db: Database> Storage<Db> {
     pub fn new(db: Db, tables: Tables) -> WasmResult<Self> {
         Ok(Storage { db, tables })

--- a/packages/wasm/crate/tests/test_planner_send_max.rs
+++ b/packages/wasm/crate/tests/test_planner_send_max.rs
@@ -10,7 +10,6 @@ use penumbra_shielded_pool::Note;
 use penumbra_tct::StateCommitment;
 use penumbra_wasm::database::interface::Database;
 use penumbra_wasm::database::mock::{get_mock_tables, MockDb};
-use penumbra_wasm::error::WasmError;
 use penumbra_wasm::note_record::SpendableNoteRecord;
 use penumbra_wasm::planner::plan_transaction_inner;
 use penumbra_wasm::storage::{byte_array_to_base64, Storage, Tables};
@@ -21,7 +20,7 @@ mod utils;
 use penumbra_asset::asset::Metadata;
 use penumbra_proto::core::asset::v1 as pb;
 use penumbra_proto::DomainType;
-
+use penumbra_transaction::ActionPlan;
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /////////////////////////////////////////////// SETUP ENVIRONMENT //////////////////////////////////////////////////////
@@ -253,7 +252,167 @@ async fn setup_env_zero_val_notes(mock_db: &MockDb, tables: &Tables) {
         .unwrap();
 }
 
-/////////////////////////////////////////////// SPEND AMOUNT VALIDATION ////////////////////////////////////////////////
+/////////////////////////////////////////////// CONSTRAINT 1: EMPTY ACTIONLIST /////////////////////////////////////////
+///                                                                                                                  ///
+/// This is the first safety check we have in-place, enforcing that the Spend transaction planner request            ///
+/// is constructed in isolation. ie. the Spend transaction will fail if you attempt to construct a transaction       ///
+/// planner request with multiple different actions plans.                                                           ///
+///                                                                                                                  ///
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// #[wasm_bindgen_test]
+// async fn test_multiple_action_plans_in_transaction_request() {
+//     let mock_db = MockDb::new();
+//     let tables = get_mock_tables();
+
+//     setup_env_native_staking_only(&mock_db, &tables).await;
+
+//     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+//     let reciever_address = &Address::dummy(&mut OsRng);
+
+//     let fee_id = *STAKING_TOKEN_ASSET_ID;
+
+//     #[allow(deprecated)]
+//     let invalid_request = TransactionPlannerRequest {
+//         expiry_height: 0,
+//         memo: None,
+//         source: None,
+//         outputs: vec![
+//             Output {
+//                 address: Some(reciever_address.into()),
+//                 value: Some(
+//                     Value {
+//                         amount: 1558828u64.into(),
+//                         asset_id: fee_id,
+//                     }
+//                     .into(),
+//                 ),
+//             }
+//         ],
+//         spends: vec![
+//             Spend {
+//                 address: Some(reciever_address.into()),
+//                 value: Some(
+//                     Value {
+//                         amount: 1558828u64.into(),
+//                         asset_id: fee_id,
+//                     }
+//                     .into(),
+//                 ),
+//             }
+//         ],
+//         swaps: vec![],
+//         swap_claims: vec![],
+//         delegations: vec![],
+//         undelegations: vec![],
+//         undelegation_claims: vec![],
+//         ibc_relay_actions: vec![],
+//         ics20_withdrawals: vec![],
+//         position_opens: vec![],
+//         position_closes: vec![],
+//         position_withdraws: vec![],
+//         dutch_auction_schedule_actions: vec![],
+//         dutch_auction_end_actions: vec![],
+//         dutch_auction_withdraw_actions: vec![],
+//         delegator_votes: vec![],
+//         epoch_index: 0,
+//         epoch: None,
+//         fee_mode: None,
+//     };
+//     let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+//     let invalid_response = plan_transaction_inner(
+//         storage.clone(),
+//         invalid_request,
+//         full_viewing_key.clone(),
+//         fee_id,
+//     )
+//     .await;
+
+//     let error_message = invalid_response.unwrap_err().to_string();
+//     assert!(error_message.contains("Invalid transaction: Spend action must be the only action in the planner request."));
+// }
+
+/////////////////////////////////////////////// CONSTRAINT 2: MULTIPLE SPEND REQUESTS //////////////////////////////////
+///                                                                                                                  ///
+/// This is the second safety check we have in-place, enforcing that the transaction planner request is              ///
+/// constructed with a single spend request.                                                                         ///
+///                                                                                                                  ///
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// #[wasm_bindgen_test]
+// async fn test_multiple_spend_requests() {
+//     let mock_db = MockDb::new();
+//     let tables = get_mock_tables();
+
+//     setup_env_native_staking_only(&mock_db, &tables).await;
+
+//     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+//     let reciever_address = &Address::dummy(&mut OsRng);
+
+//     let fee_id = *STAKING_TOKEN_ASSET_ID;
+
+//     #[allow(deprecated)]
+//     let invalid_request = TransactionPlannerRequest {
+//         expiry_height: 0,
+//         memo: None,
+//         source: None,
+//         outputs: vec![],
+//         spends: vec![
+//             Spend {
+//                 address: Some(reciever_address.into()),
+//                 value: Some(
+//                     Value {
+//                         amount: 1558828u64.into(),
+//                         asset_id: fee_id,
+//                     }
+//                     .into(),
+//                 ),
+//             },
+//             Spend {
+//                 address: Some(reciever_address.into()),
+//                 value: Some(
+//                     Value {
+//                         amount: 1558828u64.into(),
+//                         asset_id: fee_id,
+//                     }
+//                     .into(),
+//                 ),
+//             },
+//         ],
+//         swaps: vec![],
+//         swap_claims: vec![],
+//         delegations: vec![],
+//         undelegations: vec![],
+//         undelegation_claims: vec![],
+//         ibc_relay_actions: vec![],
+//         ics20_withdrawals: vec![],
+//         position_opens: vec![],
+//         position_closes: vec![],
+//         position_withdraws: vec![],
+//         dutch_auction_schedule_actions: vec![],
+//         dutch_auction_end_actions: vec![],
+//         dutch_auction_withdraw_actions: vec![],
+//         delegator_votes: vec![],
+//         epoch_index: 0,
+//         epoch: None,
+//         fee_mode: None,
+//     };
+//     let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+//     let invalid_response = plan_transaction_inner(
+//         storage.clone(),
+//         invalid_request,
+//         full_viewing_key.clone(),
+//         fee_id,
+//     )
+//     .await;
+
+//     let error_message = invalid_response.unwrap_err().to_string();
+//     assert!(error_message.contains("Invalid transaction: only one Spend action allowed in planner request."));
+// }
+
+/////////////////////////////////////////////// CONSTRAINT 3: SPEND AMOUNT VALIDATION //////////////////////////////////
 ///                                                                                                                  ///
 /// This is the first safety check we have in-place, verifying that the user's request spend amount                  ///
 /// is exactly equal to the total accumulated note balance.                                                          ///
@@ -263,11 +422,9 @@ async fn setup_env_zero_val_notes(mock_db: &MockDb, tables: &Tables) {
 ///                                                                                                                  ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Constructs two transaction planner requests: the first sends the entire balance of the native
-/// staking token, successfully creating a fully-formed transaction plan; the second attempts a
-/// partial spend, resulting in an appropriate error.
+/// Sends the entire balance of the native staking token, successfully creating a fully-formed transaction plan.
 #[wasm_bindgen_test]
-async fn test_spend_amount_validation_with_native_token() {
+async fn test_valid_spend_amount_validation_with_native_token() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
@@ -275,6 +432,8 @@ async fn test_spend_amount_validation_with_native_token() {
 
     let storage = Storage::new(mock_db, tables).unwrap();
     let reciever_address = &Address::dummy(&mut OsRng);
+
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
 
     #[allow(deprecated)]
     let valid_request = TransactionPlannerRequest {
@@ -312,9 +471,7 @@ async fn test_spend_amount_validation_with_native_token() {
     };
     let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
 
-    let fee_id = *STAKING_TOKEN_ASSET_ID;
-
-    let valid_response = plan_transaction_inner(
+    let valid_response: penumbra_transaction::TransactionPlan = plan_transaction_inner(
         storage.clone(),
         valid_request,
         full_viewing_key.clone(),
@@ -324,6 +481,35 @@ async fn test_spend_amount_validation_with_native_token() {
     .unwrap();
 
     assert_eq!(valid_response.actions.len(), 3);
+
+    // Filter the actions to get only the Output actions
+    let output_actions: Vec<_> = valid_response
+        .actions
+        .iter()
+        .filter(|action| matches!(action, ActionPlan::Output(_)))
+        .collect();
+
+    // Assert that there is exactly one Output action
+    assert_eq!(output_actions.len(), 1);
+
+    // Check if the output action correctly overwrites the change destination address
+    if let Some(ActionPlan::Output(output_plan)) = output_actions.first() {
+        assert_eq!(output_plan.dest_address, *reciever_address);
+    }
+}
+
+/// Attempts a partial max spend, resulting in an appropriate error.
+#[wasm_bindgen_test]
+async fn test_invalid_spend_amount_validation_with_native_token() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
+
+    setup_env_native_staking_only(&mock_db, &tables).await;
+
+    let storage = Storage::new(mock_db, tables).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
+
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
 
     #[allow(deprecated)]
     let invalid_request = TransactionPlannerRequest {
@@ -359,20 +545,17 @@ async fn test_spend_amount_validation_with_native_token() {
         epoch: None,
         fee_mode: None,
     };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
 
     let invalid_response =
         plan_transaction_inner(storage, invalid_request, full_viewing_key, fee_id).await;
 
-    match invalid_response {
-        Ok(_) => panic!(),
-        Err(e) => {
-            if let WasmError::Anyhow(err) = e {
-                let error_message = err.to_string();
-                assert!(error_message
-                    .contains("Invalid transaction: The transaction was constructed improperly."));
-            }
-        }
-    }
+    let error_message = invalid_response.unwrap_err().to_string();
+    assert!(error_message.contains(
+        "Invalid transaction: The requested spend amount does not match the available balance."
+    ));
 }
 
 /// Constructs two transaction planner requests: the first sends the entire balance of an alternative
@@ -461,6 +644,21 @@ async fn test_spend_amount_validation_with_alternative_token() {
 
     assert_eq!(valid_response.actions.len(), 3);
 
+    // Filter the actions to get only the Output actions
+    let output_actions: Vec<_> = valid_response
+        .actions
+        .iter()
+        .filter(|action| matches!(action, ActionPlan::Output(_)))
+        .collect();
+
+    // Assert that there is exactly one Output action
+    assert_eq!(output_actions.len(), 1);
+
+    // Check if the output action correctly overwrites the change destination address
+    if let Some(ActionPlan::Output(output_plan)) = output_actions.first() {
+        assert_eq!(output_plan.dest_address, *reciever_address);
+    }
+
     #[allow(deprecated)]
     let invalid_request = TransactionPlannerRequest {
         expiry_height: 0,
@@ -499,30 +697,23 @@ async fn test_spend_amount_validation_with_alternative_token() {
     let invalid_response =
         plan_transaction_inner(storage, invalid_request, full_viewing_key, fee_id).await;
 
-    match invalid_response {
-        Ok(_) => panic!(),
-        Err(e) => {
-            if let WasmError::Anyhow(err) = e {
-                let error_message = err.to_string();
-                assert!(error_message
-                    .contains("Invalid transaction: The transaction was constructed improperly."));
-            }
-        }
-    }
+    let error_message = invalid_response.unwrap_err().to_string();
+    assert!(error_message.contains(
+        "Invalid transaction: The requested spend amount does not match the available balance."
+    ));
 }
 
-/////////////////////////////////////////////// ASSET ID VALIDATION /////////////////////////////////////////////////////
+/////////////////////////////////////////////// CONSTRAINT 4: ASSET ID VALIDATION ///////////////////////////////////////
 ///                                                                                                                   ///
 /// This sanity checks the second safety check we have in-place, verifying that each spend action's asset ID          ///
 /// matches the fee asset ID.                                                                                         ///
 ///                                                                                                                   ///
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Constructs two transaction planner requests: the first, where the asset ID matches the fee asset ID,
-/// successfully creates a fully-formed transaction plan; the second, where the asset ID does not match
-/// the fee asset ID, results in an appropriate error.
+/// Constructs a transaction planner request where the asset ID does not match the fee asset ID, results
+/// in an appropriate error.
 #[wasm_bindgen_test]
-async fn test_fee_asset_id_validation() {
+async fn test_invalid_fee_asset_id_validation() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
@@ -601,16 +792,10 @@ async fn test_fee_asset_id_validation() {
     )
     .await;
 
-    match invalid_response {
-        Ok(_) => panic!(),
-        Err(e) => {
-            if let WasmError::Anyhow(err) = e {
-                let error_message = err.to_string();
-                assert!(error_message
-                    .contains("Invalid transaction: The transaction was constructed improperly."));
-            }
-        }
-    }
+    let error_message = invalid_response.unwrap_err().to_string();
+    assert!(error_message.contains(
+        "Invalid transaction: The asset ID for the spend action does not match the fee asset ID."
+    ));
 }
 
 /////////////////////////////////////////////// FILTER ZERO-VALUED NOTES VALIDATION ////////////////////////////////////
@@ -633,7 +818,7 @@ async fn test_filter_zero_value_notes() {
     let fee_id = *STAKING_TOKEN_ASSET_ID;
 
     #[allow(deprecated)]
-    let invalid_request = TransactionPlannerRequest {
+    let valid_request = TransactionPlannerRequest {
         expiry_height: 0,
         memo: None,
         source: None,
@@ -668,16 +853,31 @@ async fn test_filter_zero_value_notes() {
     };
     let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
 
-    let invalid_response = plan_transaction_inner(
+    let valid_response = plan_transaction_inner(
         storage.clone(),
-        invalid_request,
+        valid_request,
         full_viewing_key.clone(),
         fee_id,
     )
     .await
     .unwrap();
 
-    assert_eq!(invalid_response.actions.len(), 3);
+    assert_eq!(valid_response.actions.len(), 3);
+
+    // Filter the actions to get only the Output actions
+    let output_actions: Vec<_> = valid_response
+        .actions
+        .iter()
+        .filter(|action| matches!(action, ActionPlan::Output(_)))
+        .collect();
+
+    // Assert that there is exactly one Output action
+    assert_eq!(output_actions.len(), 1);
+
+    // Check if the output action correctly overwrites the change destination address
+    if let Some(ActionPlan::Output(output_plan)) = output_actions.first() {
+        assert_eq!(output_plan.dest_address, *reciever_address);
+    }
 }
 
 #[wasm_bindgen_test]
@@ -736,94 +936,8 @@ async fn test_empty_note_set() {
     )
     .await;
 
-    match invalid_response {
-        Ok(_) => panic!(),
-        Err(e) => {
-            if let WasmError::Anyhow(err) = e {
-                let error_message = err.to_string();
-                assert!(error_message
-                    .contains("Invalid transaction: The transaction was constructed improperly."));
-            }
-        }
-    }
-}
-
-#[wasm_bindgen_test]
-async fn test_multiple_spend_requests() {
-    let mock_db = MockDb::new();
-    let tables = get_mock_tables();
-
-    setup_env_native_staking_only(&mock_db, &tables).await;
-
-    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
-    let reciever_address = &Address::dummy(&mut OsRng);
-
-    let fee_id = *STAKING_TOKEN_ASSET_ID;
-
-    #[allow(deprecated)]
-    let invalid_request = TransactionPlannerRequest {
-        expiry_height: 0,
-        memo: None,
-        source: None,
-        outputs: vec![],
-        spends: vec![
-            Spend {
-                address: Some(reciever_address.into()),
-                value: Some(
-                    Value {
-                        amount: 1558828u64.into(),
-                        asset_id: fee_id,
-                    }
-                    .into(),
-                ),
-            },
-            Spend {
-                address: Some(reciever_address.into()),
-                value: Some(
-                    Value {
-                        amount: 1558828u64.into(),
-                        asset_id: fee_id,
-                    }
-                    .into(),
-                ),
-            },
-        ],
-        swaps: vec![],
-        swap_claims: vec![],
-        delegations: vec![],
-        undelegations: vec![],
-        undelegation_claims: vec![],
-        ibc_relay_actions: vec![],
-        ics20_withdrawals: vec![],
-        position_opens: vec![],
-        position_closes: vec![],
-        position_withdraws: vec![],
-        dutch_auction_schedule_actions: vec![],
-        dutch_auction_end_actions: vec![],
-        dutch_auction_withdraw_actions: vec![],
-        delegator_votes: vec![],
-        epoch_index: 0,
-        epoch: None,
-        fee_mode: None,
-    };
-    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
-
-    let invalid_response = plan_transaction_inner(
-        storage.clone(),
-        invalid_request,
-        full_viewing_key.clone(),
-        fee_id,
-    )
-    .await;
-
-    match invalid_response {
-        Ok(_) => panic!(),
-        Err(e) => {
-            if let WasmError::Anyhow(err) = e {
-                let error_message = err.to_string();
-                assert!(error_message
-                    .contains("Invalid transaction: The transaction was constructed improperly."));
-            }
-        }
-    }
+    let error_message = invalid_response.unwrap_err().to_string();
+    assert!(error_message.contains(
+        "Invalid transaction: The requested spend amount does not match the available balance."
+    ));
 }

--- a/packages/wasm/crate/tests/test_planner_send_max.rs
+++ b/packages/wasm/crate/tests/test_planner_send_max.rs
@@ -3,6 +3,7 @@ use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_fee::GasPrices;
 use penumbra_keys::Address;
 use penumbra_keys::FullViewingKey;
+use penumbra_proto::view::v1::transaction_planner_request::Output;
 use penumbra_proto::view::v1::transaction_planner_request::Spend;
 use penumbra_proto::view::v1::TransactionPlannerRequest;
 use penumbra_sct::{CommitmentSource, Nullifier};
@@ -260,78 +261,76 @@ async fn setup_env_zero_val_notes(mock_db: &MockDb, tables: &Tables) {
 ///                                                                                                                  ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// #[wasm_bindgen_test]
-// async fn test_multiple_action_plans_in_transaction_request() {
-//     let mock_db = MockDb::new();
-//     let tables = get_mock_tables();
+#[wasm_bindgen_test]
+async fn test_multiple_action_plans_in_transaction_request() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
 
-//     setup_env_native_staking_only(&mock_db, &tables).await;
+    setup_env_native_staking_only(&mock_db, &tables).await;
 
-//     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
-//     let reciever_address = &Address::dummy(&mut OsRng);
+    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
 
-//     let fee_id = *STAKING_TOKEN_ASSET_ID;
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
 
-//     #[allow(deprecated)]
-//     let invalid_request = TransactionPlannerRequest {
-//         expiry_height: 0,
-//         memo: None,
-//         source: None,
-//         outputs: vec![
-//             Output {
-//                 address: Some(reciever_address.into()),
-//                 value: Some(
-//                     Value {
-//                         amount: 1558828u64.into(),
-//                         asset_id: fee_id,
-//                     }
-//                     .into(),
-//                 ),
-//             }
-//         ],
-//         spends: vec![
-//             Spend {
-//                 address: Some(reciever_address.into()),
-//                 value: Some(
-//                     Value {
-//                         amount: 1558828u64.into(),
-//                         asset_id: fee_id,
-//                     }
-//                     .into(),
-//                 ),
-//             }
-//         ],
-//         swaps: vec![],
-//         swap_claims: vec![],
-//         delegations: vec![],
-//         undelegations: vec![],
-//         undelegation_claims: vec![],
-//         ibc_relay_actions: vec![],
-//         ics20_withdrawals: vec![],
-//         position_opens: vec![],
-//         position_closes: vec![],
-//         position_withdraws: vec![],
-//         dutch_auction_schedule_actions: vec![],
-//         dutch_auction_end_actions: vec![],
-//         dutch_auction_withdraw_actions: vec![],
-//         delegator_votes: vec![],
-//         epoch_index: 0,
-//         epoch: None,
-//         fee_mode: None,
-//     };
-//     let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+    #[allow(deprecated)]
+    let invalid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![Output {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: fee_id,
+                }
+                .into(),
+            ),
+        }],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: fee_id,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
 
-//     let invalid_response = plan_transaction_inner(
-//         storage.clone(),
-//         invalid_request,
-//         full_viewing_key.clone(),
-//         fee_id,
-//     )
-//     .await;
+    let invalid_response = plan_transaction_inner(
+        storage.clone(),
+        invalid_request,
+        full_viewing_key.clone(),
+        fee_id,
+    )
+    .await;
 
-//     let error_message = invalid_response.unwrap_err().to_string();
-//     assert!(error_message.contains("Invalid transaction: Spend action must be the only action in the planner request."));
-// }
+    let error_message = invalid_response.unwrap_err().to_string();
+    assert!(error_message.contains(
+        "Invalid transaction: Spend action must be the only action in the planner request."
+    ));
+}
 
 /////////////////////////////////////////////// CONSTRAINT 2: MULTIPLE SPEND REQUESTS //////////////////////////////////
 ///                                                                                                                  ///
@@ -340,77 +339,78 @@ async fn setup_env_zero_val_notes(mock_db: &MockDb, tables: &Tables) {
 ///                                                                                                                  ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// #[wasm_bindgen_test]
-// async fn test_multiple_spend_requests() {
-//     let mock_db = MockDb::new();
-//     let tables = get_mock_tables();
+#[wasm_bindgen_test]
+async fn test_multiple_spend_requests() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
 
-//     setup_env_native_staking_only(&mock_db, &tables).await;
+    setup_env_native_staking_only(&mock_db, &tables).await;
 
-//     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
-//     let reciever_address = &Address::dummy(&mut OsRng);
+    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
 
-//     let fee_id = *STAKING_TOKEN_ASSET_ID;
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
 
-//     #[allow(deprecated)]
-//     let invalid_request = TransactionPlannerRequest {
-//         expiry_height: 0,
-//         memo: None,
-//         source: None,
-//         outputs: vec![],
-//         spends: vec![
-//             Spend {
-//                 address: Some(reciever_address.into()),
-//                 value: Some(
-//                     Value {
-//                         amount: 1558828u64.into(),
-//                         asset_id: fee_id,
-//                     }
-//                     .into(),
-//                 ),
-//             },
-//             Spend {
-//                 address: Some(reciever_address.into()),
-//                 value: Some(
-//                     Value {
-//                         amount: 1558828u64.into(),
-//                         asset_id: fee_id,
-//                     }
-//                     .into(),
-//                 ),
-//             },
-//         ],
-//         swaps: vec![],
-//         swap_claims: vec![],
-//         delegations: vec![],
-//         undelegations: vec![],
-//         undelegation_claims: vec![],
-//         ibc_relay_actions: vec![],
-//         ics20_withdrawals: vec![],
-//         position_opens: vec![],
-//         position_closes: vec![],
-//         position_withdraws: vec![],
-//         dutch_auction_schedule_actions: vec![],
-//         dutch_auction_end_actions: vec![],
-//         dutch_auction_withdraw_actions: vec![],
-//         delegator_votes: vec![],
-//         epoch_index: 0,
-//         epoch: None,
-//         fee_mode: None,
-//     };
-//     let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+    #[allow(deprecated)]
+    let invalid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![
+            Spend {
+                address: Some(reciever_address.into()),
+                value: Some(
+                    Value {
+                        amount: 1558828u64.into(),
+                        asset_id: fee_id,
+                    }
+                    .into(),
+                ),
+            },
+            Spend {
+                address: Some(reciever_address.into()),
+                value: Some(
+                    Value {
+                        amount: 1558828u64.into(),
+                        asset_id: fee_id,
+                    }
+                    .into(),
+                ),
+            },
+        ],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
 
-//     let invalid_response = plan_transaction_inner(
-//         storage.clone(),
-//         invalid_request,
-//         full_viewing_key.clone(),
-//         fee_id,
-//     )
-//     .await;
+    let invalid_response = plan_transaction_inner(
+        storage.clone(),
+        invalid_request,
+        full_viewing_key.clone(),
+        fee_id,
+    )
+    .await;
 
-//     let error_message = invalid_response.unwrap_err().to_string();
-//     assert!(error_message.contains("Invalid transaction: only one Spend action allowed in planner request."));
-// }
+    let error_message = invalid_response.unwrap_err().to_string();
+    assert!(error_message
+        .contains("Invalid transaction: only one Spend action allowed in planner request."));
+}
 
 /////////////////////////////////////////////// CONSTRAINT 3: SPEND AMOUNT VALIDATION //////////////////////////////////
 ///                                                                                                                  ///

--- a/packages/wasm/crate/tests/test_planner_send_max.rs
+++ b/packages/wasm/crate/tests/test_planner_send_max.rs
@@ -34,7 +34,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Populate database with only native staking token.
-async fn setup_env_1(mock_db: &MockDb, tables: &Tables) {
+async fn setup_env_native_staking_only(mock_db: &MockDb, tables: &Tables) {
     seed_params_in_db(mock_db, tables).await;
 
     let sender_address = &Address::dummy(&mut OsRng);
@@ -96,7 +96,7 @@ async fn setup_env_1(mock_db: &MockDb, tables: &Tables) {
 }
 
 /// Populate database with only alternative fee token.
-async fn setup_env_2(mock_db: &MockDb, tables: &Tables) {
+async fn setup_env_alt_fee(mock_db: &MockDb, tables: &Tables) {
     seed_params_in_db(mock_db, tables).await;
 
     let sender_address = &Address::dummy(&mut OsRng);
@@ -165,7 +165,7 @@ async fn setup_env_2(mock_db: &MockDb, tables: &Tables) {
 }
 
 /// Populate database with native staking token and dummy zero-valued notes.
-async fn setup_env_3(mock_db: &MockDb, tables: &Tables) {
+async fn setup_env_zero_val_notes(mock_db: &MockDb, tables: &Tables) {
     seed_params_in_db(mock_db, tables).await;
 
     let sender_address = &Address::dummy(&mut OsRng);
@@ -271,7 +271,7 @@ async fn test_spend_amount_validation_with_native_token() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
-    setup_env_1(&mock_db, &tables).await;
+    setup_env_native_staking_only(&mock_db, &tables).await;
 
     let storage = Storage::new(mock_db, tables).unwrap();
     let reciever_address = &Address::dummy(&mut OsRng);
@@ -383,7 +383,7 @@ async fn test_spend_amount_validation_with_alternative_token() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
-    setup_env_2(&mock_db, &tables).await;
+    setup_env_alt_fee(&mock_db, &tables).await;
 
     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
     let reciever_address = &Address::dummy(&mut OsRng);
@@ -526,7 +526,7 @@ async fn test_fee_asset_id_validation() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
-    setup_env_1(&mock_db, &tables).await;
+    setup_env_native_staking_only(&mock_db, &tables).await;
 
     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
     let reciever_address = &Address::dummy(&mut OsRng);
@@ -625,7 +625,7 @@ async fn test_filter_zero_value_notes() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
-    setup_env_3(&mock_db, &tables).await;
+    setup_env_zero_val_notes(&mock_db, &tables).await;
 
     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
     let reciever_address = &Address::dummy(&mut OsRng);
@@ -753,7 +753,7 @@ async fn test_multiple_spend_requests() {
     let mock_db = MockDb::new();
     let tables = get_mock_tables();
 
-    setup_env_1(&mock_db, &tables).await;
+    setup_env_native_staking_only(&mock_db, &tables).await;
 
     let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
     let reciever_address = &Address::dummy(&mut OsRng);

--- a/packages/wasm/crate/tests/test_planner_send_max.rs
+++ b/packages/wasm/crate/tests/test_planner_send_max.rs
@@ -1,0 +1,738 @@
+use crate::utils::planner_setup::seed_params_in_db;
+use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_fee::GasPrices;
+use penumbra_keys::Address;
+use penumbra_keys::FullViewingKey;
+use penumbra_proto::view::v1::transaction_planner_request::Spend;
+use penumbra_proto::view::v1::TransactionPlannerRequest;
+use penumbra_sct::{CommitmentSource, Nullifier};
+use penumbra_shielded_pool::Note;
+use penumbra_tct::StateCommitment;
+use penumbra_wasm::database::interface::Database;
+use penumbra_wasm::database::mock::{get_mock_tables, MockDb};
+use penumbra_wasm::error::WasmError;
+use penumbra_wasm::note_record::SpendableNoteRecord;
+use penumbra_wasm::planner::plan_transaction_inner;
+use penumbra_wasm::storage::{byte_array_to_base64, Storage, Tables};
+use rand_core::OsRng;
+use std::str::FromStr;
+use wasm_bindgen_test::wasm_bindgen_test;
+mod utils;
+use penumbra_asset::asset::Metadata;
+use penumbra_proto::core::asset::v1 as pb;
+use penumbra_proto::DomainType;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+/////////////////////////////////////////////// SETUP ENVIRONMENT //////////////////////////////////////////////////////
+///                                                                                                                  ///
+/// To comprehensively cover the domain space, construct various accounts with note balances comprising:             ///
+///     1. Only the native staking token,                                                                            ///
+///     2. Only the alternative fee token,                                                                           ///
+///     3. Both the native staking token and the alternative fee token,                                              ///    
+///     4. Empty note balance                                                                                        ///
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Populate database with only native staking token.
+async fn setup_env_1(mock_db: &MockDb, tables: &Tables) {
+    seed_params_in_db(mock_db, tables).await;
+
+    let sender_address = &Address::dummy(&mut OsRng);
+
+    let fee_note = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 1u64.into(),
+                asset_id: *STAKING_TOKEN_ASSET_ID,
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            76, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    let fee_note_2 = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 1558827u64.into(),
+                asset_id: *STAKING_TOKEN_ASSET_ID,
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            75, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note", &fee_note)
+        .await
+        .unwrap();
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note_2", &fee_note_2)
+        .await
+        .unwrap();
+}
+
+/// Populate database with only alternative fee token.
+async fn setup_env_2(mock_db: &MockDb, tables: &Tables) {
+    seed_params_in_db(mock_db, tables).await;
+
+    let sender_address = &Address::dummy(&mut OsRng);
+
+    let metadata_in_db_proto = pb::Metadata {
+        base: "penumbravalid1hz2hqlgx4w55vkxzv0n3u93czlkvm6zpgftyny2psg3dp8vcygxqd7fedt"
+            .to_string(),
+        ..Default::default()
+    };
+    let metadata: Metadata = metadata_in_db_proto.clone().try_into().unwrap();
+
+    let fee_note = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 1u64.into(),
+                asset_id: metadata.id(),
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            76, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    let fee_note_2 = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 1558827u64.into(),
+                asset_id: metadata.id(),
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            75, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note", &fee_note)
+        .await
+        .unwrap();
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note_2", &fee_note_2)
+        .await
+        .unwrap();
+}
+
+/// Populate database with native staking token and dummy zero-valued notes.
+async fn setup_env_3(mock_db: &MockDb, tables: &Tables) {
+    seed_params_in_db(mock_db, tables).await;
+
+    let sender_address = &Address::dummy(&mut OsRng);
+
+    let fee_note = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 1u64.into(),
+                asset_id: *STAKING_TOKEN_ASSET_ID,
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            76, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    let fee_note_2 = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 1558827u64.into(),
+                asset_id: *STAKING_TOKEN_ASSET_ID,
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            75, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    let fee_note_3 = SpendableNoteRecord {
+        note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
+        note: Note::generate(
+            &mut OsRng,
+            &sender_address,
+            Value {
+                amount: 0u64.into(),
+                asset_id: *STAKING_TOKEN_ASSET_ID,
+            },
+        ),
+        address_index: Default::default(),
+        nullifier: Nullifier::try_from(vec![
+            78, 12, 37, 160, 207, 93, 129, 238, 230, 254, 29, 227, 107, 97, 138, 12, 172, 130, 138,
+            66, 123, 217, 253, 148, 178, 91, 112, 125, 247, 32, 189, 2,
+        ])
+        .unwrap(),
+        height_created: 0,
+        height_spent: None,
+        position: Default::default(),
+        source: CommitmentSource::Genesis,
+        return_address: None,
+    };
+
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note", &fee_note)
+        .await
+        .unwrap();
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note_2", &fee_note_2)
+        .await
+        .unwrap();
+    mock_db
+        .put_with_key(&tables.spendable_notes, "fee_note_3", &fee_note_3)
+        .await
+        .unwrap();
+}
+
+/////////////////////////////////////////////// SPEND AMOUNT VALIDATION ////////////////////////////////////////////////
+///                                                                                                                  ///
+/// This is the first safety check we have in-place, verifying that the user's request spend amount                  ///
+/// is exactly equal to the total accumulated note balance.                                                          ///
+///                                                                                                                  ///  
+/// (1) "Exact Match": requested spend amount === total accumulated notes, planner is constructed successfully.      ///
+/// (2) "Non-Exact Match": requested spend amount !=== total accumulated notes, planner handles the error properly.  ///
+///                                                                                                                  ///
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Constructs two transaction planner requests: the first sends the entire balance of the native
+/// staking token, successfully creating a fully-formed transaction plan; the second attempts a
+/// partial spend, resulting in an appropriate error.
+#[wasm_bindgen_test]
+async fn test_spend_amount_validation_with_native_token() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
+
+    setup_env_1(&mock_db, &tables).await;
+
+    let storage = Storage::new(mock_db, tables).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
+
+    #[allow(deprecated)]
+    let valid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: *STAKING_TOKEN_ASSET_ID,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
+
+    let valid_response = plan_transaction_inner(
+        storage.clone(),
+        valid_request,
+        full_viewing_key.clone(),
+        fee_id,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(valid_response.actions.len(), 3);
+
+    #[allow(deprecated)]
+    let invalid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1u64.into(),
+                    asset_id: fee_id,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+
+    let invalid_response =
+        plan_transaction_inner(storage, invalid_request, full_viewing_key, fee_id).await;
+
+    match invalid_response {
+        Ok(_) => panic!(),
+        Err(e) => {
+            if let WasmError::Anyhow(err) = e {
+                let error_message = err.to_string();
+                assert!(error_message
+                    .contains("Invalid transaction: The transaction was constructed improperly."));
+            }
+        }
+    }
+}
+
+/// Constructs two transaction planner requests: the first sends the entire balance of an alternative
+/// fee token, successfully creating a fully-formed transaction plan; the second attempts a partial
+/// spend, resulting in an appropriate error.
+#[wasm_bindgen_test]
+async fn test_spend_amount_validation_with_alternative_token() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
+
+    setup_env_2(&mock_db, &tables).await;
+
+    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
+
+    let metadata_in_db_proto = pb::Metadata {
+        base: "penumbravalid1hz2hqlgx4w55vkxzv0n3u93czlkvm6zpgftyny2psg3dp8vcygxqd7fedt"
+            .to_string(),
+        ..Default::default()
+    };
+    let metadata: Metadata = metadata_in_db_proto.clone().try_into().unwrap();
+
+    let fee_id = metadata.id();
+
+    let gas_prices = GasPrices {
+        asset_id: fee_id,
+        block_space_price: 100,
+        compact_block_space_price: 2000,
+        verification_price: 150,
+        execution_price: 300,
+    };
+    mock_db
+        .put_with_key(
+            &tables.gas_prices,
+            byte_array_to_base64(&fee_id.to_proto().inner),
+            &gas_prices,
+        )
+        .await
+        .unwrap();
+
+    #[allow(deprecated)]
+    let valid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: fee_id,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+    let valid_response = plan_transaction_inner(
+        storage.clone(),
+        valid_request,
+        full_viewing_key.clone(),
+        fee_id,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(valid_response.actions.len(), 3);
+
+    #[allow(deprecated)]
+    let invalid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1u64.into(),
+                    asset_id: metadata.id(),
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+
+    let invalid_response =
+        plan_transaction_inner(storage, invalid_request, full_viewing_key, fee_id).await;
+
+    match invalid_response {
+        Ok(_) => panic!(),
+        Err(e) => {
+            if let WasmError::Anyhow(err) = e {
+                let error_message = err.to_string();
+                assert!(error_message
+                    .contains("Invalid transaction: The transaction was constructed improperly."));
+            }
+        }
+    }
+}
+
+/////////////////////////////////////////////// ASSET ID VALIDATION /////////////////////////////////////////////////////
+///                                                                                                                   ///
+/// This sanity checks the second safety check we have in-place, verifying that each spend action's asset ID          ///
+/// matches the fee asset ID.                                                                                         ///
+///                                                                                                                   ///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Constructs two transaction planner requests: the first, where the asset ID matches the fee asset ID,
+/// successfully creates a fully-formed transaction plan; the second, where the asset ID does not match
+/// the fee asset ID, results in an appropriate error.
+#[wasm_bindgen_test]
+async fn test_fee_asset_id_validation() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
+
+    setup_env_1(&mock_db, &tables).await;
+
+    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
+
+    let metadata_in_db_proto = pb::Metadata {
+        base: "penumbravalid1hz2hqlgx4w55vkxzv0n3u93czlkvm6zpgftyny2psg3dp8vcygxqd7fedt"
+            .to_string(),
+        ..Default::default()
+    };
+    let metadata: Metadata = metadata_in_db_proto.clone().try_into().unwrap();
+
+    let fee_id = metadata.id();
+
+    let gas_prices = GasPrices {
+        asset_id: fee_id,
+        block_space_price: 100,
+        compact_block_space_price: 2000,
+        verification_price: 150,
+        execution_price: 300,
+    };
+
+    mock_db
+        .put_with_key(
+            &tables.gas_prices,
+            byte_array_to_base64(&fee_id.to_proto().inner),
+            &gas_prices,
+        )
+        .await
+        .unwrap();
+
+    #[allow(deprecated)]
+    let invalid_request = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: *STAKING_TOKEN_ASSET_ID,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+    let invalid_response = plan_transaction_inner(
+        storage.clone(),
+        invalid_request,
+        full_viewing_key.clone(),
+        fee_id,
+    )
+    .await;
+
+    match invalid_response {
+        Ok(_) => panic!(),
+        Err(e) => {
+            if let WasmError::Anyhow(err) = e {
+                let error_message = err.to_string();
+                assert!(error_message
+                    .contains("Invalid transaction: The transaction was constructed improperly."));
+            }
+        }
+    }
+}
+
+/////////////////////////////////////////////// FILTER ZERO-VALUED NOTES VALIDATION ////////////////////////////////////
+///                                                                                                                  ///
+/// This ensures that zero-valued notes are correctly filtered out of the spendable note record (SNR) set.           ///
+/// It also checks the planner's behavior when no spendable notes are available.                                     ///
+///                                                                                                                  ///
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[wasm_bindgen_test]
+async fn test_filter_zero_value_notes() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
+
+    setup_env_3(&mock_db, &tables).await;
+
+    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
+
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
+
+    #[allow(deprecated)]
+    let req = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: fee_id,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+    let res = plan_transaction_inner(storage.clone(), req, full_viewing_key.clone(), fee_id)
+        .await
+        .unwrap();
+
+    assert_eq!(res.actions.len(), 3);
+}
+
+#[wasm_bindgen_test]
+async fn test_empty_note_set() {
+    let mock_db = MockDb::new();
+    let tables = get_mock_tables();
+
+    seed_params_in_db(&mock_db, &tables).await;
+
+    let storage = Storage::new(mock_db.clone(), tables.clone()).unwrap();
+    let reciever_address = &Address::dummy(&mut OsRng);
+
+    let fee_id = *STAKING_TOKEN_ASSET_ID;
+
+    #[allow(deprecated)]
+    let req = TransactionPlannerRequest {
+        expiry_height: 0,
+        memo: None,
+        source: None,
+        outputs: vec![],
+        spends: vec![Spend {
+            address: Some(reciever_address.into()),
+            value: Some(
+                Value {
+                    amount: 1558828u64.into(),
+                    asset_id: fee_id,
+                }
+                .into(),
+            ),
+        }],
+        swaps: vec![],
+        swap_claims: vec![],
+        delegations: vec![],
+        undelegations: vec![],
+        undelegation_claims: vec![],
+        ibc_relay_actions: vec![],
+        ics20_withdrawals: vec![],
+        position_opens: vec![],
+        position_closes: vec![],
+        position_withdraws: vec![],
+        dutch_auction_schedule_actions: vec![],
+        dutch_auction_end_actions: vec![],
+        dutch_auction_withdraw_actions: vec![],
+        delegator_votes: vec![],
+        epoch_index: 0,
+        epoch: None,
+        fee_mode: None,
+    };
+    let full_viewing_key = FullViewingKey::from_str("penumbrafullviewingkey1mnm04x7yx5tyznswlp0sxs8nsxtgxr9p98dp0msuek8fzxuknuzawjpct8zdevcvm3tsph0wvsuw33x2q42e7sf29q904hwerma8xzgrxsgq2").unwrap();
+
+    let res = plan_transaction_inner(storage.clone(), req, full_viewing_key.clone(), fee_id).await;
+
+    match res {
+        Ok(_) => panic!(),
+        Err(e) => {
+            if let WasmError::Anyhow(err) = e {
+                let error_message = err.to_string();
+                assert!(error_message
+                    .contains("Invalid transaction: The transaction was constructed improperly."));
+            }
+        }
+    }
+}

--- a/packages/wasm/crate/tests/test_planner_send_max.rs
+++ b/packages/wasm/crate/tests/test_planner_send_max.rs
@@ -43,7 +43,7 @@ async fn setup_env_1(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 1u64.into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,
@@ -66,7 +66,7 @@ async fn setup_env_1(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 1558827u64.into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,
@@ -112,7 +112,7 @@ async fn setup_env_2(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 1u64.into(),
                 asset_id: metadata.id(),
@@ -135,7 +135,7 @@ async fn setup_env_2(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 1558827u64.into(),
                 asset_id: metadata.id(),
@@ -174,7 +174,7 @@ async fn setup_env_3(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 1u64.into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,
@@ -197,7 +197,7 @@ async fn setup_env_3(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 1558827u64.into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,
@@ -220,7 +220,7 @@ async fn setup_env_3(mock_db: &MockDb, tables: &Tables) {
         note_commitment: StateCommitment::try_from([0; 32]).unwrap(),
         note: Note::generate(
             &mut OsRng,
-            &sender_address,
+            sender_address,
             Value {
                 amount: 0u64.into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,


### PR DESCRIPTION
references https://github.com/penumbra-zone/web/issues/1660, and partially references https://github.com/penumbra-zone/web/issues/692. 

Implements wasm bindgen unit tests for sanity-checking the critical logic paths and safety checks for the send max feature.

https://github.com/penumbra-zone/web/pull/1698 to follow.