### PR TITLE
fix: latest swaps

### DIFF
--- a/.changeset/curvy-buses-doubt.md
+++ b/.changeset/curvy-buses-doubt.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/services': patch
+---
+
+Fix latestSwaps method by picking initial swap block height instead of claim height

--- a/packages/services/src/view-service/latest-swaps.test.ts
+++ b/packages/services/src/view-service/latest-swaps.test.ts
@@ -321,6 +321,7 @@ const getSwap = ({ account, to, from, height, input, output }: GetSwapOptions) =
       claimAddress: getAddressByIndex(testFullViewingKey, account),
     },
     outputData: {
+      height: BigInt(height),
       tradingPair: {
         asset1: from.penumbraAssetId,
         asset2: to.penumbraAssetId,

--- a/packages/services/src/view-service/latest-swaps.ts
+++ b/packages/services/src/view-service/latest-swaps.ts
@@ -42,7 +42,7 @@ export const latestSwaps: Impl['latestSwaps'] = async function* (_req, ctx) {
       counter++;
       yield {
         id: new TransactionId({ inner: swapRecord.source.source.value.id }),
-        blockHeight: swapRecord.heightClaimed,
+        blockHeight: swapRecord.outputData.height,
         pair: new DirectedTradingPair({
           start: swapRecord.outputData.tradingPair.asset1,
           end: swapRecord.outputData.tradingPair.asset2,


### PR DESCRIPTION
After discussing Prax <–> Pindexer connection with protocol devs, it turned out that Pindexer stores swap execution data based on the time when the swap happened, but `latestSwaps` method of the ViewService was returning the height when user claimed the swap. This PR fixes the issue, so that `latestSwaps` can be easily merged with Pindexer data