### PR TITLE
Typo fix 003-action-views.md

### DIFF
--- a/docs/adrs/003-action-views.md
+++ b/docs/adrs/003-action-views.md
@@ -87,7 +87,7 @@ This specification is intended to inform what information should be comprehended
 ## 8. [ActionDutchAuctionSchedule View](https://buf.build/penumbra-zone/penumbra/docs/78be1d64b1cb484ba4bc666d54dc76c5/penumbra.core.component.auction.v1alpha1#penumbra.core.component.auction.v1alpha1.ActionDutchAuctionSchedule)
 
 - `ActionDutchAuctionSchedule`
-  - `DutchAuctionDescription`: <u>**_opaque_**</u> field since the amounts and asset types can be public similiar to swaps.
+  - `DutchAuctionDescription`: <u>**_opaque_**</u> field since the amounts and asset types can be public similar to swaps.
   - `AuctionId`: <u>**_opaque_**</u> field since the unique identifier reveals no information about the auction.
   - `Metadata`: <u>**_opaque_**</u> field that augments the view with additional input and output metadata to assist clients in rendering its contents.
 


### PR DESCRIPTION
# Pull Request: Typo Fix in 003-action-views.md

## Description
This pull request resolves a typo in the `003-action-views.md` documentation file. The word **"similiar"** has been corrected to **"similar"** in the following context:

### Before:
> `DutchAuctionDescription`: <u>**_opaque_**</u> field since the amounts and asset types can be public **similiar** to swaps.

### After:
> `DutchAuctionDescription`: <u>**_opaque_**</u> field since the amounts and asset types can be public **similar** to swaps.

## Changes Made
- Corrected the typo to improve the clarity and professionalism of the document.

## Commit Details
- **Commit Hash:** _<commit_hash_here>_
- **Author:** @VitalikBerashvili
- **Date:** January 20, 2025

## Additional Information
- **Branch:** `Fix-typo`
- **Base Branch:** `main`
- **Status:** Able to merge.

## Checklist
- [x] Verified the typo correction.
- [x] Ensured no other changes were introduced.
- [x] PR allows edits by maintainers.

## Notes for Reviewers
This minor change enhances the
