### PR TITLE
Fix spelling errors across Documentation Files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ https://excalidraw.com/#json=_3b4K0RpWFJWAtVCH5ymB,CHegLkto1X_NdKG67LNh2A
 ### Some critical details
 
 Prax and Minifront [share React components](./ui-library.md) and some other
-reuseable dependencies.
+reusable dependencies.
 
 Both Prax and Minifront manage running state with Zustand. For storage, Prax
 uses extension storage and idb. Minifront does not store anything.

--- a/docs/adrs/004-privacy-invariants.md
+++ b/docs/adrs/004-privacy-invariants.md
@@ -41,10 +41,10 @@ Generally, the local and session storage need to be more restricted.
 ```
 Invariant 2.
 
-The Content Security Policy (CSP) defined in the Manifest V3 file must restrict permissions to only those that are necessary, ensuring no extranous security risks are introduced.
+The Content Security Policy (CSP) defined in the Manifest V3 file must restrict permissions to only those that are necessary, ensuring no extraneous security risks are introduced.
 ```
 
-Currently, we define `wasm-unsafe-eval` in the manifest file to enable dynamic loading of WebAssembly modules. Without the `wasm-unsafe-eval` CSP directive, WebAssembly is blocked from loading and executing on the page. However, `wasm-unsafe-eval` opens up the possiblity for attackers to inject and execute malicious WebAssembly code:
+Currently, we define `wasm-unsafe-eval` in the manifest file to enable dynamic loading of WebAssembly modules. Without the `wasm-unsafe-eval` CSP directive, WebAssembly is blocked from loading and executing on the page. However, `wasm-unsafe-eval` opens up the possibility for attackers to inject and execute malicious WebAssembly code:
 
 ```
 const maliciousCode = "(wasm binary code)";

--- a/docs/extension-services.md
+++ b/docs/extension-services.md
@@ -1,6 +1,6 @@
 ## Service Implementation
 
-Services in this repository should eventually be re-useable, but you can also
+Services in this repository should eventually be reusable, but you can also
 implement your own services. Implementation is much like developing a web
 service, using the normal ConnectRPC server-side metaphors and types.
 

--- a/docs/guiding-principles.md
+++ b/docs/guiding-principles.md
@@ -26,7 +26,7 @@ code quality high. See [CI/CD guide](ci-cd.md) for running commands locally.
 
 ## Modularity from the beginning
 
-We should attempt to be liberal about adding packages if we think it can get re-use from another
+We should attempt to be liberal about adding packages if we think it can get reuse from another
 app in this repo or even outside. This will allow us to expose critical functionality
 that can make developing further apps easier.
 


### PR DESCRIPTION
- `reuseable` to `reusable`.
- `extranous` to `extraneous` and `possiblity` to `possibility`.
- `re-useable` to `reusable`.
- `re-use` to `reuse`.
