### PR TITLE
Session improvements

### DIFF
--- a/.changeset/forty-buckets-know.md
+++ b/.changeset/forty-buckets-know.md
@@ -1,0 +1,12 @@
+---
+'@penumbra-zone/transport-chrome': major
+---
+
+significant updates to sessions:
+
+- improvement of session-client
+- session-client can now be terminated by static method
+- improvement of session-manager
+- individual session logic now encapsulated in dedicated class
+- session-manager killOrigin returns set of senders
+- session-manager now primarily concerned with port lifecycles

--- a/packages/transport-chrome/docs/sessions.md
+++ b/packages/transport-chrome/docs/sessions.md
@@ -1,0 +1,128 @@
+# Sessions
+
+The classes `CRSessionClient` and `CRSessionManager` provide a way to adapt a `@penumbra-zone/transport-dom` channel transport to the Chrome extension runtime.
+
+The high-level `CRSessionManager` is used as a singleton in the extension's background worker. A `CRSessionClient` is created for each client connection, providing a `MessagePort` that can be used by DOM channel transports.
+
+The class `CRSession` is used by `CRSessionManager` to encapsulate individual client sessions, handling request processing and response delivery.
+
+## Session Lifecycle
+
+The session lifecycle involves `CRSessionManager` (Manager) and `CRSession` (Session) on the extension side, and `CRSessionClient` (Client) on the document side.
+
+### Initialization
+
+1. The extension initializes a Manager with a service entry function, a client validation callback, and a `managerId`.
+2. Manager attaches an `onConnect` handler to respond to incoming connection attempts.
+3. **async then Client**
+4. A document is navigated, and a content script provides some way to request a session.
+5. The document requests a session.
+6. The content script creates a `MessageChannel` using `CRSessionClient.init(managerId)`, which returns a `MessagePort`.
+7. One `MessagePort` is provided to the document for creation of a channel transport, while the other is retained by the `CRSessionClient`.
+8. Client calls `chrome.runtime.connect({name: sessionName})` and obtains a `chrome.runtime.Port`.
+9. Client attaches handlers to the `chrome.runtime.Port` for bidirectional communication.
+10. **async then Manager**
+11. The Manager's `onConnect` listener activates and receives the connection.
+12. Manager performs basic synchronous validation (checking name format and origin).
+13. Manager creates a new `CRSession` instance with the port.
+14. The Session attaches message listeners immediately to avoid missing messages.
+15. Asynchronous port validation begins, blocking handler execution, but not blocking message reception.
+16. **async**
+
+The Session is now in charge of the connection with the Client.
+
+Enter any other phase.
+
+### Communication
+
+#### MethodKind.Unary
+
+1. Client sends a `TransportMessage` with a new request ID
+2. **async then Manager**
+3. Session receives the message
+4. Session obtains a response message from the service
+5. Session sends a `TransportMessage` response to the client
+6. **async then Client**
+7. Client receives the `TransportMessage`
+8. Client forwards the `TransportMessage`
+
+Enter any other phase.
+
+#### MethodKind.ServerStreaming
+
+1. Client sends a `TransportMessage` with a new request ID
+2. **async then Manager**
+3. Session receives the message
+4. Session obtains a response stream from the service
+5. Session sinks the stream into a `PortStreamSink`
+6. Session sends a `TransportInitChannel` response to the Client
+7. **async then Client**
+8. Client receives the `TransportInitChannel`
+9. Client sources the stream from a `PortStreamSource`
+10. Client forwards a `TransportStream`
+
+Enter any other phase.
+
+#### MethodKind.ClientStreaming, MethodKind.BidiStreaming
+
+Support for client-streaming methods is experimental, and disabled unless `globalThis.__DEV__` is truthy.
+
+1. Client creates a unique stream channel name.
+2. Client sets up an `onConnect` listener for the stream subchannel.
+3. Client sends a `TransportInitChannel` message with the channel name.
+4. Client waits for the service to connect to this subchannel.
+5. **async then Manager**
+6. Session receives the `TransportInitChannel` message.
+7. Session uses the stream channel name to connect to the client's offered subchannel.
+8. Session creates a `PortStreamSource` to receive the stream data.
+9. Session passes the `ReadableStream` to the service handler.
+10. The service processes the client stream and may produce a response.
+
+### Termination
+
+#### Success: Client destroyed
+
+1. The client is destroyed.
+2. **async then Manager**
+3. Session's `onDisconnect` handler activates.
+4. The Session is aborted.
+
+Complete.
+
+#### Failure: Validation Error
+
+1. The validation promise of a Session is rejected (port fails validation).
+2. The Session is aborted with an Unauthenticated error code.
+3. The port is disconnected.
+4. **async then Client**
+5. Client's `onDisconnect` handler activates.
+6. The Client attempts to reconnect.
+7. If validation continues to fail, the client will eventually stop.
+
+# TODO: investigate behavior
+
+Complete.
+
+#### Failure: Origin Killed
+
+1. Manager calls `killOrigin()` on the `CRSessionManager`
+2. Manager aborts all sessions from that origin
+3. Manager aborts all connections with that origin
+4. **async then Client** (for each affected client)
+5. Each client's `onDisconnect` handler activates
+6. Each client attempts to reconnect.
+
+# TODO: investigate behavior
+
+Complete.
+
+#### Reconnection
+
+1. The extension worker is killed or the connection is otherwise lost.
+2. **async then Client**
+3. Client's `onDisconnect` handler activates.
+4. Client triggers the reconnect process.
+5. Client creates a new port with `chrome.runtime.connect()` using the same session name.
+6. The extension worker is re-initialized to handle the incoming connection.
+
+Enter Initialization phase.

--- a/packages/transport-chrome/package.json
+++ b/packages/transport-chrome/package.json
@@ -36,7 +36,8 @@
     "@bufbuild/protobuf": "^1.10.0",
     "@connectrpc/connect": "^1.4.0",
     "@penumbra-zone/transport-dom": "workspace:*",
-    "@types/chrome": "^0.0.268"
+    "@types/chrome": "^0.0.268",
+    "exponential-backoff": "^3.1.2"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.10.0",

--- a/packages/transport-chrome/package.json
+++ b/packages/transport-chrome/package.json
@@ -36,8 +36,7 @@
     "@bufbuild/protobuf": "^1.10.0",
     "@connectrpc/connect": "^1.4.0",
     "@penumbra-zone/transport-dom": "workspace:*",
-    "@types/chrome": "^0.0.268",
-    "exponential-backoff": "^3.1.2"
+    "@types/chrome": "^0.0.268"
   },
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.10.0",

