### PR TITLE
build: make zip file exports deterministic

### DIFF
--- a/scripts/build-for-deployment.sh
+++ b/scripts/build-for-deployment.sh
@@ -29,12 +29,16 @@ while getopts "o:r:" opt; do
 done
 
 cd "$REPO_ROOT" || exit 2
+pnpm install
 pnpm build
 
 cd "$REPO_ROOT/apps/minifront/dist" || exit 2
-zip -r minifront.zip ./*
+# clobber timestamps for the input files to unix epoch, for reproducible zip files.
+find . -type f -exec touch -t 197001010000.00 {} +
+zip -r -X minifront.zip ./*
 mv minifront.zip "${OUTPUT_DIR}"
 
 cd "$REPO_ROOT/apps/node-status/dist" || exit 2
-zip -r node-status.zip ./*
+find . -type f -exec touch -t 197001010000.00 {} +
+zip -r -X node-status.zip ./*
 mv node-status.zip "${OUTPUT_DIR}"


### PR DESCRIPTION
## Description of Changes



As long as the zip files are exported from the same git commit, the resulting archives should be byte-for-byte identical. Having fully reproducible builds will require comprehensive dependency pinning, e.g. via nix flake or similar, to ensure that the wasm artifacts are built identically, but for now, simply clobbering the timestamps of the exported asset files provides decent reproducibility.


## Related Issue

No request in an issue, simply making opportunistic improvements, as with #2056. Was motivated to try this while updating the bundled assets in https://github.com/penumbra-zone/penumbra/pull/5119. 

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.

^ N/A, as this script only makes changes to build scripts, not to app code.
