### PR TITLE
feat(ui): updates for button, density and colors

### DIFF
--- a/.changeset/two-hotels-lie.md
+++ b/.changeset/two-hotels-lie.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Update Button component to match the latest designs

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -23,8 +23,8 @@ const DensityWrapper = ({ children, showDensityControl }) => {
           <Tabs
             options={[
               { label: 'Sparse', value: 'sparse' },
-              { label: 'Medium', value: 'medium' },
               { label: 'Compact', value: 'compact' },
+              { label: 'Slim', value: 'slim' },
             ]}
             value={density}
             onChange={setDensity}
@@ -36,12 +36,12 @@ const DensityWrapper = ({ children, showDensityControl }) => {
     </div>
   );
 
-  if (density === 'medium') {
-    return <Density medium>{densityTabs}</Density>;
-  }
-
   if (density === 'compact') {
     return <Density compact>{densityTabs}</Density>;
+  }
+
+  if (density === 'slim') {
+    return <Density slim>{densityTabs}</Density>;
   }
 
   return <Density sparse>{densityTabs}</Density>;

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -2,16 +2,16 @@ import { FC, forwardRef, MouseEventHandler, ReactNode } from 'react';
 import { LucideIcon } from 'lucide-react';
 import cn from 'clsx';
 import { getOutlineColorByActionType, ActionType } from '../utils/action-type';
-import { Priority, buttonBase, getBackground, getFocusOutline, getOverlays } from '../utils/button';
-import { button } from '../utils/typography';
+import {
+  Priority,
+  buttonBase,
+  getBackground,
+  getOverlays,
+  getFont,
+  getSize,
+  getIconSize,
+} from '../utils/button';
 import { useDensity } from '../utils/density';
-
-const iconOnlyAdornment = cn('rounded-full p-1 w-max');
-const sparse = (iconOnly?: boolean | 'adornment') =>
-  cn('rounded-sm h-12', iconOnly ? 'w-12 min-w-12 pl-0 pr-0' : 'w-full pl-4 pr-4');
-
-const compact = (iconOnly?: boolean | 'adornment') =>
-  cn('rounded-full h-8 min-w-8 w-max', iconOnly ? 'pl-2 pr-2' : 'pl-4 pr-4');
 
 interface BaseButtonProps {
   type?: HTMLButtonElement['type'];
@@ -109,6 +109,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const density = useDensity();
+    const styleAttrs = { actionType, iconOnly, density, priority };
 
     return (
       <button
@@ -121,31 +122,22 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...attrs}
         className={cn(
           buttonBase,
-          button,
-          getBackground(actionType, priority, iconOnly),
-          getFocusOutline({ density, iconOnly, actionType }),
-          getOverlays({ actionType, iconOnly, density }),
+          getFont(styleAttrs),
+          getSize(styleAttrs),
+          getBackground(styleAttrs),
+          getOverlays(styleAttrs),
 
-          '-outline-offset-1',
-          priority === 'secondary' && 'outline-1',
+          '-outline-offset-1 focus:outline-none',
+          priority === 'secondary' && 'outline outline-1',
           priority === 'secondary' && getOutlineColorByActionType(actionType),
-          'after:-outline-offset-2',
 
           'relative',
-          'flex gap-2 items-center justify-center',
           'text-neutral-contrast',
-
-          // eslint-disable-next-line no-nested-ternary -- allow
-          iconOnly === 'adornment'
-            ? iconOnlyAdornment
-            : density === 'sparse'
-              ? sparse(iconOnly)
-              : compact(iconOnly),
+          'flex items-center justify-center',
+          density === 'sparse' ? 'gap-2' : 'gap-1',
         )}
       >
-        {IconComponent && (
-          <IconComponent size={density === 'sparse' && iconOnly === true ? 24 : 16} />
-        )}
+        {IconComponent && <IconComponent size={getIconSize(density)} />}
 
         {!iconOnly && children}
       </button>

--- a/packages/ui/src/Density/index.tsx
+++ b/packages/ui/src/Density/index.tsx
@@ -2,9 +2,9 @@ import { ReactNode } from 'react';
 import { Density as TDensity, DensityContext } from '../utils/density';
 
 export type DensityPropType =
-  | { sparse: true; medium?: never; compact?: never }
-  | { medium: true; sparse?: never; compact?: never }
-  | { compact: true; sparse?: never; medium?: never };
+  | { sparse: true; slim?: never; compact?: never }
+  | { slim: true; sparse?: never; compact?: never }
+  | { compact: true; sparse?: never; slim?: never };
 
 export type DensityProps = DensityPropType & {
   children?: ReactNode;
@@ -71,9 +71,9 @@ export type DensityProps = DensityPropType & {
  * />
  * ```
  */
-export const Density = ({ children, sparse, medium, compact }: DensityProps) => {
+export const Density = ({ children, sparse, slim, compact }: DensityProps) => {
   const density: TDensity =
-    (sparse && 'sparse') ?? (medium && 'medium') ?? (compact && 'compact') ?? 'sparse';
+    (sparse && 'sparse') ?? (compact && 'compact') ?? (slim && 'slim') ?? 'sparse';
 
   return <DensityContext.Provider value={density}>{children}</DensityContext.Provider>;
 };

--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -27,20 +27,20 @@ const getBorderColor = (actionType: LimitedActionType): string => {
 };
 
 const getDensityClasses = (density: Density): string => {
-  if (density === 'compact') {
+  if (density === 'slim') {
     return cn('h-7 gap-4');
   }
-  if (density === 'medium') {
+  if (density === 'compact') {
     return cn('h-[44px] gap-2');
   }
   return cn('h-[44px] gap-4');
 };
 
 const getDensityItemClasses = (density: Density): string => {
-  if (density === 'medium') {
+  if (density === 'compact') {
     return cn(tabMedium, 'p-2');
   }
-  if (density === 'compact') {
+  if (density === 'slim') {
     return cn(tabSmall, 'py-1 px-2');
   }
   return cn(tab, 'grow shrink basis-0 p-2');

--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -8,12 +8,12 @@ type LimitedActionType = Exclude<ActionType, 'destructive'>;
 
 const getIndicatorColor = (actionType: LimitedActionType): string => {
   if (actionType === 'accent') {
-    return cn('bg-tabAccent');
+    return cn('bg-accentRadialGradient');
   }
   if (actionType === 'unshield') {
-    return cn('bg-tabUnshield');
+    return cn('bg-unshieldRadialGradient');
   }
-  return cn('bg-tabNeutral');
+  return cn('bg-neutralRadialGradient');
 };
 
 const getBorderColor = (actionType: LimitedActionType): string => {

--- a/packages/ui/src/ValueView/index.tsx
+++ b/packages/ui/src/ValueView/index.tsx
@@ -132,7 +132,7 @@ const getGap = (density: Density) => {
   if (density === 'sparse') {
     return 'gap-2';
   }
-  if (density === 'medium') {
+  if (density === 'compact') {
     return 'gap-1.5';
   }
   return 'gap-1';
@@ -142,7 +142,7 @@ const getIconSize = (density: Density) => {
   if (density === 'sparse') {
     return 'lg';
   }
-  if (density === 'medium') {
+  if (density === 'compact') {
     return 'md';
   }
   return 'sm';

--- a/packages/ui/src/theme/theme.ts
+++ b/packages/ui/src/theme/theme.ts
@@ -99,10 +99,11 @@ const PALETTE = {
   },
   base: {
     black: '#000000',
+    blackAlt: '#0D0D0D',
     white: '#ffffff',
     transparent: 'transparent',
   },
-};
+} as const;
 
 /**
  * Call `theme.spacing(x)`, where `x` is the number of spacing units (in the
@@ -192,6 +193,7 @@ export const theme = {
     },
     base: {
       black: PALETTE.base.black,
+      blackAlt: PALETTE.base.blackAlt,
       white: PALETTE.base.white,
       transparent: PALETTE.base.transparent,
     },
@@ -204,12 +206,13 @@ export const theme = {
     action: {
       hoverOverlay: PALETTE.teal['400'] + hexOpacity(0.15),
       activeOverlay: PALETTE.neutral['950'] + hexOpacity(0.15),
-      disabledOverlay: PALETTE.neutral['950'] + hexOpacity(0.8),
+      disabledOverlay: PALETTE.neutral['950'] + hexOpacity(0.6),
       primaryFocusOutline: PALETTE.orange['400'],
       secondaryFocusOutline: PALETTE.teal['400'],
       unshieldFocusOutline: PALETTE.purple['400'],
       neutralFocusOutline: PALETTE.neutral['400'],
       destructiveFocusOutline: PALETTE.red['400'],
+      successFocusOutline: PALETTE.green['400'],
     },
     other: {
       tonalStroke: PALETTE.neutral['50'] + hexOpacity(0.15),

--- a/packages/ui/src/theme/theme.ts
+++ b/packages/ui/src/theme/theme.ts
@@ -206,7 +206,7 @@ export const theme = {
     action: {
       hoverOverlay: PALETTE.teal['400'] + hexOpacity(0.15),
       activeOverlay: PALETTE.neutral['950'] + hexOpacity(0.15),
-      disabledOverlay: PALETTE.neutral['950'] + hexOpacity(0.6),
+      disabledOverlay: PALETTE.neutral['950'] + hexOpacity(0.8),
       primaryFocusOutline: PALETTE.orange['400'],
       secondaryFocusOutline: PALETTE.teal['400'],
       unshieldFocusOutline: PALETTE.purple['400'],
@@ -218,19 +218,29 @@ export const theme = {
       tonalStroke: PALETTE.neutral['50'] + hexOpacity(0.15),
       tonalFill5: PALETTE.neutral['50'] + hexOpacity(0.05),
       tonalFill10: PALETTE.neutral['50'] + hexOpacity(0.1),
-      solidStroke: PALETTE.neutral['700'],
+      solidStroke: PALETTE.neutral['900'],
       dialogBackground: PALETTE.teal['700'] + hexOpacity(0.1),
       overlay: PALETTE.base.black + hexOpacity(0.5),
     },
   },
   gradient: {
     card: 'linear-gradient(136deg, rgba(250, 250, 250, 0.1) 6.32%, rgba(250, 250, 250, 0.01) 75.55%)',
-    tabNeutral: 'radial-gradient(at 50% 100%, rgba(163, 163, 163, 0.35) 0%, transparent 50%)',
-    tabAccent: 'radial-gradient(at 50% 100%, rgba(244, 156, 67, 0.35) 0%, transparent 50%)',
-    tabUnshield: 'radial-gradient(at 50% 100%, rgba(193, 166, 204, 0.35) 0%, transparent 50%)',
-    dialogSuccess: `radial-gradient(100% 100% at 0% 0%, rgba(83, 174, 168, 0.20) 0%, rgba(83, 174, 168, 0.02) 100%)`,
-    dialogCaution: `radial-gradient(100% 100% at 0% 0%, rgba(153, 97, 15, 0.20) 0%, rgba(153, 97, 15, 0.02) 100%)`,
-    dialogError: `radial-gradient(100% 100% at 0% 0%, rgba(175, 38, 38, 0.20) 0%, rgba(175, 38, 38, 0.02) 100%)`,
+    neutralRadialGradient:
+      'radial-gradient(50% 100% at 50% 100%, rgba(163, 163, 163, 0.35) 0%, rgba(163, 163, 163, 0.00) 95%)',
+    accentRadialGradient:
+      'radial-gradient(50% 100% at 50% 100%, rgba(186, 77, 20, 0.35) 0%, rgba(186, 77, 20, 0.00) 95%)',
+    unshieldRadialGradient:
+      'radial-gradient(50% 100% at 50% 100%, rgba(112, 82, 121, 0.35) 0%, rgba(112, 82, 121, 0.00) 95%)',
+    accentRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(244, 156, 67, 0.25) 0%, rgba(244, 156, 67, 0.03) 100%)',
+    unshieldRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(193, 166, 204, 0.25) 0%, rgba(193, 166, 204, 0.03) 100%)',
+    secondaryRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(83, 174, 168, 0.25) 0%, rgba(83, 174, 168, 0.03) 100%)',
+    cautionRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(153, 97, 15, 0.25) 0%, rgba(153, 97, 15, 0.03) 100%)',
+    destructiveRadialBackground:
+      'radial-gradient(100% 100% at 0% 0%, rgba(175, 38, 38, 0.25) 0%, rgba(175, 38, 38, 0.03) 100%)',
     buttonHover:
       'linear-gradient(0deg, rgba(83, 174, 168, 0.15) 0%, rgba(83, 174, 168, 0.15) 100%)',
     buttonDisabled: 'linear-gradient(0deg, rgba(10, 10, 10, 0.8) 0%, rgba(10, 10, 10, 0.8) 100%)',

--- a/packages/ui/src/utils/action-type.ts
+++ b/packages/ui/src/utils/action-type.ts
@@ -1,6 +1,6 @@
 import cn from 'clsx';
 
-export type ActionType = 'default' | 'accent' | 'unshield' | 'destructive';
+export type ActionType = 'default' | 'accent' | 'unshield' | 'destructive' | 'success';
 
 export const getColorByActionType = (actionType: ActionType): string => {
   if (actionType === 'destructive') {
@@ -9,18 +9,12 @@ export const getColorByActionType = (actionType: ActionType): string => {
   return cn('text-text-primary');
 };
 
-const AFTER_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
-  default: cn('focus-within:after:outline-action-neutralFocusOutline'),
-  accent: cn('focus-within:after:outline-action-primaryFocusOutline'),
-  unshield: cn('focus-within:after:outline-action-unshieldFocusOutline'),
-  destructive: cn('focus-within:after:outline-action-destructiveFocusOutline'),
-};
-
 const OUTLINE_COLOR_MAP: Record<ActionType, string> = {
-  default: cn('outline-neutral-main'),
+  default: cn('outline-other-tonalStroke'),
   accent: cn('outline-primary-main'),
   unshield: cn('outline-unshield-main'),
   destructive: cn('outline-destructive-main'),
+  success: cn('outline-success-main'),
 };
 
 const BEFORE_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
@@ -28,6 +22,7 @@ const BEFORE_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('focus:before:outline-action-primaryFocusOutline'),
   unshield: cn('focus:before:outline-action-unshieldFocusOutline'),
   destructive: cn('focus:before:outline-action-destructiveFocusOutline'),
+  success: cn('focus:before:outline-action-successFocusOutline'),
 };
 
 const FOCUS_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
@@ -35,6 +30,7 @@ const FOCUS_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('focus:outline-action-primaryFocusOutline'),
   unshield: cn('focus:outline-action-unshieldFocusOutline'),
   destructive: cn('focus:outline-action-destructiveFocusOutline'),
+  success: cn('focus:outline-action-successFocusOutline'),
 };
 
 const FOCUS_WITHIN_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
@@ -42,6 +38,7 @@ const FOCUS_WITHIN_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('focus-within:outline-action-primaryFocusOutline'),
   unshield: cn('focus-within:outline-action-unshieldFocusOutline'),
   destructive: cn('focus-within:outline-action-destructiveFocusOutline'),
+  success: cn('focus-within:outline-action-successFocusOutline'),
 };
 
 const ARIA_CHECKED_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
@@ -49,6 +46,7 @@ const ARIA_CHECKED_OUTLINE_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('aria-checked:outline-action-primaryFocusOutline'),
   unshield: cn('aria-checked:outline-action-unshieldFocusOutline'),
   destructive: cn('aria-checked:outline-action-destructiveFocusOutline'),
+  success: cn('aria-checked:outline-action-successFocusOutline'),
 };
 
 const BORDER_COLOR_MAP: Record<ActionType, string> = {
@@ -56,6 +54,7 @@ const BORDER_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('border-primary-main'),
   unshield: cn('border-unshield-main'),
   destructive: cn('border-destructive-main'),
+  success: cn('border-success-main'),
 };
 
 const BACKGROUND_COLOR_MAP: Record<ActionType, string> = {
@@ -63,10 +62,7 @@ const BACKGROUND_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('bg-primary-main'),
   unshield: cn('bg-unshield-main'),
   destructive: cn('bg-destructive-main'),
-};
-
-export const getAfterOutlineColorByActionType = (actionType: ActionType): string => {
-  return AFTER_OUTLINE_COLOR_MAP[actionType];
+  success: cn('bg-success-main'),
 };
 
 export const getBeforeOutlineColorByActionType = (actionType: ActionType): string => {

--- a/packages/ui/src/utils/button.ts
+++ b/packages/ui/src/utils/button.ts
@@ -1,7 +1,6 @@
 import cn from 'clsx';
 import type { Density } from './density';
 import {
-  getAfterOutlineColorByActionType,
   getBeforeOutlineColorByActionType,
   ActionType,
   getBackgroundColorByActionType,
@@ -13,40 +12,27 @@ interface ButtonStyleAttributes {
   density: Density;
   iconOnly?: boolean | 'adornment';
   actionType: ActionType;
+  priority: Priority;
 }
 
 /** Shared styles to use for any `<button />` */
 export const buttonBase = cn('appearance-none border-none text-inherit cursor-pointer p-0');
 
-export const getFocusOutline = ({ density, iconOnly, actionType }: ButtonStyleAttributes) =>
-  cn(
-    'relative',
-
-    // :after styles
-    'after:content-[""] after:absolute after:inset-0 after:z-[1] after:outline-2 after:outline after:outline-transparent after:transition-[outline-color] after:duration-150',
-    density === 'sparse' && iconOnly !== 'adornment' ? 'after:rounded-sm' : 'after:rounded-full',
-    iconOnly === 'adornment' && 'after:outline-offset-0',
-
-    // :disabled styles
-    'disabled:pointer-events-none',
-    'disabled:after:pointer-events-none',
-
-    /**
-     * The focus outline is styled on the `::after` pseudo-element, rather than
-     * just adding an `outline` to the base element. This is because, if we only
-     * used `outline`, and the currently focused button is right before a
-     * disabled button, the overlay of the disabled button would be above the
-     * outline, making the outline appear to be partly cut off.
-     */
-    'focus-within:outline-none',
-    getAfterOutlineColorByActionType(actionType),
-  );
+export const getFont = ({ density }: ButtonStyleAttributes): string => {
+  if (density === 'compact') {
+    return cn('font-default text-textSm font-medium leading-textSm');
+  }
+  if (density === 'slim') {
+    return cn('font-default text-textXs font-medium leading-textXs');
+  }
+  return cn('font-default text-textBase font-medium leading-textBase');
+};
 
 /** Adds overlays to a button for when it's hovered, active, or disabled. */
 export const getOverlays = ({ actionType, density }: ButtonStyleAttributes): string =>
   cn(
     'relative',
-    'before:content-[""] before:absolute before:inset-0 before:z-[1] before:outline-2 before:outline before:outline-transparent duration-150 before:transition-[background-color] before:transition-[outline-color]',
+    'before:content-[""] before:absolute before:inset-0 before:z-[1] before:outline-[1.5] before:outline before:outline-transparent duration-150 before:transition-[background-color,outline-color]',
     'hover:before:bg-action-hoverOverlay',
     'active:before:bg-action-activeOverlay',
     'disabled:before:cursor-not-allowed disabled:before:bg-action-disabledOverlay',
@@ -54,23 +40,42 @@ export const getOverlays = ({ actionType, density }: ButtonStyleAttributes): str
     density === 'sparse' ? 'before:rounded-sm' : 'before:rounded-full',
   );
 
-export const getBackground = (
-  actionType: ActionType,
-  priority: Priority,
-  iconOnly?: boolean | 'adornment',
-): string => {
+export const getBackground = ({
+  priority,
+  actionType,
+  iconOnly,
+}: ButtonStyleAttributes): string => {
   if (priority === 'secondary' || iconOnly === 'adornment') {
     return cn('bg-transparent');
   }
 
   switch (actionType) {
-    case 'accent':
-      return cn('bg-primary-main');
-
     case 'default':
       return cn('bg-other-tonalFill10');
 
     default:
       return getBackgroundColorByActionType(actionType);
   }
+};
+
+export const getSize = ({ iconOnly, density }: ButtonStyleAttributes) => {
+  if (density === 'compact') {
+    return cn('rounded-full h-8 min-w-8 w-max', iconOnly ? 'pl-2 pr-2' : 'pl-4 pr-4');
+  }
+
+  if (density === 'slim') {
+    return cn('rounded-full h-6 min-w-6 w-max', iconOnly ? 'pl-1 pr-1' : 'pl-2 pr-2');
+  }
+
+  return cn('rounded-sm h-12', iconOnly ? 'w-12 min-w-12 pl-0 pr-0' : 'w-full pl-4 pr-4');
+};
+
+export const getIconSize = (density: Density): number => {
+  if (density === 'compact') {
+    return 16;
+  }
+  if (density === 'slim') {
+    return 12;
+  }
+  return 24;
 };

--- a/packages/ui/src/utils/color.ts
+++ b/packages/ui/src/utils/color.ts
@@ -62,6 +62,7 @@ export const COLOR_CLASS_MAP: Record<ThemeColor, [string, string]> = {
   'success.dark': ['text-success-dark', 'bg-success-dark'],
   'success.contrast': ['text-success-contrast', 'bg-success-contrast'],
   'base.black': ['text-base-black', 'bg-base-black'],
+  'base.blackAlt': ['text-base-blackAlt', 'bg-base-blackAlt'],
   'base.white': ['text-base-white', 'bg-base-white'],
   'base.transparent': ['text-base-transparent', 'bg-base-transparent'],
   'text.primary': ['text-text-primary', 'bg-text-primary'],
@@ -90,6 +91,10 @@ export const COLOR_CLASS_MAP: Record<ThemeColor, [string, string]> = {
   'action.destructiveFocusOutline': [
     'text-action-destructiveFocusOutline',
     'bg-action-destructiveFocusOutline',
+  ],
+  'action.successFocusOutline': [
+    'text-action-successFocusOutline',
+    'bg-action-successFocusOutline',
   ],
   'other.tonalStroke': ['text-other-tonalStroke', 'bg-other-tonalStroke'],
   'other.tonalFill5': ['text-other-tonalFill5', 'bg-other-tonalFill5'],

--- a/packages/ui/src/utils/density.ts
+++ b/packages/ui/src/utils/density.ts
@@ -3,12 +3,12 @@ import { createContext, useContext } from 'react';
 /**
  * The density for a given layout. Generally, `sparse` is the correct size
  * choice (and is thus the default for any components that use the
- * `useDensity()` hook). But you can use `compact` for layouts containing a lot
+ * `useDensity()` hook). But you can use `compact` and `slim` for layouts containing a lot
  * of data that should be presented in a denser layout.
  *
  * See `<DensityContext />`
  */
-export type Density = 'compact' | 'sparse' | 'medium';
+export type Density = 'sparse' | 'compact' | 'slim';
 
 /**
  * This context is used internally by the `<Density />` component and the

--- a/packages/ui/src/utils/menu-item.ts
+++ b/packages/ui/src/utils/menu-item.ts
@@ -11,6 +11,7 @@ const OUTLINE_COLOR_MAP: Record<ActionType, string> = {
   accent: cn('[&:focus:not(:disabled)]:outline-action-primaryFocusOutline'),
   unshield: cn('[&:focus:not(:disabled)]:outline-action-unshieldFocusOutline'),
   destructive: cn('[&:focus:not(:disabled)]:outline-action-destructiveFocusOutline'),
+  success: cn('[&:focus:not(:disabled)]:outline-action-successFocusOutline'),
 };
 
 export const getMenuItem = (actionType: ActionType): string =>

--- a/packages/ui/src/utils/popover.ts
+++ b/packages/ui/src/utils/popover.ts
@@ -4,13 +4,13 @@ export type PopoverContext = 'default' | 'success' | 'caution' | 'error';
 
 const getPopoverBackground = (context: PopoverContext): string => {
   if (context === 'success') {
-    return cn('bg-dialogSuccess');
+    return cn('bg-secondaryRadialBackground');
   }
   if (context === 'caution') {
-    return cn('bg-dialogCaution');
+    return cn('bg-cautionRadialBackground');
   }
   if (context === 'error') {
-    return cn('bg-dialogError');
+    return cn('bg-destructiveRadialBackground');
   }
   return cn('bg-other-dialogBackground');
 };

--- a/packages/ui/src/utils/typography.ts
+++ b/packages/ui/src/utils/typography.ts
@@ -46,7 +46,5 @@ export const technical = cn('font-mono text-textBase font-medium leading-textBas
 
 export const xxl = cn('font-default text-text2xl font-medium leading-text2xl');
 
-export const button = cn('font-default text-textBase font-medium leading-textBase');
-
 // equals to body with the bottom margin
 export const p = cn('font-default text-textBase font-normal leading-textBase mb-6 last:mb-0');


### PR DESCRIPTION
This PR aligns basic UI components with the latest designs:
- Sync colors and gradients
- Remove `medium` density and add `slim` density, while replacing `medium` for `compact`
- Update `Button` component to support all existing variants

Check here: https://penumbra-ui-preview--pr1939-feat-asset-selector-bd416kcb.web.app/?path=/docs/ui-library-button--docs