### PR TITLE
time out stalled streams, emit stream abort events

### DIFF
--- a/.changeset/popular-keys-look.md
+++ b/.changeset/popular-keys-look.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/transport-dom': patch
+---
+
+response streams will now respect the request's timeout configuration..

--- a/.changeset/popular-keys-look.md
+++ b/.changeset/popular-keys-look.md
@@ -2,4 +2,4 @@
 '@penumbra-zone/transport-dom': patch
 ---
 
-response streams will now respect the request's timeout configuration..
+response streams will now respect the request's timeout configuration.

--- a/packages/transport-chrome/src/with-dom.test.ts
+++ b/packages/transport-chrome/src/with-dom.test.ts
@@ -470,7 +470,7 @@ describe('session client with transport-dom', () => {
     });
 
     describe("doesn't emit abort events", () => {
-      it('can cancel streams before init, but does not emit an abort', async () => {
+      it.fails('can cancel streams before init, but does not emit an abort', async () => {
         const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
           replaceUncaughtExceptionListener();
         onTestFinished(restoreUncaughtExceptionListener);
@@ -503,7 +503,7 @@ describe('session client with transport-dom', () => {
         expect(uncaughtExceptionListener).not.toHaveBeenCalled();
       });
 
-      it('can cancel streams already in progress, but does not emit an abort', async () => {
+      it.fails('can cancel streams already in progress, but does not emit an abort', async () => {
         const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
           replaceUncaughtExceptionListener();
         onTestFinished(restoreUncaughtExceptionListener);
@@ -577,7 +577,7 @@ describe('session client with transport-dom', () => {
     });
 
     describe('emits abort events', () => {
-      it.fails('can cancel streams before init, and emits an abort', async () => {
+      it('can cancel streams before init, and emits an abort', async () => {
         const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
           replaceUncaughtExceptionListener();
         onTestFinished(restoreUncaughtExceptionListener);
@@ -629,7 +629,7 @@ describe('session client with transport-dom', () => {
         expect(uncaughtExceptionListener).not.toHaveBeenCalled();
       });
 
-      it.fails('can cancel streams already in progress, and emits an abort', async () => {
+      it('can cancel streams already in progress, and emits an abort', async () => {
         const { uncaughtExceptionListener, restoreUncaughtExceptionListener } =
           replaceUncaughtExceptionListener();
         onTestFinished(restoreUncaughtExceptionListener);

--- a/packages/transport-dom/src/create.test.ts
+++ b/packages/transport-dom/src/create.test.ts
@@ -391,7 +391,7 @@ describe('channel transport', () => {
       expect(messages).toMatchObject(introduceResponse);
     });
 
-    it.fails('should time out streaming requests that stall', async () => {
+    it('should time out streaming requests that stall', async () => {
       otherEnd.mockImplementation((event: MessageEvent<unknown>) => {
         const { requestId } = event.data as TransportMessage;
         const stream = ReadableStream.from(
@@ -480,7 +480,7 @@ describe('channel transport', () => {
     });
 
     describe("doesn't emit abort events", () => {
-      it('can cancel streams before init, but does not emit an abort', async () => {
+      it.fails('can cancel streams before init, but does not emit an abort', async () => {
         expect(otherEnd).not.toHaveBeenCalled();
 
         const ac = new AbortController();
@@ -508,7 +508,7 @@ describe('channel transport', () => {
         expect(otherEnd).toHaveBeenCalledOnce();
       });
 
-      it('can cancel streams already in progress, but does not emit an abort', async () => {
+      it.fails('can cancel streams already in progress, but does not emit an abort', async () => {
         const errorEventListener = vi.fn();
         window.addEventListener('error', errorEventListener);
         onTestFinished(() => window.removeEventListener('error', errorEventListener));
@@ -575,7 +575,7 @@ describe('channel transport', () => {
     });
 
     describe('emits abort events', () => {
-      it.fails('can cancel streams before init, and emits an abort', async () => {
+      it('can cancel streams before init, and emits an abort', async () => {
         expect(otherEnd).not.toHaveBeenCalled();
 
         const ac = new AbortController();
@@ -611,7 +611,7 @@ describe('channel transport', () => {
         );
       });
 
-      it.fails('can cancel streams already in progress, and emits an abort', async () => {
+      it('can cancel streams already in progress, and emits an abort', async () => {
         const defaultTimeoutMs = 200;
         const responses: PlainMessage<IntroduceResponse>[] = [
           { sentence: 'something remarkably similar' },

--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -159,7 +159,9 @@ export const createChannelTransport = ({
       header: HeadersInit | undefined,
       input: PartialMessage<I>,
     ): Promise<UnaryResponse<I, O>> {
-      transportFailure.signal.throwIfAborted();
+      if (transportFailure.signal.aborted) {
+        throw transportFailure.signal.reason;
+      }
       port ??= await connect();
 
       const requestId = crypto.randomUUID();
@@ -229,7 +231,9 @@ export const createChannelTransport = ({
       header: HeadersInit | undefined,
       input: AsyncIterable<PartialMessage<I>>,
     ): Promise<StreamResponse<I, O>> {
-      transportFailure.signal.throwIfAborted();
+      if (transportFailure.signal.aborted) {
+        throw transportFailure.signal.reason;
+      }
       port ??= await connect();
 
       const requestId = crypto.randomUUID();

--- a/packages/transport-dom/src/create.ts
+++ b/packages/transport-dom/src/create.ts
@@ -267,6 +267,9 @@ export const createChannelTransport = ({
                 // confirm the input stream ended after one message with content
                 if (done && typeof value === 'object' && value !== null) {
                   const message = Any.pack(new method.I(value as object)).toJson(jsonOptions);
+                  signal.addEventListener('abort', () =>
+                    port?.postMessage({ requestId, abort: true } satisfies TransportAbort),
+                  );
                   port.postMessage({
                     requestId,
                     message,
@@ -292,6 +295,9 @@ export const createChannelTransport = ({
                     transform: (chunk: PartialMessage<I>, cont) =>
                       cont.enqueue(Any.pack(new method.I(chunk)).toJson(jsonOptions)),
                   }),
+                );
+                signal.addEventListener('abort', () =>
+                  port?.postMessage({ requestId, abort: true } satisfies TransportAbort),
                 );
                 port.postMessage(
                   {


### PR DESCRIPTION
## Description of Changes

Streaming responses now use the per-request or transport default timeout configuration to abort a stalled stream.

## Related Issue

- [x] https://github.com/penumbra-zone/web/issues/2073

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
