### PR TITLE
view service: LQT scaffolding 

### DIFF
--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -16,7 +16,7 @@
     "gen:ibc": "buf generate buf.build/cosmos/ibc:7ab44ae956a0488ea04e04511efa5f70",
     "gen:ics23": "buf generate buf.build/cosmos/ics23:55085f7c710a45f58fa09947208eb70b",
     "gen:noble": "buf generate buf.build/noble-assets/forwarding:5a8609a6772d417584a9c60cd8b80881",
-    "gen:penumbra": "buf generate buf.build/penumbra-zone/penumbra:adb116eefae84c1abd53a1594b895360",
+    "gen:penumbra": "buf generate buf.build/penumbra-zone/penumbra:542067b93465664d263a45c42a5a962423d2b8c9",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",

--- a/packages/protobuf/src/services/penumbra-core.ts
+++ b/packages/protobuf/src/services/penumbra-core.ts
@@ -12,3 +12,4 @@ export { QueryService as GovernanceService } from '../../gen/penumbra/core/compo
 export { QueryService as SctService } from '../../gen/penumbra/core/component/sct/v1/sct_connect.js';
 export { QueryService as ShieldedPoolService } from '../../gen/penumbra/core/component/shielded_pool/v1/shielded_pool_connect.js';
 export { QueryService as StakeService } from '../../gen/penumbra/core/component/stake/v1/stake_connect.js';
+export { FundingService } from '../../gen/penumbra/core/component/funding/v1/funding_connect.js';

