### PR TITLE
Adjust Max button for -0.1 asset

### DIFF
--- a/apps/minifront/src/state/swap/instant-swap.ts
+++ b/apps/minifront/src/state/swap/instant-swap.ts
@@ -186,16 +186,22 @@ const assembleSwapRequest = async ({
   }
 
   const addressIndex = getAddressIndex(assetIn.accountAddress);
+  const exponent = getDisplayDenomExponentFromValueView(assetIn.balanceView);
+  
+  // Convert amount to BigNumber and subtract 0.1
+  const adjustedAmount = BigNumber(amount).minus(0.1);
+  
+  // Ensure we don't go negative
+  if (adjustedAmount.isLessThan(0)) {
+    throw new Error('Amount too small for swap');
+  }
 
   return new TransactionPlannerRequest({
     swaps: [
       {
         targetAsset: getAssetId(assetOut),
         value: {
-          amount: toBaseUnit(
-            BigNumber(amount),
-            getDisplayDenomExponentFromValueView(assetIn.balanceView),
-          ),
+          amount: toBaseUnit(adjustedAmount, exponent),
           assetId: getAssetIdFromValueView(assetIn.balanceView),
         },
         claimAddress: await getAddressByIndex(addressIndex.account),


### PR DESCRIPTION
Max swap would previously fail because it doesn't automatically adjust for gas fees. This change should alter the max to be -0.1, then check to make sure the balance stays positive, before attempting to swap, so it works right away off the bat without user interference. Just an idea as a potential UI improvement. 

![image](https://github.com/user-attachments/assets/34822714-bd63-432c-a06f-2110bf169cfa)
