### PR TITLE
views: prop for optionally displaying value on ValueViewComponent

### DIFF
--- a/.changeset/dull-bikes-reflect.md
+++ b/.changeset/dull-bikes-reflect.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+showValue prop for ValueViewComponent to display amounts

--- a/packages/ui/src/ValueView/index.tsx
+++ b/packages/ui/src/ValueView/index.tsx
@@ -36,9 +36,9 @@ export interface ValueViewComponentProps<SelectedContext extends Context> {
    */
   priority?: PillProps['priority'];
   /**
-   * If true, the asset symbol will be hidden.
+   * If true, the asset symbol will be visible.
    */
-  hideSymbol?: boolean;
+  showSymbol?: boolean;
   /**
    * If true, the displayed amount will be shortened.
    */
@@ -60,7 +60,7 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
   valueView,
   context,
   priority = 'primary',
-  hideSymbol = false,
+  showSymbol = true,
   abbreviate = false,
   showValue = true,
 }: ValueViewComponentProps<SelectedContext>) => {
@@ -72,12 +72,8 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
 
   let formattedAmount: string | undefined;
   if (showValue) {
-    if (abbreviate) {
-      const amount = getFormattedAmtFromValueView(valueView, false);
-      formattedAmount = shortify(Number(amount));
-    } else {
-      formattedAmount = getFormattedAmtFromValueView(valueView, true);
-    }
+    const amount = getFormattedAmtFromValueView(valueView, !abbreviate);
+    formattedAmount = abbreviate ? shortify(Number(amount)) : amount;
   }
 
   const metadata = getMetadata.optional(valueView);
@@ -121,7 +117,7 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
               <ValueText density={density}>{formattedAmount}</ValueText>
             </div>
           )}
-          {!hideSymbol && (
+          {showSymbol && (
             <div className='shrink grow truncate' title={symbol}>
               <ValueText density={density}>{symbol}</ValueText>
             </div>

--- a/packages/ui/src/ValueView/index.tsx
+++ b/packages/ui/src/ValueView/index.tsx
@@ -43,6 +43,10 @@ export interface ValueViewComponentProps<SelectedContext extends Context> {
    * If true, the displayed amount will be shortened.
    */
   abbreviate?: boolean;
+  /**
+   * If false, the amount will not be displayed.
+   */
+  showValue?: boolean;
 }
 
 /**
@@ -58,6 +62,7 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
   priority = 'primary',
   hideSymbol = false,
   abbreviate = false,
+  showValue = true,
 }: ValueViewComponentProps<SelectedContext>) => {
   const density = useDensity();
 
@@ -65,12 +70,14 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
     return null;
   }
 
-  let formattedAmount: string;
-  if (abbreviate) {
-    const amount = getFormattedAmtFromValueView(valueView, false);
-    formattedAmount = shortify(Number(amount));
-  } else {
-    formattedAmount = getFormattedAmtFromValueView(valueView, true);
+  let formattedAmount: string | undefined;
+  if (showValue) {
+    if (abbreviate) {
+      const amount = getFormattedAmtFromValueView(valueView, false);
+      formattedAmount = shortify(Number(amount));
+    } else {
+      formattedAmount = getFormattedAmtFromValueView(valueView, true);
+    }
   }
 
   const metadata = getMetadata.optional(valueView);
@@ -109,9 +116,11 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
             getGap(density),
           )}
         >
-          <div className='shrink grow' title={formattedAmount}>
-            <ValueText density={density}>{formattedAmount}</ValueText>
-          </div>
+          {showValue && (
+            <div className='shrink grow' title={formattedAmount ?? undefined}>
+              <ValueText density={density}>{formattedAmount}</ValueText>
+            </div>
+          )}
           {!hideSymbol && (
             <div className='shrink grow truncate' title={symbol}>
               <ValueText density={density}>{symbol}</ValueText>


### PR DESCRIPTION
the V2 `ValueViewComponent` needs a `showValue` prop. For instance the [prepaid claim fee](https://github.com/penumbra-zone/web/issues/889) amount can't be shown in the public view and will need to set the prop to `false`.