### PR TITLE
registry: bump deps to v12.4.0

### DIFF
--- a/.changeset/three-lies-tickle.md
+++ b/.changeset/three-lies-tickle.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/storage': patch
+'minifront': patch
+---
+
+bump registry versions in web packages

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -22,7 +22,7 @@
     "@cosmos-kit/core": "^2.15.0",
     "@cosmos-kit/react": "^2.20.1",
     "@interchain-ui/react": "^1.26.1",
-    "@penumbra-labs/registry": "^12.0.0",
+    "@penumbra-labs/registry": "^12.3.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/client": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -22,7 +22,7 @@
     "@cosmos-kit/core": "^2.15.0",
     "@cosmos-kit/react": "^2.20.1",
     "@interchain-ui/react": "^1.26.1",
-    "@penumbra-labs/registry": "^12.3.0",
+    "@penumbra-labs/registry": "^12.4.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/client": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -39,13 +39,13 @@
     "idb": "^8.0.0"
   },
   "devDependencies": {
-    "@penumbra-labs/registry": "^12.3.0",
+    "@penumbra-labs/registry": "^12.4.0",
     "@penumbra-zone/protobuf": "workspace:*",
     "fetch-mock": "^10.0.7"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.10.0",
-    "@penumbra-labs/registry": "^12.3.0",
+    "@penumbra-labs/registry": "^12.4.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -39,13 +39,13 @@
     "idb": "^8.0.0"
   },
   "devDependencies": {
-    "@penumbra-labs/registry": "^12.0.0",
+    "@penumbra-labs/registry": "^12.3.0",
     "@penumbra-zone/protobuf": "workspace:*",
     "fetch-mock": "^10.0.7"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.10.0",
-    "@penumbra-labs/registry": "^12.0.0",
+    "@penumbra-labs/registry": "^12.3.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 3.3.0(vite@5.3.3(@types/node@22.10.2)(terser@5.37.0))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0)(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
+        version: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0(playwright@1.45.1)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
 
   apps/minifront:
     dependencies:
@@ -181,8 +181,8 @@ importers:
         specifier: ^1.26.1
         version: 1.26.1(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@penumbra-labs/registry':
-        specifier: ^12.0.0
-        version: 12.0.0
+        specifier: ^12.3.0
+        version: 12.3.0
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../../packages/bech32m
@@ -330,7 +330,7 @@ importers:
         version: 5.3.3(@types/node@22.10.2)(terser@5.37.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0)(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
+        version: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0(playwright@1.45.1)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
 
   apps/node-status:
     dependencies:
@@ -585,8 +585,8 @@ importers:
         version: 8.0.0
     devDependencies:
       '@penumbra-labs/registry':
-        specifier: ^12.0.0
-        version: 12.0.0
+        specifier: ^12.3.0
+        version: 12.3.0
       '@penumbra-zone/protobuf':
         specifier: workspace:*
         version: link:../protobuf
@@ -3511,8 +3511,8 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
 
-  '@penumbra-labs/registry@12.0.0':
-    resolution: {integrity: sha512-fQ4onHovusiOZL2nhoCoEo+/sQovK9NAQmNvehIw7Q0dhw9InXIZBTUSOKujhvyrcca+vA9FsaHWr0DSv/pDsw==}
+  '@penumbra-labs/registry@12.3.0':
+    resolution: {integrity: sha512-MThpOVpPjroXkQWf4ATY0omBK/EXWj1tEWMC04OcHDuaHSUiZG8uypFRyYM0mjt92rwuGkfem7qCTw7amFbQbQ==}
 
   '@penumbra-zone/bech32m@7.0.0':
     resolution: {integrity: sha512-OqSH4G8pQ/mjy/7EfS9KlxF8Pdr3h/Ib8ZDOjDyQJB4/L+ZYkK3bWFGrFpAI8XDoc0phoMXkL77fZEpR18JoAg==}
@@ -9938,6 +9938,9 @@ packages:
 
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
+
+  node-fetch-native@1.6.6:
+    resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -17349,7 +17352,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@penumbra-labs/registry@12.0.0': {}
+  '@penumbra-labs/registry@12.3.0': {}
 
   '@penumbra-zone/bech32m@7.0.0(@penumbra-zone/protobuf@6.3.0(@bufbuild/protobuf@1.10.0))':
     dependencies:
@@ -20923,7 +20926,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
     optionalDependencies:
-      vitest: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0)(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
+      vitest: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0(playwright@1.45.1)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
 
   '@testing-library/jest-dom@6.5.0':
     dependencies:
@@ -21621,7 +21624,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       magic-string: 0.30.10
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0)(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
+      vitest: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0(playwright@1.45.1)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
     optionalDependencies:
       playwright: 1.45.1
 
@@ -23377,7 +23380,7 @@ snapshots:
   cosmos-directory-client@0.0.6:
     dependencies:
       cosmos-directory-types: 0.0.6
-      node-fetch-native: 1.6.4
+      node-fetch-native: 1.6.6
 
   cosmos-directory-types@0.0.6: {}
 
@@ -24221,7 +24224,7 @@ snapshots:
       '@typescript-eslint/utils': 7.16.0(eslint@9.6.0)(typescript@5.5.3)
       eslint: 9.6.0
     optionalDependencies:
-      vitest: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0)(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
+      vitest: 1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0(playwright@1.45.1)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -26332,6 +26335,8 @@ snapshots:
       minimatch: 3.1.2
 
   node-fetch-native@1.6.4: {}
+
+  node-fetch-native@1.6.6: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -28978,7 +28983,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.37.0
 
-  vitest@1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0)(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0):
+  vitest@1.6.0(@types/node@22.10.2)(@vitest/browser@1.6.0(playwright@1.45.1)(vitest@1.6.0))(jsdom@24.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.37.0):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: ^1.26.1
         version: 1.26.1(@types/react@18.3.3)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@penumbra-labs/registry':
-        specifier: ^12.3.0
-        version: 12.3.0
+        specifier: ^12.4.0
+        version: 12.4.0
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../../packages/bech32m
@@ -585,8 +585,8 @@ importers:
         version: 8.0.0
     devDependencies:
       '@penumbra-labs/registry':
-        specifier: ^12.3.0
-        version: 12.3.0
+        specifier: ^12.4.0
+        version: 12.4.0
       '@penumbra-zone/protobuf':
         specifier: workspace:*
         version: link:../protobuf
@@ -3511,8 +3511,8 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
 
-  '@penumbra-labs/registry@12.3.0':
-    resolution: {integrity: sha512-MThpOVpPjroXkQWf4ATY0omBK/EXWj1tEWMC04OcHDuaHSUiZG8uypFRyYM0mjt92rwuGkfem7qCTw7amFbQbQ==}
+  '@penumbra-labs/registry@12.4.0':
+    resolution: {integrity: sha512-EGjAuB0vfYUR7Fqgvt4yA4OsR/gbtSzHgP2AeQuF060df94NhnkO/QXRu+jKOK7ykvrHlOV+8HPdNiwxZKE30g==}
 
   '@penumbra-zone/bech32m@7.0.0':
     resolution: {integrity: sha512-OqSH4G8pQ/mjy/7EfS9KlxF8Pdr3h/Ib8ZDOjDyQJB4/L+ZYkK3bWFGrFpAI8XDoc0phoMXkL77fZEpR18JoAg==}
@@ -9935,9 +9935,6 @@ packages:
   node-dir@0.1.17:
     resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
     engines: {node: '>= 0.10.5'}
-
-  node-fetch-native@1.6.4:
-    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
 
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
@@ -17352,7 +17349,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@penumbra-labs/registry@12.3.0': {}
+  '@penumbra-labs/registry@12.4.0': {}
 
   '@penumbra-zone/bech32m@7.0.0(@penumbra-zone/protobuf@6.3.0(@bufbuild/protobuf@1.10.0))':
     dependencies:
@@ -26334,8 +26331,6 @@ snapshots:
     dependencies:
       minimatch: 3.1.2
 
-  node-fetch-native@1.6.4: {}
-
   node-fetch-native@1.6.6: {}
 
   node-fetch@2.7.0:
@@ -26499,7 +26494,7 @@ snapshots:
   ofetch@1.3.4:
     dependencies:
       destr: 2.0.3
-      node-fetch-native: 1.6.4
+      node-fetch-native: 1.6.6
       ufo: 1.5.3
 
   ohash@1.1.3: {}
@@ -28706,7 +28701,7 @@ snapshots:
       consola: 3.2.3
       defu: 6.1.4
       mime: 3.0.0
-      node-fetch-native: 1.6.4
+      node-fetch-native: 1.6.6
       pathe: 1.1.2
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -28748,7 +28743,7 @@ snapshots:
       listhen: 1.7.2
       lru-cache: 10.4.3
       mri: 1.2.0
-      node-fetch-native: 1.6.4
+      node-fetch-native: 1.6.6
       ofetch: 1.3.4
       ufo: 1.5.3
     optionalDependencies:


### PR DESCRIPTION
## Description of Changes

bumps registry to latest tagged release, `v12.4.0`

## Related Issue

https://github.com/prax-wallet/registry/releases/tag/v12.4.0

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