--- a/packages/protobuf/src/web.ts
+++ b/packages/protobuf/src/web.ts
@@ -9,6 +9,7 @@ import {
 import type { CustodyService } from './services/penumbra-custody.js';
 import type { ViewService } from './services/penumbra-view.js';
 import type {
+  FundingService,
   AppService,
   AuctionService,
   CommunityPoolService,
@@ -43,4 +44,5 @@ export type PenumbraService =
   | typeof SimulationService
   | typeof StakeService
   | typeof TendermintProxyService
-  | typeof ViewService;
+  | typeof ViewService
+  | typeof FundingService;

--- a/packages/services/src/view-service/index.ts
+++ b/packages/services/src/view-service/index.ts
@@ -31,6 +31,8 @@ import { witness } from './witness.js';
 import { witnessAndBuild } from './witness-and-build.js';
 import { transparentAddress } from './transparent-address.js';
 import { latestSwaps } from './latest-swaps.js';
+import { lqtVotingNotes } from './lqt-voting-notes.js';
+import { tournamentVotes } from './tournament-votes.js';
 
 export type Impl = ServiceImpl<typeof ViewService>;
 
@@ -66,4 +68,6 @@ export const viewImpl: Impl = {
   witnessAndBuild,
   transparentAddress,
   latestSwaps,
+  lqtVotingNotes,
+  tournamentVotes,
 };

--- a/packages/services/src/view-service/lqt-voting-notes.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.ts
@@ -14,7 +14,6 @@ export const lqtVotingNotes: Impl['lqtVotingNotes'] = async function* (req, ctx)
 
   // Get the starting block height for the corresponding epoch index.
   let epoch = await indexedDb.getBlockHeightByEpoch(req.epochIndex);
-  console.log('starting_block_height {} for epoch index {}', epoch?.startHeight, req.epochIndex);
 
   // Retrieve SNRs from storage ('ASSETS' in IndexedDB) that are eligible for voting at the start height
   // of the current epoch. Alternatively, a wasm helper `get_voting_notes` can be used to perform the same function.
@@ -28,14 +27,14 @@ export const lqtVotingNotes: Impl['lqtVotingNotes'] = async function* (req, ctx)
 
   // Iterate through each voting note and check if it has already been used for voting
   // by performing a nullifier point query against the rpc provided by the funding service.
-  for await (const voting_note of votingNotes) {
-    if (voting_note.noteRecord) {
+  for await (const votingNote of votingNotes) {
+    if (votingNote.noteRecord) {
       const lqtCheckNullifierResponse = await querier.funding.lqtCheckNullifier(
         epoch?.index!,
-        voting_note.noteRecord.nullifier as Nullifier,
+        votingNote.noteRecord.nullifier as Nullifier,
       );
       if (lqtCheckNullifierResponse.alreadyVoted == false) {
-        spendableNoteRecords.push(voting_note.noteRecord as SpendableNoteRecord);
+        spendableNoteRecords.push(votingNote.noteRecord as SpendableNoteRecord);
       }
     }
   }

--- a/packages/services/src/view-service/lqt-voting-notes.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.ts
@@ -1,0 +1,47 @@
+import type { Impl } from './index.js';
+import { servicesCtx } from '../ctx/prax.js';
+import { notesForVoting } from './notes-for-voting.js';
+import {
+  LqtVotingNotesResponse,
+  NotesForVotingRequest,
+  SpendableNoteRecord,
+} from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+import { Nullifier } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
+
+export const lqtVotingNotes: Impl['lqtVotingNotes'] = async function* (req, ctx) {
+  const services = await ctx.values.get(servicesCtx)();
+  const { indexedDb, querier } = await services.getWalletServices();
+
+  // Get the starting block height for the corresponding epoch index.
+  let epoch = await indexedDb.getBlockHeightByEpoch(req.epochIndex);
+  console.log('starting_block_height {} for epoch index {}', epoch?.startHeight, req.epochIndex);
+
+  // Retrieve SNRs from storage ('ASSETS' in IndexedDB) that are eligible for voting at the start height
+  // of the current epoch. Alternatively, a wasm helper `get_voting_notes` can be used to perform the same function.
+  const notesForVotingRequest = new NotesForVotingRequest({
+    addressIndex: req.accountFilter,
+    votableAtHeight: epoch?.startHeight,
+  });
+  const votingNotes = notesForVoting(notesForVotingRequest, ctx);
+
+  const spendableNoteRecords: SpendableNoteRecord[] = [];
+
+  // Iterate through each voting note and check if it has already been used for voting
+  // by performing a nullifier point query against the rpc provided by the funding service.
+  for await (const voting_note of votingNotes) {
+    if (voting_note.noteRecord) {
+      const lqtCheckNullifierResponse = await querier.funding.lqtCheckNullifier(
+        epoch?.index!,
+        voting_note.noteRecord.nullifier as Nullifier,
+      );
+      if (lqtCheckNullifierResponse.alreadyVoted == false) {
+        spendableNoteRecords.push(voting_note.noteRecord as SpendableNoteRecord);
+      }
+    }
+  }
+
+  // Yield the SNRs that haven't been used for voting yet.
+  for (const record of spendableNoteRecords) {
+    yield new LqtVotingNotesResponse({ noteRecord: record });
+  }
+};

--- a/packages/services/src/view-service/tournament-votes.ts
+++ b/packages/services/src/view-service/tournament-votes.ts
@@ -1,9 +1,24 @@
 import type { Impl } from './index.js';
 import { TournamentVotesResponse } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+import { servicesCtx } from '../ctx/prax.js';
 
-export const tournamentVotes: Impl['tournamentVotes'] = async (_req, _ctx) => {
-  // todo: this will make use of our new LQT tables.
+export const tournamentVotes: Impl['tournamentVotes'] = async (req, ctx) => {
+  const services = await ctx.values.get(servicesCtx)();
+  const { indexedDb } = await services.getWalletServices();
 
-  // Return a stub `TournamentVotesResponse`
+  // Get the starting block height for the corresponding epoch index.
+  let epoch = await indexedDb.getBlockHeightByEpoch(req.epochIndex);
+
+  // Retrieve list of all transactions.
+  const votingNotes = indexedDb.iterateTransactions();
+
+  // TODO: For each transaction, verify if its height falls within the current epoch range,
+  // and return the votes for the liquidity tournament.
+  for await (const transaction of votingNotes) {
+    if (transaction.height > epoch?.startHeight!) {
+    }
+  }
+
+  // Stub `TournamentVotesResponse`
   return new TournamentVotesResponse();
 };

--- a/packages/services/src/view-service/tournament-votes.ts
+++ b/packages/services/src/view-service/tournament-votes.ts
@@ -1,0 +1,9 @@
+import type { Impl } from './index.js';
+import { TournamentVotesResponse } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+
+export const tournamentVotes: Impl['tournamentVotes'] = async (_req, _ctx) => {
+  // todo: this will make use of our new LQT tables.
+
+  // Return a stub `TournamentVotesResponse`
+  return new TournamentVotesResponse();
+};

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -741,6 +741,23 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   /**
+   * Get the block height for the correspinding epoch index.
+   */
+  async getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined> {
+    let epoch: Epoch | undefined;
+
+    // Iterate over epochs and return the one with the matching epoch index.
+    for await (const cursor of this.db.transaction('EPOCHS', 'readonly').store) {
+      const currentEpoch = Epoch.fromJson(cursor.value);
+      if (currentEpoch.index == epoch_index) {
+        epoch = currentEpoch;
+      }
+    }
+
+    return epoch;
+  }
+
+  /**
    * Inserts the validator info into the database, or updates an existing
    * validator info if one with the same identity key exists.
    */

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -111,6 +111,7 @@ export interface IndexedDbInterface {
   ): Promise<void>;
   addEpoch(startHeight: bigint): Promise<void>;
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
+  getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined>;
   upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;
   iterateValidatorInfos(): AsyncGenerator<ValidatorInfo, void>;
   clearValidatorInfos(): Promise<void>;

--- a/packages/types/src/querier.ts
+++ b/packages/types/src/querier.ts
@@ -9,7 +9,9 @@ import {
   DutchAuction,
 } from '@penumbra-zone/protobuf/penumbra/core/component/auction/v1/auction_pb';
 import { CompactBlock } from '@penumbra-zone/protobuf/penumbra/core/component/compact_block/v1/compact_block_pb';
+import { LqtCheckNullifierResponse } from '@penumbra-zone/protobuf/penumbra/core/component/funding/v1/funding_pb';
 import {
+  Nullifier,
   TimestampByHeightRequest,
   TimestampByHeightResponse,
 } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
@@ -35,6 +37,7 @@ export interface RootQuerierInterface {
   sct: SctQuerierInterface;
   cnidarium: CnidariumQuerierInterface;
   auction: AuctionQuerierInterface;
+  funding: FundingQuerierInterface;
 }
 
 export interface AppQuerierInterface {
@@ -82,4 +85,8 @@ export interface AuctionQuerierInterface {
 
 export interface SctQuerierInterface {
   timestampByHeight(req: TimestampByHeightRequest): Promise<TimestampByHeightResponse>;
+}
+
+export interface FundingQuerierInterface {
+  lqtCheckNullifier(epochIndex: bigint, nullifier: Nullifier): Promise<LqtCheckNullifierResponse>;
 }

--- a/packages/ui-deprecated/components/ui/tx/action-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/action-view.tsx
@@ -47,6 +47,7 @@ const CASE_TO_LABEL: Record<Case, string> = {
   communityPoolDeposit: 'Community Pool Deposit',
   communityPoolOutput: 'Community Pool Output',
   communityPoolSpend: 'Community Pool Spend',
+  actionLiquidityTournamentVote: 'Liquidity Tournament Vote',
 };
 
 const getLabelForActionCase = (actionCase: ActionView['actionView']['case']): string => {
@@ -144,6 +145,9 @@ export const ActionViewComponent = ({
 
     case 'communityPoolDeposit':
       return <UnimplementedView label='Community Deposit' />;
+
+    case 'actionLiquidityTournamentVote':
+      return <UnimplementedView label='Liquidity Tournament Vote' />;
 
     default:
       return <UnimplementedView label={getLabelForActionCase(actionView.case)} />;

--- a/packages/wasm/crate/src/lib.rs
+++ b/packages/wasm/crate/src/lib.rs
@@ -15,3 +15,4 @@ pub mod tree;
 pub mod tx;
 pub mod utils;
 pub mod view_server;
+pub mod voting;

--- a/packages/wasm/crate/src/voting.rs
+++ b/packages/wasm/crate/src/voting.rs
@@ -1,0 +1,34 @@
+use crate::error::WasmResult;
+use crate::storage::{init_idb_storage, DbConstants};
+use crate::utils;
+use penumbra_keys::keys::AddressIndex;
+use penumbra_proto::DomainType;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+/// Utility for requesting voting notes.
+#[wasm_bindgen]
+pub async fn get_voting_notes(
+    address_index: &[u8],
+    votable_at_height: u64,
+    idb_constants: JsValue,
+) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
+    let constants: DbConstants = serde_wasm_bindgen::from_value(idb_constants).expect("msg");
+    let storage = init_idb_storage(constants).await.expect("msg");
+
+    let address_index: AddressIndex = AddressIndex::decode(address_index).expect("msg");
+    let proto_address_index = penumbra_proto::core::keys::v1::AddressIndex::from(address_index);
+
+    let voting_notes: Vec<(
+        crate::note_record::SpendableNoteRecord,
+        penumbra_stake::IdentityKey,
+    )> = storage
+        .get_notes_for_voting(Some(proto_address_index), votable_at_height)
+        .await
+        .expect("msg");
+
+    let result = serde_wasm_bindgen::to_value(&voting_notes).expect("Failed to convert to JsValue");
+    Ok(result)
+}

--- a/packages/wasm/src/voting.ts
+++ b/packages/wasm/src/voting.ts
@@ -1,0 +1,22 @@
+import { IdbConstants } from '@penumbra-zone/types/indexed-db';
+import { AddressIndex, IdentityKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
+import { get_voting_notes } from '../wasm/index.js';
+import { SpendableNoteRecord } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+
+export const getVotingNotes = async (
+  address_index: AddressIndex,
+  votable_at_height: bigint,
+  idbConstants: IdbConstants,
+): Promise<[SpendableNoteRecord, IdentityKey][]> => {
+  console.log('entered getVotingNotes!');
+  const voting_notes: any[] = await get_voting_notes(
+    address_index.toBinary(),
+    votable_at_height,
+    idbConstants,
+  );
+
+  return voting_notes.map(([note, identityKey]) => [
+    SpendableNoteRecord.fromJson(note),
+    IdentityKey.fromJson(identityKey),
+  ]);
+};


### PR DESCRIPTION
## Description of Changes

WIP: `LqtVotingNotes` and `TournamentVotes` view service rpc impls.

- leverages existing IndexedDB storage method `getNotesForVoting` to retrieve eligible voting notes.
- exposes an equivalent utility storage method in wasm. 
- extends queriers to the funding service, enabling nullifier checks for voting eligibility.

## Related Issue

references https://github.com/penumbra-zone/web/issues/2027 and https://github.com/penumbra-zone/web/issues/2028 and https://github.com/penumbra-zone/penumbra/pull/5080

pairs with https://github.com/prax-wallet/prax/pull/290

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
