### PR TITLE
Update Tooltip message prop to support ReactNode

### DIFF
--- a/.changeset/strange-nails-perform.md
+++ b/.changeset/strange-nails-perform.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Update Tooltip message prop to support ReactNode

--- a/packages/ui/src/Tooltip/tooltip.tsx
+++ b/packages/ui/src/Tooltip/tooltip.tsx
@@ -12,7 +12,7 @@ export interface TooltipProps {
    * A string message to show in the tooltip. Note that only strings are
    * allowed; for interactive content, use a `<Popover />` or a `<Dialog />`.
    */
-  message: string;
+  message: string | ReactNode;
   /**
    * The trigger for the tooltip.
    *


### PR DESCRIPTION
## Description of Changes

- Update Tooltip message prop to support ReactNode

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
