### PR TITLE
Fix asset selector onchange event

### DIFF
--- a/.changeset/proud-ducks-marry.md
+++ b/.changeset/proud-ducks-marry.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Fix asset selector not firing onChange event

--- a/packages/ui/src/Dialog/RadioItem.tsx
+++ b/packages/ui/src/Dialog/RadioItem.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEventHandler, ReactNode, useMemo } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { RadioGroupItem } from '@radix-ui/react-radio-group';
 import { styled } from 'styled-components';
 import { motion } from 'framer-motion';
@@ -97,15 +97,20 @@ export const RadioItem = ({
   onClose,
   onSelect,
 }: DialogRadioItemProps) => {
-  const onEnter: KeyboardEventHandler<HTMLButtonElement> = event => {
-    if (event.key === 'Enter') {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // Is a click and not an arrow key up/down
+    if (event.detail > 0) {
+      onSelect?.();
       onClose?.();
     }
   };
 
-  const onClick = () => {
-    onSelect?.();
-    onClose?.();
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect?.();
+      onClose?.();
+    }
   };
 
   const descriptionText = useMemo(() => {
@@ -126,7 +131,11 @@ export const RadioItem = ({
 
   return (
     <RadioGroupItem key={value} disabled={disabled} value={value} asChild>
-      <Root {...asTransientProps({ actionType, disabled })} onKeyDown={onEnter} onClick={onClick}>
+      <Root
+        {...asTransientProps({ actionType, disabled })}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      >
         <Info>
           {startAdornment}
           <div>

--- a/packages/ui/src/Dialog/RadioItem.tsx
+++ b/packages/ui/src/Dialog/RadioItem.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEventHandler, MouseEventHandler, ReactNode, useMemo } from 'react';
+import { KeyboardEventHandler, ReactNode, useMemo } from 'react';
 import { RadioGroupItem } from '@radix-ui/react-radio-group';
 import { styled } from 'styled-components';
 import { motion } from 'framer-motion';
@@ -103,16 +103,9 @@ export const RadioItem = ({
     }
   };
 
-  const onMouseDown: MouseEventHandler<HTMLButtonElement> = () => {
-    // close only after the value is selected by onClick
-    setTimeout(() => {
-      onClose?.();
-    }, 0);
-  };
-
-  // click is triggered by radix-ui on focus, click, arrow selection, etc. – basically always
   const onClick = () => {
     onSelect?.();
+    onClose?.();
   };
 
   const descriptionText = useMemo(() => {
@@ -133,12 +126,7 @@ export const RadioItem = ({
 
   return (
     <RadioGroupItem key={value} disabled={disabled} value={value} asChild>
-      <Root
-        {...asTransientProps({ actionType, disabled })}
-        onKeyDown={onEnter}
-        onMouseDown={onMouseDown}
-        onClick={onClick}
-      >
+      <Root {...asTransientProps({ actionType, disabled })} onKeyDown={onEnter} onClick={onClick}>
         <Info>
           {startAdornment}
           <div>


### PR DESCRIPTION
Before:


https://github.com/user-attachments/assets/27af6cf7-87de-4a12-b56c-683ea6ced49b





After:


https://github.com/user-attachments/assets/5248f3db-83f1-48ce-b7ac-9c8d06c5b980


When a user clicks on the item, the `onMouseDown` event fires, the unmounting of the component prevents the `onClick` from firing.