### PR TITLE
Update ui exports

### DIFF
--- a/.changeset/orange-boxes-suffer.md
+++ b/.changeset/orange-boxes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Update @penumbra-zone/ui exports

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,21 +44,13 @@
         "types": "./dist/src/tailwindConfig.d.ts",
         "default": "./dist/src/tailwindConfig.js"
       },
-      "./components/*": {
+      "./componsents/*": {
         "types": "./dist/components/ui/*.d.ts",
         "default": "./dist/components/ui/*.js"
       },
-      "./theme": {
-        "types": "./dist/src/PenumbraUIProvider/theme.d.ts",
-        "default": "./dist/src/PenumbraUIProvider/theme.js"
-      },
-      "./lib/toast/*": {
-        "types": "./dist/lib/toast/*.d.ts",
-        "default": "./dist/lib/toast/*.js"
-      },
-      "./utils/*": {
-        "types": "./dist/src/utils/*.d.ts",
-        "default": "./dist/src/utils/*.js"
+      "./utils/typography": {
+        "types": "./dist/src/utils/typography.d.ts",
+        "default": "./dist/src/utils/typography.js"
       },
       "./*": {
         "types": "./dist/src/*/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,7 @@
         "types": "./dist/src/tailwindConfig.d.ts",
         "default": "./dist/src/tailwindConfig.js"
       },
-      "./componsents/*": {
+      "./components/*": {
         "types": "./dist/components/ui/*.d.ts",
         "default": "./dist/components/ui/*.js"
       },

--- a/packages/ui/src/PenumbraUIProvider/index.tsx
+++ b/packages/ui/src/PenumbraUIProvider/index.tsx
@@ -20,3 +20,5 @@ export const PenumbraUIProvider = ({ children }: PropsWithChildren) => (
     </MotionConfig>
   </ThemeProvider>
 );
+
+export { theme } from './theme';

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -26,11 +26,6 @@ const getAllUIComponents = (): Record<string, string> => {
   );
 };
 
-const getAllLibToastComponents = (): Record<string, string> => {
-  const source = resolve(__dirname, 'lib', 'toast');
-  return getRecursiveTsxFiles(source, 'lib/toast');
-};
-
 const getDeprecatedUIComponents = (): Record<string, string> => {
   const source = resolve(__dirname, 'components/ui');
   return getRecursiveTsxFiles(source, 'components/ui');
@@ -59,8 +54,7 @@ const getAllEntries = (): Record<string, string> => {
   return {
     tailwindconfig: resolve('../tailwind-config'),
     'src/tailwindConfig': join(__dirname, 'src', 'tailwindConfig.ts'),
-    'src/PenumbraUIProvider/theme': join(__dirname, 'src', 'PenumbraUIProvider', 'theme.ts'),
-    ...getAllLibToastComponents(),
+    'src/utils/typography': join(__dirname, 'src', 'utils', 'typography.ts'),
     ...getDeprecatedUIComponents(),
     ...getAllUIComponents(),
   };


### PR DESCRIPTION
- Removed deprecated toast exports
- theme is now exported from PenumbraUIProvider/index.tsx
- added utils/typography to exports