### PR TITLE
web: readable sync error message

### DIFF
--- a/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
+++ b/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
@@ -5,7 +5,6 @@ import { LineWave } from 'react-loader-spinner';
 import { cn } from '../../../lib/utils';
 import { Progress } from '../progress';
 import { useNewBlockDelay, useSyncProgress } from './hooks';
-import { useEffect } from 'react';
 
 export const CondensedBlockSyncStatus = ({
   latestKnownBlockHeight,
@@ -43,13 +42,9 @@ export const CondensedBlockSyncStatus = ({
 };
 
 const BlockSyncErrorState = () => {
-  useEffect(() => {
-    const reloadTimeout = setTimeout(() => {
-      window.location.reload();
-    }, 5000);
-
-    return () => clearTimeout(reloadTimeout);
-  }, []);
+  const reload = () => {
+    window.location.reload();
+  };
 
   return (
     <motion.div
@@ -61,8 +56,15 @@ const BlockSyncErrorState = () => {
       <div className='absolute w-full px-2'>
         <div className='mt-[-5.5px] flex gap-2'>
           <span className='font-mono text-[10px] text-red-300'>
-            Sync error detected. Reloading page...
+            Block sync error. Ensure your internet connection is stable.
           </span>
+          <button
+            type='button'
+            className='border-none bg-none font-mono text-[10px] text-red-300 underline'
+            onClick={reload}
+          >
+            Reload
+          </button>
         </div>
       </div>
     </motion.div>

--- a/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
+++ b/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
@@ -5,6 +5,7 @@ import { LineWave } from 'react-loader-spinner';
 import { cn } from '../../../lib/utils';
 import { Progress } from '../progress';
 import { useNewBlockDelay, useSyncProgress } from './hooks';
+import { useEffect } from 'react';
 
 export const CondensedBlockSyncStatus = ({
   latestKnownBlockHeight,
@@ -16,7 +17,7 @@ export const CondensedBlockSyncStatus = ({
   error?: unknown;
 }) => {
   if (error) {
-    return <BlockSyncErrorState error={error} />;
+    return <BlockSyncErrorState />;
   }
   if (!latestKnownBlockHeight || !fullSyncHeight) {
     return <AwaitingSyncState genesisSyncing={!fullSyncHeight} />;
@@ -41,10 +42,14 @@ export const CondensedBlockSyncStatus = ({
   );
 };
 
-const BlockSyncErrorState = ({ error }: { error: unknown }) => {
-  const reload = () => {
-    window.location.reload();
-  };
+const BlockSyncErrorState = () => {
+  useEffect(() => {
+    const reloadTimeout = setTimeout(() => {
+      window.location.reload();
+    }, 5000);
+
+    return () => clearTimeout(reloadTimeout);
+  }, []);
 
   return (
     <motion.div
@@ -56,15 +61,8 @@ const BlockSyncErrorState = ({ error }: { error: unknown }) => {
       <div className='absolute w-full px-2'>
         <div className='mt-[-5.5px] flex gap-2'>
           <span className='font-mono text-[10px] text-red-300'>
-            Block sync error: {String(error)}
+            Sync error detected. Reloading page...
           </span>
-          <button
-            type='button'
-            className='border-none bg-none font-mono text-[10px] text-red-300 underline'
-            onClick={reload}
-          >
-            Reload
-          </button>
         </div>
       </div>
     </motion.div>


### PR DESCRIPTION
## Description of Changes

Previously, syncing displayed varying illegible error states (eg. `ConnectError` and `DataCloneError`). These can be caused by unstable internet connections, locking the wallet which [resets the service worker](https://github.com/prax-wallet/prax/pull/62/files#diff-649ac305e4633910768bd425c904f22bf9fe627e30b0762fb18d19bbe8fa0d52R74-R78) for security, etc. The error handling has been improved to provide a clearer error message and programmatically reload the page with `window.location.reload()` every **5s** when a sync error occurs. 

_update:_ because of the investigation in https://github.com/penumbra-zone/web/issues/1885#issuecomment-2614630687, this PR simply just makes the error messaging nicer rather than doing any auto page reloading. 

## Related Issue

references  https://github.com/penumbra-zone/web/issues/1378 and https://github.com/penumbra-zone/web/issues/1898

pairs with https://github.com/prax-wallet/prax/pull/278

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.

---------------------

_before_

<img width="1728" alt="Screenshot 2025-01-26 at 12 58 25 PM" src="https://github.com/user-attachments/assets/633ed887-dbfe-4401-952c-92a2a71e32a1" />

------------

_after_

<img width="1840" alt="Screenshot 2025-01-26 at 3 32 04 PM" src="https://github.com/user-attachments/assets/78edbafa-3b84-4742-9510-6601d46b7528" />
