### PR TITLE
wasm: bump deps to v0.81.3

### DIFF
--- a/.changeset/tender-bobcats-invite.md
+++ b/.changeset/tender-bobcats-invite.md
@@ -2,4 +2,4 @@
 '@penumbra-zone/wasm': minor
 ---
 
-bump deps to v0.81.2
+bump deps to v0.81.3

--- a/.changeset/tender-bobcats-invite.md
+++ b/.changeset/tender-bobcats-invite.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': minor
+---
+
+bump deps to v0.81.2

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -804,8 +804,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -818,8 +818,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -2104,8 +2104,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2143,8 +2143,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2188,8 +2188,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2218,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2249,8 +2249,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2302,8 +2302,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2318,8 +2318,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2342,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2391,8 +2391,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2426,8 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "aes",
  "anyhow",
@@ -2470,8 +2470,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2506,8 +2506,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2531,8 +2531,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2558,8 +2558,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2591,8 +2591,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2642,8 +2642,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2683,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2712,8 +2712,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2763,8 +2763,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.81.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
+version = "0.81.3"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.3#8521a130b43aca39892a5ba27eb95eddc9a263ed"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -804,8 +804,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -818,8 +818,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -2104,8 +2104,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2143,8 +2143,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2188,8 +2188,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2218,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2249,8 +2249,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2302,8 +2302,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2318,8 +2318,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2342,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2391,8 +2391,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2426,8 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "aes",
  "anyhow",
@@ -2470,8 +2470,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2506,8 +2506,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2531,8 +2531,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2558,8 +2558,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2591,8 +2591,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2642,8 +2642,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2683,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2712,8 +2712,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2763,8 +2763,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.81.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.0#8df36a4247ae90acc8aecc48bfa37e55785f779f"
+version = "0.81.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.81.2#14c4b8c72d71c3f8ec05f5257adcbe4ba7d4cadf"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,21 +15,21 @@ mock-database = []
 
 [dependencies]
 # Update to tag dependency once https://github.com/penumbra-zone/penumbra/pull/4878 is in a release
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.0", package = "penumbra-transaction", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-transaction", default-features = false }
 
 anyhow = "1.0.89"
 ark-ff = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -15,21 +15,21 @@ mock-database = []
 
 [dependencies]
 # Update to tag dependency once https://github.com/penumbra-zone/penumbra/pull/4878 is in a release
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.2", package = "penumbra-transaction", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.81.3", package = "penumbra-transaction", default-features = false }
 
 anyhow = "1.0.89"
 ark-ff = { version = "0.4.2", features = ["std"] }


### PR DESCRIPTION
## Description of Changes

update wasm deps to latest [tagged v0.81.3 release
](https://github.com/penumbra-zone/penumbra/releases/tag/v0.81.3)
## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
