### PR TITLE
minifront: reduce status stream timeout

### DIFF
--- a/.changeset/friendly-mugs-push.md
+++ b/.changeset/friendly-mugs-push.md
@@ -1,0 +1,5 @@
+---
+'minifront': minor
+---
+
+reduce status stream timeout

--- a/apps/minifront/src/fetchers/status.ts
+++ b/apps/minifront/src/fetchers/status.ts
@@ -11,7 +11,7 @@ export const getInitialStatus = async (opt?: CallOptions): Promise<PlainMessage<
   toPlainMessage(await penumbra.service(ViewService).status({}, opt));
 
 /**
- * Stream status updates. Default timeout of 30 seconds unless specified.
+ * Stream status updates. Default timeout of 15 seconds unless specified.
  *
  * @param opt connectrpc call options
  */
@@ -20,7 +20,7 @@ export async function* getStatusStream(
 ): AsyncGenerator<PlainMessage<StatusStreamResponse>> {
   for await (const item of penumbra
     .service(ViewService)
-    .statusStream({}, { timeoutMs: 30_000, ...opt })) {
+    .statusStream({}, { timeoutMs: 15_000, ...opt })) {
     yield toPlainMessage(item);
   }
 }


### PR DESCRIPTION
## Description of Changes

reverts https://github.com/penumbra-zone/web/pull/2080/commits/7fa28d100c8c6be9c92c24a643e33be0fa0d9955

I think the timeout may be too long — I can't consistently replicate the behavior I was seeing in https://github.com/penumbra-zone/web/pull/2080#discussion_r1974112717 which the user should be actively seeing while the status stream attempts to self-correct.

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
