### PR TITLE
minifront: detect genesis sync state more accurately

### DIFF
--- a/.changeset/seven-dots-change.md
+++ b/.changeset/seven-dots-change.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui-deprecated': patch
+---
+
+detect genesis sync state more accurately

--- a/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
+++ b/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
@@ -19,7 +19,7 @@ export const CondensedBlockSyncStatus = ({
     return <BlockSyncErrorState />;
   }
   if (!latestKnownBlockHeight || !fullSyncHeight) {
-    return <AwaitingSyncState genesisSyncing={!fullSyncHeight} />;
+    return <AwaitingSyncState genesisSyncing={!!latestKnownBlockHeight && !fullSyncHeight} />;
   }
 
   const isSyncing = latestKnownBlockHeight - fullSyncHeight > 10;


### PR DESCRIPTION
## Description of Changes

Presently, the header progress bar will display a 'Genesis sync' status when it's waiting for status data. This change will cause the header progress bar to only display a 'Genesis sync' status when the synced height is zero/undefined, but a remote block height is known.

## Related Issue

https://github.com/penumbra-zone/web/issues/2064

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
