### PR TITLE
feat(ui): #2053: implement `SwapClaim` action view

### DIFF
--- a/.changeset/famous-meals-check.md
+++ b/.changeset/famous-meals-check.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/getters': minor
+'@penumbra-zone/ui': minor
+---
+
+Implement `SwapClaim` action view

--- a/packages/getters/src/swap-claim-view.ts
+++ b/packages/getters/src/swap-claim-view.ts
@@ -2,6 +2,11 @@ import { SwapClaimView } from '@penumbra-zone/protobuf/penumbra/core/component/d
 import { createGetter } from './utils/create-getter.js';
 import { getValue } from './note-view.js';
 
+export const getOutputData = createGetter(
+  (swapClaimView?: SwapClaimView) =>
+    swapClaimView?.swapClaimView.value?.swapClaim?.body?.outputData,
+);
+
 export const getOutput1 = createGetter((swapClaimView?: SwapClaimView) =>
   swapClaimView?.swapClaimView.case === 'visible'
     ? swapClaimView.swapClaimView.value.output1

--- a/packages/ui/src/ActionView/action-view.tsx
+++ b/packages/ui/src/ActionView/action-view.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { ActionView as ActionViewMessage } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
-import { ActionViewType, ActionViewValueType } from './types';
+import { ActionViewType, ActionViewValueType, GetMetadataByAssetId } from './types';
 import { UnknownAction } from './actions/unknown';
 
 import { SpendAction } from './actions/spend';
@@ -30,15 +30,24 @@ import { CommunityPoolOutputAction } from './actions/community-pool-output';
 import { CommunityPoolSpendAction } from './actions/community-pool-spend';
 
 export interface ActionViewProps {
+  /**
+   * The `ActionViewMessage` protobuf describing an action within a transaction in Penumbra.
+   * Can be one of multiple types: Spend, Output, Swap, SwapClaim, etc.
+   */
   action: ActionViewMessage;
+  /**
+   * A helper function that is needed for better fees calculation.
+   * Can be omitted, but it generally improves the rendering logic, especially for opaque views.
+   */
+  getMetadataByAssetId?: GetMetadataByAssetId;
 }
 
 const componentMap = {
   spend: SpendAction,
   output: OutputAction,
   swap: SwapAction,
-  // TODO: Implement the actions below
   swapClaim: SwapClaimAction,
+  // TODO: Implement the actions below
   delegate: DelegateAction,
   delegatorVote: DelegatorVoteAction,
   undelegate: UndelegateAction,
@@ -67,9 +76,12 @@ const componentMap = {
  * In Penumbra, each transaction has 'actions' of different types,
  * representing a blockchain state change performed by a transaction.
  */
-export const ActionView = ({ action }: ActionViewProps) => {
+export const ActionView = ({ action, getMetadataByAssetId }: ActionViewProps) => {
   const type = action.actionView.case ?? 'unknown';
-  const Component = componentMap[type] as FC<{ value?: ActionViewValueType }>;
+  const Component = componentMap[type] as FC<{
+    value?: ActionViewValueType;
+    getMetadataByAssetId?: GetMetadataByAssetId;
+  }>;
 
-  return <Component value={action.actionView.value} />;
+  return <Component value={action.actionView.value} getMetadataByAssetId={getMetadataByAssetId} />;
 };

--- a/packages/ui/src/ActionView/actions/swap-claim.tsx
+++ b/packages/ui/src/ActionView/actions/swap-claim.tsx
@@ -1,10 +1,143 @@
+import { useMemo } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { isZero } from '@penumbra-zone/types/amount';
+import { shorten } from '@penumbra-zone/types/string';
+import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
+import { getAmount, getMetadata } from '@penumbra-zone/getters/value-view';
 import { SwapClaimView } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
-import { UnknownAction } from './unknown';
+import {
+  getOutput1Value,
+  getOutput2Value,
+  getSwapClaimFee,
+  getOutputData,
+} from '@penumbra-zone/getters/swap-claim-view';
+import { Density } from '../../Density';
+import { ValueViewComponent } from '../../ValueView';
+import { useDensity } from '../../utils/density';
+import { ActionRow } from './action-row';
+import { ActionWrapper } from './wrapper';
+import { parseSwapFees } from './swap';
+import { GetMetadataByAssetId } from '../types';
+import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 
 export interface SwapClaimActionProps {
   value: SwapClaimView;
+  /** A helper needed to calculate the SwapClaim fees */
+  getMetadataByAssetId?: GetMetadataByAssetId;
 }
 
-export const SwapClaimAction = ({ value }: SwapClaimActionProps) => {
-  return <UnknownAction label='Swap Claim' opaque={value.swapClaimView.case === 'opaque'} />;
+/**
+ * Based on the visibility of the SwapClaim view, retrieves its values from the `value`
+ * property for 'visible', and from `outputData` for 'opaque'.
+ */
+const useSwapClaimValues = ({ value, getMetadataByAssetId }: SwapClaimActionProps) => {
+  if (value.swapClaimView.case === 'visible') {
+    const value1 = getOutput1Value.optional(value);
+    const value2 = getOutput2Value.optional(value);
+
+    return {
+      value1,
+      value2,
+    };
+  }
+
+  const outputData = getOutputData.optional(value);
+  const value1 =
+    outputData?.lambda1 &&
+    new ValueView({
+      valueView:
+        outputData.tradingPair?.asset1 && getMetadataByAssetId
+          ? {
+              case: 'knownAssetId',
+              value: {
+                amount: outputData.lambda1,
+                metadata: getMetadataByAssetId(outputData.tradingPair.asset1),
+              },
+            }
+          : {
+              case: 'unknownAssetId',
+              value: {
+                amount: outputData.lambda1,
+                assetId: outputData.tradingPair?.asset1,
+              },
+            },
+    });
+
+  const value2 =
+    outputData?.lambda2 &&
+    new ValueView({
+      valueView:
+        outputData.tradingPair?.asset2 && getMetadataByAssetId
+          ? {
+              case: 'knownAssetId',
+              value: {
+                amount: outputData.lambda2,
+                metadata: getMetadataByAssetId(outputData.tradingPair.asset2),
+              },
+            }
+          : {
+              case: 'unknownAssetId',
+              value: {
+                amount: outputData.lambda2,
+                assetId: outputData.tradingPair?.asset2,
+              },
+            },
+    });
+
+  return {
+    value1,
+    value2,
+  };
+};
+
+export const SwapClaimAction = ({ value, getMetadataByAssetId }: SwapClaimActionProps) => {
+  const density = useDensity();
+
+  const { value1, value2 } = useSwapClaimValues({ value, getMetadataByAssetId });
+
+  const amount1 = getAmount.optional(value1);
+  const amount2 = getAmount.optional(value2);
+
+  const txId = useMemo(() => {
+    if (value.swapClaimView.case === 'opaque' || !value.swapClaimView.value?.swapTx) {
+      return undefined;
+    }
+    return uint8ArrayToHex(value.swapClaimView.value.swapTx.inner);
+  }, [value]);
+
+  const fee = useMemo(() => {
+    const claimFee = getSwapClaimFee.optional(value);
+    const asset1 = getMetadata.optional(value1);
+    const asset2 = getMetadata.optional(value2);
+    return parseSwapFees(claimFee, asset1, asset2, getMetadataByAssetId);
+  }, [getMetadataByAssetId, value1, value2, value]);
+
+  return (
+    <ActionWrapper
+      title='Swap Claim'
+      opaque={value.swapClaimView.case === 'opaque'}
+      infoRows={
+        <>
+          {!!fee && <ActionRow label='Swap Claim Fee' info={fee} />}
+          {!!txId && (
+            <ActionRow label='Swap Claim Transaction' info={shorten(txId, 8)} copyText={txId} />
+          )}
+        </>
+      }
+    >
+      <Density slim>
+        <ValueViewComponent
+          valueView={value1}
+          showValue={amount1 && !isZero(amount1)}
+          priority={density === 'sparse' ? 'primary' : 'tertiary'}
+        />
+        <ArrowRight className='size-3 text-neutral-contrast' />
+        <ValueViewComponent
+          valueView={value2}
+          showValue={amount2 && !isZero(amount2)}
+          priority={density === 'sparse' ? 'primary' : 'tertiary'}
+        />
+      </Density>
+    </ActionWrapper>
+  );
 };

--- a/packages/ui/src/ActionView/actions/swap-claim.tsx
+++ b/packages/ui/src/ActionView/actions/swap-claim.tsx
@@ -120,7 +120,7 @@ export const SwapClaimAction = ({ value, getMetadataByAssetId }: SwapClaimAction
         <>
           {!!fee && <ActionRow label='Swap Claim Fee' info={fee} />}
           {!!txId && (
-            <ActionRow label='Swap Claim Transaction' info={shorten(txId, 8)} copyText={txId} />
+            <ActionRow label='Swap Transaction' info={shorten(txId, 8)} copyText={txId} />
           )}
         </>
       }

--- a/packages/ui/src/ActionView/actions/swap-claim.tsx
+++ b/packages/ui/src/ActionView/actions/swap-claim.tsx
@@ -119,9 +119,7 @@ export const SwapClaimAction = ({ value, getMetadataByAssetId }: SwapClaimAction
       infoRows={
         <>
           {!!fee && <ActionRow label='Swap Claim Fee' info={fee} />}
-          {!!txId && (
-            <ActionRow label='Swap Transaction' info={shorten(txId, 8)} copyText={txId} />
-          )}
+          {!!txId && <ActionRow label='Swap Transaction' info={shorten(txId, 8)} copyText={txId} />}
         </>
       }
     >

--- a/packages/ui/src/ActionView/actions/swap.tsx
+++ b/packages/ui/src/ActionView/actions/swap.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { SwapView } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { Metadata, ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { Fee } from '@penumbra-zone/protobuf/penumbra/core/component/fee/v1/fee_pb';
 import {
   getAsset1Metadata,
   getAsset2Metadata,
@@ -14,6 +15,7 @@ import { isZero } from '@penumbra-zone/types/amount';
 import { getFormattedAmtFromValueView } from '@penumbra-zone/types/value-view';
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 import { shorten } from '@penumbra-zone/types/string';
+import { GetMetadataByAssetId } from '../types';
 import { ValueViewComponent } from '../../ValueView';
 import { useDensity } from '../../utils/density';
 import { Density } from '../../Density';
@@ -22,6 +24,8 @@ import { ActionRow } from './action-row';
 
 export interface SwapActionProps {
   value: SwapView;
+  /** A helper needed to calculate the Swap fees */
+  getMetadataByAssetId: GetMetadataByAssetId;
 }
 
 const renderAmount = (value?: ValueView) => {
@@ -32,7 +36,61 @@ const renderAmount = (value?: ValueView) => {
   return symbol ? `${getFormattedAmtFromValueView(value)} ${symbol}` : undefined;
 };
 
-export const SwapAction = ({ value }: SwapActionProps) => {
+/**
+ * For Swap and SwapClaim actions, fees contain only the assetId and amount. This function
+ * calculates a Metadata from this assetId. It firstly tries to get the info from the action itself,
+ * and if it fails, it takes the Metadata from the registry (or ViewService, if passed).
+ */
+export const parseSwapFees = (
+  fee?: Fee,
+  asset1?: Metadata,
+  asset2?: Metadata,
+  getMetadataByAssetId?: SwapActionProps['getMetadataByAssetId'],
+): string | undefined => {
+  if (!fee) {
+    return undefined;
+  }
+
+  let metadata: Metadata | undefined = undefined;
+  if (fee.assetId?.equals(asset1?.penumbraAssetId)) {
+    metadata = asset1;
+  }
+  if (fee.assetId?.equals(asset2?.penumbraAssetId)) {
+    metadata = asset1;
+  }
+
+  if (!metadata && fee.assetId && getMetadataByAssetId) {
+    metadata = getMetadataByAssetId(fee.assetId);
+  }
+
+  if (metadata) {
+    return renderAmount(
+      new ValueView({
+        valueView: {
+          case: 'knownAssetId',
+          value: {
+            metadata,
+            amount: fee.amount,
+          },
+        },
+      }),
+    );
+  }
+
+  return renderAmount(
+    new ValueView({
+      valueView: {
+        case: 'unknownAssetId',
+        value: {
+          assetId: fee.assetId,
+          amount: fee.amount,
+        },
+      },
+    }),
+  );
+};
+
+export const SwapAction = ({ value, getMetadataByAssetId }: SwapActionProps) => {
   const density = useDensity();
 
   const isOneWay = isOneWaySwap(value);
@@ -52,50 +110,13 @@ export const SwapAction = ({ value }: SwapActionProps) => {
     return uint8ArrayToHex(claim.inner);
   }, [value]);
 
-  // This function calculates metadata based on fee's AssetId from input or output metadata.
-  // TODO: implement fees paid from non-input/output assets (e.g. connect with registry)
   const fee = useMemo(() => {
     const claimFee = getClaimFeeFromSwapView.optional(value);
-    if (!claimFee) {
-      return undefined;
-    }
-
-    let metadata: Metadata | undefined = undefined;
     const asset1 = getAsset1Metadata.optional(value);
     const asset2 = getAsset2Metadata.optional(value);
-    if (claimFee.assetId?.equals(asset1?.penumbraAssetId)) {
-      metadata = asset1;
-    }
-    if (claimFee.assetId?.equals(asset2?.penumbraAssetId)) {
-      metadata = asset1;
-    }
 
-    if (metadata) {
-      return renderAmount(
-        new ValueView({
-          valueView: {
-            case: 'knownAssetId',
-            value: {
-              metadata,
-              amount: claimFee.amount,
-            },
-          },
-        }),
-      );
-    }
-
-    return renderAmount(
-      new ValueView({
-        valueView: {
-          case: 'unknownAssetId',
-          value: {
-            assetId: claimFee.assetId,
-            amount: claimFee.amount,
-          },
-        },
-      }),
-    );
-  }, [value]);
+    return parseSwapFees(claimFee, asset1, asset2, getMetadataByAssetId);
+  }, [getMetadataByAssetId, value]);
 
   if (!isOneWay) {
     return (
@@ -110,7 +131,7 @@ export const SwapAction = ({ value }: SwapActionProps) => {
       infoRows={
         isVisible && (
           <>
-            {!!fee && <ActionRow label='Swap Claim fee' info={fee} />}
+            {!!fee && <ActionRow label='Swap Claim Fee' info={fee} />}
             {!!txId && (
               <ActionRow label='Swap Claim Transaction' info={shorten(txId, 8)} copyText={txId} />
             )}

--- a/packages/ui/src/ActionView/index.stories.tsx
+++ b/packages/ui/src/ActionView/index.stories.tsx
@@ -10,6 +10,8 @@ import {
   OutputActionOpaque,
   SwapActionOpaque,
   SwapClaimAction,
+  SwapClaimActionOpaque,
+  registry,
 } from '../utils/bufs';
 
 const OPTIONS: Record<string, ActionViewMessage> = {
@@ -20,6 +22,7 @@ const OPTIONS: Record<string, ActionViewMessage> = {
   'Opaque: Spend': SpendActionOpaque,
   'Opaque: Output': OutputActionOpaque,
   'Opaque: Swap': SwapActionOpaque,
+  'Opaque: SwapClaim': SwapClaimActionOpaque,
 };
 
 const meta: Meta<typeof ActionView> = {
@@ -39,5 +42,6 @@ type Story = StoryObj<typeof ActionView>;
 export const Basic: Story = {
   args: {
     action: SpendAction,
+    getMetadataByAssetId: registry.tryGetMetadata,
   },
 };

--- a/packages/ui/src/ActionView/types.ts
+++ b/packages/ui/src/ActionView/types.ts
@@ -1,5 +1,8 @@
 import { ActionView } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
+import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 
 export type ActionViewType = Exclude<ActionView['actionView']['case'], undefined>;
 
 export type ActionViewValueType = Exclude<ActionView['actionView']['value'], undefined>;
+
+export type GetMetadataByAssetId = (assetId: AssetId) => Metadata | undefined;

--- a/packages/ui/src/utils/bufs/action-view.ts
+++ b/packages/ui/src/utils/bufs/action-view.ts
@@ -143,7 +143,7 @@ export const SwapClaimAction = new ActionView({
           }),
           output2: new NoteView({
             address: ADDRESS_VIEW_DECODED,
-            value: PENUMBRA_VALUE_VIEW_ZERO,
+            value: PENUMBRA_VALUE_VIEW,
           }),
           swapTx: new TransactionId({
             inner: new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]),
@@ -154,6 +154,35 @@ export const SwapClaimAction = new ActionView({
                 amount: AMOUNT_999,
                 assetId: PENUMBRA_METADATA.penumbraAssetId,
               }),
+            },
+          },
+        },
+      },
+    }),
+  },
+});
+
+export const SwapClaimActionOpaque = new ActionView({
+  actionView: {
+    case: 'swapClaim',
+    value: new SwapClaimView({
+      swapClaimView: {
+        case: 'opaque',
+        value: {
+          swapClaim: {
+            body: {
+              fee: new Fee({
+                amount: AMOUNT_999,
+                assetId: PENUMBRA_METADATA.penumbraAssetId,
+              }),
+              outputData: {
+                tradingPair: {
+                  asset1: USDC_METADATA.penumbraAssetId,
+                  asset2: PENUMBRA_METADATA.penumbraAssetId,
+                },
+                lambda1: AMOUNT_123_456_789,
+                lambda2: AMOUNT_999,
+              },
             },
           },
         },

--- a/packages/ui/src/utils/bufs/index.ts
+++ b/packages/ui/src/utils/bufs/index.ts
@@ -3,6 +3,7 @@
  * environments only, and should not be used in the resulting library code.
  */
 
+export * from './registry';
 export * from './metadata';
 export * from './value-view';
 export * from './address-view';

--- a/packages/ui/src/utils/bufs/registry.ts
+++ b/packages/ui/src/utils/bufs/registry.ts
@@ -1,0 +1,17 @@
+import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { USDC_METADATA, PENUMBRA_METADATA, OSMO_METADATA } from './metadata';
+import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
+
+const METADATA_MAP: Record<string, Metadata> = {
+  /* eslint-disable @typescript-eslint/no-non-null-assertion -- it's only for storybook purposes */
+  [uint8ArrayToBase64(USDC_METADATA.penumbraAssetId!.inner)]: USDC_METADATA,
+  [uint8ArrayToBase64(PENUMBRA_METADATA.penumbraAssetId!.inner)]: PENUMBRA_METADATA,
+  [uint8ArrayToBase64(OSMO_METADATA.penumbraAssetId!.inner)]: OSMO_METADATA,
+  /* eslint-enable @typescript-eslint/no-non-null-assertion -- enable again */
+};
+
+export const registry = {
+  tryGetMetadata: (assetId: AssetId): Metadata | undefined => {
+    return METADATA_MAP[uint8ArrayToBase64(assetId.inner)];
+  },
+};


### PR DESCRIPTION
Relates to #2053 

Implements SwapClaim action view. The old version didn't display the opaque view, this one does.

Live: https://penumbra-ui-preview--pr2061-feat-2053-action-vi-khqajj28.web.app/?path=/docs/ui-library-actionview--docs

Before

Visible             |  Opaque
:-------------------------:|:-------------------------:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/f1a7e510-7195-4275-b64d-665a6be42b0a" />  |  <img width="815" alt="image" src="https://github.com/user-attachments/assets/b5865a99-6f0f-42a4-9e96-8c28076f5df7" />


Now

Visible             |  Opaque
:-------------------------:|:-------------------------:
<img width="955" alt="image" src="https://github.com/user-attachments/assets/71356f00-4872-422e-92df-72b7ef065f8b" />  |  <img width="949" alt="image" src="https://github.com/user-attachments/assets/6a19fc9f-5375-409a-ae16-2096a2038b22" />

