### PR TITLE
client: fix connection persistence bug

### DIFF
--- a/.changeset/tasty-pears-knock.md
+++ b/.changeset/tasty-pears-knock.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/client': minor
+---
+
+attempt to reconnect on broken client connection

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -190,11 +190,11 @@ export class PenumbraClient {
     this.connection ??= this.createConnection();
 
     try {
-        await this.connection.port;
+      await this.connection.port;
     } catch (error) {
-        this.disconnect();
-        this.connection = this.createConnection();
-        await this.connection.port;
+      await this.disconnect();
+      this.connection = this.createConnection();
+      await this.connection.port;
     }
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -188,7 +188,14 @@ export class PenumbraClient {
       await this.attach(providerOrigin);
     }
     this.connection ??= this.createConnection();
-    await this.connection.port;
+
+    try {
+        await this.connection.port;
+    } catch (error) {
+        this.disconnect();
+        this.connection = this.createConnection();
+        await this.connection.port;
+    }
   }
 
   /** Call `disconnect` on the associated provider to release connection

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -202,8 +202,8 @@ export class PenumbraClient {
         }
       }
 
-      // todo: clean up existing connection resources and attempt to establish reconnection
-
+      // Clean up dangling connection resources and attempt to establish reconnection
+      this.destroyConnection();
       this.connection = this.createConnection();
       await this.connection.port;
     }


### PR DESCRIPTION
references https://github.com/penumbra-zone/dex-explorer/issues/154

this is a subtle wallet connection bug. Initially, I thought the culprit was related to mobx's observer HOC, where the connection state wasn't properly being observed. Upon digging deeper, I narrowed in on the client connection implementation, specifically this [no-op](https://github.com/penumbra-zone/web/blob/main/packages/client/src/client.ts#L151-L153) comment. If the connection is set, indicating an active connection, the nullish coalescing operator prevents initializing a new connection. Debugging the connection state revealed that this no-op behavior becomes problematic in a specific (yet common) case: the connection is _set_, but the underlying connection is broken. This could be from either the connection timing out, provider detaching, etc. and the no-op behavior prevents the frontend from re-establishing connection, _even_ when the extension is logged in. 

<img width="535" alt="Screenshot 2024-12-09 at 10 04 23 PM" src="https://github.com/user-attachments/assets/d21be667-a621-4519-93c1-6349d548ea6f">


Problematically, the same error is encountered when the user manually _denies_ the connection. If this error isn't explicitly caught and propagated back to the caller, then a a denied connection would immediately trigger an attempt to re-establish the connection. For other types of errors, the `connect` method was modified to clean up the existing connection resources and attempts to establish a new connection to the attached provider.

We should sanity check the security implications of this remediation given that the last audit caught some connection related vulnerabilities.

--------------------------------------

https://github.com/user-attachments/assets/6da56808-52fb-4e89-a9b6-976202d3bce0
