### PR TITLE
Add theme & lib/toast UI exports

### DIFF
--- a/.changeset/shy-dogs-draw.md
+++ b/.changeset/shy-dogs-draw.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Add theme and lib/toast exports

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,8 +57,8 @@
         "default": "./dist/lib/toast/*.js"
       },
       "./utils/*": {
-        "types": "./src/utils/*.d.ts",
-        "default": "./src/utils/*.js"
+        "types": "./dist/src/utils/*.d.ts",
+        "default": "./dist/src/utils/*.js"
       },
       "./*": {
         "types": "./dist/src/*/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
     "./tailwind": "./src/tailwindConfig.ts",
     "./postcss.config.js": "./postcss.config.js",
     "./styles/*": "./styles/*",
+    "./theme": "./src/PenumbraUIProvider/theme.ts",
     "./hooks/*": "./src/hooks/*/index.ts",
     "./*": "./src/*/index.tsx"
   },
@@ -45,6 +46,14 @@
       "./components/*": {
         "types": "./dist/components/ui/*.d.ts",
         "default": "./dist/components/ui/*.js"
+      },
+      "./theme": {
+        "types": "./dist/src/PenumbraUIProvider/theme.d.ts",
+        "default": "./dist/src/PenumbraUIProvider/theme.js"
+      },
+      "./lib/toast/*": {
+        "types": "./dist/lib/toast/*.d.ts",
+        "default": "./dist/lib/toast/*.js"
       },
       "./*": {
         "types": "./dist/src/*/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "./postcss.config.js": "./postcss.config.js",
     "./styles/*": "./styles/*",
     "./theme": "./src/PenumbraUIProvider/theme.ts",
+    "./utils/*": "./src/utils/*.ts",
     "./hooks/*": "./src/hooks/*/index.ts",
     "./*": "./src/*/index.tsx"
   },
@@ -54,6 +55,10 @@
       "./lib/toast/*": {
         "types": "./dist/lib/toast/*.d.ts",
         "default": "./dist/lib/toast/*.js"
+      },
+      "./utils/*": {
+        "types": "./src/utils/*.d.ts",
+        "default": "./src/utils/*.js"
       },
       "./*": {
         "types": "./dist/src/*/index.d.ts",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -26,6 +26,11 @@ const getAllUIComponents = (): Record<string, string> => {
   );
 };
 
+const getAllLibToastComponents = (): Record<string, string> => {
+  const source = resolve(__dirname, 'lib', 'toast');
+  return getRecursiveTsxFiles(source, 'lib/toast');
+};
+
 const getDeprecatedUIComponents = (): Record<string, string> => {
   const source = resolve(__dirname, 'components/ui');
   return getRecursiveTsxFiles(source, 'components/ui');
@@ -54,6 +59,8 @@ const getAllEntries = (): Record<string, string> => {
   return {
     tailwindconfig: resolve('../tailwind-config'),
     'src/tailwindConfig': join(__dirname, 'src', 'tailwindConfig.ts'),
+    'src/PenumbraUIProvider/theme': join(__dirname, 'src', 'PenumbraUIProvider', 'theme.ts'),
+    ...getAllLibToastComponents(),
     ...getDeprecatedUIComponents(),
     ...getAllUIComponents(),
   };


### PR DESCRIPTION
Currently we can't access theme and lib/toast within the dex-explorer. This should fix that.