### PR TITLE
Update skip pre-selected assets

### DIFF
--- a/apps/minifront/src/components/ibc/deposit-skip/index.tsx
+++ b/apps/minifront/src/components/ibc/deposit-skip/index.tsx
@@ -1,10 +1,9 @@
 import { Widget } from '@skip-go/widget';
 
 const defaultRoute = {
-  srcChainId: 'osmosis-1',
-  srcAssetDenom: 'ibc/23104D411A6EB6031FA92FB75F227422B84989969E91DCAD56A535DD7FF0A373', // $USDY on osmosis
+  srcChainId: 'noble-1',
+  srcAssetDenom: 'ausdy',
   destChainId: 'penumbra-1',
-  destAssetDenom: 'ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349', // $UM on penumbra
 };
 
 const filter = {


### PR DESCRIPTION
At the moment, we are defaulting to usdc in (not currently supported)

<img width="773" alt="Screenshot 2024-12-12 at 5 42 20 PM" src="https://github.com/user-attachments/assets/79f0fd44-29f3-456c-99cf-ccf8975db660" />
<img width="602" alt="Screenshot 2024-12-12 at 5 42 17 PM" src="https://github.com/user-attachments/assets/17756c8d-f0d8-4a03-9b49-de658566395f" />
