### PR TITLE
Typo 003-action-views.md

### DIFF
--- a/docs/adrs/003-action-views.md
+++ b/docs/adrs/003-action-views.md
@@ -43,7 +43,7 @@ This specification is intended to inform what information should be comprehended
 - `BatchSwapOutputData`: <u>**_opaque_**</u> field since the BSOD in the TxP does not leak any information about the specific output notes that the view service computes for the swap using the BSOD. Computing the output notes already assumes decrypting the swap ciphertext. The BSOD contains the results of the batch swap and is emitted in an event.
 - `ValueView`: <u>**_opaque_**</u> field since the swap values are in the clear.
 - `Metadata`: <u>**_opaque_**</u> field and the metadata is reported on-chain.
-- `SwapPlaintext`: <u>**_visible_**</u> field since the decrypted swap ciphertext enables, alongside the BSOD, to retrieve output notes, which amonst other fields includes the private address controlling the note.
+- `SwapPlaintext`: <u>**_visible_**</u> field since the decrypted swap ciphertext enables, alongside the BSOD, to retrieve output notes, which amongst other fields includes the private address controlling the note.
 - `TransactionId`: <u>**_visible_**</u> field since it's associated with a commitment that will eventually be nullified, and since nullifiers are public, revealing the transaction ID creates a link between the commitment and the nullifier that commitment nullifies.
 - `NoteView`: <u>**_visible_**</u> field since it consists of sensitive fields like the claim address which should not be leaked.
 


### PR DESCRIPTION
### Pull Request Title  
Fix Typo in 003-action-views.md  

---

### Description  
This pull request fixes a typo in the `003-action-views.md` file located in the `docs/adrs/` directory.

- **Original:** `amonst`  
- **Corrected:** `amongst`  

The typo was found in the explanation of the `SwapPlaintext` field.

---

### Checklist  
- [x] Corrected the typo.  
- [ ] Verified the file for any additional errors or inconsistencies.  
- [ ] Confirmed adherence to project guidelines.  

---

If further adjustments or reviews are needed, feel free to comment! 🚀  
