### PR TITLE
reduce transport channel timeout period by half

### DIFF
--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -77,7 +77,7 @@ const rejectOnSignal = (...signals: (AbortSignal | undefined)[]) => {
 export const createChannelTransport = ({
   getPort,
   jsonOptions,
-  defaultTimeoutMs = 60_000,
+  defaultTimeoutMs = 30_000,
 }: ChannelTransportOptions): Transport => {
   const pending = new Map<string, (response: TransportEvent) => void>();
 


### PR DESCRIPTION
## Description of Changes

after some investigation, after losing connection, [transportFailure.abort](https://github.com/penumbra-zone/web/blob/main/packages/transport-dom/src/create.ts#L119) is triggered at the transport layer, poisoning the transport and closing the connection channel. The extension's service worker terminates shortly after, and the combination of the [60 second timeout](https://github.com/penumbra-zone/web/blob/990291f6daef61bdb219f0c98bfbe481f25cfd83/packages/transport-dom/src/create.ts#L80) in our channel transport + service worker restart refractory period prevents an immediate reconnection. But after some time, reloading the page re-injects the content scripts (setting up the connection listeners) and initializes a new connection handle.

basically, we can reduce the timeout period in our custom transport-dom package or manually call chrome.runtime.reload()to force an extension restart (similar to locking the wallet which [resets the service worker](https://github.com/prax-wallet/prax/pull/62/files#diff-649ac305e4633910768bd425c904f22bf9fe627e30b0762fb18d19bbe8fa0d52R74-R78)).

the connection errors will eventually resolve on their own, but we can reduce the time required to reestablish the connection.

## Related Issue

references https://github.com/prax-wallet/prax/issues/277

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
