### PR TITLE
Connection lifecycle work

### DIFF
--- a/.changeset/violet-coats-remember.md
+++ b/.changeset/violet-coats-remember.md
@@ -1,0 +1,9 @@
+---
+'@penumbra-zone/transport-chrome': minor
+---
+
+Transport session reliability improvements.
+
+- No external API change.
+- Remove singleton restriction of `CRSessionClient`.
+- Don't retain port reference to respect object transfer rules.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@eslint/js": "^9.6.0",
     "@microsoft/api-extractor": "^7.47.0",
     "@penumbra-zone/configs": "workspace:*",
+    "@penumbra-zone/mock-chrome": "workspace:*",
     "@repo/tailwind-config": "workspace:*",
     "@storybook/react-vite": "^8.4.2",
     "@testing-library/jest-dom": "^6.4.5",

--- a/packages/mock-chrome/package.json
+++ b/packages/mock-chrome/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@penumbra-zone/mock-chrome",
+  "version": "0.0.1",
+  "private": true,
+  "license": "(MIT OR Apache-2.0)",
+  "type": "module",
+  "engine": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",
+    "test": "vitest run"
+  },
+  "exports": {
+    "./*": "./src/*.api..ts",
+    "./runtime/*": "./src/runtime/*.api.ts"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.268"
+  }
+}

--- a/packages/mock-chrome/src/chrome.d.ts
+++ b/packages/mock-chrome/src/chrome.d.ts
@@ -1,0 +1,21 @@
+// Renamed, rewritten, and some slightly narrowed types to make them easier to work with
+
+declare interface ChromeEvent<
+  T extends (...args: P) => void = (...args: unknown) => void,
+  P extends unknown[] = Parameters<T>,
+> {
+  addListener: (callback: T) => void;
+  hasListener: (callback: T) => boolean;
+  hasListeners: () => boolean;
+  removeListener: (callback: T) => void;
+}
+
+declare type ChromeEventListener<E> = E extends ChromeEvent<infer T> ? T : never;
+declare type ChromeSender = chrome.runtime.MessageSender;
+declare type ChromeConnectInfo = chrome.runtime.ConnectInfo;
+declare type ChromePort = chrome.runtime.Port;
+
+/** `chrome.runtime.connect` but narrower, to exclude the inter-extension case */
+declare type ChromeConnect = (info?: ChromeConnectInfo) => ChromePort;
+
+declare type ChromeExtensionConnectEvent = chrome.runtime.ExtensionConnectEvent;

--- a/packages/mock-chrome/src/event.mock.ts
+++ b/packages/mock-chrome/src/event.mock.ts
@@ -1,0 +1,54 @@
+import { vi, MockedFunction, Mocked } from 'vitest';
+
+export const eventMocked = <E extends ChromeEvent>(event: E): MockedChromeEvent<E> =>
+  event as unknown as MockedChromeEvent<E>;
+
+/**
+ * Mock the listeners manager for any `chrome.events.Event` type, such as
+ * `chrome.runtime.ExtensionConnectEvent` or `chrome.runtime.PortMessageEvent`.
+ *
+ * Does not support event rules or listeners with `filter` parameters.
+ *
+ * @param listeners set object, will be used for internal state
+ * @returns event manager with mocked features, direct dispatch, and insight to listeners
+ */
+
+export const mockEvent = <
+  E extends ChromeEvent,
+  L extends E extends ChromeEvent<infer T> ? T : never = E extends ChromeEvent<infer T> ? T : never,
+>(
+  listeners = new Set<L>(),
+): MockedChromeEvent<E> => {
+  // dispatch method to activate the listeners
+  const dispatch = (...i: Parameters<L>) => listeners.forEach(listener => listener(...i));
+
+  const addListener = (i: L): void => void listeners.add(i);
+  const hasListener = (i: L): boolean => listeners.has(i);
+  const hasListeners = (): boolean => listeners.size > 0;
+  const removeListener = (i: L): void => void listeners.delete(i);
+
+  return {
+    listeners,
+    dispatch: vi.fn(dispatch),
+
+    addListener: vi.fn(addListener),
+    hasListener: vi.fn(hasListener),
+    hasListeners: vi.fn(hasListeners),
+    removeListener: vi.fn(removeListener),
+  } as unknown as MockedChromeEvent<E>;
+};
+
+export interface MockedChromeEvent<T extends ChromeEvent = ChromeEvent>
+  extends Mocked<ChromeEvent<ChromeEventListener<T>>> {
+  listeners: Set<ChromeEventListener<T>>;
+
+  dispatch: MockedFunction<(...args: Parameters<ChromeEventListener<T>>) => void>;
+
+  addListener: MockedFunction<(callback: ChromeEventListener<T>) => void>;
+
+  hasListener: MockedFunction<(callback: ChromeEventListener<T>) => boolean>;
+
+  hasListeners: MockedFunction<() => boolean>;
+
+  removeListener: MockedFunction<(callback: ChromeEventListener<T>) => void>;
+}

--- a/packages/mock-chrome/src/event.test.ts
+++ b/packages/mock-chrome/src/event.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mockEvent } from './event.mock.js';
+
+describe('mockEvent', () => {
+  it('should manage listeners', () => {
+    const event = mockEvent();
+
+    const listener = vi.fn();
+    const listener2 = vi.fn();
+
+    event.addListener(listener);
+
+    expect(event.hasListeners()).toBe(true);
+    expect(event.hasListener(listener)).toBe(true);
+    expect(event.hasListener(listener2)).toBe(false);
+
+    event.removeListener(listener);
+    expect(event.hasListeners()).toBe(false);
+    expect(event.hasListener(listener)).toBe(false);
+    expect(event.hasListener(listener2)).toBe(false);
+
+    event.addListener(listener2);
+    expect(event.hasListeners()).toBe(true);
+    expect(event.hasListener(listener)).toBe(false);
+    expect(event.hasListener(listener2)).toBe(true);
+
+    event.dispatch('yeah');
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(listener2).toHaveBeenCalledWith('yeah');
+
+    // directly manipulate internal state
+    event.listeners.has(listener2);
+    event.listeners.clear();
+    expect(event.hasListeners()).toBe(false);
+    expect(event.hasListener(listener2)).toBe(false);
+
+    event.listeners.add(listener);
+    expect(event.hasListeners()).toBe(true);
+    expect(event.hasListener(listener)).toBe(true);
+  });
+});

--- a/packages/mock-chrome/src/runtime/channel.fixtures.ts
+++ b/packages/mock-chrome/src/runtime/channel.fixtures.ts
@@ -1,0 +1,43 @@
+export const exampleOrigin = 'https://example.com';
+export const crxOrigin = 'chrome-extension://mockextensionid';
+
+export const tabSender: chrome.runtime.MessageSender = {
+  documentId: 'a unique string',
+  documentLifecycle: 'active',
+  frameId: 0,
+  origin: exampleOrigin,
+  tlsChannelId: 'very random string',
+  url: exampleOrigin + '/',
+  tab: {
+    active: true,
+    autoDiscardable: false,
+    discarded: false,
+    groupId: -1,
+    highlighted: false,
+    id: 1337,
+    incognito: false,
+    index: 1,
+    pinned: false,
+    selected: true,
+    url: exampleOrigin + '/',
+    windowId: 1,
+  },
+};
+
+export const crxSender: chrome.runtime.MessageSender = {
+  id: 'mock-extension-id',
+  origin: crxOrigin,
+  url: crxOrigin + '/background.js',
+};
+
+export const throwDisconnectedPortError = () => {
+  throw new Error('Attempting to use a disconnected port object');
+};
+
+export const addTlsChannelId = (
+  senderBase: chrome.runtime.MessageSender,
+  { includeTlsChannelId }: chrome.runtime.ConnectInfo = {},
+) => ({
+  ...senderBase,
+  tlsChannelId: includeTlsChannelId ? 'mock-tls-channel-id' : undefined,
+});

