### PR TITLE
fix(ui): add refresh button to block sync status

### DIFF
--- a/packages/ui/components/ui/block-sync-status/block-sync-status.tsx
+++ b/packages/ui/components/ui/block-sync-status/block-sync-status.tsx
@@ -42,6 +42,10 @@ export const CondensedBlockSyncStatus = ({
 };
 
 const BlockSyncErrorState = ({ error }: { error: unknown }) => {
+  const reload = () => {
+    window.location.reload();
+  };
+
   return (
     <motion.div
       className='flex w-full select-none flex-col'
@@ -49,9 +53,18 @@ const BlockSyncErrorState = ({ error }: { error: unknown }) => {
       animate={{ opacity: 1, transition: { duration: 0.5, ease: 'easeOut' } }}
     >
       <Progress status='error' value={100} shape='squared' />
-      <div className='absolute flex w-full justify-between px-2'>
-        <div className='mt-[-5.5px] font-mono text-[10px] text-red-300'>
-          Block sync error: {String(error)}
+      <div className='absolute w-full px-2'>
+        <div className='mt-[-5.5px] flex gap-2'>
+          <span className='font-mono text-[10px] text-red-300'>
+            Block sync error: {String(error)}
+          </span>
+          <button
+            type='button'
+            className='border-none bg-none font-mono text-[10px] text-red-300 underline'
+            onClick={reload}
+          >
+            Reload
+          </button>
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
Simply adds a "Reload" button next to the error message in sync status.

Relates to https://github.com/prax-wallet/prax/pull/217 as it gives users a sense that the error might be recovered by the refresh

<img width="382" alt="image" src="https://github.com/user-attachments/assets/0f8c80cd-f82a-4dda-a90b-5b5784a237a7">
