### PR TITLE
Updates for Positions Table

### DIFF
--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -102,13 +102,15 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       actionType = 'default',
       type = 'button',
       priority = 'primary',
+      density: densityProp,
       ...attrs
       // needed for the Radix's `asChild` prop to work correctly
       // https://www.radix-ui.com/primitives/docs/guides/composition#composing-with-your-own-react-components
     },
     ref,
   ) => {
-    const density = useDensity();
+    const densityContext = useDensity();
+    const density = densityProp ?? densityContext;
     const styleAttrs = { actionType, iconOnly, density, priority };
 
     return (
@@ -133,7 +135,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
           'relative',
           'text-neutral-contrast',
-          'flex items-center justify-center',
+          'inline-flex items-center justify-center',
           density === 'sparse' ? 'gap-2' : 'gap-1',
         )}
       >

--- a/packages/ui/src/Table/index.tsx
+++ b/packages/ui/src/Table/index.tsx
@@ -3,6 +3,7 @@ import cn from 'clsx';
 import { tableHeading, tableItem } from '../utils/typography';
 import { Density, useDensity } from '../utils/density';
 import { ConditionalWrap } from '../ConditionalWrap';
+import { getThemeColorClass, ThemeColor } from '../utils/color';
 
 export interface TableProps {
   /** Content that will appear above the table. */
@@ -10,6 +11,8 @@ export interface TableProps {
   children: ReactNode;
   /** Which CSS `table-layout` property to use. */
   tableLayout?: 'fixed' | 'auto';
+  /** The background color of the table. */
+  bgColor?: ThemeColor;
 }
 
 /**
@@ -53,7 +56,12 @@ export interface TableProps {
  * </Table>
  * ```
  */
-export const Table = ({ title, children, tableLayout }: TableProps) => (
+export const Table = ({
+  title,
+  children,
+  tableLayout,
+  bgColor = 'other.tonalFill5',
+}: TableProps) => (
   <ConditionalWrap
     if={!!title}
     then={children => (
@@ -67,7 +75,8 @@ export const Table = ({ title, children, tableLayout }: TableProps) => (
       cellSpacing={0}
       cellPadding={0}
       className={cn(
-        'w-full bg-other-tonalFill5 pl-3 pr-3 rounded-sm',
+        getThemeColorClass(bgColor).bg,
+        'w-full pl-3 pr-3 rounded-sm',
         tableLayout === 'fixed' ? 'table-fixed' : 'table-auto',
       )}
     >
@@ -82,16 +91,22 @@ Table.Thead = Thead;
 const Tbody = ({ children }: PropsWithChildren) => <tbody>{children}</tbody>;
 Table.Tbody = Tbody;
 
-const Tr = ({ children }: PropsWithChildren) => (
-  <tr className='[&>td:last-child]:border-b-0'>{children}</tr>
-);
+const Tr = ({ children }: PropsWithChildren) => <tr>{children}</tr>;
 Table.Tr = Tr;
 
 type HAlign = 'left' | 'center' | 'right';
 type VAlign = 'top' | 'middle' | 'bottom';
 
-const getCell = (density: Density) =>
-  cn('box-border', 'pl-3 pr-3', density === 'sparse' ? 'pt-4 pb-4' : 'pt-3 pb-3');
+const densityPaddingMapping = {
+  slim: 'px-3 py-2',
+  compact: 'px-3 py-3',
+  sparse: 'px-3 py-4',
+};
+
+const getCell = (density: Density) => {
+  const padding = densityPaddingMapping[density];
+  return cn('box-border', padding);
+};
 
 const Th = ({
   children,
@@ -99,6 +114,7 @@ const Th = ({
   hAlign,
   vAlign,
   width,
+  density: densityProp,
 }: PropsWithChildren<{
   colSpan?: number;
   /** A CSS `width` value to use for this cell. */
@@ -107,8 +123,10 @@ const Th = ({
   hAlign?: HAlign;
   /** Controls the CSS `vertical-align` property for this cell. */
   vAlign?: VAlign;
+  density?: Density;
 }>) => {
-  const density = useDensity();
+  const densityContext = useDensity();
+  const density = densityProp ?? densityContext;
 
   return (
     <th
@@ -133,6 +151,7 @@ const Td = ({
   hAlign,
   vAlign,
   width,
+  density: densityProp,
 }: PropsWithChildren<{
   colSpan?: number;
   /** A CSS `width` value to use for this cell. */
@@ -141,8 +160,10 @@ const Td = ({
   hAlign?: HAlign;
   /** Controls the CSS `vertical-align` property for this cell. */
   vAlign?: VAlign;
+  density?: Density;
 }>) => {
-  const density = useDensity();
+  const densityContext = useDensity();
+  const density = densityProp ?? densityContext;
 
   return (
     <td

--- a/packages/ui/src/Text/index.tsx
+++ b/packages/ui/src/Text/index.tsx
@@ -16,6 +16,9 @@ import {
   p,
   getTextBase,
   xxs,
+  tableHeading,
+  tableHeadingMedium,
+  tableHeadingSmall,
 } from '../utils/typography';
 import { ElementType, ReactNode } from 'react';
 import { ThemeColor } from '../utils/color';
@@ -135,6 +138,9 @@ const VARIANT_MAP: Record<TextVariant, { element: ElementType; classes: string }
   detailTechnical: { element: 'span', classes: detailTechnical },
   technical: { element: 'span', classes: technical },
   body: { element: 'span', classes: body },
+  tableHeading: { element: 'span', classes: tableHeading },
+  tableHeadingMedium: { element: 'span', classes: tableHeadingMedium },
+  tableHeadingSmall: { element: 'span', classes: tableHeadingSmall },
 };
 
 /**

--- a/packages/ui/src/Text/types.ts
+++ b/packages/ui/src/Text/types.ts
@@ -12,7 +12,10 @@ export type TextVariant =
   | 'small'
   | 'detailTechnical'
   | 'technical'
-  | 'body';
+  | 'body'
+  | 'tableHeading'
+  | 'tableHeadingMedium'
+  | 'tableHeadingSmall';
 
 type TextType = {
   [K in TextVariant]: Record<K, true> & Partial<Record<Exclude<TextVariant, K>, never>>;

--- a/packages/ui/src/ValueView/index.tsx
+++ b/packages/ui/src/ValueView/index.tsx
@@ -18,6 +18,10 @@ const ValueText = ({ children, density }: { children: ReactNode; density: Densit
     return <Text body>{children}</Text>;
   }
 
+  if (density === 'slim') {
+    return <Text detailTechnical>{children}</Text>;
+  }
+
   return <Text detail>{children}</Text>;
 };
 
@@ -36,6 +40,10 @@ export interface ValueViewComponentProps<SelectedContext extends Context> {
    */
   priority?: PillProps['priority'];
   /**
+   * If true, the asset icon will be visible.
+   */
+  showIcon?: boolean;
+  /**
    * If true, the asset symbol will be visible.
    */
   showSymbol?: boolean;
@@ -51,6 +59,11 @@ export interface ValueViewComponentProps<SelectedContext extends Context> {
    * If true, the amount will have trailing zeros.
    */
   trailingZeros?: boolean;
+  /**
+   * The density to use for the component. If not provided, the density will be
+   * determined by the `Density` context.
+   */
+  density?: Density;
 }
 
 /**
@@ -64,12 +77,15 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
   valueView,
   context,
   priority = 'primary',
+  showIcon = true,
   showSymbol = true,
   abbreviate = false,
   showValue = true,
   trailingZeros = false,
+  density: densityProps,
 }: ValueViewComponentProps<SelectedContext>) => {
-  const density = useDensity();
+  const densityContext = useDensity();
+  const density = densityProps ?? densityContext;
 
   if (!valueView) {
     return null;
@@ -102,9 +118,11 @@ export const ValueViewComponent = <SelectedContext extends Context = 'default'>(
       )}
     >
       <span className={cn('flex w-max max-w-full items-center text-ellipsis', getGap(density))}>
-        <div className='shrink-0'>
-          <AssetIcon size={getIconSize(density)} metadata={metadata} />
-        </div>
+        {showIcon && (
+          <div className='shrink-0'>
+            <AssetIcon size={getIconSize(density)} metadata={metadata} />
+          </div>
+        )}
 
         <div
           className={cn(

--- a/packages/ui/src/utils/typography.ts
+++ b/packages/ui/src/utils/typography.ts
@@ -61,4 +61,4 @@ export const button = cn('font-default text-textBase font-medium leading-textBas
 
 export const buttonMedium = cn('font-default text-textBase font-medium leading-textBase');
 
-export const buttonSmall = cn('font-default text-textBase font-medium leading-textBase');
+export const buttonSmall = cn('font-default text-textXs font-medium leading-textBase');


### PR DESCRIPTION
There's an issue reported with Density [here](https://penumbralabs.slack.com/archives/C074P1TPBH9/p1734715004799049).
TLDR: Different density components use the same context variable, so when you have multiple densities within the page there's a case where the children of one density get the value of another density.

This PR includes a temporary solution and is not meant to be a permanent solution, but merely a way to not block our progress with the position table in the DEX.

Other changes:
- Change button display type from flex to inline-flex
- Improved Table styling to match dex designs for "slim" density
- Added table-headings support to the Text component