--- a/packages/mock-chrome/src/runtime/channel.mock.ts
+++ b/packages/mock-chrome/src/runtime/channel.mock.ts
@@ -1,0 +1,165 @@
+import { MockedFunction, vi } from 'vitest';
+import { MockedChromeEvent, mockEvent } from '../event.mock.js';
+import {
+  addTlsChannelId,
+  crxSender,
+  tabSender,
+  throwDisconnectedPortError,
+} from './channel.fixtures.js';
+
+export type MockConnectImpl = (info?: ChromeConnectInfo) => MockedPort;
+export type MockSendersImpl = (info?: ChromeConnectInfo) => {
+  connectSender: ChromeSender;
+  onConnectSender: ChromeSender;
+};
+export type MockPortsImpl = (
+  mockSenders: MockedFunction<MockSendersImpl>,
+  connectInfo?: ChromeConnectInfo,
+) => {
+  connectPort: MockedPort;
+  onConnectPort: MockedPort;
+};
+
+export interface MockedChannel {
+  connect: MockedFunction<MockConnectImpl>;
+  onConnect: MockedChromeEvent<chrome.runtime.ExtensionConnectEvent>;
+  mockSenders: MockedFunction<MockSendersImpl>;
+  mockPorts: MockedFunction<MockPortsImpl>;
+}
+
+export type MockedPort = Omit<ChromePort, 'onDisconnect' | 'onMessage'> & {
+  name: string;
+  sender: ChromeSender;
+  disconnect: MockedFunction<ChromePort['disconnect']>;
+  postMessage: MockedFunction<ChromePort['postMessage']>;
+  onDisconnect: MockedChromeEvent<chrome.runtime.PortDisconnectEvent>;
+  onMessage: MockedChromeEvent<chrome.runtime.PortMessageEvent>;
+  asPort: ChromePort;
+};
+
+/**
+ * Create a pair of `chrome.runtime.MessageSender` objects, one for the caller
+ * of `chrome.runtime.connect` and one for the listener of `chrome.runtime.onConnect`.
+ *
+ * @param connectInfo info passed to the `chrome.runtime.connect` call
+ * @returns a pair of `chrome.runtime.MessageSender` objects
+ */
+export const mockSendersDefault: MockSendersImpl = (
+  connectInfo?: ChromeConnectInfo,
+): {
+  connectSender: ChromeSender;
+  onConnectSender: ChromeSender;
+} => ({
+  connectSender: addTlsChannelId(tabSender, connectInfo),
+  onConnectSender: crxSender,
+});
+
+/**
+ * Create a pair of ports, one for the caller of `chrome.runtime.connect` and
+ * one for the listener of `chrome.runtime.onConnect`.
+ *
+ * @param mockSenders function to create a pair of `chrome.runtime.MessageSender`
+ * @param connectInfo info passed to the `chrome.runtime.connect` call
+ * @param onConnectSender function to create a 'sender' representing the listener of `chrome.runtime.onConnect`
+ */
+export const mockPortsDefault: MockPortsImpl = (
+  mockSenders = mockSendersDefault,
+  connectInfo?: ChromeConnectInfo,
+): {
+  connectPort: MockedPort;
+  onConnectPort: MockedPort;
+} => {
+  const name = connectInfo?.name ?? 'mock-port-' + crypto.randomUUID();
+
+  const { connectSender, onConnectSender } = mockSenders(connectInfo);
+
+  const connectPort: MockedPort = {
+    name,
+    sender: onConnectSender,
+    onDisconnect: mockEvent<chrome.runtime.PortDisconnectEvent>(),
+    onMessage: mockEvent<chrome.runtime.PortMessageEvent>(),
+
+    disconnect: vi.fn<[], void>(() => {
+      onConnectPort.onDisconnect.dispatch(onConnectPort.asPort);
+      connectPort.postMessage.mockImplementation(throwDisconnectedPortError);
+      connectPort.disconnect.mockImplementation(() => void null);
+      onConnectPort.postMessage.mockImplementation(throwDisconnectedPortError);
+      onConnectPort.disconnect.mockImplementation(() => void null);
+    }),
+
+    postMessage: vi.fn<[unknown], void>(message =>
+      onConnectPort.onMessage.dispatch(JSON.parse(JSON.stringify(message)), onConnectPort.asPort),
+    ),
+
+    get asPort() {
+      return connectPort as unknown as ChromePort;
+    },
+  };
+
+  const onConnectPort: MockedPort = {
+    name,
+    sender: connectSender,
+    onDisconnect: mockEvent<chrome.runtime.PortDisconnectEvent>(),
+    onMessage: mockEvent<chrome.runtime.PortMessageEvent>(),
+
+    disconnect: vi.fn<[], void>(() => {
+      connectPort.onDisconnect.dispatch(connectPort.asPort);
+      connectPort.postMessage.mockImplementation(throwDisconnectedPortError);
+      connectPort.disconnect.mockImplementation(() => void null);
+      onConnectPort.postMessage.mockImplementation(throwDisconnectedPortError);
+      onConnectPort.disconnect.mockImplementation(() => void null);
+    }),
+
+    postMessage: vi.fn<[unknown], void>(message =>
+      connectPort.onMessage.dispatch(JSON.parse(JSON.stringify(message)), connectPort.asPort),
+    ),
+
+    get asPort() {
+      return onConnectPort as unknown as ChromePort;
+    },
+  };
+
+  return { connectPort, onConnectPort };
+};
+
+/**
+ * Call this to mock the chrome.runtime.connect and chrome.runtime.onConnect
+ * APIs. To avoid clobbering other stubs, they aren't automatically injected.
+ * You'll need to stub them like this:
+ *
+ * ```ts
+ * vi.stubGlobal('chrome', {
+ *   // collect all your `chrome` stubs in the same `stubGlobal` call
+ *   runtime: { connect: mockConnect, onConnect: mockOnConnect },
+ * });
+ * ```
+ *
+ * You may only want to stub one end, and use the other in your test functions.
+ *
+ * Each set of mocks is scoped, and each `connect` call will create a new scoped
+ * channel. If multiple mocks must be injected into the same global scope to
+ * host different scripts simultaneously, you might manage it with an
+ * intermediate layer of mocks.
+ *
+ * @returns a pair of mocks for chrome.runtime.connect and chrome.runtime.onConnect
+ */
+export const mockChannel = ({
+  mockSenders = vi.fn(mockSendersDefault),
+  mockPorts = vi.fn(mockPortsDefault),
+} = {}): MockedChannel => {
+  // create the chrome.runtime.onConnect{...} event manager
+  const onConnect = mockEvent<chrome.runtime.ExtensionConnectEvent>();
+
+  // create the chrome.runtime.connect(...) function
+  const connect = vi.fn((info?: ChromeConnectInfo) => {
+    const { connectPort, onConnectPort } = mockPorts(mockSenders, info);
+    try {
+      onConnect.dispatch(onConnectPort.asPort); // send the .onConnect listener's port
+    } catch (e) {
+      console.debug('onConnect dispatch failed', e);
+    }
+    return connectPort; // return the .connect() caller's port
+  });
+
+  return { connect, onConnect, mockSenders, mockPorts };
+};

