### PR TITLE
minifront: transaction view rendering 

### DIFF
--- a/.changeset/pink-rabbits-fry.md
+++ b/.changeset/pink-rabbits-fry.md
@@ -1,0 +1,5 @@
+---
+'minifront': minor
+---
+
+transaction view ui fixes

--- a/apps/minifront/src/components/tx-details/tx-viewer.tsx
+++ b/apps/minifront/src/components/tx-details/tx-viewer.tsx
@@ -18,14 +18,14 @@ import { penumbra } from '../../penumbra';
 
 export enum TxDetailsTab {
   PUBLIC = 'public',
-  PRIVATE = 'private',
   RECEIVER = 'receiver',
+  PRIVATE = 'private',
 }
 
 const OPTIONS = [
   { label: 'Your View', value: TxDetailsTab.PRIVATE },
-  { label: 'Public View', value: TxDetailsTab.PUBLIC },
   { label: 'Receiver View', value: TxDetailsTab.RECEIVER },
+  { label: 'Public View', value: TxDetailsTab.PUBLIC },
 ];
 
 const getMetadata: MetadataFetchFn = async ({ assetId }) => {
@@ -84,7 +84,8 @@ export const TxViewer = ({ txInfo }: { txInfo?: TransactionInfo }) => {
         <>
           <TransactionViewComponent
             txv={
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: justify
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
+              // transaction view component will always be populated.
               txInfo.view!
             }
             metadataFetcher={getMetadata}

--- a/apps/minifront/src/components/tx-details/tx-viewer.tsx
+++ b/apps/minifront/src/components/tx-details/tx-viewer.tsx
@@ -84,8 +84,7 @@ export const TxViewer = ({ txInfo }: { txInfo?: TransactionInfo }) => {
         <>
           <TransactionViewComponent
             txv={
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
-              // transaction view component will always be populated.
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- txInfo.view is guaranteed to be populated
               txInfo.view!
             }
             metadataFetcher={getMetadata}

--- a/packages/ui-deprecated/components/ui/tx/memo-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/memo-view.tsx
@@ -13,11 +13,12 @@ export const MemoViewComponent = ({ memo: { memoView } }: { memo: MemoView }) =>
             <div className='flex flex-col gap-4'>
               <ActionDetails>
                 <ActionDetails.Row label='Return Address'>
-                  <AddressViewComponent view={memoView.value.plaintext?.returnAddress} />
+                  {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- field is always populated when the component is rendered */}
+                  <AddressViewComponent view={memoView.value.plaintext!.returnAddress} />
                 </ActionDetails.Row>
                 <ActionDetails.Row label='Memo Text'>
                   <span
-                    className='text-gray-300 italic pr-2 overflow-visible'
+                    className='overflow-visible pr-2 italic text-gray-300'
                     style={{ wordBreak: 'normal' }}
                   >
                     {memoView.value.plaintext?.text}

--- a/packages/ui-deprecated/components/ui/tx/memo-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/memo-view.tsx
@@ -13,11 +13,13 @@ export const MemoViewComponent = ({ memo: { memoView } }: { memo: MemoView }) =>
             <div className='flex flex-col gap-4'>
               <ActionDetails>
                 <ActionDetails.Row label='Return Address'>
-                  {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: justify not using '?' operator */}
-                  <AddressViewComponent view={memoView.value.plaintext!.returnAddress} />
+                  <AddressViewComponent view={memoView.value.plaintext?.returnAddress} />
                 </ActionDetails.Row>
                 <ActionDetails.Row label='Memo Text'>
-                  <span className='italic' style={{ wordBreak: 'normal' }}>
+                  <span
+                    className='text-gray-300 italic pr-2 overflow-visible'
+                    style={{ wordBreak: 'normal' }}
+                  >
                     {memoView.value.plaintext?.text}
                   </span>
                 </ActionDetails.Row>


### PR DESCRIPTION
reorders the transaction view visibility settings in https://github.com/penumbra-zone/web/issues/1873 and addresses the truncated memo field flagged by the beta reviewers.

-----------------------------

_before_

<img width="747" alt="Screenshot 2024-12-25 at 10 38 47 PM" src="https://github.com/user-attachments/assets/5ff8c22e-a163-4f56-a289-1b1a4a5be9d5" />


_after_

<img width="751" alt="Screenshot 2024-12-25 at 10 39 04 PM" src="https://github.com/user-attachments/assets/58ad36f2-24c8-48ce-bcf7-16cabaaf1312" />
