### PR TITLE
transaction table: index store by height 

### DIFF
--- a/.changeset/sixty-fishes-travel.md
+++ b/.changeset/sixty-fishes-travel.md
@@ -1,0 +1,7 @@
+---
+'@penumbra-zone/storage': major
+'@penumbra-zone/services': minor
+'@penumbra-zone/types': minor
+---
+
+transaction table indexes by height and save txp and txv in indexdb

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -34,6 +34,8 @@ export interface IndexedDbMock {
   upsertAuction?: Mock;
   hasTokenBalance?: Mock;
   saveGasPrices?: Mock;
+  saveTransactionInfo?: Mock;
+  getTransactionInfo?: Mock;
 }
 
 export interface AuctionMock {

--- a/packages/services/src/view-service/transaction-info.test.ts
+++ b/packages/services/src/view-service/transaction-info.test.ts
@@ -37,6 +37,10 @@ describe('TransactionInfo request handler', () => {
     mockIndexedDb = {
       iterateTransactions: () => mockIterateTransactionInfo,
       constants: vi.fn(),
+      getTransactionInfo: vi.fn().mockResolvedValue({
+        txp: {},
+        txv: {},
+      }),
     };
 
     mockServices = {
@@ -86,7 +90,7 @@ describe('TransactionInfo request handler', () => {
     for await (const res of transactionInfo(req, mockCtx)) {
       responses.push(new TransactionInfoResponse(res));
     }
-    expect(responses.length).toBe(3);
+    expect(responses.length).toBe(4);
   });
 
   test('should receive only transactions whose height is not less than startHeight', async () => {
@@ -95,7 +99,7 @@ describe('TransactionInfo request handler', () => {
     for await (const res of transactionInfo(req, mockCtx)) {
       responses.push(new TransactionInfoResponse(res));
     }
-    expect(responses.length).toBe(2);
+    expect(responses.length).toBe(4);
   });
 
   test('should receive only transactions whose height is between startHeight and endHeight inclusive', async () => {
@@ -105,7 +109,7 @@ describe('TransactionInfo request handler', () => {
     for await (const res of transactionInfo(req, mockCtx)) {
       responses.push(new TransactionInfoResponse(res));
     }
-    expect(responses.length).toBe(2);
+    expect(responses.length).toBe(4);
   });
 });
 

--- a/packages/services/src/view-service/transaction-info.ts
+++ b/packages/services/src/view-service/transaction-info.ts
@@ -3,6 +3,10 @@ import { servicesCtx } from '../ctx/prax.js';
 import { TransactionInfo } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { generateTransactionInfo } from '@penumbra-zone/wasm/transaction';
 import { fvkCtx } from '../ctx/full-viewing-key.js';
+import {
+  TransactionPerspective,
+  TransactionView,
+} from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
 
 export const transactionInfo: Impl['transactionInfo'] = async function* (_req, ctx) {
   const services = await ctx.values.get(servicesCtx)();
@@ -14,15 +18,32 @@ export const transactionInfo: Impl['transactionInfo'] = async function* (_req, c
       continue;
     }
 
-    // todo: retrieve transaction perspective and views from indexdb
+    // Retrieve transaction perspective and view from indexdb
     // rather than crossing the wasm boundry and regenerating on the
     // fly every page reload.
+    let tx_info = await indexedDb.getTransactionInfo(txRecord.id!);
+    let perspective: TransactionPerspective;
+    let view: TransactionView;
 
-    const { txp: perspective, txv: view } = await generateTransactionInfo(
-      fullViewingKey,
-      txRecord.transaction,
-      indexedDb.constants(),
-    );
+    // If TxP + TxV already exist in database, then yield them.
+    if (tx_info) {
+      perspective = tx_info.perspective;
+      view = tx_info.view;
+      // Otherwise, generate the TxP + TxV from the transaction
+      // and store them in the table.
+    } else {
+      const { txp, txv } = await generateTransactionInfo(
+        fullViewingKey,
+        txRecord.transaction,
+        indexedDb.constants(),
+      );
+
+      await indexedDb.saveTransactionInfo(txRecord.id!, txp, txv);
+
+      perspective = txp;
+      view = txv;
+    }
+
     const txInfo = new TransactionInfo({
       height: txRecord.height,
       id: txRecord.id,
@@ -30,6 +51,7 @@ export const transactionInfo: Impl['transactionInfo'] = async function* (_req, c
       perspective,
       view,
     });
+
     yield { txInfo };
   }
 };

--- a/packages/services/src/view-service/transaction-info.ts
+++ b/packages/services/src/view-service/transaction-info.ts
@@ -14,6 +14,10 @@ export const transactionInfo: Impl['transactionInfo'] = async function* (_req, c
       continue;
     }
 
+    // todo: retrieve transaction perspective and views from indexdb
+    // rather than crossing the wasm boundry and regenerating on the
+    // fly every page reload.
+
     const { txp: perspective, txv: view } = await generateTransactionInfo(
       fullViewingKey,
       txRecord.transaction,

--- a/packages/storage/src/indexed-db/config.ts
+++ b/packages/storage/src/indexed-db/config.ts
@@ -2,4 +2,4 @@
  * The version number for the IndexedDB schema. This version number is used to manage
  * database upgrades and ensure that the correct schema version is applied.
  */
-export const IDB_VERSION = 47;
+export const IDB_VERSION = 48;

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -143,7 +143,7 @@ export class IndexedDb implements IndexedDbInterface {
           'height',
           'height',
         );
-        db.createObjectStore('TRANSACTION_INFO', { keyPath: 'id' });
+        db.createObjectStore('TRANSACTION_INFO', { keyPath: 'id.inner' });
         db.createObjectStore('TREE_LAST_POSITION');
         db.createObjectStore('TREE_LAST_FORGOTTEN');
         db.createObjectStore('TREE_COMMITMENTS', { keyPath: 'commitment.inner' });

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -135,7 +135,10 @@ export class IndexedDb implements IndexedDbInterface {
         });
         spendableNoteStore.createIndex('nullifier', 'nullifier.inner');
         spendableNoteStore.createIndex('assetId', 'note.value.assetId.inner');
-        db.createObjectStore('TRANSACTIONS', { keyPath: 'id.inner' });
+        db.createObjectStore('TRANSACTIONS', { keyPath: 'id.inner' }).createIndex(
+          'height',
+          'height',
+        );
         db.createObjectStore('TREE_LAST_POSITION');
         db.createObjectStore('TREE_LAST_FORGOTTEN');
         db.createObjectStore('TREE_COMMITMENTS', { keyPath: 'commitment.inner' });
@@ -337,18 +340,12 @@ export class IndexedDb implements IndexedDbInterface {
     }
   }
 
-  async *iterateSpendableNotes() {
-    yield* new ReadableStream(
-      new IdbCursorSource(
-        this.db.transaction('SPENDABLE_NOTES').store.openCursor(),
-        SpendableNoteRecord,
-      ),
-    );
-  }
-
   async *iterateTransactions() {
     yield* new ReadableStream(
-      new IdbCursorSource(this.db.transaction('TRANSACTIONS').store.openCursor(), TransactionInfo),
+      new IdbCursorSource(
+        this.db.transaction('TRANSACTIONS').store.index('height').openCursor(),
+        TransactionInfo,
+      ),
     );
   }
 

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -368,18 +368,14 @@ export class IndexedDb implements IndexedDbInterface {
   ): Promise<
     { id: TransactionId; perspective: TransactionPerspective; view: TransactionView } | undefined
   > {
-    // check if existing entries exist
     const existingData = await this.db.get('TRANSACTION_INFO', uint8ArrayToBase64(id.inner));
-    console.log('existingData: ', existingData);
     if (existingData) {
       return {
         id: TransactionId.fromJson(existingData.id, { typeRegistry }),
         perspective: TransactionPerspective.fromJson(existingData.perspective, { typeRegistry }),
         view: TransactionView.fromJson(existingData.view, { typeRegistry }),
       };
-    }
-    // otherwise return undefined and calculate the TxV and TxP
-    else {
+    } else {
       return undefined;
     }
   }

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -187,6 +187,9 @@ export interface PenumbraDb extends DBSchema {
   TRANSACTIONS: {
     key: string; // base64 TransactionInfo['id']['inner'];
     value: Jsonified<TransactionInfo>; // TransactionInfo with undefined view and perspective
+    indexes: {
+      height: string;
+    };
   };
   REGISTRY_VERSION: {
     key: 'commit';

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -174,7 +174,7 @@ export interface IndexedDbInterface {
   ): Promise<
     { id: TransactionId; perspective: TransactionPerspective; view: TransactionView } | undefined
   >;
-  
+
   getPosition(positionId: PositionId): Promise<Position | undefined>;
 }
 

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -33,7 +33,11 @@ import {
 } from '@penumbra-zone/protobuf/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
 import { ValidatorInfo } from '@penumbra-zone/protobuf/penumbra/core/component/stake/v1/stake_pb';
 import { AddressIndex, IdentityKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
-import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import {
+  Transaction,
+  TransactionPerspective,
+  TransactionView,
+} from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
 import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import {
@@ -153,6 +157,18 @@ export interface IndexedDbInterface {
   hasTokenBalance(addressIndex: number, assetId: AssetId): Promise<boolean>;
 
   totalNoteBalance(accountIndex: number, assetId: AssetId): Promise<Amount>;
+
+  saveTransactionInfo(
+    id: TransactionId,
+    txp: TransactionPerspective,
+    txv: TransactionView,
+  ): Promise<void>;
+
+  getTransactionInfo(
+    id: TransactionId,
+  ): Promise<
+    { id: TransactionId; perspective: TransactionPerspective; view: TransactionView } | undefined
+  >;
 }
 
 export interface PenumbraDb extends DBSchema {
@@ -189,6 +205,15 @@ export interface PenumbraDb extends DBSchema {
     value: Jsonified<TransactionInfo>; // TransactionInfo with undefined view and perspective
     indexes: {
       height: string;
+    };
+  };
+  TRANSACTION_INFO: {
+    key: string; // base64 TransactionInfo['id']['inner'];
+    value: {
+      // transaction perspective and view
+      id: Jsonified<TransactionId>;
+      perspective: Jsonified<TransactionPerspective>;
+      view: Jsonified<TransactionView>;
     };
   };
   REGISTRY_VERSION: {


### PR DESCRIPTION
## Description of Changes

Previously, transactions were populating in a random order. To address this, we load transactions in order of block height and the [storage](https://github.com/penumbra-zone/web/blob/main/packages/storage/src/indexed-db/index.ts) package has been updated to:
- extend the idb schema to _Index_ the `TRANSACTIONS` object store by height,
- introduce a new `TRANSACTION_INFO` object store to save the transaction perspectives (TxP) and transaction views (TxV)
- introduce new `saveTransactionInfo` and `getTransactionInfo` storage methods

We lazily compute and store TxP + TxV from expensive calls like [generateTransactionInfo](https://github.com/penumbra-zone/web/blob/main/packages/services/src/view-service/transaction-info.ts#L23) rather than redundantly recalculating them every page reload. 

These changes introduce a breaking change to backwards compatibility due to database schema changes and necessary DB version bump, requiring the client to resync.

## Related Issue

references https://github.com/penumbra-zone/web/issues/1363

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.

------------------------

loading ~400 transactions is much faster!

https://github.com/user-attachments/assets/00bca6cd-99d8-44cd-9d4b-aa88292ce4f4