--- a/packages/mock-chrome/src/runtime/channel.test.ts
+++ b/packages/mock-chrome/src/runtime/channel.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockChannel, MockedChannel } from './channel.mock.js';
+
+describe('mockChannel', () => {
+  let mockedChannel: MockedChannel;
+  let testName: string = undefined as never;
+
+  const extMessageListener = vi.fn<[unknown, chrome.runtime.Port], void>();
+  const onConnectListener = vi.fn<[chrome.runtime.Port], void>(port =>
+    port.onMessage.addListener(extMessageListener),
+  );
+
+  beforeEach(({ expect }) => {
+    vi.clearAllMocks();
+
+    expect(expect.getState().currentTestName).toBeDefined();
+    testName = expect.getState().currentTestName!.split(' ').join('_');
+    expect(testName).toBeDefined();
+
+    mockedChannel = mockChannel();
+    mockedChannel.onConnect.addListener(onConnectListener);
+  });
+
+  it('executes its configurable fixtures', () => {
+    const clientPort = mockedChannel.connect({ name: testName });
+
+    expect(clientPort).toBeDefined();
+    expect(onConnectListener).toHaveBeenCalledOnce();
+    expect(onConnectListener).toHaveBeenCalledWith(expect.objectContaining({ name: testName }));
+    expect(mockedChannel.mockSenders).toHaveBeenCalledOnce();
+    expect(mockedChannel.mockPorts).toHaveBeenCalledOnce();
+  });
+
+  it('transmits simple messages', () => {
+    const extMessageListener = vi.fn<[unknown, chrome.runtime.Port], void>();
+
+    onConnectListener.mockImplementationOnce(port => {
+      port.onMessage.addListener(extMessageListener);
+    });
+
+    const clientPort = mockedChannel.connect({ name: testName });
+    const extPort = onConnectListener.mock.lastCall?.[0];
+
+    expect(extPort?.name).toBe(testName);
+
+    const randomString = crypto.randomUUID();
+    clientPort.postMessage(randomString);
+    expect(extMessageListener).toHaveBeenCalledWith(randomString, extPort);
+  });
+
+  it('transmits JSON items', () => {
+    const extMessageListener = vi.fn<[unknown, chrome.runtime.Port], void>();
+
+    onConnectListener.mockImplementationOnce(port => {
+      port.onMessage.addListener(extMessageListener);
+    });
+
+    const clientPort = mockedChannel.connect({ name: testName });
+    const extPort = onConnectListener.mock.lastCall?.[0];
+
+    expect(extPort?.name).toBe(testName);
+
+    const complexMessage = {
+      first_name: 'John',
+      last_name: 'Smith',
+      is_alive: true,
+      age: 27,
+      address: {
+        street_address: '21 2nd Street',
+        city: 'New York',
+        state: 'NY',
+        postal_code: '10021-3100',
+      },
+      phone_numbers: [
+        { type: 'home', number: '212 555-1234' },
+        { type: 'office', number: '646 555-4567' },
+      ],
+      children: ['Catherine', 'Thomas', 'Trevor'],
+      spouse: null,
+    };
+
+    clientPort.postMessage(complexMessage);
+    expect(extMessageListener).toHaveBeenCalledWith(complexMessage, extPort);
+  });
+
+  it('degrades non-JSONifiable items', () => {
+    onConnectListener.mockImplementationOnce(port => {
+      port.onMessage.addListener(extMessageListener);
+    });
+
+    const clientPort = mockedChannel.connect({ name: testName });
+    const extPort = onConnectListener.mock.lastCall?.[0];
+
+    expect(extPort?.name).toBe(testName);
+
+    // doesn't transmit functions
+    const functionMessage = {
+      test: 'functionMessage',
+      data: (...no: unknown[]) => console.log(no, 'yes'),
+    };
+
+    clientPort.postMessage(functionMessage);
+
+    expect(extMessageListener).toHaveBeenCalledWith({ test: 'functionMessage' }, extPort);
+
+    extMessageListener.mockClear();
+
+    // doesn't transmit streams
+    const streamMessage = { test: 'streamMessage', data: new ReadableStream() };
+
+    clientPort.postMessage(streamMessage);
+
+    expect(extMessageListener).toHaveBeenLastCalledWith(
+      { test: 'streamMessage', data: {} },
+      extPort,
+    );
+
+    extMessageListener.mockClear();
+
+    // doesn't transmit byte fields
+    const byteMessage = {
+      test: 'byteMessage',
+      data: new Uint8Array([0, 1, 2, 4, 8, 16, 32, 64, 128]),
+    };
+
+    clientPort.postMessage(byteMessage);
+
+    expect(extMessageListener).toHaveBeenLastCalledWith(
+      { test: 'byteMessage', data: { 0: 0, 1: 1, 2: 2, 3: 4, 4: 8, 5: 16, 6: 32, 7: 64, 8: 128 } },
+      extPort,
+    );
+
+    extMessageListener.mockClear();
+
+    // doesn't transmit errors
+    const errorMessage = { test: 'errorMessage', data: new Error('test error') };
+
+    clientPort.postMessage(errorMessage);
+
+    expect(extMessageListener).toHaveBeenLastCalledWith(
+      { test: 'errorMessage', data: {} },
+      extPort,
+    );
+
+    extMessageListener.mockClear();
+
+    const bigintMessage = { test: 'bigintMessage', data: BigInt(1234567890) };
+
+    expect(() => clientPort.postMessage(bigintMessage)).toThrowError(
+      /**
+       * @todo difference between vitest and chrome. in chrome, this is actually:
+       * ```
+       * Uncaught TypeError: Error in invocation of runtime.sendMessage(optional string extensionId, any message, optional object options, optional function callback): Could not serialize message.
+       * ```
+       */
+      TypeError('Do not know how to serialize a BigInt'),
+    );
+
+    expect(extMessageListener).not.toHaveBeenCalled();
+  });
+
+  it('disconnects properly', () => {
+    const extDisconnectListener = vi.fn<[chrome.runtime.Port], void>();
+    onConnectListener.mockImplementationOnce(port => {
+      port.onMessage.addListener(extMessageListener);
+      port.onDisconnect.addListener(extDisconnectListener);
+    });
+
+    const clientPort = mockedChannel.connect({ name: testName });
+
+    const clientDisconnectListener = vi.fn<[], void>();
+    clientPort.onDisconnect.addListener(clientDisconnectListener);
+    const clientMessageListener = vi.fn<[unknown], void>();
+    clientPort.onMessage.addListener(clientMessageListener);
+
+    const extPort = onConnectListener.mock.lastCall![0];
+
+    expect(extDisconnectListener).not.toHaveBeenCalled();
+    expect(clientDisconnectListener).not.toHaveBeenCalled();
+
+    extPort.postMessage("it's working");
+    expect(clientMessageListener).toHaveBeenCalledWith("it's working", clientPort);
+
+    clientPort.disconnect();
+
+    expect(extDisconnectListener).toHaveBeenCalledWith(extPort);
+    // disconnect event does not fire on the side which called disconnect
+    expect(clientDisconnectListener).not.toHaveBeenCalled();
+
+    expect(() => clientPort.postMessage("won't make it")).toThrow(
+      'Attempting to use a disconnected port object',
+    );
+
+    expect(extMessageListener).not.toHaveBeenCalled();
+
+    clientMessageListener.mockClear();
+
+    expect(() => extPort.postMessage("won't make it")).toThrow(
+      'Attempting to use a disconnected port object',
+    );
+
+    expect(clientMessageListener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mock-chrome/src/runtime/connect.api.ts
+++ b/packages/mock-chrome/src/runtime/connect.api.ts
@@ -1,0 +1,2 @@
+/// <reference path="../chrome.d.ts" />
+export * from './channel.mock.js';

--- a/packages/mock-chrome/tsconfig.json
+++ b/packages/mock-chrome/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "composite": true,
+    "module": "Node16",
+    "noEmit": true,
+    "target": "ESNext"
+  },
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "include": ["src", "tests-setup.ts"]
+}

--- a/packages/mock-chrome/vitest.config.ts
+++ b/packages/mock-chrome/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import topLevelAwait from 'vite-plugin-top-level-await';
+
+export default defineConfig({
+  plugins: [topLevelAwait()],
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/transport-chrome/src/global.d.ts
+++ b/packages/transport-chrome/src/global.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-var -- injected mode flag
+declare var __DEV__: boolean | undefined;

--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -1,0 +1,556 @@
+import { ConnectError } from '@connectrpc/connect';
+import { errorToJson } from '@connectrpc/connect/protocol-connect';
+import { mockChannel, MockedChannel, MockedPort } from '@penumbra-zone/mock-chrome/runtime/connect';
+import type { TransportMessage, TransportStream } from '@penumbra-zone/transport-dom/messages';
+import { afterEach, beforeEach, describe, expect, it, type Mock, onTestFinished, vi } from 'vitest';
+import { ChannelLabel, nameConnection } from './channel-names.js';
+import { lastResult, replaceUncaughtExceptionListener } from './util/test-utils.js';
+import type { TransportInitChannel } from './message.js';
+import { CRSessionClient } from './session-client.js';
+import { JsonValue } from '@bufbuild/protobuf';
+
+Object.assign(CRSessionClient, {
+  clearSingleton() {
+    // @ts-expect-error -- manipulating private property
+    CRSessionClient.singleton = undefined;
+  },
+});
+
+// @ts-expect-error -- manipulating private property
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- manipulating private property
+const clearSingleton = () => void CRSessionClient.clearSingleton();
+
+describe('CRSessionClient', () => {
+  let testName: string = undefined as never;
+
+  let domPort: MessagePort | undefined;
+
+  let mockedChannel: MockedChannel;
+
+  let domMessageHandler: undefined | Mock<[MessageEvent<unknown>], void>;
+  let domMessageErrorHandler: undefined | Mock<[MessageEvent<unknown>], void>;
+
+  beforeEach(({ expect }) => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.stubGlobal('__DEV__', true);
+
+    clearSingleton();
+
+    testName = (expect.getState().currentTestName ?? 'no test name').split(' ').join('_');
+    expect(testName).toBeDefined();
+
+    domMessageHandler = undefined;
+    domMessageErrorHandler = undefined;
+    domPort = undefined;
+
+    mockedChannel = mockChannel();
+
+    vi.stubGlobal('chrome', { runtime: { connect: mockedChannel.connect } });
+  });
+
+  it('should return `MessagePort` on init, and connect the extension', () => {
+    expect(mockedChannel.connect).not.toHaveBeenCalled();
+    expect(mockedChannel.onConnect.dispatch).not.toHaveBeenCalled();
+
+    domPort = CRSessionClient.init(testName);
+    expect(domPort).toBeDefined();
+
+    expect(mockedChannel.connect).toHaveBeenCalledOnce();
+    expect(mockedChannel.onConnect.dispatch).toHaveBeenCalledOnce();
+  });
+
+  describe('repeated calls to init', () => {
+    it('should return the same port for each call', () => {
+      const ports: MessagePort[] = [];
+
+      for (let i = 0; i < 3; i++) {
+        ports.push(CRSessionClient.init(testName));
+        ports.map(porty => expect(porty).toBeInstanceOf(MessagePort));
+        expect(ports.every(porty => ports.every(porty2 => porty === porty2))).toBe(true);
+        expect(mockedChannel.connect).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it.fails('should return a new port for each call', () => {
+      const ports: MessagePort[] = [];
+
+      for (let i = 0; i < 3; i++) {
+        const newPort = CRSessionClient.init(testName);
+        expect(ports.every(porty => porty !== newPort)).toBe(true);
+        ports.push(newPort);
+      }
+
+      expect(mockedChannel.connect).toHaveBeenCalledTimes(ports.length);
+    });
+  });
+
+  it('should attach callbacks to the port and forward messages', async () => {
+    const exampleMessage: TransportMessage = { message: 'example message', requestId: '123' };
+
+    domPort = CRSessionClient.init(testName);
+
+    const extPort = lastResult(mockedChannel.mockPorts).onConnectPort;
+
+    expect(extPort.onMessage.dispatch).not.toHaveBeenCalled();
+    domPort.postMessage(exampleMessage);
+    await vi.waitFor(() => expect(extPort.onMessage.dispatch).toHaveBeenCalled());
+
+    expect(extPort.onMessage.dispatch).toHaveBeenLastCalledWith(
+      exampleMessage,
+      expect.objectContaining({
+        name: expect.stringContaining(testName) as string,
+      }),
+    );
+    expect(mockedChannel.mockSenders).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        name: expect.stringContaining(testName) as string,
+      }),
+    );
+  });
+
+  describe('should report errors', () => {
+    const testMessage: TransportMessage = { requestId: '123', message: 'normal message' };
+    const postThrowError = Error('wololo', { cause: 'bad thing happened' });
+    const postThrowFunction = () => 'why would you do this?';
+    const postThrowObject = { seriously: 'you should probably be throwing errors' };
+
+    let connectPortPostMessage: Mock<[unknown], void>;
+
+    let domPort: MessagePort;
+
+    beforeEach(() => {
+      domMessageHandler = vi.fn();
+      domMessageErrorHandler = vi.fn();
+
+      domPort = CRSessionClient.init(testName);
+      domPort.addEventListener('message', domMessageHandler);
+      domPort.addEventListener('messageerror', domMessageErrorHandler);
+
+      connectPortPostMessage = lastResult(mockedChannel.connect).postMessage;
+
+      domPort.start();
+    });
+
+    describe('when forwarding the input throws an error', () => {
+      let messageEventError: unknown;
+
+      beforeEach(async () => {
+        expect(domMessageHandler).not.toHaveBeenCalled();
+
+        connectPortPostMessage.mockImplementationOnce(() => {
+          throw postThrowError;
+        });
+
+        domPort.postMessage(testMessage);
+        await vi.waitFor(() => expect(domMessageHandler).toHaveBeenCalled());
+        expect(domMessageErrorHandler).not.toHaveBeenCalled();
+        expect(domMessageHandler).toHaveBeenLastCalledWith(expect.any(MessageEvent));
+        messageEventError = domMessageHandler?.mock.lastCall?.[0]?.data;
+      });
+
+      it('responds with failure missing a `requestId`', () => {
+        expect(messageEventError).not.toHaveProperty('requestId');
+        expect(messageEventError).toMatchObject({
+          error: {
+            message: postThrowError.message,
+            details: [
+              {
+                type: postThrowError.name,
+                value: postThrowError.cause,
+              },
+              testMessage,
+            ],
+          },
+        });
+      });
+
+      it.fails('responds with failure including a `requestId`', () => {
+        expect(messageEventError).toMatchObject({
+          requestId: testMessage.requestId,
+          error: errorToJson(ConnectError.from(postThrowError), undefined),
+        });
+      });
+    });
+
+    describe('when forwarding the input throws a non-error object', () => {
+      let throwObjectResponse: unknown;
+
+      beforeEach(async () => {
+        connectPortPostMessage.mockImplementationOnce(() => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error -- testing incorrect use
+          throw postThrowObject;
+        });
+
+        domPort.postMessage(testMessage);
+        await vi.waitFor(() => expect(domMessageHandler).toHaveBeenCalled());
+        expect(domMessageHandler).toHaveBeenLastCalledWith(expect.any(MessageEvent));
+        throwObjectResponse = domMessageHandler?.mock.lastCall?.[0].data;
+      });
+
+      it('incorrectly responds with failure missing a `requestId`', () => {
+        expect(throwObjectResponse).not.toHaveProperty('requestId');
+        expect(throwObjectResponse).toMatchObject({
+          error: {
+            message: String(postThrowObject),
+            details: [
+              {
+                type: (Object.getPrototypeOf(postThrowObject) as unknown)?.constructor?.name,
+                value: postThrowObject,
+              },
+              testMessage,
+            ],
+          },
+        });
+      });
+
+      it.fails('correctly responds with failure including a `requestId`', () => {
+        expect(throwObjectResponse).toMatchObject({
+          requestId: testMessage.requestId,
+          error: errorToJson(ConnectError.from(postThrowObject), undefined),
+        });
+      });
+    });
+
+    describe('when forwarding the input throws a non-cloneable item', () => {
+      beforeEach(() => {
+        connectPortPostMessage.mockImplementationOnce(() => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error -- testing incorrect use
+          throw postThrowFunction;
+        });
+      });
+
+      it('does not report failure and throws an uncaught `DataCloneError`', async () => {
+        const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
+          replaceUncaughtExceptionListener();
+        onTestFinished(restoreUncaughtExceptionListener);
+
+        expect(domMessageHandler).not.toHaveBeenCalled();
+        domPort.postMessage(testMessage);
+
+        await vi.waitFor(() =>
+          expect(uncaughtExceptionListener).toHaveBeenLastCalledWith(
+            expect.objectContaining({ name: 'DataCloneError' }),
+            'uncaughtException',
+          ),
+        );
+
+        expect(domMessageHandler).not.toHaveBeenCalled();
+      });
+
+      it.fails('reports failure', async () => {
+        const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
+          replaceUncaughtExceptionListener();
+        onTestFinished(restoreUncaughtExceptionListener);
+
+        expect(domMessageHandler).not.toHaveBeenCalled();
+        domPort.postMessage(testMessage);
+
+        await vi.waitFor(() =>
+          expect(domMessageHandler).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              data: {
+                requestId: testMessage.requestId,
+                error: errorToJson(ConnectError.from(postThrowFunction), undefined),
+              },
+            }),
+          ),
+        );
+
+        expect(uncaughtExceptionListener).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the input is invalid', () => {
+    const badTransport: JsonValue[] = [
+      { unknownFormat: true, requestId: '123' },
+      { otherObject: 'whatever' },
+      2,
+      'hello',
+      null,
+    ];
+
+    describe.each(badTransport)(
+      'when the input is not a known `TransportEvent` %s',
+      (badRequest: JsonValue) => {
+        let domPort: MessagePort;
+        let extPort: MockedPort;
+        const mockWarn = vi.fn();
+
+        beforeEach(() => {
+          domMessageHandler = vi.fn();
+          domMessageErrorHandler = vi.fn();
+          domPort = CRSessionClient.init(testName);
+          domPort.addEventListener('message', domMessageHandler);
+          domPort.addEventListener('messageerror', domMessageErrorHandler);
+          domPort.start();
+
+          vi.stubGlobal('console', { log: console.log, warn: mockWarn });
+
+          extPort = lastResult(mockedChannel.mockPorts).onConnectPort;
+        });
+
+        afterEach(() => {
+          expect(extPort.onMessage.dispatch).not.toHaveBeenCalled();
+          expect(domMessageErrorHandler).not.toHaveBeenCalled();
+        });
+
+        it('does not respond and only prints a console warning', async () => {
+          expect(mockWarn).not.toHaveBeenCalled();
+          domPort.postMessage(badRequest);
+          await vi.waitFor(() => expect(mockWarn).toHaveBeenCalled());
+
+          expect(domMessageHandler).not.toHaveBeenCalled();
+        });
+
+        it.fails('responds with a failure and prints a console warning', async () => {
+          expect(mockWarn).not.toHaveBeenCalled();
+          domPort.postMessage(badRequest);
+          await vi.waitFor(() => expect(mockWarn).toHaveBeenCalled());
+          expect(domMessageHandler).toHaveBeenCalled();
+
+          const messageEventErrorResponse = domMessageHandler?.mock.lastCall?.[0];
+
+          const badRequestHasId =
+            badRequest && typeof badRequest === 'object' && 'requestId' in badRequest;
+
+          expect(messageEventErrorResponse).toMatchObject({
+            data: badRequestHasId
+              ? {
+                  requestId: badRequest['requestId'],
+                  error: expect.objectContaining({
+                    message: expect.stringContaining('Unsupported request from client') as string,
+                  }) as unknown,
+                }
+              : {
+                  requestId: undefined,
+                  error: expect.objectContaining({
+                    message: expect.stringContaining('Unknown item from client') as string,
+                  }) as unknown,
+                },
+          });
+        });
+      },
+    );
+  });
+
+  describe('disconnect behavior', () => {
+    let sessionPort: MockedPort;
+    let extPort: MockedPort;
+    let domPort: MessagePort;
+
+    const expectChannelClosed = async () => {
+      const messageAfterDisconnect: TransportMessage = {
+        message: 'going nowhere',
+        requestId: '123',
+      };
+      sessionPort.postMessage.mockClear();
+      extPort.onMessage.dispatch.mockClear();
+
+      // try to send a message again.
+      domPort.postMessage(messageAfterDisconnect);
+
+      // there are no events to wait for, so just give it a moment
+      await new Promise(resolve => void setTimeout(resolve, 50));
+
+      // the messages don't get through.
+      expect(sessionPort.postMessage).not.toHaveBeenCalled();
+      expect(extPort.onMessage.dispatch).not.toHaveBeenCalled();
+    };
+
+    const expectNoActivity = () => {
+      // not disconnected yet, no messages yet
+      expect(domMessageHandler).not.toHaveBeenCalled();
+      expect(extPort.onDisconnect.dispatch).not.toHaveBeenCalled();
+      expect(extPort.onMessage.dispatch).not.toHaveBeenCalled();
+      expect(sessionPort.onDisconnect.dispatch).not.toHaveBeenCalled();
+      expect(sessionPort.onMessage.dispatch).not.toHaveBeenCalled();
+    };
+
+    beforeEach(() => {
+      domPort = CRSessionClient.init(testName);
+
+      domMessageHandler = vi.fn();
+      domMessageErrorHandler = vi.fn();
+      domPort.addEventListener('message', domMessageHandler);
+      domPort.addEventListener('messageerror', domMessageErrorHandler);
+      domPort.start();
+
+      const lastPorts = lastResult(mockedChannel.mockPorts);
+      sessionPort = lastPorts.connectPort;
+      extPort = lastPorts.onConnectPort;
+    });
+
+    // a `chrome.runtime.Port` emits disconnect events, but a `MessagePort` does
+    // not. so there is no good way to identify that a closed `MessagePort` is
+    // closed. the holder of the port must track and understand when they have
+    // closed the port.
+    //
+    // the session transmits `false` to represent the `MessagePort` will be
+    // closed. the dom transport should handle this, and clients should not
+    // persist in using transports that indicate they are disconnected.
+    it('disconnects from the extension when the client transmits `false` message, and transmits a confirming `false` back to the dom', async () => {
+      expectNoActivity();
+
+      // announce disconnect
+      domPort.postMessage(false);
+
+      // client should discard the transport at this point.
+      await vi.waitFor(() => expect(extPort.onDisconnect.dispatch).toHaveBeenCalledOnce());
+
+      // disconnect is reported back to the dom. this would poison a typical transport.
+      await vi.waitFor(() =>
+        expect(domMessageHandler).toHaveBeenCalledWith(expect.objectContaining({ data: false })),
+      );
+
+      expect(sessionPort.disconnect).toHaveBeenCalledOnce();
+      expect(sessionPort.postMessage).not.toHaveBeenCalled();
+      expect(extPort.onMessage.dispatch).not.toHaveBeenCalled();
+
+      await expectChannelClosed();
+    });
+
+    it('sends `false` to dom when the port is disconnected by something else', async () => {
+      expectNoActivity();
+
+      // extension-side disconnect
+      extPort.disconnect();
+
+      // page will be notified of the extension-side disconnect
+      await vi.waitFor(() => expect(sessionPort.onDisconnect.dispatch).toHaveBeenCalled());
+
+      // disconnect is reported back to the dom. this would poison a typical transport.
+      await vi.waitFor(() =>
+        expect(domMessageHandler).toHaveBeenLastCalledWith(
+          expect.objectContaining({ data: false }),
+        ),
+      );
+
+      expect(extPort.onMessage.dispatch).not.toHaveBeenCalled();
+      expect(extPort.onDisconnect.dispatch).toHaveBeenCalledOnce();
+
+      await expectChannelClosed();
+    });
+
+    it.fails('reconnects silently if the port is disconnected by something else', async () => {
+      const testRequest: TransportMessage = { message: 'hello', requestId: '123' };
+
+      expectNoActivity();
+
+      const nextOnMessageListener = vi.fn<[unknown, ChromePort]>();
+      const nextOnConnectListener = vi.fn((port: ChromePort) =>
+        port.onMessage.addListener(nextOnMessageListener),
+      );
+      mockedChannel.onConnect.addListener(nextOnConnectListener);
+
+      // extension-side disconnect
+      extPort.disconnect();
+
+      // page will not be notified of the disconnect
+      await vi.waitFor(() => expect(domMessageHandler).not.toHaveBeenCalled());
+
+      // the session should reconnect
+      await vi.waitFor(() => {
+        expect(sessionPort.onDisconnect.dispatch).toHaveBeenCalledOnce();
+        expect(mockedChannel.onConnect.dispatch).toHaveBeenCalledTimes(2);
+      });
+
+      expect(nextOnConnectListener).toHaveBeenCalledOnce();
+      expect(nextOnMessageListener).not.toHaveBeenCalled();
+
+      // try to send a message after disconnect
+      domPort.postMessage(testRequest);
+
+      await vi.waitFor(() =>
+        expect(nextOnMessageListener).toHaveBeenCalledWith(
+          testRequest,
+          lastResult(mockedChannel.mockPorts).onConnectPort,
+        ),
+      );
+    });
+  });
+
+  describe('stream subchannels', () => {
+    it('when receiving a stream channel response, should connect to stream subchannels', async () => {
+      const unaryRequest: TransportMessage = { message: 'unary message', requestId: '123' };
+      const streamResponse: TransportInitChannel = {
+        channel: nameConnection(testName, ChannelLabel.STREAM),
+        requestId: '123',
+      };
+
+      const extStreamConnectListener = vi.fn<[ChromePort]>();
+      const extOnMessageListener = vi.fn<[unknown, ChromePort]>();
+      const extSessionConnectListener = vi.fn((port: ChromePort) => {
+        if (port.name.startsWith(testName)) {
+          port.onMessage.addListener(extOnMessageListener);
+        }
+      });
+
+      mockedChannel.onConnect.addListener(extSessionConnectListener);
+
+      domPort = CRSessionClient.init(testName);
+      expect(domPort).toBeDefined();
+      expect(mockedChannel.connect).toHaveBeenCalledTimes(1);
+      expect(mockedChannel.onConnect.dispatch).toHaveBeenCalledTimes(1);
+
+      extOnMessageListener.mockImplementationOnce((_, port) => {
+        mockedChannel.onConnect.addListener(extStreamConnectListener);
+        port.postMessage(streamResponse);
+      });
+      domPort.postMessage(unaryRequest);
+      await vi.waitFor(() => expect(mockedChannel.onConnect.dispatch).toHaveBeenCalledTimes(2));
+
+      expect(mockedChannel.connect).toHaveBeenCalledTimes(2);
+      expect(extOnMessageListener).toHaveBeenCalledOnce();
+      expect(extStreamConnectListener).toHaveBeenCalledOnce();
+      expect(extSessionConnectListener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          name: streamResponse.channel,
+        }),
+      );
+      expect(mockedChannel.connect).toHaveBeenLastCalledWith(
+        expect.objectContaining({ name: streamResponse.channel }),
+      );
+    });
+
+    it('when making a stream channel request, should listen for stream subchannels', async () => {
+      const mockedChannel2 = mockChannel();
+
+      // stub the chrome runtime in both directions, for this test
+      vi.stubGlobal('chrome', {
+        runtime: { connect: mockedChannel.connect, onConnect: mockedChannel2.onConnect },
+      });
+
+      const streamRequest: TransportStream = {
+        stream: new ReadableStream({
+          pull(controller) {
+            controller.enqueue({ done: true });
+            controller.close();
+          },
+        }),
+        requestId: '123',
+      };
+
+      domPort = CRSessionClient.init(testName);
+      expect(domPort).toBeDefined();
+      expect(mockedChannel.connect).toHaveBeenCalledOnce();
+      const extPort = lastResult(mockedChannel.mockPorts).onConnectPort;
+
+      domPort.postMessage(streamRequest, [streamRequest.stream]);
+      await vi.waitFor(() => expect(mockedChannel2.onConnect.addListener).toHaveBeenCalled());
+
+      const channelInitMsg = extPort.onMessage.dispatch.mock.lastCall?.[0] as TransportInitChannel;
+
+      expect(channelInitMsg).toMatchObject(
+        expect.objectContaining({
+          channel: expect.stringContaining(ChannelLabel.STREAM) as string,
+        }),
+      );
+
+      const acceptStream = mockedChannel2.connect({ name: channelInitMsg.channel });
+
+      expect(acceptStream.name).toBe(channelInitMsg.channel);
+    });
+  });
+});

--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -61,7 +61,7 @@ describe('CRSessionClient', () => {
   });
 
   describe('repeated calls to init', () => {
-    it('should return the same port for each call', () => {
+    it.fails('should return the same port for each call', () => {
       const ports: MessagePort[] = [];
 
       for (let i = 0; i < 3; i++) {
@@ -72,7 +72,7 @@ describe('CRSessionClient', () => {
       }
     });
 
-    it.fails('should return a new port for each call', () => {
+    it('should return a new port for each call', () => {
       const ports: MessagePort[] = [];
 
       for (let i = 0; i < 3; i++) {

--- a/packages/transport-chrome/src/session-client.ts
+++ b/packages/transport-chrome/src/session-client.ts
@@ -112,6 +112,7 @@ export class CRSessionClient {
         console.warn('Unknown item from client', ev.data);
       }
     } catch (e) {
+      console.error('Error in client listener', e);
       this.clientPort.postMessage({ error: localErrorJson(e, ev.data) });
     }
   };

--- a/packages/transport-chrome/src/session-manager.test.ts
+++ b/packages/transport-chrome/src/session-manager.test.ts
@@ -1,0 +1,487 @@
+import type { JsonValue } from '@bufbuild/protobuf';
+import { ConnectError } from '@connectrpc/connect';
+import { errorToJson } from '@connectrpc/connect/protocol-connect';
+import {
+  mockChannel,
+  type MockedChannel,
+  type MockSendersImpl,
+} from '@penumbra-zone/mock-chrome/runtime/connect';
+import type { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
+import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
+import { ChannelLabel, nameConnection } from './channel-names.js';
+import { CRSessionManager as CRSessionManagerOriginal } from './session-manager.js';
+import { lastResult } from './util/test-utils.js';
+
+const CRSessionManager: typeof CRSessionManagerOriginal & {
+  // forward-compatible type. third parameter of init is required in new
+  // signature, but absent in old signature.  a new implementation will use it,
+  // an old implementation will ignore it.
+  init: (
+    prefix: string,
+    handler: ChannelHandlerFn,
+    approvePort: (
+      port: chrome.runtime.Port,
+    ) => Promise<chrome.runtime.Port & { sender: { origin: string } }>,
+  ) => ReturnType<typeof CRSessionManagerOriginal.init>;
+} = CRSessionManagerOriginal;
+
+const getOnlySession = (sessions: ReturnType<typeof CRSessionManager.init>) => {
+  expect(sessions.size).toBe(1);
+  const onlySession = sessions.values().next();
+  if (!onlySession.done) {
+    return onlySession.value;
+  }
+  expect.unreachable('No session found');
+};
+
+describe('CRSessionManager', () => {
+  let testName: string;
+  let mockedChannel: MockedChannel;
+
+  const tab: chrome.tabs.Tab = {
+    id: 1,
+    index: 0,
+    pinned: false,
+    highlighted: false,
+    windowId: 1,
+    incognito: false,
+    active: true,
+    selected: true,
+    discarded: false,
+    autoDiscardable: false,
+    groupId: -1,
+  };
+
+  const extHost: chrome.runtime.MessageSender = {
+    id: 'test-extension-id',
+    origin: 'chrome-extension://test-extension-id',
+  };
+
+  // extension page client
+  const extClient: chrome.runtime.MessageSender = {
+    id: 'test-extension-id',
+    origin: 'chrome-extension://test-extension-id',
+    url: 'chrome-extension://test-extension-id/index.html',
+    tab,
+  };
+
+  // localhost dapp client
+  const localhostClient: chrome.runtime.MessageSender = {
+    origin: 'http://localhost:8080',
+    url: 'http://localhost:8080/index.html',
+    tab,
+  };
+
+  // https dapp client
+  const httpsClient: chrome.runtime.MessageSender = {
+    origin: 'https://example.com',
+    url: 'https://example.com/index.html',
+    tab,
+  };
+
+  const httpClient: chrome.runtime.MessageSender = {
+    origin: 'http://example.com',
+    url: 'http://example.com/index.html',
+    tab,
+  };
+
+  const checkPortSender = vi.fn(
+    (port: chrome.runtime.Port): Promise<chrome.runtime.Port & { sender: { origin: string } }> => {
+      return Promise.resolve(port as chrome.runtime.Port & { sender: { origin: string } });
+    },
+  );
+
+  const mockHandler: MockedFunction<ChannelHandlerFn> = vi.fn(
+    async (
+      req: JsonValue | ReadableStream<JsonValue>,
+    ): Promise<JsonValue | ReadableStream<JsonValue>> => {
+      expect(req).toBeDefined();
+      const res = 'test';
+      return await Promise.resolve(res as JsonValue | ReadableStream<JsonValue>);
+    },
+  );
+
+  beforeEach(({ expect }) => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    if (!Object.hasOwn(CRSessionManager, 'clearSingleton')) {
+      Object.assign(CRSessionManager, {
+        clearSingleton() {
+          // @ts-expect-error -- manipulating undeclared private property
+          CRSessionManager.singleton = undefined;
+        },
+      });
+    }
+    // @ts-expect-error -- calling undeclared method
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    CRSessionManager.clearSingleton();
+
+    testName = (expect.getState().currentTestName ?? 'no test name').split(' ').join('_');
+    expect(testName).toBeDefined();
+
+    mockedChannel = mockChannel({
+      mockSenders: vi.fn<Parameters<MockSendersImpl>>(() => ({
+        connectSender: httpsClient,
+        onConnectSender: extHost,
+      })),
+    });
+
+    vi.stubGlobal('chrome', {
+      runtime: {
+        onConnect: mockedChannel.onConnect,
+        id: 'test-extension-id',
+      },
+    });
+  });
+
+  it('should be a singleton', () => {
+    const sessions1 = CRSessionManager.init(testName, mockHandler, checkPortSender);
+    expect(sessions1).toBeDefined();
+    expect(sessions1).toBeInstanceOf(Map);
+
+    const sessions2 = CRSessionManager.init(testName, mockHandler, checkPortSender);
+    expect(sessions2).toBe(sessions1);
+  });
+
+  describe('origin validation', () => {
+    const testRequest = { requestId: '123', message: 'test' };
+    const allSenders = [extClient, localhostClient, httpsClient, httpClient];
+
+    it.each(allSenders)(
+      'should accept or reject $origin according to internal sender validation logic',
+      async someSender => {
+        const badSenders = [httpClient];
+        const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+        expect(sessions.size).toBe(0);
+
+        const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+        mockedChannel.mockSenders.mockReturnValueOnce({
+          connectSender: someSender,
+          onConnectSender: extHost,
+        });
+
+        const clientPort = mockedChannel.connect({ name: channelName });
+        expect(clientPort).toMatchObject({ name: channelName, sender: extHost });
+
+        await vi.waitFor(() => expect(mockedChannel.onConnect.dispatch).toHaveBeenCalled());
+
+        if (badSenders.includes(someSender)) {
+          expect(
+            lastResult(mockedChannel.mockPorts).onConnectPort.onMessage.addListener,
+          ).not.toHaveBeenCalled();
+          expect(sessions.size).toBe(0);
+        } else {
+          expect(
+            lastResult(mockedChannel.mockPorts).onConnectPort.onMessage.addListener,
+          ).toHaveBeenCalled();
+          expect(sessions.size).toBe(1);
+        }
+
+        clientPort.postMessage(testRequest);
+
+        if (!badSenders.includes(someSender)) {
+          await vi.waitFor(() =>
+            expect(mockHandler).toHaveBeenLastCalledWith(
+              testRequest.message,
+              expect.any(AbortSignal),
+            ),
+          );
+        } else {
+          expect(
+            lastResult(mockedChannel.mockPorts).onConnectPort.onMessage.addListener,
+          ).not.toHaveBeenCalled();
+          expect(mockHandler).not.toHaveBeenCalled();
+        }
+
+        expect(checkPortSender).not.toHaveBeenCalled();
+      },
+    );
+
+    const badSenders = allSenders.sort(() => Math.random() - 0.5).slice(2);
+    it.fails.each(allSenders)(
+      `should accept or reject sender %# according to external sender validation callback permitting ${badSenders.map(s => allSenders.indexOf(s)).join(', ')}`,
+      async someSender => {
+        checkPortSender.mockImplementationOnce(port => {
+          if (badSenders.includes(port.sender!)) {
+            console.log('rejecting', port.sender!.origin);
+            throw new Error('Bad sender');
+          }
+          console.log('accepting', port.sender!.origin);
+          return Promise.resolve(port as chrome.runtime.Port & { sender: { origin: string } });
+        });
+
+        const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+        expect(sessions.size).toBe(0);
+
+        const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+        mockedChannel.mockSenders.mockReturnValueOnce({
+          connectSender: someSender,
+          onConnectSender: extHost,
+        });
+
+        const clientPort = mockedChannel.connect({ name: channelName });
+        expect(clientPort).toMatchObject({ name: channelName, sender: extHost });
+
+        await vi.waitFor(() => {
+          expect(mockedChannel.onConnect.dispatch).toHaveBeenCalled();
+          expect(checkPortSender).toHaveBeenCalledWith(
+            expect.objectContaining({ name: channelName, sender: someSender }),
+          );
+        });
+
+        if (!badSenders.includes(someSender)) {
+          await vi.waitFor(() =>
+            expect(
+              lastResult(mockedChannel.mockPorts).onConnectPort.onMessage.addListener,
+            ).toHaveBeenCalled(),
+          );
+          expect(sessions.size).toBe(1);
+        } else {
+          expect(sessions.size).toBe(0);
+        }
+
+        expect(mockHandler).not.toHaveBeenCalled();
+
+        clientPort.postMessage(testRequest);
+
+        if (!badSenders.includes(someSender)) {
+          await vi.waitFor(() =>
+            expect(mockHandler).toHaveBeenLastCalledWith(
+              testRequest.message,
+              expect.any(AbortSignal),
+            ),
+          );
+        } else {
+          expect(checkPortSender.mock.results.at(-1)?.type).toBe('throw');
+          expect(mockHandler).not.toHaveBeenCalled();
+        }
+      },
+    );
+  });
+
+  describe('request handling', () => {
+    it('should handle unary requests, and generate a response', async () => {
+      const testRequest = { requestId: '123', message: 'test-request' };
+      const clientListener = vi.fn();
+
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+      expect(sessions.size).toBe(0);
+
+      const testResponse = { requestId: '123', message: 'test-response' };
+      mockHandler.mockResolvedValueOnce(testResponse.message);
+
+      const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+      const clientPort = mockedChannel.connect({ name: channelName });
+      clientPort.onMessage.addListener(clientListener);
+
+      await vi.waitFor(() => expect(sessions.size).toBe(1));
+      expect(mockHandler).not.toHaveBeenCalled();
+      clientPort.postMessage(testRequest);
+
+      await vi.waitFor(() => expect(clientListener).toHaveBeenCalled());
+      expect(mockHandler).toHaveBeenCalledWith(testRequest.message, expect.any(AbortSignal));
+      expect(clientListener).toHaveBeenLastCalledWith(testResponse, clientPort);
+    });
+
+    it('should handle requests that generate a response stream by announcing a new channel', async () => {
+      const testRequest = { requestId: '123', message: 'test-request' };
+      const clientListener = vi.fn();
+
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+      expect(sessions.size).toBe(0);
+
+      mockHandler.mockResolvedValueOnce(
+        new ReadableStream({
+          start: cont => {
+            cont.enqueue({ value: 'a' });
+            cont.enqueue({ value: 'b' });
+            cont.enqueue({ value: 'c' });
+            cont.enqueue({ done: true });
+            cont.close();
+          },
+        }),
+      );
+
+      const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+      const clientPort = mockedChannel.connect({ name: channelName });
+      clientPort.onMessage.addListener(clientListener);
+
+      expect(mockedChannel.onConnect.addListener).toHaveBeenCalledTimes(1);
+      const mgrPort = lastResult(mockedChannel.mockPorts).onConnectPort;
+      await vi.waitFor(() => expect(mgrPort.onMessage.addListener).toHaveBeenCalled());
+
+      clientPort.postMessage(testRequest);
+
+      await vi.waitFor(() => expect(mockHandler).toHaveBeenCalled());
+
+      await vi.waitFor(() => expect(mockedChannel.onConnect.addListener).toHaveBeenCalledTimes(2));
+
+      expect(mockHandler).toHaveBeenLastCalledWith(testRequest.message, expect.any(AbortSignal));
+      await vi.waitFor(() => expect(clientPort.onMessage.dispatch).toHaveBeenCalled());
+
+      expect(clientListener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          requestId: testRequest.requestId,
+          channel: expect.stringMatching(`^${testName} STREAM `) as string,
+        }),
+        clientPort,
+      );
+    });
+
+    it('should forward errors thrown by request handlers', async () => {
+      const handlerError = new Error('Handler error');
+      const testRequest = { requestId: '123', message: 'hello' };
+      const testResponse = {
+        requestId: '123',
+        error: errorToJson(ConnectError.from(handlerError), undefined),
+      };
+      const clientListener = vi.fn();
+
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+
+      const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+      const clientPort = mockedChannel.connect({ name: channelName });
+      clientPort.onMessage.addListener(clientListener);
+
+      mockHandler.mockRejectedValueOnce(handlerError);
+
+      await vi.waitFor(() => expect(sessions.size).toBe(1));
+      // make a request that triggers an error from the handler
+      clientPort.postMessage(testRequest);
+      // wait for the serialized error response
+      await vi.waitFor(() => expect(clientListener).toHaveBeenCalled());
+
+      expect(mockHandler).toHaveBeenLastCalledWith(testRequest.message, expect.any(AbortSignal));
+      expect(clientListener).toHaveBeenLastCalledWith(testResponse, clientPort);
+    });
+  });
+
+  describe('session management', () => {
+    it('should abort sessions on client disconnect', async () => {
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+      expect(sessions.size).toBe(0);
+
+      const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+      const clientPort = mockedChannel.connect({ name: channelName });
+
+      await vi.waitFor(() => expect(sessions.size).toBe(1));
+      const testSession = getOnlySession(sessions);
+
+      clientPort.disconnect();
+      await vi.waitFor(() =>
+        expect(
+          lastResult(mockedChannel.mockPorts).onConnectPort.onDisconnect.dispatch,
+        ).toHaveBeenCalled(),
+      );
+
+      expect(testSession.signal.aborted).toBe(true);
+    });
+
+    it('should disconnect sessions on session abort', async () => {
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+      expect(sessions.size).toBe(0);
+
+      const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+      const clientPort = mockedChannel.connect({ name: channelName });
+
+      await vi.waitFor(() => expect(sessions.size).toBe(1));
+      const testSession = getOnlySession(sessions);
+
+      testSession.abort();
+
+      await vi.waitFor(() => expect(testSession.signal.aborted).toBe(true));
+
+      expect(clientPort.onDisconnect.dispatch).toHaveBeenCalled();
+    });
+
+    it.fails('should remove aborted sessions from the session list', async () => {
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+      expect(sessions.size).toBe(0);
+
+      const channelName = nameConnection(testName, ChannelLabel.TRANSPORT);
+      const clientPort = mockedChannel.connect({ name: channelName });
+
+      await vi.waitFor(() => expect(sessions.size).toBe(1));
+      const testSession = getOnlySession(sessions);
+
+      clientPort.disconnect();
+
+      await vi.waitFor(() => expect(testSession.signal.aborted).toBe(true));
+
+      expect(sessions.size).toBe(0);
+    });
+
+    it('should abort all sessions for specific origin when killOrigin is called', async () => {
+      const testRequest = { requestId: '123', message: 'test' };
+
+      const sessions = CRSessionManager.init(testName, mockHandler, checkPortSender);
+      expect(sessions.size).toBe(0);
+
+      // Create a session for some other origin
+      mockedChannel.mockSenders.mockReturnValueOnce({
+        connectSender: localhostClient,
+        onConnectSender: extHost,
+      });
+      const localhostClientPort = mockedChannel.connect({
+        name: nameConnection(testName, ChannelLabel.TRANSPORT),
+      });
+      const localhostClientListener = vi.fn();
+      localhostClientPort.onMessage.addListener(localhostClientListener);
+
+      // Create multiple sessions for the same origin
+      const httpsClientPorts = [
+        mockedChannel.connect({ name: nameConnection(testName, ChannelLabel.TRANSPORT) }),
+        mockedChannel.connect({ name: nameConnection(testName, ChannelLabel.TRANSPORT) }),
+        mockedChannel.connect({ name: nameConnection(testName, ChannelLabel.TRANSPORT) }),
+      ];
+
+      mockedChannel.mockSenders.mockReturnValueOnce({
+        connectSender: extClient,
+        onConnectSender: extHost,
+      });
+      const extClientPort = mockedChannel.connect({
+        name: nameConnection(testName, ChannelLabel.TRANSPORT),
+      });
+      const extClientListener = vi.fn();
+      extClientPort.onMessage.addListener(extClientListener);
+
+      await vi.waitFor(() => expect(sessions.size).toBe(5));
+      // expect(checkPortSender).toHaveBeenCalledTimes(5);
+
+      const targetOrigin = httpsClient.origin!;
+
+      const sessionsSnapshot = Array.from(sessions.values());
+      expect(sessionsSnapshot.some(({ signal }) => signal.aborted)).toBeFalsy();
+
+      // kill
+      CRSessionManager.killOrigin(targetOrigin);
+      expect(sessionsSnapshot.some(({ signal }) => signal.aborted)).toBeTruthy();
+
+      expect(
+        sessionsSnapshot.every(
+          session => session.signal.aborted === (session.origin === targetOrigin),
+        ),
+      ).toBeTruthy();
+
+      // the other sessions should continue to function normally
+      extClientPort.postMessage(testRequest);
+      await vi.waitFor(() => expect(extClientListener).toHaveBeenCalled());
+      expect(mockHandler).toHaveBeenLastCalledWith(testRequest.message, expect.any(AbortSignal));
+      mockHandler.mockClear();
+
+      localhostClientPort.postMessage(testRequest);
+      await vi.waitFor(() => expect(localhostClientListener).toHaveBeenCalled());
+      expect(mockHandler).toHaveBeenLastCalledWith(testRequest.message, expect.any(AbortSignal));
+      mockHandler.mockClear();
+
+      // the aborted sessions should not be able to send messages
+      for (const port of httpsClientPorts) {
+        expect(() => port.postMessage(testRequest)).toThrowError(
+          'Attempting to use a disconnected port object',
+        );
+        expect(mockHandler).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/packages/transport-chrome/src/util/test-utils.ts
+++ b/packages/transport-chrome/src/util/test-utils.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion -- test utils */
+import { expect, MockedFunction, vi } from 'vitest';
+
+/**
+ * Returns the last result of a mocked function.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test utility
+export const lastResult = <T extends (...args: any[]) => any>(
+  mfn: MockedFunction<T>,
+): ReturnType<T> => {
+  const last = mfn.mock.results.at(-1);
+  if (last?.type === 'return') {
+    return last.value as never;
+  }
+  throw last?.value;
+};
+
+/** Default for replaced listeners. */
+const replacedUnhandledExceptionLogger: NodeJS.UncaughtExceptionListener = (
+  uncaughtException,
+  exceptionOrigin,
+): void =>
+  console.debug(
+    '\x1b[33m%s\x1b[0m',
+    `replaced ${exceptionOrigin} listener called with items:`,
+    uncaughtException,
+  );
+
+const replacedUnhandledRejectionLogger: NodeJS.UnhandledRejectionListener = (
+  unhandledRejection,
+  promiseOrigin,
+): void => {
+  console.debug(
+    '\x1b[33m%s\x1b[0m',
+    'replaced unhandledRejection listener detected promise rejection',
+    { unhandledRejection, promiseOrigin },
+  );
+};
+
+/**
+ * Necessary for old vitest.
+ * @see https://github.com/vitest-dev/vitest/commit/c8d56fe5fceabfc61b8f1e42e9d30f740e671638#diff-c49d7f13cf089b49c98c93fc496d9f17280b7d50142330a79d3b03cb5bd1bc06R60-R68
+ *
+ * Must be used like this:
+ * ```ts
+ * const { uncaughtExceptionListener, restoreUncaughtExceptionListener } = replaceUncaughtExceptionListener();
+ * onTestFinished(restoreUncaughtExceptionListener);
+ * ```
+ */
+export const replaceUncaughtExceptionListener = (
+  uncaughtExceptionListener = vi.fn(replacedUnhandledExceptionLogger),
+) => {
+  expect(process.listeners('uncaughtException').length).toBe(1);
+  const originalUncaughtExceptionListener = process.listeners('uncaughtException')[0]!;
+  process.removeListener('uncaughtException', originalUncaughtExceptionListener);
+  process.addListener('uncaughtException', uncaughtExceptionListener);
+  const restoreUncaughtExceptionListener = () => {
+    process.removeListener('uncaughtException', uncaughtExceptionListener);
+    process.addListener('uncaughtException', originalUncaughtExceptionListener);
+  };
+  return { uncaughtExceptionListener, restoreUncaughtExceptionListener };
+};
+
+/**
+ * Necessary for old vitest.
+ * @see https://github.com/vitest-dev/vitest/commit/c8d56fe5fceabfc61b8f1e42e9d30f740e671638#diff-c49d7f13cf089b49c98c93fc496d9f17280b7d50142330a79d3b03cb5bd1bc06R60-R68
+ *
+ * Must be used like this:
+ * ```ts
+ * const { unhandledRejectionListener, restoreUnhandledRejectionListener } = replaceUnhandledRejectionListener();
+ * onTestFinished(restoreUnhandledRejectionListener);
+ * ```
+ */
+export const replaceUnhandledRejectionListener = (
+  unhandledRejectionListener = vi.fn(replacedUnhandledRejectionLogger),
+) => {
+  expect(process.listeners('unhandledRejection').length).toBe(1);
+  const originalUnhandledRejectionListener = process.listeners('unhandledRejection')[0]!;
+  process.removeListener('unhandledRejection', originalUnhandledRejectionListener);
+  process.addListener('unhandledRejection', unhandledRejectionListener);
+  const restoreUnhandledRejectionListener = () => {
+    process.removeListener('unhandledRejection', unhandledRejectionListener);
+    process.addListener('unhandledRejection', originalUnhandledRejectionListener);
+  };
+  return {
+    unhandledRejectionListener,
+    restoreUnhandledRejectionListener,
+  };
+};

--- a/packages/transport-chrome/src/with-dom.test.ts
+++ b/packages/transport-chrome/src/with-dom.test.ts
@@ -1,0 +1,490 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  ConverseRequest,
+  ConverseResponse,
+  IntroduceRequest,
+  IntroduceResponse,
+  SayRequest,
+  SayResponse,
+} from '@buf/connectrpc_eliza.bufbuild_es/connectrpc/eliza/v1/eliza_pb.js';
+import { ElizaService } from '@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect.js';
+import { Any, createRegistry, type PlainMessage } from '@bufbuild/protobuf';
+import type { Transport } from '@connectrpc/connect';
+import { mockChannel, MockedChannel } from '@penumbra-zone/mock-chrome/runtime/connect';
+import { CRSessionClient } from '@penumbra-zone/transport-chrome/session-client';
+import {
+  type ChannelTransportOptions,
+  createChannelTransport,
+} from '@penumbra-zone/transport-dom/create';
+import type { TransportMessage } from '@penumbra-zone/transport-dom/messages';
+import { beforeEach, describe, expect, it, Mock, onTestFinished, vi } from 'vitest';
+import { ChannelLabel, nameConnection } from './channel-names.js';
+import { lastResult, replaceUnhandledRejectionListener } from './util/test-utils.js';
+
+import ReadableStream from '@penumbra-zone/transport-dom/ReadableStream.from';
+import { PortStreamSink } from './stream.js';
+import { TransportInitChannel } from './message.js';
+
+Object.assign(CRSessionClient, {
+  clearSingleton() {
+    // @ts-expect-error -- manipulating private property
+    CRSessionClient.singleton = undefined;
+  },
+});
+
+// @ts-expect-error -- manipulating private property
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+const clearSingleton = (): void => CRSessionClient.clearSingleton();
+
+const sayRequest: PlainMessage<SayRequest> = { sentence: 'Hello' };
+const sayResponse: PlainMessage<SayResponse> = { sentence: 'world' };
+const introduceRequest: PlainMessage<IntroduceRequest> = { name: 'Qud' };
+const introduceResponses: PlainMessage<IntroduceResponse>[] = [
+  { sentence: 'Yo' },
+  { sentence: 'This' },
+  { sentence: 'Streams' },
+];
+const converseRequests: PlainMessage<ConverseRequest>[] = [
+  { sentence: 'Hello' },
+  { sentence: 'world' },
+];
+const converseResponses: PlainMessage<ConverseResponse>[] = [
+  { sentence: 'Goodbye' },
+  { sentence: 'world' },
+];
+const defaultTimeoutMs = 200;
+
+const typeRegistry = createRegistry(ElizaService);
+
+describe('message transport', () => {
+  let domPort: MessagePort;
+  let transportOptions: ChannelTransportOptions;
+  let transport: Transport;
+
+  const defaultTimeoutMs = 10000;
+
+  const extOnMessage: Mock<[unknown, chrome.runtime.Port], void> = vi.fn();
+  const extOnDisconnect: Mock<[chrome.runtime.Port], void> = vi.fn();
+  const extOnConnect = vi.fn((p: chrome.runtime.Port): void => {
+    p.onDisconnect.addListener(extOnDisconnect);
+    p.onMessage.addListener(extOnMessage);
+  });
+
+  let mockedChannel: MockedChannel;
+  let mockedChannel2: MockedChannel;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    clearSingleton();
+
+    mockedChannel = mockChannel();
+    mockedChannel2 = mockChannel();
+    mockedChannel.onConnect.addListener(extOnConnect);
+
+    vi.stubGlobal('chrome', {
+      runtime: {
+        connect: mockedChannel.connect,
+        onConnect: mockedChannel2.onConnect,
+      },
+    });
+
+    domPort = CRSessionClient.init('test');
+
+    transportOptions = {
+      getPort: () => Promise.resolve(domPort),
+      jsonOptions: { typeRegistry },
+      defaultTimeoutMs,
+    };
+    transport = createChannelTransport(transportOptions);
+  });
+
+  it('should send and receive unary request/response', async () => {
+    const unaryRequestResponse = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      undefined,
+      undefined,
+      undefined,
+      new SayRequest(sayRequest),
+    );
+
+    extOnMessage.mockImplementation((m, p) => {
+      const { requestId, message } = m as TransportMessage;
+      expect(requestId).toBeTypeOf('string');
+      expect(message).toMatchObject({
+        ...sayRequest,
+        '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayRequest',
+      });
+
+      p.postMessage({
+        requestId,
+        message: {
+          ...sayResponse,
+          '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayResponse',
+        },
+      });
+    });
+
+    await vi.waitFor(() => expect(extOnMessage).toHaveBeenCalled());
+
+    await expect(unaryRequestResponse).resolves.toMatchObject({ message: sayResponse });
+  });
+
+  it('should send and receive server-streaming request/response', async () => {
+    const streamChannel = nameConnection('test', ChannelLabel.STREAM);
+    const streamListener = vi.fn((sub: chrome.runtime.Port) => {
+      if (sub.name === streamChannel) {
+        mockedChannel.onConnect.removeListener(streamListener);
+        const stream = new ReadableStream({
+          start(cont) {
+            for (const chunk of introduceResponses) {
+              cont.enqueue(Any.pack(new IntroduceResponse(chunk)).toJson({ typeRegistry }));
+            }
+            cont.close();
+          },
+        });
+
+        void stream
+          .pipeTo(new WritableStream(new PortStreamSink(sub)))
+          .finally(() => sub.disconnect());
+      }
+    });
+
+    extOnMessage.mockImplementation((m, p) => {
+      const { requestId } = m as TransportMessage;
+
+      mockedChannel.onConnect.addListener(streamListener);
+      p.postMessage({ requestId, channel: streamChannel });
+    });
+
+    const streamRequestResponse = transport.stream(
+      ElizaService,
+      ElizaService.methods.introduce,
+      undefined,
+      undefined,
+      undefined,
+      ReadableStream.from([new IntroduceRequest(introduceRequest)]),
+    );
+
+    await vi.waitFor(() => {
+      expect(mockedChannel.connect).toHaveBeenCalledTimes(2);
+      expect(mockedChannel.connect).toHaveBeenLastCalledWith({ name: streamChannel });
+    });
+    const streamPort = lastResult(mockedChannel.connect);
+    expect(streamListener).toHaveBeenCalled();
+    expect(streamPort.onMessage.dispatch).toHaveBeenCalled();
+
+    const response = await streamRequestResponse;
+    console.log('response.message', response.message);
+
+    for await (const chunk of response.message) {
+      console.log('chunk', chunk);
+    }
+  });
+
+  it('should send and receive bidi-streaming request/response', async () => {
+    const responseChannelName = nameConnection('test', ChannelLabel.STREAM);
+    const responseOnConnectListener = vi.fn((sub: chrome.runtime.Port) => {
+      if (sub.name === responseChannelName) {
+        mockedChannel.onConnect.removeListener(responseOnConnectListener);
+        const stream = new ReadableStream({
+          start(cont) {
+            for (const chunk of converseResponses) {
+              cont.enqueue(Any.pack(new ConverseResponse(chunk)).toJson({ typeRegistry }));
+            }
+            cont.close();
+          },
+        });
+
+        void stream
+          .pipeTo(new WritableStream(new PortStreamSink(sub)))
+          .finally(() => sub.disconnect());
+      }
+    });
+
+    const streamRequestCollected = new Array<unknown>();
+
+    extOnMessage.mockImplementation((m, p) => {
+      console.log('bidi onMessage', m);
+      const { requestId, channel } = m as TransportInitChannel;
+
+      const requestChannel = mockedChannel2.connect({ name: channel });
+      requestChannel.onMessage.addListener(m => {
+        console.log('bidi request chunk', m);
+        streamRequestCollected.push(m);
+      });
+
+      mockedChannel.onConnect.addListener(responseOnConnectListener);
+      p.postMessage({ requestId, channel: responseChannelName });
+    });
+
+    const bidiRequestResponse = transport.stream(
+      ElizaService,
+      ElizaService.methods.converse,
+      undefined,
+      undefined,
+      undefined,
+      ReadableStream.from(converseRequests.map(r => new ConverseRequest(r))),
+    );
+
+    await vi.waitFor(() =>
+      expect(extOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: expect.stringContaining('STREAM'),
+        }),
+        expect.anything(),
+      ),
+    );
+    expect(mockedChannel.connect).toHaveBeenCalledTimes(2);
+    expect(mockedChannel.connect).toHaveBeenLastCalledWith({ name: responseChannelName });
+
+    const streamPort = lastResult(mockedChannel.connect);
+    expect(responseOnConnectListener).toHaveBeenCalled();
+    expect(streamPort.onMessage.dispatch).toHaveBeenCalled();
+
+    const expectedResponses = converseResponses[Symbol.iterator]();
+    for await (const chunk of (await bidiRequestResponse).message) {
+      expect(chunk).toMatchObject(expectedResponses.next().value);
+    }
+
+    expect(streamRequestCollected).toMatchObject([
+      ...converseRequests.map(value => ({ value })),
+      { done: true },
+    ]);
+  });
+});
+
+describe('transport timeouts', () => {
+  let domPort: MessagePort;
+  let transportOptions: ChannelTransportOptions;
+  let transport: Transport;
+
+  const extOnMessage: Mock<[unknown, chrome.runtime.Port], void> = vi.fn();
+  const extOnDisconnect: Mock<[chrome.runtime.Port], void> = vi.fn();
+  const extOnConnect = vi.fn((p: chrome.runtime.Port): void => {
+    p.onDisconnect.addListener(extOnDisconnect);
+    p.onMessage.addListener(extOnMessage);
+  });
+
+  let mockedChannel: MockedChannel;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    performance.clearMarks();
+
+    clearSingleton();
+
+    mockedChannel = mockChannel();
+    mockedChannel.onConnect.addListener(extOnConnect);
+
+    vi.stubGlobal('chrome', { runtime: { connect: mockedChannel.connect } });
+
+    domPort = CRSessionClient.init('test');
+
+    transportOptions = {
+      getPort: () => Promise.resolve(domPort),
+      jsonOptions: { typeRegistry },
+      defaultTimeoutMs,
+    };
+    transport = createChannelTransport(transportOptions);
+  });
+
+  it('should time out unary requests', async () => {
+    const input = { sentence: 'hello' };
+    const response = { sentence: '.........hello' };
+
+    const unaryRequest = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      undefined,
+      undefined,
+      undefined,
+      new SayRequest(input),
+    );
+
+    extOnMessage.mockImplementation((m, p) => {
+      const { requestId, message } = m as TransportMessage;
+
+      expect(requestId).toBeTypeOf('string');
+      expect(message).toMatchObject({
+        ...input,
+        '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayRequest',
+      });
+
+      setTimeout(() => {
+        p.postMessage({
+          requestId,
+          message: {
+            ...response,
+            '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayResponse',
+          },
+        });
+      }, defaultTimeoutMs * 2);
+    });
+
+    await expect(unaryRequest).rejects.toThrow('[deadline_exceeded]');
+    await vi.waitFor(() => expect(extOnMessage).toHaveBeenCalled());
+  });
+
+  it('should time out unary requests at a specified custom time', async () => {
+    const customTimeoutMs = 100;
+
+    const input: PlainMessage<SayRequest> = { sentence: 'hello' };
+    const response: PlainMessage<SayResponse> = { sentence: '.........hello' };
+
+    const unaryRequest = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      undefined,
+      customTimeoutMs,
+      undefined,
+      new SayRequest(input),
+    );
+
+    extOnMessage.mockImplementation((m, p) => {
+      const { requestId, message } = m as TransportMessage;
+
+      expect(requestId).toBeTypeOf('string');
+      expect(message).toMatchObject({
+        ...input,
+        '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayRequest',
+      });
+
+      setTimeout(() => {
+        p.postMessage({
+          requestId,
+          message: {
+            ...response,
+            '@type': 'type.googleapis.com/connectrpc.eliza.v1.SayResponse',
+          },
+        });
+      }, defaultTimeoutMs / 2);
+    });
+
+    await expect(unaryRequest).rejects.toThrow('[deadline_exceeded]');
+    await vi.waitFor(() => expect(extOnMessage).toHaveBeenCalled());
+  });
+});
+
+describe('transport aborts', () => {
+  let domPort: MessagePort;
+  let transportOptions: ChannelTransportOptions;
+  let transport: Transport;
+  let ac: AbortController;
+
+  const extOnMessage: Mock<[unknown, chrome.runtime.Port], void> = vi.fn();
+  const extOnDisconnect: Mock<[chrome.runtime.Port], void> = vi.fn();
+  const extOnConnect = vi.fn((p: chrome.runtime.Port): void => {
+    p.onDisconnect.addListener(extOnDisconnect);
+    p.onMessage.addListener(extOnMessage);
+  });
+
+  let mockedChannel: MockedChannel;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    clearSingleton();
+
+    mockedChannel = mockChannel();
+    mockedChannel.onConnect.addListener(extOnConnect);
+
+    vi.stubGlobal('chrome', { runtime: { connect: mockedChannel.connect } });
+
+    domPort = CRSessionClient.init('test');
+
+    transportOptions = {
+      getPort: () => Promise.resolve(domPort),
+      jsonOptions: { typeRegistry },
+      defaultTimeoutMs,
+    };
+    transport = createChannelTransport(transportOptions);
+    ac = new AbortController();
+  });
+
+  it('should cancel unary requests with no reason at caller', async () => {
+    const { unhandledRejectionListener, restoreUnhandledRejectionListener } =
+      replaceUnhandledRejectionListener();
+    onTestFinished(() => restoreUnhandledRejectionListener());
+
+    expect(unhandledRejectionListener).not.toHaveBeenCalled();
+
+    const unaryRequest = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      ac.signal,
+      undefined,
+      undefined,
+      new SayRequest(sayRequest),
+    );
+
+    await vi.waitFor(() => {
+      expect(extOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: expect.any(String),
+          message: expect.objectContaining(sayRequest),
+        }),
+        expect.anything(),
+      );
+    });
+
+    ac.abort();
+
+    await vi.waitFor(() => {
+      expect(extOnMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          requestId: expect.any(String),
+          abort: true,
+        }),
+        expect.anything(),
+      );
+    });
+
+    await expect(unaryRequest).rejects.toThrow('[canceled]');
+  });
+
+  it('should abort unary requests with reason at caller', async () => {
+    const { unhandledRejectionListener, restoreUnhandledRejectionListener } =
+      replaceUnhandledRejectionListener();
+    onTestFinished(() => restoreUnhandledRejectionListener());
+
+    expect(unhandledRejectionListener).not.toHaveBeenCalled();
+
+    const unaryRequest = transport.unary(
+      ElizaService,
+      ElizaService.methods.say,
+      ac.signal,
+      undefined,
+      undefined,
+      new SayRequest(sayRequest),
+    );
+
+    await vi.waitFor(() => {
+      expect(extOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: expect.any(String),
+          message: expect.objectContaining(sayRequest),
+        }),
+        expect.anything(),
+      );
+    });
+
+    ac.abort('some reason');
+
+    await vi.waitFor(() => {
+      expect(extOnMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          requestId: expect.any(String),
+          abort: true,
+        }),
+        expect.anything(),
+      );
+    });
+
+    await expect(unaryRequest).rejects.toThrow('[aborted] some reason');
+  });
+});

