### PR TITLE
Add ReactNode to Toast description prop type

### DIFF
--- a/.changeset/forty-pumpkins-eat.md
+++ b/.changeset/forty-pumpkins-eat.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Add ReactNode proptype to description Toast prop

--- a/packages/ui/src/Toast/open.ts
+++ b/packages/ui/src/Toast/open.ts
@@ -16,7 +16,7 @@ const toastFnMap: Record<ToastType, ToastFn> = {
 export interface ToastProps {
   type: ToastType;
   message: string;
-  description?: string | ReactNode;
+  description?: ReactNode;
   persistent?: boolean;
   dismissible?: boolean;
   action?: ExternalToast['action'];

--- a/packages/ui/src/Toast/open.ts
+++ b/packages/ui/src/Toast/open.ts
@@ -16,7 +16,7 @@ const toastFnMap: Record<ToastType, ToastFn> = {
 export interface ToastProps {
   type: ToastType;
   message: string;
-  description?: string;
+  description?: string | ReactNode;
   persistent?: boolean;
   dismissible?: boolean;
   action?: ExternalToast['action'];


### PR DESCRIPTION
Add ReactNode to Toast description prop type.

Needed to provide a progress bar to the transaction toast.