### PR TITLE
disable client-streaming in transport-dom outside of dev mode

### DIFF
--- a/.changeset/empty-ads-repeat.md
+++ b/.changeset/empty-ads-repeat.md
@@ -1,0 +1,8 @@
+---
+'@penumbra-zone/transport-chrome': patch
+'@penumbra-zone/transport-dom': patch
+---
+
+disable unsupported client-streaming requests. if you are experimenting with
+development of client-streaming requests, define the `globalThis.__DEV__` flag
+in your bundler to enable them.

--- a/packages/transport-chrome/src/session-client.ts
+++ b/packages/transport-chrome/src/session-client.ts
@@ -112,6 +112,9 @@ export class CRSessionClient {
         console.warn('Unknown item from client', ev.data);
       }
     } catch (e) {
+      if (globalThis.__DEV__) {
+        console.warn('Error in client listener', e);
+      }
       this.clientPort.postMessage({ error: localErrorJson(e, ev.data) });
     }
   };

--- a/packages/transport-chrome/vitest.config.ts
+++ b/packages/transport-chrome/vitest.config.ts
@@ -3,6 +3,6 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => ({
-  define: { 'globalThis.__DEV__': mode !== 'production' },
+  define: { __DEV__: mode !== 'production' },
   test: { include: ['src/*.test.ts'] },
 }));

--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -26,6 +26,11 @@ import {
 
 import ReadableStream from './ReadableStream.from.js';
 
+declare global {
+  // eslint-disable-next-line no-var -- global dev mode flag
+  var __DEV__: boolean | undefined;
+}
+
 const forceTransportOptions = {
   httpClient: null as never,
   baseUrl: 'https://in-memory',
@@ -276,6 +281,9 @@ export const createChannelTransport = ({
             case MethodKind.BiDiStreaming:
               // send as an actual stream
               {
+                if (!globalThis.__DEV__) {
+                  throw new ConnectError('MethodKind not supported', Code.Unimplemented);
+                }
                 const stream: ReadableStream<JsonValue> = ReadableStream.from(input).pipeThrough(
                   new TransformStream({
                     transform: (chunk: PartialMessage<I>, cont) =>

--- a/packages/transport-dom/vitest.config.ts
+++ b/packages/transport-dom/vitest.config.ts
@@ -2,7 +2,8 @@
 
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  define: { __DEV__: mode !== 'production' },
   test: {
     include: ['src/*.test.ts'],
     browser: {
@@ -12,4 +13,4 @@ export default defineConfig({
       headless: true,
     },
   },
-});
+}));


### PR DESCRIPTION
## Description of Changes

Moves client streaming request support to a `globalThis.__DEV__` conditional, which will be codesplit by bundlers or skipped in execution unless defined.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
