### PR TITLE
Remove validator info throttler

### DIFF
--- a/.changeset/tough-mayflies-collect.md
+++ b/.changeset/tough-mayflies-collect.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/query': patch
+---
+
+Remove validator info throttle

--- a/packages/query/src/block-processor.ts
+++ b/packages/query/src/block-processor.ts
@@ -646,8 +646,6 @@ export class BlockProcessor implements BlockProcessorInterface {
     }
   }
 
-  // TODO: refactor. there is definitely a better way to do this.  batch
-  // endpoint issue https://github.com/penumbra-zone/penumbra/issues/4688
   private async updateValidatorInfos(nextEpochStartHeight: bigint): Promise<void> {
     // It's important to clear the table so any stale (jailed, tombstoned, etc) entries are filtered out.
     await this.indexedDb.clearValidatorInfos();
@@ -662,18 +660,6 @@ export class BlockProcessor implements BlockProcessorInterface {
       await this.updatePriceForValidatorDelegationToken(
         validatorInfoResponse,
         nextEpochStartHeight,
-      );
-
-      // this loop requests delegation token metadata for each validator
-      // individually. there may be very many, so we must artificially delay
-      // this loop or the RPC may hard-ratelimit us.
-      await new Promise(
-        resolve =>
-          void setTimeout(
-            resolve,
-            // an entire second
-            1000,
-          ),
       );
     }
   }


### PR DESCRIPTION
Previously, the loop was using a version of `updatePriceForValidatorDelegationToken()` that made a request for metadata from the node. This caused rate-limiting issues that a throttle was put into place to slow down the requests: https://github.com/penumbra-zone/web/pull/1392.

Now that delegation metadata is generated locally (versus a request) with https://github.com/penumbra-zone/web/issues/1189, we can get rid of the throttle. 

This will also be helpful to have the speedup so the staking page is immediately populated on a fresh sync and doesn't have to wait for +1 minute to get all validator infos. 