### PR TITLE
Change tabProps prop type

### DIFF
--- a/.changeset/six-colts-sip.md
+++ b/.changeset/six-colts-sip.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Change tabProps prop type

--- a/packages/ui/src/Tabs/index.tsx
+++ b/packages/ui/src/Tabs/index.tsx
@@ -51,7 +51,7 @@ export interface TabsTab {
   label: string;
   disabled?: boolean;
   as?: React.ElementType;
-  tabProps?: Record<string, React.HTMLAttributes<HTMLElement>>;
+  tabProps?: Record<string, unknown>;
 }
 
 export interface TabsProps {


### PR DESCRIPTION
## Description of Changes

A follow up for https://github.com/penumbra-zone/web/pull/2039 to fix the lint error related to the tabProps type.

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
