### PR TITLE
minifront: modify sync modal

### DIFF
--- a/.changeset/fast-maps-allow.md
+++ b/.changeset/fast-maps-allow.md
@@ -1,0 +1,5 @@
+---
+'minifront': minor
+---
+
+prompt user to keep extension open in sync modal

--- a/apps/minifront/src/components/syncing-dialog/index.tsx
+++ b/apps/minifront/src/components/syncing-dialog/index.tsx
@@ -3,7 +3,6 @@ import { statusSelector, useStatus } from '../../state/status';
 import { SyncAnimation } from './sync-animation';
 import { Text } from '@penumbra-zone/ui-deprecated/Text';
 import { useEffect, useState } from 'react';
-import { useSyncProgress } from '@penumbra-zone/ui-deprecated/components/ui/block-sync-status';
 
 export const SyncingDialog = () => {
   const status = useStatus({
@@ -23,11 +22,16 @@ export const SyncingDialog = () => {
   return (
     <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)}>
       <Dialog.Content title='Your client is syncing...' zIndex={9999}>
+        <div style={{ textAlign: 'center' }}>
+          <Text body as='p'>
+            <b>Keep the extension open to improve sync speed</b>
+          </Text>
+        </div>
         <SyncAnimation />
 
         <div className='text-center'>
-          <Text body as='p'>
-            Decrypting blocks to update your local state
+          <Text small as='p'>
+            Decrypting blocks to update your local state.
           </Text>
           <Text small as='p'>
             You can click away, but your data <i>may</i> not be current
@@ -42,25 +46,8 @@ export const SyncingDialog = () => {
               </Text>
             )}
           </div>
-          {!!status?.isCatchingUp && status.latestKnownBlockHeight ? (
-            <RemainingTime
-              fullSyncHeight={status.fullSyncHeight}
-              latestKnownBlockHeight={status.latestKnownBlockHeight}
-            />
-          ) : null}
         </div>
       </Dialog.Content>
     </Dialog>
   );
-};
-
-const RemainingTime = ({
-  fullSyncHeight,
-  latestKnownBlockHeight,
-}: {
-  fullSyncHeight: bigint;
-  latestKnownBlockHeight: bigint;
-}) => {
-  const { formattedTimeRemaining } = useSyncProgress(fullSyncHeight, latestKnownBlockHeight);
-  return <Text technical>(Estimated time remaining: {formattedTimeRemaining})</Text>;
 };


### PR DESCRIPTION
## Description of Changes

prompts the user to keep the extension open during the initial sync since syncing is [~2x faster](https://github.com/penumbra-zone/web/issues/1961#issue-2756296559), and removes the "estimated time remaining" which is highly inaccurate and drastically fluctuates when syncing congested blocks or on slower internet connections. I'd argue the sync percentage is a sufficient indicator of syncing progress (and the syncing bar at the top of Minifront already displays the estimated time remaining), but open to reviewers opinions. 

---------------

_before_

<img width="455" alt="398199155-79493107-89cc-40c0-9497-db571d767b24" src="https://github.com/user-attachments/assets/8e6f9a1e-704f-4ac4-885f-b94fd1b08378" />

---------------

_after_

<img width="456" alt="Screenshot 2025-01-07 at 12 06 14 AM" src="https://github.com/user-attachments/assets/551f5207-d22f-4fd8-a30d-476c41636371" />

## Related Issue

references https://github.com/penumbra-zone/web/issues/1961

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
