### PR TITLE
incremental transport-chrome session improvements

### DIFF
--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -149,7 +149,7 @@ describe('CRSessionClient', () => {
         messageEventError = domMessageHandler?.mock.lastCall?.[0]?.data;
       });
 
-      it('responds with failure missing a `requestId`', () => {
+      it.fails('responds with failure missing a `requestId`', () => {
         expect(messageEventError).not.toHaveProperty('requestId');
         expect(messageEventError).toMatchObject({
           error: {
@@ -165,7 +165,7 @@ describe('CRSessionClient', () => {
         });
       });
 
-      it.fails('responds with failure including a `requestId`', () => {
+      it('responds with failure including a `requestId`', () => {
         expect(messageEventError).toMatchObject({
           requestId: testMessage.requestId,
           error: errorToJson(ConnectError.from(postThrowError), undefined),
@@ -188,7 +188,7 @@ describe('CRSessionClient', () => {
         throwObjectResponse = domMessageHandler?.mock.lastCall?.[0].data;
       });
 
-      it('incorrectly responds with failure missing a `requestId`', () => {
+      it.fails('incorrectly responds with failure missing a `requestId`', () => {
         expect(throwObjectResponse).not.toHaveProperty('requestId');
         expect(throwObjectResponse).toMatchObject({
           error: {
@@ -204,7 +204,7 @@ describe('CRSessionClient', () => {
         });
       });
 
-      it.fails('correctly responds with failure including a `requestId`', () => {
+      it('correctly responds with failure including a `requestId`', () => {
         expect(throwObjectResponse).toMatchObject({
           requestId: testMessage.requestId,
           error: errorToJson(ConnectError.from(postThrowObject), undefined),
@@ -220,7 +220,7 @@ describe('CRSessionClient', () => {
         });
       });
 
-      it('does not report failure and throws an uncaught `DataCloneError`', async () => {
+      it.fails('does not report failure and throws an uncaught `DataCloneError`', async () => {
         const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
           replaceUncaughtExceptionListener();
         onTestFinished(restoreUncaughtExceptionListener);
@@ -238,7 +238,7 @@ describe('CRSessionClient', () => {
         expect(domMessageHandler).not.toHaveBeenCalled();
       });
 
-      it.fails('reports failure', async () => {
+      it('reports failure', async () => {
         const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
           replaceUncaughtExceptionListener();
         onTestFinished(restoreUncaughtExceptionListener);
@@ -296,7 +296,7 @@ describe('CRSessionClient', () => {
           expect(domMessageErrorHandler).not.toHaveBeenCalled();
         });
 
-        it('does not respond and only prints a console warning', async () => {
+        it.fails('does not respond and only prints a console warning', async () => {
           expect(mockWarn).not.toHaveBeenCalled();
           domPort.postMessage(badRequest);
           await vi.waitFor(() => expect(mockWarn).toHaveBeenCalled());
@@ -304,7 +304,7 @@ describe('CRSessionClient', () => {
           expect(domMessageHandler).not.toHaveBeenCalled();
         });
 
-        it.fails('responds with a failure and prints a console warning', async () => {
+        it('responds with a failure and prints a console warning', async () => {
           expect(mockWarn).not.toHaveBeenCalled();
           domPort.postMessage(badRequest);
           await vi.waitFor(() => expect(mockWarn).toHaveBeenCalled());

--- a/packages/transport-chrome/src/session-client.ts
+++ b/packages/transport-chrome/src/session-client.ts
@@ -1,68 +1,47 @@
-/**
- * CRSessionClient is a Chrome runtime session client: it handles channel
- * Transport client sessions in the Chrome runtime.
- *
- * Simple handlers unconditionally forward messages back and forth. Chrome
- * runtime disconnect is detected and surfaced as an error.
- *
- * Only a basic same-window origin check and structural typing are performed.
- * Content scripts are ultimately untrusted, so services are responsible for
- * confirming legitimacy.
- *
- * A `ReadableStream` or `AsyncIterable` cannot cross the runtime, so streaming
- * methods sink/source a dedicated `chrome.runtime.Port` at this boundary.
- */
-
+import { Code, ConnectError } from '@connectrpc/connect';
+import { errorToJson } from '@connectrpc/connect/protocol-connect';
 import {
   isTransportAbort,
   isTransportError,
+  isTransportEvent,
   isTransportMessage,
   isTransportStream,
-  TransportStream,
+  type TransportAbort,
+  type TransportError,
+  type TransportMessage,
+  type TransportStream,
 } from '@penumbra-zone/transport-dom/messages';
 import { ChannelLabel, nameConnection } from './channel-names.js';
-import { isTransportInitChannel, TransportInitChannel } from './message.js';
+import { isTransportInitChannel, type TransportInitChannel } from './message.js';
 import { PortStreamSink, PortStreamSource } from './stream.js';
 
-const localErrorJson = (err: unknown, relevantMessage?: unknown) =>
-  err instanceof Error
-    ? {
-        message: err.message,
-        details: [
-          {
-            type: err.name,
-            value: err.cause,
-          },
-          relevantMessage,
-        ],
-      }
-    : {
-        message: String(err),
-        details: [
-          {
-            type: String(
-              // eslint-disable-next-line no-nested-ternary -- readable ternary nesting
-              typeof err === 'function'
-                ? err.name
-                : typeof err === 'object'
-                  ? ((Object.getPrototypeOf(err) as unknown)?.constructor?.name ?? String(err))
-                  : typeof err,
-            ),
-            value: err,
-          },
-          relevantMessage,
-        ],
-      };
-
+/**
+ * Transparently adapts `Transport`s using `MessageChannel` DOM connections to
+ * use Chrome `chrome.runtime.Port` extension connections.
+ *
+ * Simple handlers unconditionally forward messages back and forth. Channel
+ * disconnects are detected, and transparently re-established if possible.
+ *
+ * Content scripts are ultimately untrusted, so the counterpart session manager
+ * is considered responsible for all validation.
+ *
+ * The chrome runtime does not support object transfer, so `ReadableStream` or
+ * `AsyncIterable` cannot cross the message boundary. Instead, `PortStreamSink`
+ * and `PortStreamSource` are used with dedicated sub-channels to encapsulate
+ * streams.
+ */
 export class CRSessionClient {
   private readonly sessionName: string;
-  private readonly servicePort: chrome.runtime.Port;
+  private servicePort: chrome.runtime.Port;
+  private pendingChannels = new Map<string, AbortController>();
 
+  /** Private constructor. Launch a session with `CRSessionClient.init`. */
   private constructor(
-    private readonly prefix: string,
+    private readonly managerId: string,
     private readonly clientPort: MessagePort,
   ) {
-    this.sessionName = nameConnection(prefix, ChannelLabel.TRANSPORT);
+    // create a permanent, unique session name
+    this.sessionName = nameConnection(managerId, ChannelLabel.TRANSPORT);
 
     // listen to service
     this.servicePort = chrome.runtime.connect({
@@ -74,78 +53,213 @@ export class CRSessionClient {
 
     // listen to client
     this.clientPort.addEventListener('message', this.clientListener);
+    if (globalThis.__DEV__) {
+      this.clientPort.addEventListener('messageerror', ev =>
+        console.warn('CRSessionClient.clientPort messageerror', ev),
+      );
+    }
     this.clientPort.start();
   }
 
   /**
-   * Establishes a new connection from this document to the extension.
+   * Establishes a new session client.
    *
-   * @param prefix a string containing no spaces
+   * @param managerId identifies the counterpart session manager
    * @returns a `MessagePort` that can be provided to DOM channel transports
    */
-  public static init(prefix: string): MessagePort {
+  public static init(managerId: string): MessagePort {
     const { port1, port2 } = new MessageChannel();
-    new CRSessionClient(prefix, port1);
+    new CRSessionClient(managerId, port1);
     return port2;
   }
 
+  /** Forward a service-emitted response or error (response failure) to the client. */
+  private clientPortPostMessage = (
+    msg: TransportMessage | TransportStream | TransportError<string>,
+  ) => {
+    'stream' in msg
+      ? this.clientPort.postMessage(msg, [msg.stream])
+      : this.clientPort.postMessage(msg);
+  };
+
+  /** Forward a client-emitted request or abort (request cancel) to the service. */
+  private servicePortPostMessage = (
+    msg: TransportMessage | TransportInitChannel | TransportAbort,
+  ) => {
+    this.servicePort.postMessage(msg);
+  };
+
+  /**
+   * Serialize and report a local error to the client. If `requestId` is
+   * provided, it will be used to reject that pending request.
+   */
+  private clientPortPostError = (cause: unknown, requestId?: string) => {
+    const connectError = ConnectError.from(cause);
+    if (globalThis.__DEV__) {
+      console.warn('CRSessionClient failure', cause, connectError);
+    }
+    const metadata: [string, string][] = Array.from(connectError.metadata);
+    const msg: TransportError<string | undefined> = {
+      requestId,
+      metadata: metadata.length ? metadata : undefined,
+      error: errorToJson(connectError, undefined),
+    };
+    this.clientPort.postMessage(msg);
+  };
+
+  /**
+   * Used to tear down this session when the client announces channel closure,
+   * or when the extension channel disconnects.
+   *
+   * Announces closure from this side towards the document, and ensures closure
+   * of both ports. Listeners are automatically gargbage-collected. This session
+   * is complete.
+   */
   private disconnect = () => {
-    this.clientPort.removeEventListener('message', this.clientListener);
+    // announce closure, ok even if already closed
     this.clientPort.postMessage(false);
+    this.pendingChannels.forEach(ac => ac.abort());
+
     this.clientPort.close();
-    this.servicePort.onMessage.removeListener(this.serviceListener);
-    this.servicePort.onDisconnect.removeListener(this.disconnect);
     this.servicePort.disconnect();
   };
 
+  /**
+   * Listens for messages from the client, and forwards them to the service.
+   *
+   * If an unidentifiable message arrives, this handler will report the failure
+   * back to the specific request if possible, or, as a top-level transport
+   * error.
+   *
+   * Since a `MessagePort` has no event or callback indicating closure, the
+   * client may announce port closure by posting a `false` value.
+   *
+   * @param tev `TransportEvent` or `false` message payload
+   */
   private clientListener = (ev: MessageEvent<unknown>) => {
-    try {
-      if (ev.data === false) {
-        this.disconnect();
-      } else if (isTransportAbort(ev.data) || isTransportMessage(ev.data)) {
-        this.servicePort.postMessage(ev.data);
-      } else if (isTransportStream(ev.data)) {
-        this.servicePort.postMessage(this.makeChannelStreamRequest(ev.data));
-      } else {
-        console.warn('Unknown item from client', ev.data);
+    if (ev.data === false) {
+      // client announced closure
+      this.disconnect();
+    } else if (isTransportEvent(ev.data)) {
+      // event contains a requestId
+      const { requestId } = ev.data;
+      try {
+        if (isTransportAbort(ev.data, requestId)) {
+          // abort control for a specific request
+          this.servicePortPostMessage(ev.data);
+
+          // only pending client-stream requests are aborted here.
+          // - active client-stream requests abort via stream control.
+          // - server-stream responses abort via stream control.
+          // - non-streaming messages need no abort control.
+          this.pendingChannels.get(requestId)?.abort();
+        } else if (isTransportMessage(ev.data, requestId)) {
+          // request, client message
+          this.servicePortPostMessage(ev.data);
+        } else if (isTransportStream(ev.data, requestId) && globalThis.__DEV__) {
+          // request, client stream
+          this.servicePortPostMessage(this.makeChannelStreamRequest(ev.data));
+        } else {
+          // something unsupported
+          throw new ConnectError('Unsupported request from client', Code.Unimplemented);
+        }
+      } catch (cause) {
+        this.clientPortPostError(cause, requestId);
       }
-    } catch (e) {
-      console.error('Error in client listener', e);
-      this.clientPort.postMessage({ error: localErrorJson(e, ev.data) });
+    } else {
+      this.clientPortPostError(new ConnectError('Unknown item from client', Code.Unknown));
     }
   };
 
+  /**
+   * Listens for events from the service, and forwards them to the client.
+   *
+   * If an unidentifiable event arrives, this handler will report the failure
+   * back to the specific request if possible, or, as a top-level transport
+   * error.
+   *
+   * @param msg service-emitted event
+   */
   private serviceListener = (msg: unknown) => {
-    try {
-      if (msg === true) {
-        this.clientPort.postMessage(true);
-      } else if (isTransportError(msg) || isTransportMessage(msg)) {
-        this.clientPort.postMessage(msg);
-      } else if (isTransportInitChannel(msg)) {
-        this.clientPort.postMessage(...this.acceptChannelStreamResponse(msg));
-      } else {
-        console.warn('Unknown item from service', msg);
+    if (isTransportEvent(msg)) {
+      // event contains a requestId
+      const { requestId } = msg;
+      try {
+        if (isTransportError(msg)) {
+          // error control for a specific request
+          this.clientPortPostMessage(msg);
+        } else if (isTransportMessage(msg)) {
+          // response, server message
+          this.clientPortPostMessage(msg);
+        } else if (isTransportInitChannel(msg)) {
+          // response, server stream
+          this.clientPortPostMessage(this.acceptChannelStreamResponse(msg));
+        } else {
+          // something unsupported
+          throw ConnectError.from('Unsupported response from service', Code.Unimplemented);
+        }
+      } catch (failure) {
+        this.clientPortPostError(failure, requestId);
       }
-    } catch (e) {
-      this.clientPort.postMessage({ error: localErrorJson(e, msg) });
+    } else {
+      this.clientPortPostError(ConnectError.from('Unknown item from service'), undefined);
     }
   };
 
-  private acceptChannelStreamResponse = ({ requestId, channel: name }: TransportInitChannel) => {
-    const stream = new ReadableStream(new PortStreamSource(chrome.runtime.connect({ name })));
-    return [{ requestId, stream }, [stream]] satisfies [TransportStream, [Transferable]];
+  /**
+   * Support server-stream responses. Takes a message representing a subchannel,
+   * and sources that into a stream.
+   *
+   * @param channel a name identifying the subchannel
+   * @param requestId a request identifier
+   * @returns a response stream
+   */
+  private acceptChannelStreamResponse = ({
+    channel,
+    requestId,
+  }: TransportInitChannel): TransportStream => {
+    const sourcePort = chrome.runtime.connect({ name: channel });
+    const stream = new ReadableStream(new PortStreamSource(sourcePort));
+    return { requestId, stream };
   };
 
-  private makeChannelStreamRequest = ({ requestId, stream }: TransportStream) => {
-    const channel = nameConnection(this.prefix, ChannelLabel.STREAM);
-    const sinkListener = (p: chrome.runtime.Port) => {
-      if (p.name !== channel) {
-        return;
+  /**
+   * Support client-stream requests. Sinks a stream into a subchannel,
+   * represented by the return message.
+   *
+   * @param stream a stream of JSON messages
+   * @param requestId a request identifier
+   * @returns a message identifying the subchannel
+   */
+  private makeChannelStreamRequest = ({
+    requestId,
+    stream,
+  }: TransportStream): TransportInitChannel => {
+    const channel = nameConnection(this.managerId, ChannelLabel.STREAM);
+
+    const ac = new AbortController();
+    this.pendingChannels.set(requestId, ac);
+
+    /** Listen for connection by unique name, accepting this client-stream
+     * request. Content scripts only connect to the parent extension. */
+    const sinkListener = (sinkPort: chrome.runtime.Port) => {
+      if (sinkPort.name === channel) {
+        chrome.runtime.onConnect.removeListener(sinkListener);
+        void stream
+          .pipeTo(new WritableStream(new PortStreamSink(sinkPort)), { signal: ac.signal })
+          // stream failure is handled in-band, but this might cover unknowns.
+          .catch((cause: unknown) => this.clientPortPostError(cause, requestId))
+          // port closure is handled in-band, but this should prevent leaks.
+          .finally(() => sinkPort.disconnect());
       }
-      chrome.runtime.onConnect.removeListener(sinkListener);
-      void stream.pipeTo(new WritableStream(new PortStreamSink(p))).catch(() => null);
     };
+
     chrome.runtime.onConnect.addListener(sinkListener);
-    return { requestId, channel } satisfies TransportInitChannel;
+    AbortSignal.any([ac.signal, AbortSignal.timeout(60_000)]).addEventListener('abort', () => {
+      this.pendingChannels.delete(requestId);
+      chrome.runtime.onConnect.removeListener(sinkListener);
+    });
+
+    return { requestId, channel };
   };
 }

--- a/packages/transport-chrome/src/session-manager.test.ts
+++ b/packages/transport-chrome/src/session-manager.test.ts
@@ -395,7 +395,7 @@ describe('CRSessionManager', () => {
       expect(clientPort.onDisconnect.dispatch).toHaveBeenCalled();
     });
 
-    it.fails('should remove aborted sessions from the session list', async () => {
+    it('should remove aborted sessions from the session list', async () => {
       const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
       expect(sessions.size).toBe(0);
 

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -1,22 +1,51 @@
-import { ConnectError } from '@connectrpc/connect';
+import type { JsonValue } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { errorToJson } from '@connectrpc/connect/protocol-connect';
+import type { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
+import {
+  isTransportAbort,
+  isTransportEvent,
+  isTransportMessage,
+  TransportEvent,
+  type TransportError,
+  type TransportMessage,
+  type TransportStream,
+} from '@penumbra-zone/transport-dom/messages';
 import { ChannelLabel, nameConnection, parseConnectionName } from './channel-names.js';
 import { isTransportInitChannel, TransportInitChannel } from './message.js';
 import { PortStreamSink, PortStreamSource } from './stream.js';
-import { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
-import {
-  isTransportAbort,
-  isTransportMessage,
-  TransportEvent,
-  TransportMessage,
-  TransportStream,
-} from '@penumbra-zone/transport-dom/messages';
 
-interface CRSession extends AbortController {
-  clientId: string;
+interface CRSession {
+  abort: (reason?: unknown) => void;
+  signal: AbortSignal;
+  sessionId: string;
   port: chrome.runtime.Port;
   origin: string;
+  requests: Map<string, AbortController>;
 }
+
+type SenderWithOrigin = chrome.runtime.MessageSender & { origin: string };
+type PortWithOrigin = chrome.runtime.Port & { sender: SenderWithOrigin };
+export type CheckPortSenderFn = (port: chrome.runtime.Port) => Promise<PortWithOrigin>;
+
+// Move port validation logic to a distinct function, anticipating to parameterize it.
+const defaultCheckPortSender: CheckPortSenderFn = port => {
+  // Allow connections from the same extension, from https pages, or from http://localhost
+  if (port.sender?.origin) {
+    const fromThisExtension = port.sender.id === chrome.runtime.id;
+    const fromPageHttps =
+      !port.sender.frameId && !!port.sender.tab?.id && port.sender.origin.startsWith('https://');
+    const isLocalhost =
+      port.sender.origin.startsWith('http://localhost:') ||
+      port.sender.origin === 'http://localhost';
+
+    if (isLocalhost || fromPageHttps || fromThisExtension) {
+      return Promise.resolve(port as unknown as PortWithOrigin);
+    }
+  }
+
+  throw new Error('Invalid sender');
+};
 
 /**
  * Only for use as an extension-level singleton by the extension's main
@@ -37,39 +66,66 @@ interface CRSession extends AbortController {
  *
  * If you are connecting from the same worker running this script (currently,
  * service-to-service communication) you cannot make a `chrome.runtime.connect`
- * call that activates this manager, and you should use normal DOM messaging.
+ * call that activates this manager, and you should use normal DOM messaging to
+ * enter your router.
  */
 
 export class CRSessionManager {
   private static singleton?: CRSessionManager;
   private sessions = new Map<string, CRSession>();
-  private requests = new Map<string, AbortController>();
 
+  /**
+   * Create a new session manager to accept connections from `CRSessionClient`.
+   *
+   * @param managerId a string containing no spaces, matching the prefix used in your content script
+   * @param handler your router entry function
+   * @param checkPortSender a function used to validate the sender of a connection
+   */
   private constructor(
-    private prefix: string,
-    private handler: ChannelHandlerFn,
+    private readonly managerId: string,
+    private readonly handler: ChannelHandlerFn,
+    private readonly checkPortSender: CheckPortSenderFn,
   ) {
     if (CRSessionManager.singleton) {
       throw new Error('Already constructed');
     }
+    CRSessionManager.singleton = this;
     chrome.runtime.onConnect.addListener(this.transportConnection);
   }
 
   /**
+   * Initialize the singleton session manager.
    *
-   * @param prefix a string containing no spaces, matching the prefix used in your content script
+   * @param managerId a string identifying this manager
    * @param handler your router entry function
    */
-  public static init = (prefix: string, handler: ChannelHandlerFn) => {
-    CRSessionManager.singleton ??= new CRSessionManager(prefix, handler);
+  public static init = (managerId: string, handler: ChannelHandlerFn) => {
+    CRSessionManager.singleton ??= new CRSessionManager(managerId, handler, defaultCheckPortSender);
     return CRSessionManager.singleton.sessions;
   };
 
+  /**
+   * Abort all sessions from a given origin presently active in the singleton.
+   *
+   * @param targetOrigin the origin to kill
+   */
   public static killOrigin = (targetOrigin: string) => {
     if (CRSessionManager.singleton) {
       CRSessionManager.singleton.sessions.forEach(session => {
         if (session.origin === targetOrigin) {
-          session.abort(targetOrigin);
+          session.requests.forEach(request => {
+            if (!request.signal.aborted) {
+              request.abort(
+                new Error('Kill origin request', {
+                  cause: targetOrigin,
+                }),
+              );
+            }
+          });
+          if (!session.signal.aborted) {
+            session.abort(new Error('Kill origin session', { cause: targetOrigin }));
+            session.port.disconnect();
+          }
         }
       });
     } else {
@@ -86,64 +142,109 @@ export class CRSessionManager {
    */
   private transportConnection = (port: chrome.runtime.Port) => {
     // require an identified origin
-    const sender = port.sender;
-    if (!sender?.origin) {
+    if (!port.sender?.origin) {
       return;
     }
 
-    // fast and simple name test, parse later
-    if (!port.name.startsWith(this.prefix)) {
-      return;
-    }
-
-    const fromThisExtension = sender.id === chrome.runtime.id;
-    const fromPageHttps =
-      !sender.frameId && !!sender.tab?.id && sender.origin.startsWith('https://');
-    const isLocalhost =
-      sender.origin.startsWith('http://localhost:') || sender.origin === 'http://localhost';
-
-    // Allow connections from the same extension, from https pages, or from http://localhost
-    const validOrigin = isLocalhost || fromPageHttps || fromThisExtension;
-    if (!validOrigin) {
+    // fast and simple name test
+    if (!port.name.startsWith(this.managerId)) {
       return;
     }
 
     // parse the name
     const { label: channelLabel, uuid: clientId } =
-      parseConnectionName(this.prefix, port.name) ?? {};
+      parseConnectionName(this.managerId, port.name) ?? {};
     if (channelLabel !== ChannelLabel.TRANSPORT || !clientId) {
       return;
     }
 
+    // client is re-using a present session??
     if (this.sessions.has(clientId)) {
+      port.disconnect();
       throw new Error(`Session collision: ${clientId}`);
     }
 
-    const session: CRSession = Object.assign(new AbortController(), {
-      clientId,
-      origin: sender.origin,
-      port: port,
-    });
-    this.sessions.set(clientId, session);
+    // checking port sender is async
+    void this.checkPortSender(port).then(
+      okPort => {
+        console.debug('Accepted connection', port.name);
+        this.acceptSession(okPort, clientId);
+      },
+      (e: unknown) => console.warn('Attempted connection was rejected', port.name, e),
+    );
+  };
 
-    session.signal.addEventListener('abort', () => port.disconnect());
-    port.onDisconnect.addListener(() => session.abort('Disconnect'));
+  private acceptSession = (port: PortWithOrigin, sessionId: string) => {
+    console.debug('acceptSession', port.name, sessionId);
+    const senderOrigin = port.sender.origin;
 
-    port.onMessage.addListener((i, p) => {
-      try {
-        if (isTransportAbort(i)) {
-          this.requests.get(i.requestId)?.abort();
-        } else if (isTransportMessage(i)) {
-          void this.clientMessageHandler(session, i).then(res => p.postMessage(res));
-        } else if (isTransportInitChannel(i)) {
-          console.warn('Client streaming unimplemented', this.acceptChannelStreamRequest(i));
-        } else {
-          console.warn('Unknown item in transport', i);
-        }
-      } catch (e) {
-        session.abort(e);
+    const ac = new AbortController();
+    const session: CRSession = {
+      abort: (r?: unknown) => ac.abort(r),
+      signal: ac.signal,
+      sessionId,
+      origin: senderOrigin,
+      port,
+      requests: new Map(),
+    };
+
+    const sessionAbortListener = () => {
+      console.debug('sessionAbortListener', sessionId);
+      session.requests.forEach(request => request.abort(session.signal.reason));
+      if (this.sessions.delete(sessionId)) {
+        port.disconnect();
       }
-    });
+    };
+
+    const sessionDisconnectListener = () => {
+      console.debug('sessionDisconnectListener', sessionId);
+      if (this.sessions.delete(sessionId)) {
+        session.abort(new Error('Session port disconnected'));
+      }
+    };
+
+    const sessionMessageListener = (tev: unknown) => {
+      console.debug('sessionMessageListener', tev);
+      if (isTransportEvent(tev)) {
+        void this.acceptRequest(session, tev);
+      } else {
+        console.warn('Unknown item in transport', tev);
+      }
+    };
+
+    this.sessions.set(sessionId, session);
+
+    session.signal.addEventListener('abort', sessionAbortListener);
+    port.onDisconnect.addListener(sessionDisconnectListener);
+    port.onMessage.addListener(sessionMessageListener);
+  };
+
+  private acceptRequest = async (session: CRSession, tev: TransportEvent) => {
+    console.debug('acceptRequest', session.port.name, tev);
+    const { requestId } = tev;
+
+    try {
+      if (isTransportAbort(tev, requestId)) {
+        session.requests
+          .get(requestId)
+          ?.abort(ConnectError.from('Client requested abort', Code.Canceled));
+      } else if (session.requests.has(requestId)) {
+        throw new ConnectError('Request collision', Code.Internal);
+      } else {
+        const ac = new AbortController();
+        session.requests.set(requestId, ac);
+        const response = await this.sessionRequestHandler(session, ac, tev);
+        session.port.postMessage(response);
+      }
+    } catch (cause) {
+      console.debug('acceptRequest error', cause);
+      session.port.postMessage({
+        requestId,
+        error: errorToJson(ConnectError.from(cause), undefined),
+      });
+    } finally {
+      session.requests.delete(requestId);
+    }
   };
 
   /**
@@ -154,31 +255,35 @@ export class CRSessionManager {
    * `TransportEvent`, containing json representing a response or json
    * representing an error.
    */
-  private clientMessageHandler(
+  private sessionRequestHandler = async (
     session: CRSession,
-    { requestId, message }: TransportMessage,
-  ): Promise<TransportEvent> {
-    if (this.requests.has(requestId)) {
-      throw new Error(`Request collision: ${requestId}`);
+    ac: AbortController,
+    tev: TransportEvent,
+  ): Promise<TransportMessage | TransportInitChannel | TransportError<string>> => {
+    console.debug('sessionRequestHandler', session.port.name, tev);
+    const { requestId } = tev;
+
+    let request: JsonValue | ReadableStream<JsonValue>;
+    if (isTransportMessage(tev, requestId)) {
+      request = tev.message;
+    } else if (isTransportInitChannel(tev) && globalThis.__DEV__) {
+      request = await this.acceptChannelStreamRequest(session.port.sender?.tab?.id, tev.channel);
+    } else {
+      throw new ConnectError('Unknown request kind', Code.Unimplemented);
     }
-    const requestController = new AbortController();
-    session.signal.addEventListener('abort', () => requestController.abort());
-    this.requests.set(requestId, requestController);
-    return this.handler(message, AbortSignal.any([session.signal, requestController.signal]))
+
+    return this.handler(request, AbortSignal.any([session.signal, ac.signal]))
       .then(response =>
         response instanceof ReadableStream
-          ? this.responseChannelStream(requestController.signal, {
-              requestId,
-              stream: response as unknown,
-            } as TransportStream)
-          : ({ requestId, message: response as unknown } as TransportEvent),
+          ? { requestId, channel: this.makeChannelStreamResponse(response) }
+          : { requestId, message: response },
       )
       .catch((error: unknown) => ({
         requestId,
         error: errorToJson(ConnectError.from(error), undefined),
       }))
-      .finally(() => this.requests.delete(requestId));
-  }
+      .finally(() => session.requests.delete(requestId));
+  };
 
   /**
    * Streams are not jsonifiable, so this function sinks a response stream
@@ -188,30 +293,45 @@ export class CRSessionManager {
    * A jsonifiable message identifying a unique connection name is returned
    * and should be transported to the client.  The client should open a
    * connection bearing this name to source the stream.
-   *
-   * TODO: time out if the client fails to initiate a connection
    */
-  private responseChannelStream(
-    signal: AbortSignal,
-    { requestId, stream }: TransportStream,
-  ): TransportInitChannel {
-    const channel = nameConnection(this.prefix, ChannelLabel.STREAM);
-    const sinkListener = (p: chrome.runtime.Port) => {
-      if (p.name !== channel) {
-        return;
+  private makeChannelStreamResponse = (
+    stream: TransportStream['stream'],
+  ): TransportInitChannel['channel'] => {
+    const channel = nameConnection(this.managerId, ChannelLabel.STREAM);
+    console.debug('responseChannelStream', channel);
+    const sinkListener = (sinkPort: chrome.runtime.Port) => {
+      if (sinkPort.name === channel) {
+        chrome.runtime.onConnect.removeListener(sinkListener);
+        void this.checkPortSender(sinkPort)
+          .then(
+            () =>
+              stream
+                .pipeTo(new WritableStream(new PortStreamSink(sinkPort)))
+                .catch((e: unknown) => console.debug('response channel stream error', e)),
+            (e: unknown) => console.warn('Attempted stream was rejected', sinkPort.name, e),
+          )
+          .finally(() => sinkPort.disconnect());
       }
-      chrome.runtime.onConnect.removeListener(sinkListener);
-      void stream.pipeTo(new WritableStream(new PortStreamSink(p)), { signal }).catch(() => null);
     };
-    chrome.runtime.onConnect.addListener(sinkListener);
-    return { requestId, channel };
-  }
 
-  private acceptChannelStreamRequest = ({
-    requestId,
-    channel: name,
-  }: TransportInitChannel): TransportStream => ({
-    requestId,
-    stream: new ReadableStream(new PortStreamSource(chrome.runtime.connect({ name }))),
-  });
+    AbortSignal.any([AbortSignal.timeout(60_000)]).addEventListener('abort', () =>
+      chrome.runtime.onConnect.removeListener(sinkListener),
+    );
+
+    chrome.runtime.onConnect.addListener(sinkListener);
+
+    return channel;
+  };
+
+  private acceptChannelStreamRequest = async (
+    tabId: number | undefined,
+    channel: TransportInitChannel['channel'],
+  ): Promise<TransportStream['stream']> => {
+    console.debug('requestChannelStream', channel);
+    const streamPort = tabId
+      ? chrome.tabs.connect(tabId, { name: channel })
+      : chrome.runtime.connect({ name: channel });
+
+    return new ReadableStream(new PortStreamSource(await this.checkPortSender(streamPort)));
+  };
 }


### PR DESCRIPTION
## Description of Changes

splitting the difference from #2018  towards #2034

contains all changes except reconnect, mostly focusing on reliability.

- typed senders make it harder to emit a malformed message
- incoming message checking is more thorough
- poisons transport in fewer cases
- matches errors up with relevant requests in more cases
- fewer data clone failures #2014


## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
