### PR TITLE
correctly serialize headers and timeout

### DIFF
--- a/.changeset/curly-icons-sniff.md
+++ b/.changeset/curly-icons-sniff.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/transport-dom': patch
+---
+
+convey timeout in request headers

--- a/.changeset/khaki-pandas-worry.md
+++ b/.changeset/khaki-pandas-worry.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/transport-dom': patch
+---
+
+exclude non-transferable type member from internal message types

--- a/packages/transport-chrome/src/with-dom.test.ts
+++ b/packages/transport-chrome/src/with-dom.test.ts
@@ -68,7 +68,7 @@ describe('session client with transport-dom', () => {
   let domPort: MessagePort;
   let transportOptions: ChannelTransportOptions;
   let transport: Transport;
-  const defaultTimeoutMs = 200;
+  const defaultTimeoutMs = 300;
 
   const extOnMessage: Mock<[unknown, chrome.runtime.Port], void> = vi.fn();
   const extOnDisconnect: Mock<[chrome.runtime.Port], void> = vi.fn();

--- a/packages/transport-chrome/src/with-dom.test.ts
+++ b/packages/transport-chrome/src/with-dom.test.ts
@@ -701,9 +701,7 @@ describe('session client with transport-dom', () => {
     });
   });
 
-  // can't execute these on recent node 22 for some reason, even when catching
-  // unhandled exceptions
-  describe.skip('transport headers', () => {
+  describe('transport headers', () => {
     let header: Headers;
 
     beforeEach(() => {
@@ -711,7 +709,7 @@ describe('session client with transport-dom', () => {
       header.set('x-test', testName);
     });
 
-    it.fails('should send headers', async () => {
+    it('should send headers', async () => {
       const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
         replaceUncaughtExceptionListener();
       onTestFinished(restoreUncaughtExceptionListener);
@@ -758,7 +756,7 @@ describe('session client with transport-dom', () => {
       expect(uncaughtExceptionListener).not.toHaveBeenCalled();
     });
 
-    it.fails('should send timeout headers', async () => {
+    it('should send timeout headers', async () => {
       const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
         replaceUncaughtExceptionListener();
       onTestFinished(restoreUncaughtExceptionListener);
@@ -801,7 +799,7 @@ describe('session client with transport-dom', () => {
       expect(uncaughtExceptionListener).not.toHaveBeenCalled();
     });
 
-    it.fails('should send collected headers', async () => {
+    it('should send collected headers', async () => {
       const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
         replaceUncaughtExceptionListener();
       onTestFinished(restoreUncaughtExceptionListener);

--- a/packages/transport-dom/src/create.test.ts
+++ b/packages/transport-dom/src/create.test.ts
@@ -689,7 +689,7 @@ describe('channel transport', () => {
       header.set('x-test', 'test');
     });
 
-    it.fails('should send headers', async () => {
+    it('should send headers', async () => {
       expect(otherEnd).not.toHaveBeenCalled();
 
       otherEnd.mockImplementation((ev: MessageEvent<unknown>) => {
@@ -722,7 +722,7 @@ describe('channel transport', () => {
       expect(calledHeaders.get('x-test')).toBe('test');
     });
 
-    it.fails('should send timeout headers', async () => {
+    it('should send timeout headers', async () => {
       expect(otherEnd).not.toHaveBeenCalled();
 
       otherEnd.mockImplementation((ev: MessageEvent<unknown>) => {
@@ -757,7 +757,7 @@ describe('channel transport', () => {
       expect(calledHeaders.get('headerTimeout')).toBe('200');
     });
 
-    it.fails('should send collected headers', async () => {
+    it('should send collected headers', async () => {
       expect(otherEnd).not.toHaveBeenCalled();
 
       otherEnd.mockImplementation((ev: MessageEvent<unknown>) => {

--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -23,7 +23,7 @@ import {
   TransportMessage,
   TransportStream,
 } from './messages.js';
-import { normalizeHeader } from './util.js';
+import { normalizeHeader } from './util/normalize-header.js';
 
 import ReadableStream from './ReadableStream.from.js';
 

--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -23,6 +23,7 @@ import {
   TransportMessage,
   TransportStream,
 } from './messages.js';
+import { normalizeHeader } from './util.js';
 
 import ReadableStream from './ReadableStream.from.js';
 
@@ -162,15 +163,12 @@ export const createChannelTransport = ({
       port ??= await connect();
 
       const requestId = crypto.randomUUID();
+
       const requestFailure = new AbortController();
+      const deadline = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
 
       const response = Promise.race([
-        rejectOnSignal(
-          transportFailure.signal,
-          requestFailure.signal,
-          timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
-          signal,
-        ),
+        rejectOnSignal(transportFailure.signal, requestFailure.signal, deadline, signal),
         new Promise<TransportMessage>((resolve, reject) => {
           pending.set(requestId, (tev: TransportEvent) => {
             if (isTransportMessage(tev, requestId)) {
@@ -193,7 +191,12 @@ export const createChannelTransport = ({
                 signal?.addEventListener('abort', () =>
                   port?.postMessage({ requestId, abort: true } satisfies TransportAbort),
                 );
-                port.postMessage({ requestId, message, header } satisfies TransportMessage);
+
+                port.postMessage({
+                  requestId,
+                  message,
+                  header: normalizeHeader(timeoutMs, header),
+                } satisfies TransportMessage);
               }
               break;
             default:
@@ -232,14 +235,10 @@ export const createChannelTransport = ({
       const requestId = crypto.randomUUID();
 
       const requestFailure = new AbortController();
+      const deadline = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
 
       const response = Promise.race([
-        rejectOnSignal(
-          transportFailure.signal,
-          requestFailure.signal,
-          timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
-          signal,
-        ),
+        rejectOnSignal(transportFailure.signal, requestFailure.signal, deadline, signal),
         new Promise<TransportStream>((resolve, reject) => {
           pending.set(requestId, (tev: TransportEvent) => {
             if (isTransportStream(tev, requestId)) {
@@ -268,7 +267,11 @@ export const createChannelTransport = ({
                 // confirm the input stream ended after one message with content
                 if (done && typeof value === 'object' && value !== null) {
                   const message = Any.pack(new method.I(value as object)).toJson(jsonOptions);
-                  port.postMessage({ requestId, message, header } satisfies TransportMessage);
+                  port.postMessage({
+                    requestId,
+                    message,
+                    header: normalizeHeader(timeoutMs, header),
+                  } satisfies TransportMessage);
                 } else {
                   throw new ConnectError(
                     'MethodKind.ServerStreaming expects a single request message',
@@ -290,7 +293,14 @@ export const createChannelTransport = ({
                       cont.enqueue(Any.pack(new method.I(chunk)).toJson(jsonOptions)),
                   }),
                 );
-                port.postMessage({ requestId, stream, header } satisfies TransportStream, [stream]);
+                port.postMessage(
+                  {
+                    requestId,
+                    stream,
+                    header: normalizeHeader(timeoutMs, header),
+                  } satisfies TransportStream,
+                  [stream],
+                );
               }
               break;
             default:

--- a/packages/transport-dom/src/messages.ts
+++ b/packages/transport-dom/src/messages.ts
@@ -5,7 +5,7 @@ import type { JsonValue } from '@bufbuild/protobuf';
 export interface TransportError<I extends string | undefined> extends Partial<TransportEvent> {
   requestId: I extends string ? string : string | undefined;
   error: JsonValue;
-  metadata?: HeadersInit;
+  metadata?: Extract<HeadersInit, JsonValue>;
 }
 
 // transport content
@@ -14,9 +14,8 @@ export type TransportData = TransportMessage | TransportStream;
 
 export interface TransportEvent<I extends string = string> {
   requestId: I;
-  header?: HeadersInit;
-  trailer?: HeadersInit;
-  // contextValues?: object;
+  header?: Extract<HeadersInit, JsonValue>;
+  trailer?: Extract<HeadersInit, JsonValue>;
 }
 
 export interface TransportAbort<I = string> extends TransportEvent<I extends string ? I : never> {

--- a/packages/transport-dom/src/util.ts
+++ b/packages/transport-dom/src/util.ts
@@ -1,0 +1,14 @@
+/**
+ * Collect timeout and user-provided headers to a JSON-serializable object.
+ */
+export const normalizeHeader = (timeoutMs?: number, userProvidedHeaders?: HeadersInit) => {
+  const headers = new Headers(userProvidedHeaders ?? {});
+
+  if (timeoutMs) {
+    headers.set('headerTimeout', `${timeoutMs}`);
+  }
+
+  const entries = Array.from(headers);
+
+  return entries.length ? Object.fromEntries(entries) : undefined;
+};

--- a/packages/transport-dom/src/util/normalize-header.ts
+++ b/packages/transport-dom/src/util/normalize-header.ts
@@ -8,7 +8,7 @@ export const normalizeHeader = (timeoutMs?: number, userProvidedHeaders?: Header
     headers.set('headerTimeout', `${timeoutMs}`);
   }
 
-  const entries = Array.from(headers);
+  const entries = Array.from(headers.entries());
 
   return entries.length ? Object.fromEntries(entries) : undefined;
 };


### PR DESCRIPTION
## Description of Changes

Restrict the use of `HeadersInit` in a `TransportEvent` or `TransportError` to only permit jsonifiable members.

Serialize timeout into the request header as in typical connectrpc.

Technically, an exported type becomes narrower, but the now-omitted member was invalid, and no external API has changed its accepted input/output formats. 

## Related Issue

- [x] https://github.com/penumbra-zone/web/issues/2070
- [x] https://github.com/penumbra-zone/web/issues/2072

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
