### PR TITLE
fix typo README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ repo, in which case they use turbo or the monorepo configuration.
 
 ## Tools used
 
-- **pnpm**: a package manger
+- **pnpm**: a package manager
   - pnpm's workspace feature is the foundation of the monorepo
 - **turborepo**: a monorepo scripting tool
   - parallelize script execution


### PR DESCRIPTION
# fix typo: README.md

## Description
This pull request fixes a minor typo in the `README.md` file. The word **`manger`** has been corrected to **`manager`**.

### Changes
- Fixed the typo: `package manger` → `package manager`.

