### PR TITLE
session client reconnect

### DIFF
--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -411,7 +411,7 @@ describe('CRSessionClient', () => {
       await expectChannelClosed();
     });
 
-    it('sends `false` to dom when the port is disconnected by something else', async () => {
+    it.fails('sends `false` to dom when the port is disconnected by something else', async () => {
       expectNoActivity();
 
       // extension-side disconnect
@@ -433,7 +433,7 @@ describe('CRSessionClient', () => {
       await expectChannelClosed();
     });
 
-    it.fails('reconnects silently if the port is disconnected by something else', async () => {
+    it('reconnects silently if the port is disconnected by something else', async () => {
       const testRequest: TransportMessage = { message: 'hello', requestId: '123' };
 
       expectNoActivity();

--- a/packages/transport-chrome/src/session-manager.test.ts
+++ b/packages/transport-chrome/src/session-manager.test.ts
@@ -9,21 +9,8 @@ import {
 import type { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
 import { ChannelLabel, nameConnection } from './channel-names.js';
-import { CRSessionManager as CRSessionManagerOriginal } from './session-manager.js';
+import { CRSessionManager } from './session-manager.js';
 import { lastResult } from './util/test-utils.js';
-
-const CRSessionManager: typeof CRSessionManagerOriginal & {
-  // forward-compatible type. third parameter of init is required in new
-  // signature, but absent in old signature.  a new implementation will use it,
-  // an old implementation will ignore it.
-  init: (
-    prefix: string,
-    handler: ChannelHandlerFn,
-    approvePort: (
-      port: chrome.runtime.Port,
-    ) => Promise<chrome.runtime.Port & { sender: { origin: string } }>,
-  ) => ReturnType<typeof CRSessionManagerOriginal.init>;
-} = CRSessionManagerOriginal;
 
 const getOnlySession = (sessions: ReturnType<typeof CRSessionManager.init>) => {
   expect(sessions.size).toBe(1);
@@ -148,7 +135,7 @@ describe('CRSessionManager', () => {
     const testRequest = { requestId: '123', message: 'test' };
     const allSenders = [extClient, localhostClient, httpsClient, httpClient];
 
-    it.each(allSenders)(
+    it.fails.each(allSenders)(
       'should accept or reject $origin according to internal sender validation logic',
       async someSender => {
         const badSenders = [httpClient];
@@ -199,7 +186,7 @@ describe('CRSessionManager', () => {
     );
 
     const badSenders = allSenders.sort(() => Math.random() - 0.5).slice(2);
-    it.fails.each(allSenders)(
+    it.each(allSenders)(
       `should accept or reject sender %# according to external sender validation callback permitting ${badSenders.map(s => allSenders.indexOf(s)).join(', ')}`,
       async someSender => {
         checkPortSender.mockImplementationOnce(port => {


### PR DESCRIPTION
session-client will now automatically request to reconnect when disconnected.

to support this, session-manager now uses a callback parameter to validate connection requests, instead of depending on external management of port injection.

considerations:

 - reconnect won't automatically retry individual failed requests
 - reconnect can't prevent in-flight requests from being interrupted by a disconnect
 - reconnect can't prevent a page from persistently using an actually-dead transport

discovered issues:

- permissions check must be async, so listener attachment became async. this causes a race condition under which early requests may arrive before a listener is attached.

potential issues:

- some clients may be using structural typing or string matching to detect errors. continuing to investigate possible error detection problems.