### PR TITLE
ci: fix rust:lint job

### DIFF
--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -51,3 +51,6 @@ web-sys = { version = "0.3.70", features = ["console"] }
 [dev-dependencies]
 wasm-bindgen-test = "0.3.43"
 serde_json = "1.0.128"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }


### PR DESCRIPTION

## Description of Changes

Recently, CI jobs started failing on the `rust:lint` step. One suitable workaround was to ignore the questionable lints
via Cargo.toml:

 ```
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
```

This seems to resolve. I also tried bumping the `wasm-bindgen` dep to 0.2.100, which didn't resolve on its own. See related discussion in [0].

[0] https://github.com/rustwasm/wasm-bindgen/issues/4283

## Related Issue

An example failing job can be see here: https://github.com/penumbra-zone/web/actions/runs/12819463583/job/35747206149?pr=1980

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
