### PR TITLE
fix(ui): #1806: add truncation to `ValueViewComponent`

### DIFF
--- a/.changeset/thick-parrots-lie.md
+++ b/.changeset/thick-parrots-lie.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Add ellipsis to `ValueViewComponent`

--- a/packages/ui/src/ValueViewComponent/index.tsx
+++ b/packages/ui/src/ValueViewComponent/index.tsx
@@ -50,6 +50,7 @@ const Content = styled.div<{ $context: Context; $priority: 'primary' | 'secondar
 const SymbolWrapper = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
+  min-width: 50px;
 
   overflow: hidden;
   text-overflow: ellipsis;
@@ -118,7 +119,9 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
         </AssetIconWrapper>
 
         <Content $context={context ?? 'default'} $priority={priority}>
-          <ValueText density={density}>{formattedAmount} </ValueText>
+          <SymbolWrapper title={formattedAmount}>
+            <ValueText density={density}>{formattedAmount} </ValueText>
+          </SymbolWrapper>
           <SymbolWrapper title={symbol}>
             <ValueText density={density}>{symbol}</ValueText>
           </SymbolWrapper>


### PR DESCRIPTION
Fixes #1806 

Now it truncates and adds a title on hover

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/460b1616-1108-4903-9fa7-d2c59a5c8f4e">

