### PR TITLE
feat: minifront_version_in_footer_is_a_broken_link

### DIFF
--- a/apps/minifront/src/utils/commit-info-vite-plugin.ts
+++ b/apps/minifront/src/utils/commit-info-vite-plugin.ts
@@ -11,9 +11,9 @@ export const commitInfoPlugin = (): Plugin => {
     .trim()
     .replace(/\.git$/, ''); // Origin urls often appended with .git
 
-    if (gitOriginUrl.startsWith('git@github.com:')) {
-      gitOriginUrl = gitOriginUrl.replace('git@github.com:', 'https://github.com/');
-    }
+  if (gitOriginUrl.startsWith('git@github.com:')) {
+    gitOriginUrl = gitOriginUrl.replace('git@github.com:', 'https://github.com/');
+  }
   return {
     name: 'vite-plugin-commit-info',
     enforce: 'pre',

--- a/apps/minifront/src/utils/commit-info-vite-plugin.ts
+++ b/apps/minifront/src/utils/commit-info-vite-plugin.ts
@@ -6,11 +6,14 @@ import { execSync } from 'child_process';
 export const commitInfoPlugin = (): Plugin => {
   const commitHash = execSync('git rev-parse HEAD').toString().trim();
   const commitDate = execSync('git log -1 --format=%cI').toString().trim();
-  const gitOriginUrl = execSync('git remote get-url origin')
+  let gitOriginUrl = execSync('git remote get-url origin')
     .toString()
     .trim()
     .replace(/\.git$/, ''); // Origin urls often appended with .git
 
+    if (gitOriginUrl.startsWith('git@github.com:')) {
+      gitOriginUrl = gitOriginUrl.replace('git@github.com:', 'https://github.com/');
+    }
   return {
     name: 'vite-plugin-commit-info',
     enforce: 'pre',


### PR DESCRIPTION
## Description of Changes

I did some research and found that the "GIT_ORIGIN_URL" variable gets its value from "execSync('git remote get-url origin')". This works fine when the repo is cloned using HTTPS, but if it's cloned via SSH, it returns something like [git@github.com](mailto:git@github.com):username/reponame. When this SSH URL is used in an tag, the browser treats it as a relative URL, which is why it gets prefixed with "http://localhost/:.."

To fix this, I detect the fetched URL, and if it is in SSH format, I convert it to the corresponding HTTPS format.

Please provide a clear and concise description of the changes made in this PR.
For UI changes, include images or videos to show the visual impact.

## Related Issue
Closes #2057 
Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
