### PR TITLE
localhost SSL no longer required

### DIFF
--- a/apps/minifront/vite.config.ts
+++ b/apps/minifront/vite.config.ts
@@ -2,7 +2,6 @@
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-import basicSsl from '@vitejs/plugin-basic-ssl';
 import { commitInfoPlugin } from './src/utils/commit-info-vite-plugin';
 import polyfillNode from 'vite-plugin-node-stdlib-browser';
 import svgr from 'vite-plugin-svgr';
@@ -15,7 +14,6 @@ export default defineConfig(({ mode }) => {
     plugins: [
       polyfillNode(),
       react(),
-      basicSsl(),
       commitInfoPlugin(),
       svgr({
         include: '**/*.svg',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@tsconfig/vite-react": "^3.0.2",
     "@turbo/gen": "^1.13.4",
     "@types/eslint__js": "^8.42.3",
-    "@vitejs/plugin-basic-ssl": "^1.1.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "@vitest/browser": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@types/eslint__js':
         specifier: ^8.42.3
         version: 8.42.3
-      '@vitejs/plugin-basic-ssl':
-        specifier: ^1.1.0
-        version: 1.1.0(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.3.1(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
@@ -5312,12 +5309,6 @@ packages:
 
   '@visx/vendor@3.5.0':
     resolution: {integrity: sha512-yt3SEZRVmt36+APsCISSO9eSOtzQkBjt+QRxNRzcTWuzwMAaF3PHCCSe31++kkpgY9yFoF+Gfes1TBe5NlETiQ==}
-
-  '@vitejs/plugin-basic-ssl@1.1.0':
-    resolution: {integrity: sha512-wO4Dk/rm8u7RNhOf95ZzcEmC9rYOncYgvq4z3duaJrCgjN8BxAnDVyndanfcJZ0O6XZzHz6Q0hTimxTg8Y9g/A==}
-    engines: {node: '>=14.6.0'}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   '@vitejs/plugin-react-swc@3.7.0':
     resolution: {integrity: sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==}
@@ -17980,10 +17971,6 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
       internmap: 2.0.3
-
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))':
-    dependencies:
-      vite: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
 
   '@vitejs/plugin-react-swc@3.7.0(@swc/helpers@0.5.11)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))':
     dependencies:


### PR DESCRIPTION
Removing the tooling that makes dev mode `https://localhost` and just uses `http`.

No longer necessary after prax update removing the requirement (for localhost only). 