--- a/packages/transport-chrome/src/channel-names.ts
+++ b/packages/transport-chrome/src/channel-names.ts
@@ -68,3 +68,8 @@ export const parseConnectionName = (prefix: string, name: string) => {
     uuid,
   };
 };
+
+export const parseConnectionId = (label: ChannelLabel, prefix: string, name: string) => {
+  const parsed = parseConnectionName(prefix, name);
+  return parsed?.label === label ? parsed.uuid : undefined;
+};

--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -17,6 +17,8 @@ Object.assign(CRSessionClient, {
   clearSingleton() {
     // @ts-expect-error -- manipulating private property
     CRSessionClient.singleton = undefined;
+    // @ts-expect-error -- manipulating private property
+    CRSessionClient.managerId = undefined;
   },
 });
 

--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -451,7 +451,7 @@ describe('CRSessionClient', () => {
       await expectChannelClosed(sessionPort, extPort, domPort);
     });
 
-    it('reconnects silently if the port is disconnected by something else', async () => {
+    it.fails('reconnects silently if the port is disconnected by something else', async () => {
       const testRequest: TransportMessage = { message: 'hello', requestId: '123' };
 
       expectNoActivity(sessionPort, extPort, domMessageHandler);
@@ -492,7 +492,7 @@ describe('CRSessionClient', () => {
       );
     });
 
-    it.fails('reconnects for new requests if necessary', async () => {
+    it('reconnects for new requests if necessary', async () => {
       const testRequest: TransportMessage = { message: 'hello', requestId: '123' };
 
       expectNoActivity(sessionPort, extPort, domMessageHandler);
@@ -539,7 +539,7 @@ describe('CRSessionClient', () => {
       expect(mockedChannel.onConnect.dispatch).toHaveBeenCalledTimes(2);
     });
 
-    it.fails('kills the transport if the session experiences context loss', async () => {
+    it('kills the transport if the session experiences context loss', async () => {
       const transportError = {
         requestId: undefined,
         error: { code: 'unavailable', message: 'Extension context invalidated.' },

--- a/packages/transport-chrome/src/session-client.test.ts
+++ b/packages/transport-chrome/src/session-client.test.ts
@@ -295,7 +295,7 @@ describe('CRSessionClient', () => {
           expect(domMessageErrorHandler).not.toHaveBeenCalled();
         });
 
-        it('does not respond', async () => {
+        it.fails('does not respond', async () => {
           domPort.postMessage(badRequest);
 
           // can't wait for the absence of an event, so just give it a moment
@@ -337,7 +337,7 @@ describe('CRSessionClient', () => {
           }
         });
 
-        it.fails('responds with failure, and kills the session if not an event', async () => {
+        it('responds with failure, and kills the session if not an event', async () => {
           domPort.postMessage(badRequest);
 
           const badRequestHasId =
@@ -427,7 +427,7 @@ describe('CRSessionClient', () => {
       await expectChannelClosed(sessionPort, extPort, domPort);
     });
 
-    it('sends `false` to dom when the port is disconnected by something else', async () => {
+    it.fails('sends `false` to dom when the port is disconnected by something else', async () => {
       expectNoActivity(sessionPort, extPort, domMessageHandler);
 
       // extension-side disconnect

--- a/packages/transport-chrome/src/session-client.ts
+++ b/packages/transport-chrome/src/session-client.ts
@@ -193,12 +193,12 @@ export class CRSessionClient {
       } else {
         this.signal.throwIfAborted();
 
+        // reconnect, if disconnected.
+        this.servicePort ??= this.connect();
+
         // begin handling the event
         const tev = ev.data;
         try {
-          // reconnect, if disconnected.
-          this.servicePort ??= this.connect();
-
           if (isTransportAbort(tev)) {
             // abort control for some request
             this.postAbort(tev);

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -1,253 +1,258 @@
-import { ConnectError } from '@connectrpc/connect';
-import { errorToJson } from '@connectrpc/connect/protocol-connect';
-import { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
-import {
-  isTransportAbort,
-  isTransportMessage,
-  TransportError,
-  TransportMessage,
-  TransportStream,
-} from '@penumbra-zone/transport-dom/messages';
-import { ChannelLabel, nameConnection, parseConnectionName } from './channel-names.js';
-import type { TransportInitChannel } from './message.js';
+import type { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
+import { ChannelLabel, parseConnectionName } from './channel-names.js';
+import { CRSession } from './session.js';
 import { PortStreamSink } from './stream/sink.js';
+import { PortStreamSource } from './stream/source.js';
+import {
+  assertMatchingSenders,
+  assertPortWithSenderOrigin,
+  isPortWithSenderOrigin,
+} from './util/senders.js';
 
-interface CRSession {
-  abort: AbortController['abort'];
-  signal: AbortSignal;
-  sessionId: string;
-  verifiedPort: ReturnType<ValidateSenderFn>;
-  sender: chrome.runtime.MessageSender;
-  origin: string;
-  requests: Map<string, AbortController>;
+export interface ManagedPort {
+  port: chrome.runtime.Port & { sender: { origin: string } };
+  portAc: AbortController;
 }
 
-type PortWithSenderOrigin = chrome.runtime.Port & {
-  sender: chrome.runtime.MessageSender & { origin: string };
-};
-
-const isPortWithSenderOrigin = (p?: chrome.runtime.Port): p is PortWithSenderOrigin =>
-  Boolean(p?.sender?.origin);
-
-export type ValidateSenderFn = (port: chrome.runtime.Port) => Promise<PortWithSenderOrigin>;
+export type ValidateSessionPortFn = (port: chrome.runtime.Port) => Promise<chrome.runtime.Port>;
 
 /**
  * Only for use as an extension-level singleton by the extension's main
  * background worker.
  *
+ * The extension might want to revoke permission of an origin, and kill all of
+ * that origin's connections immediately. It's simplest to provide a revoke
+ * method on the static class.
+ *
+ * Connection approval is provided by an async callback, which is used to
+ * validate each new port's sender. Message listeners are attached before async
+ * execution, so incoming requests are not dropped. Handling should only execute
+ * if approval resolves succesfully.
+ *
  * Currently this supports
- * - connections from content scripts (and thus webpages)
- * - connections from pages in this extension
- * - connections from workers in this extension
+ * - connections from content scripts (dapp pages)
+ * - connections from internal extension pages
+ * - connections from internal extension workers
  *
  * This does not support
- * - connections from a script back to itself
+ * - connections from this same worker back to itself
+ *
+ * If you are connecting from the same worker in which you init this manager,
+ * you cannot construct a session client capable of connecting to this manager.
+ * The `createDirectClient` export of `@penumbra-zone/transport-dom/direct` is
+ * more suitable.
  *
  * In the future we may want to support
- * - connections directly from webpages
+ * - connections directly from dapp pages
  * - connections from native applications
  * - connections from other extensions
- *
- * If you are connecting from the same worker running this script (currently,
- * service-to-service communication) you cannot make a `chrome.runtime.connect`
- * call that activates this manager, and you should use normal DOM messaging to
- * enter your router.
  */
 
 export class CRSessionManager {
   private static singleton?: CRSessionManager;
-  private sessions = new Map<string, CRSession>();
 
   /**
-   * Create a new session manager to accept connections from `CRSessionClient`.
-   *
-   * @param prefix a string containing no spaces, matching the prefix used in your content script
-   * @param handler your router entry function
-   * @param validateSender a function used to validate the sender of a connection
-   */
-  private constructor(
-    private readonly prefix: string,
-    private readonly handler: ChannelHandlerFn,
-    private readonly validateSender: ValidateSenderFn,
-  ) {
-    if (CRSessionManager.singleton) {
-      throw new Error('Already constructed');
-    }
-    CRSessionManager.singleton = this;
-    chrome.runtime.onConnect.addListener(this.transportConnection);
-  }
-
-  /**
-   * Initialize the singleton session manager.
+   * Initialize the singleton session manager, or return the existing singleton.
    *
    * @param managerId a string identifying this manager
    * @param handler your router entry function
-   * @param validateSender function to assert validity of a sender
+   * @param validateSessionPort callback to assert validity of a connection
    */
   public static init = (
     managerId: string,
     handler: ChannelHandlerFn,
-    validateSender: ValidateSenderFn,
-  ) => {
-    CRSessionManager.singleton ??= new CRSessionManager(managerId, handler, validateSender);
+    validateSessionPort: ValidateSessionPortFn,
+  ): ReadonlyMap<string, CRSession> => {
+    CRSessionManager.singleton ??= new CRSessionManager(managerId, handler, validateSessionPort);
+    if (
+      CRSessionManager.singleton.managerId !== managerId ||
+      CRSessionManager.singleton.handler !== handler ||
+      CRSessionManager.singleton.validateSessionPort !== validateSessionPort
+    ) {
+      throw new Error("Init parameters don't match singleton parameters");
+    }
     return CRSessionManager.singleton.sessions;
   };
 
-  /**
-   * Abort all sessions from a given origin presently active in the singleton.
-   *
-   * @param targetOrigin the origin to kill
-   */
-  public static killOrigin = (targetOrigin: string) => {
-    if (CRSessionManager.singleton) {
-      CRSessionManager.singleton.sessions.forEach(session => {
-        if (session.origin === targetOrigin) {
-          session.abort();
-        }
-      });
-    } else {
-      throw new Error('No session manager');
-    }
-  };
+  private ports = new Map<chrome.runtime.Port, AbortController>();
+  private sessions = new Map<string, CRSession>();
+  private constructor(
+    public readonly managerId: string,
+    public readonly handler: ChannelHandlerFn,
+    public readonly validateSessionPort: ValidateSessionPortFn,
+  ) {
+    CRSessionManager.assertUninitialized();
+    CRSessionManager.singleton = this;
+    chrome.runtime.onConnect.addListener(this.transportConnection);
+  }
 
   /**
    * This handler is called when a new connection is opened from any document
    * with access to the chrome runtime.
    *
    * Here we make an effort to identify these connections. If the name indicates
-   * the connection is for this manager, a handler is connected to the port.
+   * the connection is for this manager, handlers are connected to the port.
    */
-  private transportConnection = (port: chrome.runtime.Port) => {
-    // require an identified origin
-    if (!isPortWithSenderOrigin(port)) {
-      return;
-    }
+  private transportConnection = (unvalidatedPort: chrome.runtime.Port) => {
+    if (
+      // quick check for a name indicating this manager
+      unvalidatedPort.name.startsWith(this.managerId) &&
+      // require an origin
+      isPortWithSenderOrigin(unvalidatedPort)
+    ) {
+      // parse the name
+      const { label: channelLabel, uuid: sessionId } =
+        parseConnectionName(this.managerId, unvalidatedPort.name) ?? {};
+      if (channelLabel === ChannelLabel.TRANSPORT && sessionId) {
+        if (this.sessions.has(sessionId)) {
+          // client is re-using a present session??
+          // don't disconnect the port, just leave it hanging
+          throw new Error(`Session collision: ${sessionId}`);
+        }
 
-    // fast and simple name test
-    if (!port.name.startsWith(this.prefix)) {
-      return;
-    }
-
-    // parse the name
-    const { label: channelLabel, uuid: clientId } =
-      parseConnectionName(this.prefix, port.name) ?? {};
-    if (channelLabel !== ChannelLabel.TRANSPORT || !clientId) {
-      return;
-    }
-
-    if (this.sessions.has(clientId)) {
-      throw new Error(`Session collision: ${clientId}`);
-    }
-
-    // checking port sender is async, but listeners must attach immediately
-    this.attachListeners(port, this.validateSender(port), clientId);
-  };
-
-  private attachListeners = (
-    unverifiedPort: PortWithSenderOrigin,
-    verifiedPort: Promise<PortWithSenderOrigin>,
-    sessionId: string,
-  ) => {
-    const sender = unverifiedPort.sender;
-
-    const ac = new AbortController();
-    const session: CRSession = {
-      abort: (r?: unknown) => ac.abort(r),
-      signal: ac.signal,
-      sessionId,
-      origin: sender.origin,
-      sender,
-      verifiedPort,
-      requests: new Map(),
-    };
-
-    this.sessions.set(sessionId, session);
-
-    session.signal.addEventListener('abort', () => {
-      unverifiedPort.disconnect();
-      session.requests.forEach(request => request.abort(session.signal.reason));
-      this.sessions.delete(sessionId);
-    });
-    unverifiedPort.onDisconnect.addListener(() => session.abort());
-
-    unverifiedPort.onMessage.addListener(
-      (i: unknown) =>
-        void verifiedPort.then(p => {
-          try {
-            if (isTransportAbort(i)) {
-              session.requests.get(i.requestId)?.abort();
-            } else if (isTransportMessage(i)) {
-              void this.clientMessageHandler(session, i).then(res => p.postMessage(res));
-            } else {
-              console.warn('Unknown item in transport', i);
-            }
-          } catch (e) {
-            session.abort(e);
-          }
-        }),
-    );
-  };
-
-  /**
-   * This method enters the router, and returns a response.
-   *
-   * It expects a single message, so only supports unary requests and
-   * server-streaming requests. This should *always successfully return* a
-   * `TransportEvent`, containing json representing a response or json
-   * representing an error.
-   */
-  private clientMessageHandler(
-    session: CRSession,
-    { requestId, message }: TransportMessage,
-  ): Promise<TransportMessage | TransportInitChannel | TransportError<string | undefined>> {
-    if (session.requests.has(requestId)) {
-      throw new Error(`Request collision: ${requestId}`);
-    }
-    const requestController = new AbortController();
-
-    session.requests.set(requestId, requestController);
-    return this.handler(message, AbortSignal.any([session.signal, requestController.signal]))
-      .then(response =>
-        response instanceof ReadableStream
-          ? this.responseChannelStream(requestController.signal, {
-              requestId,
-              stream: response,
-            })
-          : { requestId, message: response },
-      )
-      .catch((error: unknown) => ({
-        requestId,
-        error: errorToJson(ConnectError.from(error), undefined),
-      }))
-      .finally(() => session.requests.delete(requestId));
-  }
-
-  /**
-   * Streams are not jsonifiable, so this function sinks a response stream
-   * into a dedicated chrome runtime channel, for reconstruction by the
-   * client.
-   *
-   * A jsonifiable message identifying a unique connection name is returned
-   * and should be transported to the client.  The client should open a
-   * connection bearing this name to source the stream.
-   *
-   * TODO: time out if the client fails to initiate a connection
-   */
-  private responseChannelStream(
-    signal: AbortSignal,
-    { requestId, stream }: TransportStream,
-  ): TransportInitChannel {
-    const channel = nameConnection(this.prefix, ChannelLabel.STREAM);
-    const sinkListener = (p: chrome.runtime.Port) => {
-      if (p.name !== channel) {
-        return;
+        // create a new session
+        const session = new CRSession(
+          this,
+          this.trackPort(unvalidatedPort),
+          this.validateSessionPort(unvalidatedPort),
+        );
+        this.sessions.set(sessionId, session);
+        session.signal.addEventListener('abort', () => this.sessions.delete(sessionId));
       }
-      chrome.runtime.onConnect.removeListener(sinkListener);
-      void stream
-        .pipeTo(new WritableStream(new PortStreamSink(p)), { signal })
-        .catch((e: unknown) => console.debug('session-manager makeChannelStreamResponse', e));
-    };
-    chrome.runtime.onConnect.addListener(sinkListener);
-    return { requestId, channel };
+    }
+  };
+
+  /**
+   * Kill all connections with a given origin.
+   *
+   * @param targetOrigin the origin to kill
+   */
+  public static killOrigin(targetOrigin: string) {
+    for (const [port, ac] of CRSessionManager.assertInitialized().ports.entries()) {
+      if (port.sender?.origin === targetOrigin) {
+        ac.abort();
+      }
+    }
   }
+
+  private trackPort(
+    port: chrome.runtime.Port & { sender: { origin: string } },
+    portAc = new AbortController(),
+  ): ManagedPort {
+    if (this.ports.has(port)) {
+      throw new Error('Port already tracked');
+    } else {
+      port.onDisconnect.addListener(() => {
+        if (this.ports.delete(port)) {
+          portAc.abort();
+        }
+      });
+
+      portAc.signal.addEventListener('abort', () => {
+        if (this.ports.delete(port)) {
+          port.disconnect();
+        }
+      });
+
+      this.ports.set(port, portAc);
+
+      portAc.signal.throwIfAborted();
+      return { port, portAc };
+    }
+  }
+
+  /**
+   * Wrapped `chrome.runtime.connect` for sessions to accept stream
+   * sub-channels, for incoming streaming requests.
+   *
+   * @param name the name of the sub-channel
+   * @param expectedSender the expected sender of the connection
+   * @param subAc the abort controller for the sub-channel
+   * @returns a `PortStreamSource` from a validated sender
+   */
+  public async acceptSubChannel(
+    name: string,
+    expectedSender: chrome.runtime.MessageSender,
+    subAc = new AbortController(),
+  ): Promise<PortStreamSource> {
+    const unvalidatedPort = expectedSender.tab?.id
+      ? chrome.tabs.connect(expectedSender.tab.id, { name })
+      : chrome.runtime.connect({ name });
+
+    assertMatchingSenders(expectedSender, unvalidatedPort.sender);
+    const unvalidatedSource = new PortStreamSource(unvalidatedPort);
+
+    const validSource = this.validateSessionPort(unvalidatedPort).then(
+      validPort => {
+        this.trackPort(assertPortWithSenderOrigin(validPort), subAc);
+        return unvalidatedSource; // now valid
+      },
+      (cause: unknown) => {
+        console.debug('invalid source', cause);
+        unvalidatedPort.disconnect();
+        unvalidatedSource.cancel(cause);
+        throw cause;
+      },
+    );
+
+    return validSource;
+  }
+
+  /**
+   * Wrapped `chrome.runtime.onConnect` for sessions to offer stream
+   * sub-channels, for outgoing streaming responses.
+   *
+   * The caller must independently convey the channel name.
+   *
+   * @param name the name of the sub-channel
+   * @param expectedSender the expected sender of the connection
+   * @param subAc optional pre-existing abort controller
+   * @returns a `PortStreamSink` to a validated sender
+   */
+  public async offerSubChannel(
+    name: string,
+    expectedSender: chrome.runtime.MessageSender,
+    subAc = new AbortController(),
+  ): Promise<PortStreamSink> {
+    const { promise: validSink, resolve, reject } = Promise.withResolvers<PortStreamSink>();
+
+    const sinkListener = (unvalidatedPort: chrome.runtime.Port) => {
+      // expect a port with the given channel name
+      if (unvalidatedPort.name === name) {
+        chrome.runtime.onConnect.removeListener(sinkListener);
+        assertMatchingSenders(expectedSender, unvalidatedPort.sender);
+        const unvalidatedSink = new PortStreamSink(unvalidatedPort);
+        this.validateSessionPort(unvalidatedPort).then(
+          validPort => {
+            this.trackPort(assertPortWithSenderOrigin(validPort), subAc);
+            resolve(unvalidatedSink);
+          },
+          cause => {
+            if (globalThis.__DEV__) {
+              console.debug('offerSubChannel invalid port', unvalidatedPort.name, cause);
+            }
+            unvalidatedPort.disconnect();
+            reject(cause);
+          },
+        );
+      }
+    };
+
+    chrome.runtime.onConnect.addListener(sinkListener);
+
+    return validSink;
+  }
+
+  private static assertInitialized = () => {
+    if (!CRSessionManager.singleton) {
+      throw new Error('Not initialized');
+    }
+    return CRSessionManager.singleton;
+  };
+
+  private static assertUninitialized = () => {
+    if (CRSessionManager.singleton) {
+      throw new Error('Already initialized');
+    }
+  };
 }

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -128,16 +128,22 @@ export class CRSessionManager {
   };
 
   /**
-   * Kill all connections with a given origin.
+   * Kill all connections with a given origin. Returns the collection of senders
+   * associated with the killed sessions, for further cleanup.
    *
    * @param targetOrigin the origin to kill
    */
   public static killOrigin(targetOrigin: string) {
-    for (const [port, ac] of CRSessionManager.assertInitialized().ports.entries()) {
-      if (port.sender?.origin === targetOrigin) {
-        ac.abort();
+    const killed = new Set<chrome.runtime.MessageSender>();
+
+    for (const session of CRSessionManager.assertInitialized().sessions.values()) {
+      if (session.sender.origin === targetOrigin) {
+        session.abort();
+        killed.add(session.sender);
       }
     }
+
+    return killed;
   }
 
   private trackPort(

--- a/packages/transport-chrome/src/session-manager.ts
+++ b/packages/transport-chrome/src/session-manager.ts
@@ -1,5 +1,5 @@
 import type { ChannelHandlerFn } from '@penumbra-zone/transport-dom/adapter';
-import { ChannelLabel, parseConnectionName } from './channel-names.js';
+import { ChannelLabel, parseConnectionId } from './channel-names.js';
 import { CRSession } from './session.js';
 import { PortStreamSink } from './stream/sink.js';
 import { PortStreamSource } from './stream/source.js';
@@ -8,10 +8,13 @@ import {
   assertPortWithSenderOrigin,
   isPortWithSenderOrigin,
 } from './util/senders.js';
+import { JsonValue } from '@bufbuild/protobuf';
 
 export interface ManagedPort {
-  port: chrome.runtime.Port & { sender: { origin: string } };
-  portAc: AbortController;
+  abort: AbortController['abort'];
+  signal: AbortSignal;
+  unvalid: chrome.runtime.Port & { sender: { origin: string } };
+  valid: Promise<chrome.runtime.Port>;
 }
 
 export type ValidateSessionPortFn = (port: chrome.runtime.Port) => Promise<chrome.runtime.Port>;
@@ -75,7 +78,7 @@ export class CRSessionManager {
     return CRSessionManager.singleton.sessions;
   };
 
-  private ports = new Map<chrome.runtime.Port, AbortController>();
+  private ports = new Map<string, ManagedPort>();
   private sessions = new Map<string, CRSession>();
   private constructor(
     public readonly managerId: string,
@@ -84,10 +87,10 @@ export class CRSessionManager {
   ) {
     CRSessionManager.assertUninitialized();
     CRSessionManager.singleton = this;
-    chrome.runtime.onConnect.addListener(this.transportConnection);
+    chrome.runtime.onConnect.addListener(this.onConnect);
 
     if (globalThis.__DEV__) {
-      console.debug('CRSessionManager sessions', this.sessions);
+      console.debug('CRSessionManager', this);
     }
   }
 
@@ -98,31 +101,30 @@ export class CRSessionManager {
    * Here we make an effort to identify these connections. If the name indicates
    * the connection is for this manager, handlers are connected to the port.
    */
-  private transportConnection = (unvalidatedPort: chrome.runtime.Port) => {
-    if (
-      // quick check for a name indicating this manager
-      unvalidatedPort.name.startsWith(this.managerId) &&
-      // require an origin
-      isPortWithSenderOrigin(unvalidatedPort)
-    ) {
-      // parse the name
-      const { label: channelLabel, uuid: sessionId } =
-        parseConnectionName(this.managerId, unvalidatedPort.name) ?? {};
-      if (channelLabel === ChannelLabel.TRANSPORT && sessionId) {
-        if (this.sessions.has(sessionId)) {
-          // client is re-using a present session??
-          // don't disconnect the port, just leave it hanging
-          throw new Error(`Session collision: ${sessionId}`);
-        }
+  private onConnect = (attempt: chrome.runtime.Port) => {
+    const sessionId =
+      isPortWithSenderOrigin(attempt) &&
+      parseConnectionId(ChannelLabel.TRANSPORT, this.managerId, attempt.name);
 
+    if (sessionId) {
+      if (this.sessions.has(sessionId)) {
+        // client is re-using a present session??
+        // don't disconnect the port, just leave it hanging
+        throw new Error(`Session collision: ${sessionId}`, {
+          cause: { sessionId, attempt, existing: this.sessions.get(sessionId) },
+        });
+      }
+
+      try {
         // create a new session
-        const session = new CRSession(
-          this,
-          this.trackPort(unvalidatedPort),
-          this.validateSessionPort(unvalidatedPort),
-        );
+        const session = new CRSession(this, this.trackPort(attempt));
         this.sessions.set(sessionId, session);
         session.signal.addEventListener('abort', () => this.sessions.delete(sessionId));
+      } catch (e) {
+        if (globalThis.__DEV__) {
+          console.debug('Session init failed', e);
+        }
+        attempt.disconnect();
       }
     }
   };
@@ -136,6 +138,7 @@ export class CRSessionManager {
   public static killOrigin(targetOrigin: string) {
     const killed = new Set<chrome.runtime.MessageSender>();
 
+    // kill sessions
     for (const session of CRSessionManager.assertInitialized().sessions.values()) {
       if (session.sender.origin === targetOrigin) {
         session.abort();
@@ -143,32 +146,71 @@ export class CRSessionManager {
       }
     }
 
+    // kill lingering subchannels
+    for (const port of CRSessionManager.assertInitialized().ports.values()) {
+      if (port.unvalid.sender.origin === targetOrigin) {
+        console.warn('subchannel not killed by session', port.unvalid.name);
+        port.abort();
+        killed.add(port.unvalid.sender);
+      }
+    }
+
     return killed;
   }
 
-  private trackPort(
-    port: chrome.runtime.Port & { sender: { origin: string } },
-    portAc = new AbortController(),
-  ): ManagedPort {
-    if (this.ports.has(port)) {
-      throw new Error('Port already tracked');
-    } else {
+  private trackPort(port: chrome.runtime.Port, ac = new AbortController()): ManagedPort {
+    if (globalThis.__DEV__) {
+      console.debug('trackPort', port.name);
+    }
+
+    try {
+      ac.signal.throwIfAborted();
+
+      if (this.ports.has(port.name)) {
+        throw new Error('Port already tracked', { cause: port.name });
+      }
+
       port.onDisconnect.addListener(() => {
-        if (this.ports.delete(port)) {
-          portAc.abort();
+        if (globalThis.__DEV__) {
+          console.debug('trackPort onDisconnect', port.name);
+        }
+        if (this.ports.delete(port.name)) {
+          if (globalThis.__DEV__) {
+            console.debug('trackPort onDisconnect aborting', port.name);
+          }
+          ac.abort();
         }
       });
 
-      portAc.signal.addEventListener('abort', () => {
-        if (this.ports.delete(port)) {
+      ac.signal.addEventListener('abort', () => {
+        if (globalThis.__DEV__) {
+          console.debug('trackPort signal', port.name);
+        }
+        if (this.ports.delete(port.name)) {
+          if (globalThis.__DEV__) {
+            console.debug('trackPort signal disconnecting', port.name);
+          }
           port.disconnect();
         }
       });
 
-      this.ports.set(port, portAc);
+      const managedPort: ManagedPort = {
+        abort: (r: unknown) => ac.abort(r),
+        signal: ac.signal,
+        unvalid: assertPortWithSenderOrigin(port),
+        valid: this.validateSessionPort(port),
+      };
 
-      portAc.signal.throwIfAborted();
-      return { port, portAc };
+      this.ports.set(port.name, managedPort);
+      return managedPort;
+    } catch (e) {
+      if (globalThis.__DEV__) {
+        console.debug('trackPort failed', port.name, e);
+      }
+      this.ports.delete(port.name);
+      port.disconnect();
+      ac.abort(e);
+      throw e;
     }
   }
 
@@ -181,32 +223,34 @@ export class CRSessionManager {
    * @param subAc the abort controller for the sub-channel
    * @returns a `PortStreamSource` from a validated sender
    */
-  public async acceptSubChannel(
+  public acceptSubChannel(
     name: string,
     expectedSender: chrome.runtime.MessageSender,
-    subAc = new AbortController(),
-  ): Promise<PortStreamSource> {
-    const unvalidatedPort = expectedSender.tab?.id
+    requestAc = new AbortController(),
+  ): Promise<ReadableStream<JsonValue>> {
+    const {
+      promise: validStream,
+      resolve,
+      reject,
+    } = Promise.withResolvers<ReadableStream<JsonValue>>();
+
+    requestAc.signal.addEventListener('abort', () => reject(requestAc.signal.reason));
+
+    // open a port with the given channel name
+    const attempt = expectedSender.tab?.id
       ? chrome.tabs.connect(expectedSender.tab.id, { name })
       : chrome.runtime.connect({ name });
 
-    assertMatchingSenders(expectedSender, unvalidatedPort.sender);
-    const unvalidatedSource = new PortStreamSource(unvalidatedPort);
+    try {
+      assertMatchingSenders(expectedSender, attempt.sender);
+      const port = this.trackPort(attempt);
+      const stream = new ReadableStream(new PortStreamSource(port.unvalid));
+      void port.valid.then(() => resolve(stream), reject);
+    } catch (e) {
+      reject(e);
+    }
 
-    const validSource = this.validateSessionPort(unvalidatedPort).then(
-      validPort => {
-        this.trackPort(assertPortWithSenderOrigin(validPort), subAc);
-        return unvalidatedSource; // now valid
-      },
-      (cause: unknown) => {
-        console.debug('invalid source', cause);
-        unvalidatedPort.disconnect();
-        unvalidatedSource.cancel(cause);
-        throw cause;
-      },
-    );
-
-    return validSource;
+    return validStream;
   }
 
   /**
@@ -217,41 +261,41 @@ export class CRSessionManager {
    *
    * @param name the name of the sub-channel
    * @param expectedSender the expected sender of the connection
-   * @param subAc optional pre-existing abort controller
+   * @param requestAc optional pre-existing abort controller
    * @returns a `PortStreamSink` to a validated sender
    */
-  public async offerSubChannel(
+  public offerSubChannel(
     name: string,
     expectedSender: chrome.runtime.MessageSender,
-    subAc = new AbortController(),
-  ): Promise<PortStreamSink> {
-    const { promise: validSink, ...validation } = Promise.withResolvers<PortStreamSink>();
+    requestAc = new AbortController(),
+  ): Promise<WritableStream<JsonValue>> {
+    const {
+      promise: validStream,
+      resolve,
+      reject,
+    } = Promise.withResolvers<WritableStream<JsonValue>>();
 
-    const sinkListener = (unvalidatedPort: chrome.runtime.Port) => {
-      // expect a port with the given channel name
-      if (unvalidatedPort.name === name) {
+    requestAc.signal.addEventListener('abort', () => reject(requestAc.signal.reason));
+
+    void validStream.finally(() => chrome.runtime.onConnect.removeListener(sinkListener));
+    const sinkListener = (attempt: chrome.runtime.Port) => {
+      // listen for a port with the given channel name
+      if (attempt.name === name) {
         chrome.runtime.onConnect.removeListener(sinkListener);
-        assertMatchingSenders(expectedSender, unvalidatedPort.sender);
-        const unvalidatedSink = new PortStreamSink(unvalidatedPort);
-        this.validateSessionPort(unvalidatedPort).then(
-          validPort => {
-            this.trackPort(assertPortWithSenderOrigin(validPort), subAc);
-            validation.resolve(unvalidatedSink);
-          },
-          cause => {
-            if (globalThis.__DEV__) {
-              console.debug('offerSubChannel invalid port', unvalidatedPort.name, cause);
-            }
-            unvalidatedPort.disconnect();
-            validation.reject(cause);
-          },
-        );
+
+        try {
+          assertMatchingSenders(expectedSender, attempt.sender);
+          const port = this.trackPort(attempt);
+          const stream = new WritableStream(new PortStreamSink(port.unvalid));
+          void port.valid.then(() => resolve(stream), reject);
+        } catch (e) {
+          reject(e);
+        }
       }
     };
-
     chrome.runtime.onConnect.addListener(sinkListener);
 
-    return validSink;
+    return validStream;
   }
 
   private static assertInitialized = () => {

--- a/packages/transport-chrome/src/session.ts
+++ b/packages/transport-chrome/src/session.ts
@@ -1,0 +1,204 @@
+import type { JsonValue } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { errorToJson } from '@connectrpc/connect/protocol-connect';
+import {
+  isTransportAbort,
+  isTransportEvent,
+  isTransportMessage,
+  type TransportEvent,
+  type TransportError,
+  type TransportMessage,
+} from '@penumbra-zone/transport-dom/messages';
+import { ChannelLabel, nameConnection } from './channel-names.js';
+import { isTransportInitChannel, type TransportInitChannel } from './message.js';
+import type { CRSessionManager, ManagedPort } from './session-manager.js';
+import { suppressDisconnectError } from './util/suppress-disconnect.js';
+import { assertMatchingSenders } from './util/senders.js';
+
+const isReadableStream = (value: unknown): value is ReadableStream =>
+  value instanceof ReadableStream;
+
+/** Listeners, handling, and abort control for a single transport-chrome session. */
+export class CRSession {
+  /** The session port's sender. */
+  public readonly sender: chrome.runtime.MessageSender & { origin: string };
+
+  /** Abort controllers to cancel pending requests, by requestId. */
+  public readonly pending = new Map<string, AbortController>();
+
+  /** Abort signal for the session, bound to the session port. */
+  public readonly signal: AbortSignal;
+
+  /** Abort will close the session channel, close all sub-channels, and cancel all pending requests. */
+  public readonly abort: AbortController['abort'];
+
+  private readonly approved: Promise<chrome.runtime.Port>;
+
+  /**
+   * @param manager the parent session manager
+   * @param unvalidatedPort for immediate listener attach only
+   * @param sessionAc abort controller for the session
+   * @param approved promised port validation (calls manager by default)
+   */
+  constructor(
+    /** the parent session manager */
+    private readonly manager: CRSessionManager,
+    /**
+     * this `unvalidated` port is used to synchronously attach listeners, which
+     * prevents a race against incoming messages. it should not be used to
+     * send messages, and it should not leave this constructor scope.
+     */
+    unvalidated: ManagedPort,
+    /** the `approved` parameter is used to block listener execution until the
+     * port is validated. it should resolve to match the unvalidated port. */
+    managerApproval = manager.validateSessionPort(unvalidated.port),
+  ) {
+    this.signal = unvalidated.portAc.signal;
+    this.abort = r => unvalidated.portAc.abort(r);
+
+    this.signal.addEventListener('abort', () => this.pending.forEach(ac => ac.abort()));
+
+    this.sender = unvalidated.port.sender;
+
+    this.approved = managerApproval.then(p => {
+      assertMatchingSenders(p.sender, unvalidated.port.sender);
+      return p;
+    });
+    void this.approved.catch((disapproval: unknown) =>
+      this.abort(ConnectError.from(disapproval, Code.Unauthenticated)),
+    );
+
+    unvalidated.port.onMessage.addListener(this.onMessage);
+  }
+
+  /**
+   * This listener is attached immediately, but blocks on sender validation.
+   *
+   * Basic filtering and transport control are handled here. Valid requests are
+   * passed to `sessionRequestHandler`, which issues successful responses
+   * independently.
+   *
+   * Failures are caught here and serialized for response.
+   */
+  private onMessage = (tev: unknown) =>
+    void this.approved.then(async () => {
+      try {
+        // unknown event
+        if (!isTransportEvent(tev)) {
+          throw new ConnectError(
+            'Unknown item in transport',
+            Code.Unimplemented,
+            undefined,
+            undefined,
+            tev,
+          );
+        } else if (isTransportAbort(tev)) {
+          // abort control message. no-op if absent
+          this.pending.get(tev.requestId)?.abort();
+          this.pending.delete(tev.requestId);
+        } else if (this.pending.has(tev.requestId)) {
+          // request collision would be very strange
+          throw new ConnectError('Request collision', Code.Internal, undefined, undefined, tev);
+        } else {
+          // begin request lifecycle
+          try {
+            // new request
+            const pendingAc = new AbortController();
+            this.pending.set(tev.requestId, pendingAc);
+
+            const responseInit: TransportEvent = { requestId: tev.requestId };
+            const response = await this.sessionHandler(tev, pendingAc);
+
+            await this.sessionResponder(response, responseInit, pendingAc);
+            // complete
+          } catch (cause) {
+            // failure. attempt to provide an error response
+            await this.postError({
+              requestId: tev.requestId,
+              error: errorToJson(ConnectError.from(cause), undefined),
+            });
+          } finally {
+            this.pending.delete(tev.requestId);
+          }
+          // end request lifecycle
+        }
+      } catch (e) {
+        // something really weird happened
+        console.error('CRSession.onMessage failed', e);
+        // might be sensitive so don't propagate
+        this.abort(ConnectError.from(undefined, Code.Internal));
+      }
+    });
+
+  private async sessionHandler(
+    tev: TransportEvent,
+    pendingAc: AbortController,
+  ): Promise<JsonValue | ReadableStream<JsonValue>> {
+    if (isTransportMessage(tev)) {
+      // handle a message request
+      const { message } = tev;
+      return this.manager.handler(message, pendingAc.signal);
+    } else if (isTransportInitChannel(tev) && globalThis.__DEV__) {
+      // handle a streamng request
+      const { channel } = tev;
+      return this.manager.handler(
+        new ReadableStream(await this.manager.acceptSubChannel(channel, this.sender, pendingAc)),
+        pendingAc.signal,
+      );
+    } else {
+      throw new ConnectError('Unknown request kind', Code.Unimplemented);
+    }
+  }
+
+  /**
+   * Posts a successful response back to the session channel.
+   *
+   * For unary responses, sends a TransportMessage with the response value.
+   * For streaming responses, creates a subchannel for the stream and sends a
+   * TransportInitChannel with the channel name.
+   *
+   * @param response - The response value or stream to send back
+   * @param requestId - The ID of the request being responded to
+   * @param requestAc - Abort controller for the request, used to cancel streaming
+   */
+  private async sessionResponder(
+    response: JsonValue | ReadableStream<JsonValue>,
+    responseInit: TransportEvent,
+    requestAc: AbortController,
+  ): Promise<void> {
+    if (!isReadableStream(response)) {
+      await this.postResponse({ ...responseInit, message: response });
+    } else {
+      const channel = nameConnection(this.manager.managerId, ChannelLabel.STREAM);
+      const sink = this.manager.offerSubChannel(channel, this.sender, requestAc);
+      await this.postResponse({ ...responseInit, channel });
+      await response.pipeTo(new WritableStream(await sink), { signal: requestAc.signal });
+    }
+  }
+
+  /**
+   * Typed wrapper to post successful responses to the session port.
+   * Suppresses 'disconnected' errors.
+   */
+  private postResponse = (m: TransportMessage | TransportInitChannel) =>
+    this.approved.then(approvedPort => {
+      try {
+        approvedPort.postMessage(m);
+      } catch (e) {
+        suppressDisconnectError(e);
+      }
+    });
+
+  /**
+   * Typed wrapper to post failure responses to the session port.
+   * Suppresses 'disconnected' errors.
+   */
+  private postError = (e: TransportError<string | undefined>) =>
+    this.approved.then(approvedPort => {
+      try {
+        approvedPort.postMessage(e);
+      } catch (e) {
+        suppressDisconnectError(e);
+      }
+    });
+}

--- a/packages/transport-chrome/src/util/chrome-errors.ts
+++ b/packages/transport-chrome/src/util/chrome-errors.ts
@@ -1,4 +1,10 @@
+const contextLossErrorMessage = 'Extension context invalidated.';
 const disconnectedPortErrorMessage = 'Attempting to use a disconnected port object';
+
+export const isContextLossError = (
+  reason: unknown,
+): reason is Error & { message: typeof contextLossErrorMessage } =>
+  reason instanceof Error && reason.message === contextLossErrorMessage;
 
 export const isDisconnectedPortError = (
   reason: unknown,

--- a/packages/transport-chrome/src/util/rpc-errors.ts
+++ b/packages/transport-chrome/src/util/rpc-errors.ts
@@ -1,0 +1,6 @@
+import { ConnectError, Code } from '@connectrpc/connect';
+
+export const isTransportCancelledError = (
+  reason: unknown,
+): reason is ConnectError & { code: typeof Code.Canceled } =>
+  reason instanceof ConnectError && reason.code === Code.Canceled;

--- a/packages/transport-chrome/src/util/rpc-errors.ts
+++ b/packages/transport-chrome/src/util/rpc-errors.ts
@@ -1,6 +1,11 @@
 import { ConnectError, Code } from '@connectrpc/connect';
 
-export const isTransportCancelledError = (
+export const isCanceledError = (
   reason: unknown,
 ): reason is ConnectError & { code: typeof Code.Canceled } =>
   reason instanceof ConnectError && reason.code === Code.Canceled;
+
+export const isUnavailableError = (
+  reason: unknown,
+): reason is ConnectError & { code: typeof Code.Unavailable } =>
+  reason instanceof ConnectError && reason.code === Code.Unavailable;

--- a/packages/transport-chrome/src/util/senders.ts
+++ b/packages/transport-chrome/src/util/senders.ts
@@ -1,0 +1,74 @@
+/**
+ * Basic comparison between two senders.
+ * @returns true if checked fields match
+ */
+const compareSenders = (
+  a: chrome.runtime.MessageSender,
+  b: chrome.runtime.MessageSender,
+): boolean =>
+  a.tab?.id === b.tab?.id &&
+  a.documentId === b.documentId &&
+  a.frameId === b.frameId &&
+  a.id === b.id &&
+  a.nativeApplication === b.nativeApplication &&
+  a.origin === b.origin &&
+  a.tlsChannelId === b.tlsChannelId &&
+  a.url === b.url;
+
+/**
+ * Assertion that two senders are identical.
+ * @throws if either sender is falsy, or if {@link compareSenders} returns false
+ */
+export const assertMatchingSenders = (
+  a?: chrome.runtime.MessageSender,
+  b?: chrome.runtime.MessageSender,
+) => {
+  if (!a || !b) {
+    throw new Error('Missing sender');
+  } else if (!compareSenders(a, b)) {
+    throw new Error('Sender mismatch');
+  }
+};
+
+/**
+ * Type guard confirming a sender contains a truthy `origin` field.
+ */
+export const isSenderWithOrigin = (
+  sender?: chrome.runtime.MessageSender,
+): sender is chrome.runtime.MessageSender & { origin: string } => Boolean(sender?.origin);
+
+/**
+ * Assertion that a sender has an `origin` field.
+ * @throws if the sender does not satisfy {@link isSenderWithOrigin}
+ * @returns the type-narrowed sender
+ */
+export const assertSenderWithOrigin = (
+  sender?: chrome.runtime.MessageSender,
+): chrome.runtime.MessageSender & { origin: string } => {
+  if (!isSenderWithOrigin(sender)) {
+    throw new Error('Sender has no origin');
+  }
+  return sender;
+};
+
+/**
+ * Type guard confirming a port's sender satisfies {@link isSenderWithOrigin}.
+ */
+export const isPortWithSenderOrigin = (
+  port?: chrome.runtime.Port,
+): port is chrome.runtime.Port & { sender: chrome.runtime.MessageSender & { origin: string } } =>
+  isSenderWithOrigin(port?.sender);
+
+/**
+ * Assertion that a port's sender has an `origin` field.
+ * @throws if the port's sender does not satisfy {@link isSenderWithOrigin}
+ * @returns the type-narrowed port
+ */
+export const assertPortWithSenderOrigin = (
+  port?: chrome.runtime.Port,
+): chrome.runtime.Port & { sender: chrome.runtime.MessageSender & { origin: string } } => {
+  if (!isPortWithSenderOrigin(port)) {
+    throw new Error('Port sender has no origin');
+  }
+  return port;
+};

--- a/packages/transport-chrome/src/util/senders.ts
+++ b/packages/transport-chrome/src/util/senders.ts
@@ -17,17 +17,32 @@ const compareSenders = (
 
 /**
  * Assertion that two senders are identical.
+ * @returns a is typeof b
  * @throws if either sender is falsy, or if {@link compareSenders} returns false
  */
 export const assertMatchingSenders = (
   a?: chrome.runtime.MessageSender,
   b?: chrome.runtime.MessageSender,
-) => {
+): a is typeof b => {
   if (!a || !b) {
     throw new Error('Missing sender');
   } else if (!compareSenders(a, b)) {
     throw new Error('Sender mismatch');
   }
+  return true;
+};
+
+/**
+ * Assertion that two ports have matching senders.
+ * @returns the first port parameter
+ * @throws if {@link assertMatchingSenders} throws
+ */
+export const assertMatchingPortSenders = (
+  p: chrome.runtime.Port,
+  b?: chrome.runtime.Port,
+): typeof p => {
+  assertMatchingSenders(p.sender, b?.sender);
+  return p;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,6 +629,9 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
+      exponential-backoff:
+        specifier: ^3.1.2
+        version: 3.1.2
 
   packages/transport-dom:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,9 +629,6 @@ importers:
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
-      exponential-backoff:
-        specifier: ^3.1.2
-        version: 3.1.2
 
   packages/transport-dom:
     dependencies:
@@ -25403,7 +25400,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.5
+      debug: 4.4.0
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
# Session Improvements

### Backend
- `CRSessionManager` now focuses primarily on connection lifecycles and sender validation
- Sender validation is now a callback parameter instead of built-in
- `CRSessionManager.killOrigin` returns the set of affected senders for additional cleanup
- Created manager-owned `CRSession` class to encapsulate individual client sessions
- Sync session init supports async validation while avoiding dropped messages

### Content scripts
- Added `CRSessionClient.end()` static method to terminate all clients in document
- Improved error handling including context loss
- Improved lifecycle including client reconnect

### Documentation
- Added session lifecycle documentation in `docs/sessions.md`
- Detailed initialization, communication flows, and termination scenarios