### PR TITLE
fix(ui): stop XL font responsiveness

### DIFF
--- a/.changeset/spotty-emus-notice.md
+++ b/.changeset/spotty-emus-notice.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Stop XL screen size responsiveness

--- a/packages/ui/src/theme/font-sizes.css
+++ b/packages/ui/src/theme/font-sizes.css
@@ -131,56 +131,60 @@
 
 /* EXTRA LARGE SCREENS */
 
-@screen xl {
-  .text-textXs {
-    font-size: 0.875rem;
-  }
+/*
+  TODO: create a mechanism to turn font responsiveness on/off
+*/
 
-  .text-textSm {
-    font-size: 1rem;
-  }
+/*@screen xl {*/
+/*  .text-textXs {*/
+/*    font-size: 0.875rem;*/
+/*  }*/
 
-  .text-textBase {
-    font-size: 1.125rem;
-  }
+/*  .text-textSm {*/
+/*    font-size: 1rem;*/
+/*  }*/
 
-  .text-textLg {
-    font-size: 1.25rem;
-  }
+/*  .text-textBase {*/
+/*    font-size: 1.125rem;*/
+/*  }*/
 
-  .text-textXl {
-    font-size: 1.375rem;
-  }
+/*  .text-textLg {*/
+/*    font-size: 1.25rem;*/
+/*  }*/
 
-  .text-text2xl {
-    font-size: 1.6875rem;
-  }
+/*  .text-textXl {*/
+/*    font-size: 1.375rem;*/
+/*  }*/
 
-  .text-text3xl {
-    font-size: 2.125rem;
-  }
+/*  .text-text2xl {*/
+/*    font-size: 1.6875rem;*/
+/*  }*/
 
-  .text-text4xl {
-    font-size: 2.5rem;
-  }
+/*  .text-text3xl {*/
+/*    font-size: 2.125rem;*/
+/*  }*/
 
-  .text-text5xl {
-    font-size: 3.375rem;
-  }
+/*  .text-text4xl {*/
+/*    font-size: 2.5rem;*/
+/*  }*/
 
-  .text-text6xl {
-    font-size: 4.25rem;
-  }
+/*  .text-text5xl {*/
+/*    font-size: 3.375rem;*/
+/*  }*/
 
-  .text-text7xl {
-    font-size: 5.0625rem;
-  }
+/*  .text-text6xl {*/
+/*    font-size: 4.25rem;*/
+/*  }*/
 
-  .text-text8xl {
-    font-size: 6.75rem;
-  }
+/*  .text-text7xl {*/
+/*    font-size: 5.0625rem;*/
+/*  }*/
 
-  .text-text9xl {
-    font-size: 9rem;
-  }
-}
+/*  .text-text8xl {*/
+/*    font-size: 6.75rem;*/
+/*  }*/
+
+/*  .text-text9xl {*/
+/*    font-size: 9rem;*/
+/*  }*/
+/*}*/


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/dex-explorer/issues/307

This PR simply comments out the XL screen size responsiveness. 

### Context

Sam and Artur made UI typography styles responsive, so, for example, a `text-textBase` class is 0.875rem (14px) on mobile and tablet screens, 1rem (16px) on desktop and large screens, 1.125rem (18px) on XL screens.

This feature was implemented in https://github.com/penumbra-zone/web/pull/1978 to meet the v2 designs requirements. This lead to mobile and tablet screens become pixel-perfect, better-looking for users of the DEX. However, DEX designs do not support XL text responsiveness as the components are extremely dense and need smaller text styles.

For text style reference, see the screenshots in https://github.com/penumbra-zone/web/pull/1978