### PR TITLE
database batching 

### DIFF
--- a/.changeset/spicy-terms-reflect.md
+++ b/.changeset/spicy-terms-reflect.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/storage': minor
+'@penumbra-zone/query': minor
+---
+
+batching storage operations with promises

--- a/packages/storage/src/indexed-db/updater.ts
+++ b/packages/storage/src/indexed-db/updater.ts
@@ -43,7 +43,7 @@ export class IbdUpdater {
 
     // Batch all the updates into promises
     for (const update of updates.all) {
-      tx.objectStore(update.table).put(update.value, update.key);
+      void tx.objectStore(update.table).put(update.value, update.key);
     }
 
     // Await the atomic transaction to complete

--- a/packages/storage/src/indexed-db/updater.ts
+++ b/packages/storage/src/indexed-db/updater.ts
@@ -45,17 +45,17 @@ export class IbdUpdater {
 
     // Batch all the updates into promises
     for (const update of updates.all) {
-      const putOperation = tx
-        .objectStore(update.table)
-        .put(update.value, update.key)
-        .then(() => {
-          this.notifySubscribers(update);
-        });
+      const putOperation = tx.objectStore(update.table).put(update.value, update.key);
       batchOperations.push(putOperation);
     }
     await Promise.all(batchOperations);
 
     await tx.done;
+
+    // Notify subscribers after the transaction has successfully committed
+    for (const update of updates.all) {
+      this.notifySubscribers(update);
+    }
   }
 
   async update<DBTypes extends PenumbraDb, StoreName extends StoreNames<DBTypes>>(

--- a/packages/storage/src/indexed-db/updater.ts
+++ b/packages/storage/src/indexed-db/updater.ts
@@ -41,15 +41,12 @@ export class IbdUpdater {
     const tables = updates.all.map(u => u.table);
     const tx = this.db.transaction(tables, 'readwrite');
 
-    const batchOperations = [];
-
     // Batch all the updates into promises
     for (const update of updates.all) {
-      const putOperation = tx.objectStore(update.table).put(update.value, update.key);
-      batchOperations.push(putOperation);
+      tx.objectStore(update.table).put(update.value, update.key);
     }
-    await Promise.all(batchOperations);
 
+    // Await the atomic transaction to complete
     await tx.done;
 
     // Notify subscribers after the transaction has successfully committed


### PR DESCRIPTION
references https://github.com/penumbra-zone/web/issues/1814

collectively yields **~8%** syncing improvement. 

<img width="1227" alt="Screenshot 2024-10-15 at 10 01 53 PM" src="https://github.com/user-attachments/assets/7c5de9b1-a63b-44cc-8b7f-77b22b26b15b">

Profiling indicates that the block processor performs substantially more database reads than writes. The most resource-intensive DB operations are "saveScanResult," "identifyNewAssets," and "resolveNullifiers," which account for the majority of disk I/O operations.

Currently, storage operations are executed sequentially (ie. saving transactions, metadata, etc.) in indexDB. Storage R/W blocks sync since each storage operation has an associated `await`, causing each to wait for the previous one to finish before continuing.

Those operations were refactored to use `Promise.all()`, ensuring the block processor isn't _artificially_ blocked on each `await` call. This means a concurrent execution of the promises, at the javascript level, meaning the calls will be _initiated_ at the same time.  But, the actual execution at the IndexedDB level won't be truly parallel because IndexedDB itself is single-threaded and performs DB operations one at a time. IndexedDB will handle them in a queue and execute them sequentially in an atomic transaction. 

The benefit of using `Promise.all()` here is the concurrent execution of **non-blocking** operations, reducing wait times between operations like network fetches and other async tasks. Therefore, other operations are not blocked while waiting for each individual write to complete. 

tldr; disk I/O doesn't seem to be a primary bottleneck. Still, disk I/O especially when filtered through the browser API / network stack is always going to be relatively slow. 