--- a/packages/transport-chrome/vitest.config.ts
+++ b/packages/transport-chrome/vitest.config.ts
@@ -1,0 +1,8 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => ({
+  define: { 'globalThis.__DEV__': mode !== 'production' },
+  test: { include: ['src/*.test.ts'] },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@penumbra-zone/configs':
         specifier: workspace:*
         version: link:packages/configs
+      '@penumbra-zone/mock-chrome':
+        specifier: workspace:*
+        version: link:packages/mock-chrome
       '@repo/tailwind-config':
         specifier: workspace:*
         version: link:packages/tailwind-config
@@ -493,6 +496,12 @@ importers:
         version: 5.5.3
 
   packages/keys: {}
+
+  packages/mock-chrome:
+    devDependencies:
+      '@types/chrome':
+        specifier: ^0.0.268
+        version: 0.0.268
 
   packages/perspective:
     devDependencies:


### PR DESCRIPTION
## Description of Changes

Staging branch for improving reliability of connection lifecycle.

- [ ] https://github.com/penumbra-zone/web/pull/2040 - first PR, implements tests for all following changes. no functionality changes
- [ ] https://github.com/penumbra-zone/web/pull/2018 - second PR, corrects specific failure of `CRSessionClient` blocking following work. no external api changes
- [ ] https://github.com/penumbra-zone/web/pull/2043 - third PR, enhance reliability of transport, improve internal type safety. no external api changes
- [ ] https://github.com/penumbra-zone/web/pull/2034 - fourth PR, implement reconnect at session level in transport-chrome. only session-manager sees external api changes

still testing frontend interactions. since listener attach became async, a race condition was created which could possibly miss very early messages after connection attempt.

- [ ] https://github.com/penumbra-zone/web/pull/2062

## Related Issue

- [ ] https://github.com/penumbra-zone/web/issues/1670
- [ ] https://github.com/penumbra-zone/web/issues/1779
- [ ] https://github.com/penumbra-zone/web/issues/1736
- [ ] https://github.com/penumbra-zone/web/issues/1968
- [ ] https://github.com/penumbra-zone/web/issues/2003
- [ ] https://github.com/penumbra-zone/web/issues/2014
- [ ] https://github.com/penumbra-zone/web/issues/2021

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
