### PR TITLE
don't retain port in `CRSessionClient`, remove singleton pattern

### DIFF
--- a/.changeset/violet-coats-remember.md
+++ b/.changeset/violet-coats-remember.md
@@ -1,0 +1,9 @@
+---
+'@penumbra-zone/transport-chrome': minor
+---
+
+Transport session reliability improvements.
+
+- No external API change.
+- Remove singleton restriction of `CRSessionClient`.
+- Don't retain port reference to respect object transfer rules.

--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -61,7 +61,7 @@ describe('CRSessionClient', () => {
   });
 
   describe('repeated calls to init', () => {
-    it('should return the same port for each call', () => {
+    it.fails('should return the same port for each call', () => {
       const ports: MessagePort[] = [];
 
       for (let i = 0; i < 3; i++) {
@@ -72,7 +72,7 @@ describe('CRSessionClient', () => {
       }
     });
 
-    it.fails('should return a new port for each call', () => {
+    it('should return a new port for each call', () => {
       const ports: MessagePort[] = [];
 
       for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
## Description of Changes

`CRSessionClient` of `@penumbra-zone/transport-dom` no longer retains a `MessagePort` and no longer uses a singleton pattern.

## Related Issue

fixes #1736 

rebased onto #2040 

## Checklist Before Requesting Review

Tested in combination with other work, not yet tested alone.

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
