### PR TITLE
refactor: #1622: bufbuild upgrade

### DIFF
--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0",
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",
     "@cosmos-kit/core": "^2.15.0",

--- a/apps/node-status/package.json
+++ b/apps/node-status/package.json
@@ -14,8 +14,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@connectrpc/connect": "^1.4.0",
-    "@connectrpc/connect-web": "^1.4.0",
+    "@connectrpc/connect": "^2.0.0",
+    "@connectrpc/connect-web": "^2.0.0",
     "@penumbra-zone/crypto-web": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",
     "@penumbra-zone/types": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     }
   },
   "devDependencies": {
-    "@buf/connectrpc_eliza.bufbuild_es": "1.10.0-20230913231627-233fca715f49.1",
-    "@buf/connectrpc_eliza.connectrpc_es": "1.4.0-20230913231627-233fca715f49.3",
+    "@buf/connectrpc_eliza.bufbuild_es": "2.2.2-20230913231627-233fca715f49.2",
     "@changesets/cli": "^2.27.3",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
     "@eslint/compat": "^1.1.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,15 +35,15 @@
     }
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0",
     "@penumbra-zone/protobuf": "workspace:*",
     "@penumbra-zone/transport-dom": "workspace:*",
     "@types/chrome": "^0.0.268"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0",
     "@penumbra-zone/protobuf": "workspace:*",
     "@penumbra-zone/transport-dom": "workspace:*"
   }

--- a/packages/getters/package.json
+++ b/packages/getters/package.json
@@ -32,13 +32,13 @@
     }
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",
     "typescript": "5.5.3"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*"
   }

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -47,14 +47,14 @@
     }
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",
     "@penumbra-zone/wasm": "workspace:*"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",

--- a/packages/protobuf/buf.gen.yaml
+++ b/packages/protobuf/buf.gen.yaml
@@ -1,12 +1,19 @@
-# buf.gen.yaml defines a local generation template.
-# For details, see https://docs.buf.build/configuration/v1/buf-gen-yaml
-version: v1
+# This file defines a Buf generation schema. Calling it with `pnpm gen`
+# results in downloading common protobuf definitions from the Penumbra protocol repo
+# and transforming them into a comfortable TypeScript format.
+
+# Learn more: https://buf.build/docs/configuration/v2/buf-gen-yaml
+version: v2
+clean: true
+inputs:
+  - module: buf.build/penumbra-zone/penumbra:f6682d4ef839bb06e2da4fae487eb9d565ea04d6
+  - module: buf.build/cosmos/cosmos-sdk:e7a85cef453e4b999ad9aff8714ae05f
+  - module: buf.build/cosmos/ibc:7ab44ae956a0488ea04e04511efa5f70
+  - module: buf.build/cosmos/ics23:55085f7c710a45f58fa09947208eb70b
+  - module: buf.build/noble-assets/forwarding:5a8609a6772d417584a9c60cd8b80881
 plugins:
-  # This will invoke protoc-gen-es and write output to src/gen
-  - plugin: es
+  - local: protoc-gen-es
     out: gen
-    opt: target=ts
-  # This will invoke protoc-gen-connect-es
-  - plugin: connect-es
-    out: gen
-    opt: target=ts
+    opt:
+      - import_extension=js
+      - target=js+dts

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -12,15 +12,11 @@
     "clean": "rm -rfv dist *.tsbuildinfo package penumbra-zone-*.tgz",
     "clean:proto": "rm -rfv gen",
     "dev:pack": "tsc-watch --onSuccess \"$npm_execpath pack\"",
-    "gen:cosmos-sdk": "buf generate buf.build/cosmos/cosmos-sdk:e7a85cef453e4b999ad9aff8714ae05f",
-    "gen:ibc": "buf generate buf.build/cosmos/ibc:7ab44ae956a0488ea04e04511efa5f70",
-    "gen:ics23": "buf generate buf.build/cosmos/ics23:55085f7c710a45f58fa09947208eb70b",
-    "gen:noble": "buf generate buf.build/noble-assets/forwarding:5a8609a6772d417584a9c60cd8b80881",
-    "gen:penumbra": "buf generate buf.build/penumbra-zone/penumbra:f6682d4ef839bb06e2da4fae487eb9d565ea04d6",
+    "gen": "buf generate",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",
-    "proto": "$npm_execpath run gen:cosmos-sdk --clean && $npm_execpath run gen:ibc && $npm_execpath run gen:ics23 && $npm_execpath run gen:penumbra && $npm_execpath run gen:noble && touch gen/.npmignore",
+    "proto": "$npm_execpath run gen && touch gen/.npmignore",
     "test": "vitest run"
   },
   "files": [
@@ -53,12 +49,11 @@
     }
   },
   "devDependencies": {
-    "@bufbuild/buf": "^1.0",
-    "@bufbuild/protobuf": "^1.10.0",
-    "@bufbuild/protoc-gen-es": "^1.10.0",
-    "@connectrpc/protoc-gen-connect-es": "^1.4.0"
+    "@bufbuild/buf": "^1.50.1",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@bufbuild/protoc-gen-es": "^2.2.2"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0"
+    "@bufbuild/protobuf": "^2.2.2"
   }
 }

--- a/packages/protobuf/src/registry.ts
+++ b/packages/protobuf/src/registry.ts
@@ -1,4 +1,4 @@
-import { createRegistry, IMessageTypeRegistry } from '@bufbuild/protobuf';
+import { createRegistry } from '@bufbuild/protobuf';
 
 import * as ibcCore from './services/cosmos-ibc-core.js';
 import * as penumbraCnidarium from './services/penumbra-cnidarium.js';
@@ -6,8 +6,8 @@ import * as penumbraCore from './services/penumbra-core.js';
 import * as penumbraCustody from './services/penumbra-custody.js';
 import * as penumbraUtil from './services/penumbra-util.js';
 import * as penumbraView from './services/penumbra-view.js';
-import { ClientState, Header } from '../gen/ibc/lightclients/tendermint/v1/tendermint_pb.js';
-import { DutchAuction } from '../gen/penumbra/core/component/auction/v1/auction_pb.js';
+import { ClientStateSchema, HeaderSchema } from '../gen/ibc/lightclients/tendermint/v1/tendermint_pb.js';
+import { DutchAuctionSchema } from '../gen/penumbra/core/component/auction/v1/auction_pb.js';
 
 /**
  * This type registry is for JSON serialization of protobuf messages.
@@ -20,7 +20,7 @@ import { DutchAuction } from '../gen/penumbra/core/component/auction/v1/auction_
  * encountered.
  */
 
-export const typeRegistry: IMessageTypeRegistry = createRegistry(
+export const typeRegistry = createRegistry(
   ...Object.values(ibcCore),
   ...Object.values(penumbraCnidarium),
   ...Object.values(penumbraCore),
@@ -33,11 +33,11 @@ export const typeRegistry: IMessageTypeRegistry = createRegistry(
   // e.g., they're used in an `Any` protobuf.
 
   // gen/ibc/lightclients/tendermint/v1/tendermint_pb
-  ClientState,
-  Header,
+  ClientStateSchema,
+  HeaderSchema,
 
   // penumbra/core/component/auction/v1/auction_pb
-  DutchAuction,
+  DutchAuctionSchema,
 );
 
 /**

--- a/packages/protobuf/src/services/cosmos-ibc-core.ts
+++ b/packages/protobuf/src/services/cosmos-ibc-core.ts
@@ -1,8 +1,8 @@
-export { Query as IbcChannelService } from '../../gen/ibc/core/channel/v1/query_connect.js';
-export { Msg as IbcChannelMsgService } from '../../gen/ibc/core/channel/v1/tx_connect.js';
+export { Query as IbcChannelService } from '../../gen/ibc/core/channel/v1/query_pb.js';
+export { Msg as IbcChannelMsgService } from '../../gen/ibc/core/channel/v1/tx_pb.js';
 
-export { Query as IbcClientService } from '../../gen/ibc/core/client/v1/query_connect.js';
-export { Msg as IbcClientMsgService } from '../../gen/ibc/core/client/v1/tx_connect.js';
+export { Query as IbcClientService } from '../../gen/ibc/core/client/v1/query_pb.js';
+export { Msg as IbcClientMsgService } from '../../gen/ibc/core/client/v1/tx_pb.js';
 
-export { Query as IbcConnectionService } from '../../gen/ibc/core/connection/v1/query_connect.js';
-export { Msg as IbcConnectionMsgService } from '../../gen/ibc/core/connection/v1/tx_connect.js';
+export { Query as IbcConnectionService } from '../../gen/ibc/core/connection/v1/query_pb.js';
+export { Msg as IbcConnectionMsgService } from '../../gen/ibc/core/connection/v1/tx_pb.js';

--- a/packages/protobuf/src/services/penumbra-cnidarium.ts
+++ b/packages/protobuf/src/services/penumbra-cnidarium.ts
@@ -1,1 +1,1 @@
-export { QueryService as CnidariumService } from '../../gen/penumbra/cnidarium/v1/cnidarium_connect.js';
+export { QueryService as CnidariumService } from '../../gen/penumbra/cnidarium/v1/cnidarium_pb.js';

--- a/packages/protobuf/src/services/penumbra-core.ts
+++ b/packages/protobuf/src/services/penumbra-core.ts
@@ -1,15 +1,15 @@
-export { QueryService as AppService } from '../../gen/penumbra/core/app/v1/app_connect.js';
+export { QueryService as AppService } from '../../gen/penumbra/core/app/v1/app_pb.js';
 
-export { QueryService as AuctionService } from '../../gen/penumbra/core/component/auction/v1/auction_connect.js';
-export { QueryService as CommunityPoolService } from '../../gen/penumbra/core/component/community_pool/v1/community_pool_connect.js';
-export { QueryService as CompactBlockService } from '../../gen/penumbra/core/component/compact_block/v1/compact_block_connect.js';
+export { QueryService as AuctionService } from '../../gen/penumbra/core/component/auction/v1/auction_pb.js';
+export { QueryService as CommunityPoolService } from '../../gen/penumbra/core/component/community_pool/v1/community_pool_pb.js';
+export { QueryService as CompactBlockService } from '../../gen/penumbra/core/component/compact_block/v1/compact_block_pb.js';
 export {
   QueryService as DexService,
   SimulationService,
-} from '../../gen/penumbra/core/component/dex/v1/dex_connect.js';
-export { QueryService as FeeService } from '../../gen/penumbra/core/component/fee/v1/fee_connect.js';
-export { QueryService as GovernanceService } from '../../gen/penumbra/core/component/governance/v1/governance_connect.js';
-export { QueryService as SctService } from '../../gen/penumbra/core/component/sct/v1/sct_connect.js';
-export { QueryService as ShieldedPoolService } from '../../gen/penumbra/core/component/shielded_pool/v1/shielded_pool_connect.js';
-export { QueryService as StakeService } from '../../gen/penumbra/core/component/stake/v1/stake_connect.js';
-export { FundingService } from '../../gen/penumbra/core/component/funding/v1/funding_connect.js';
+} from '../../gen/penumbra/core/component/dex/v1/dex_pb.js';
+export { QueryService as FeeService } from '../../gen/penumbra/core/component/fee/v1/fee_pb.js';
+export { QueryService as GovernanceService } from '../../gen/penumbra/core/component/governance/v1/governance_pb.js';
+export { QueryService as SctService } from '../../gen/penumbra/core/component/sct/v1/sct_pb.js';
+export { QueryService as ShieldedPoolService } from '../../gen/penumbra/core/component/shielded_pool/v1/shielded_pool_pb.js';
+export { QueryService as StakeService } from '../../gen/penumbra/core/component/stake/v1/stake_pb.js';
+export { FundingService } from '../../gen/penumbra/core/component/funding/v1/funding_pb.js';

--- a/packages/protobuf/src/services/penumbra-custody.ts
+++ b/packages/protobuf/src/services/penumbra-custody.ts
@@ -1,1 +1,1 @@
-export { CustodyService } from '../../gen/penumbra/custody/v1/custody_connect.js';
+export { CustodyService } from '../../gen/penumbra/custody/v1/custody_pb.js';

--- a/packages/protobuf/src/services/penumbra-util.ts
+++ b/packages/protobuf/src/services/penumbra-util.ts
@@ -1,1 +1,1 @@
-export { TendermintProxyService } from '../../gen/penumbra/util/tendermint_proxy/v1/tendermint_proxy_connect.js';
+export { TendermintProxyService } from '../../gen/penumbra/util/tendermint_proxy/v1/tendermint_proxy_pb.js';

--- a/packages/protobuf/src/services/penumbra-view.ts
+++ b/packages/protobuf/src/services/penumbra-view.ts
@@ -1,1 +1,1 @@
-export { ViewService } from '../../gen/penumbra/view/v1/view_connect.js';
+export { ViewService } from '../../gen/penumbra/view/v1/view_pb.js';

--- a/packages/protobuf/tsconfig.json
+++ b/packages/protobuf/tsconfig.json
@@ -11,3 +11,4 @@
   "extends": "@tsconfig/strictest/tsconfig.json",
   "include": ["src", "gen"]
 }
+

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -35,8 +35,8 @@
     }
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
@@ -48,8 +48,8 @@
     "@types/chrome": "^0.0.268"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/crypto-web": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/types": "workspace:*",
@@ -44,7 +44,7 @@
     "fetch-mock": "^10.0.7"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-labs/registry": "^12.4.0",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",

--- a/packages/transport-dom/package.json
+++ b/packages/transport-dom/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0"
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -42,14 +42,14 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",
     "@types/lodash": "^4.17.7"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/getters": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,7 +58,7 @@
     "tinycolor2": "^1.6.0"
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@chromatic-com/storybook": "^3.2.2",
     "@storybook/addon-essentials": "^8.4.2",
     "@storybook/addon-interactions": "^8.4.2",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -39,7 +39,7 @@
     }
   },
   "devDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",
     "@penumbra-zone/types": "workspace:*",
@@ -49,7 +49,7 @@
     "@penumbra-zone/keys": "workspace:*"
   },
   "peerDependencies": {
-    "@bufbuild/protobuf": "^1.10.0",
+    "@bufbuild/protobuf": "^2.2.2",
     "@penumbra-zone/bech32m": "workspace:*",
     "@penumbra-zone/protobuf": "workspace:*",
     "@penumbra-zone/types": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,8 @@ importers:
   .:
     devDependencies:
       '@buf/connectrpc_eliza.bufbuild_es':
-        specifier: 1.10.0-20230913231627-233fca715f49.1
-        version: 1.10.0-20230913231627-233fca715f49.1(@bufbuild/protobuf@1.10.0)
-      '@buf/connectrpc_eliza.connectrpc_es':
-        specifier: 1.4.0-20230913231627-233fca715f49.3
-        version: 1.4.0-20230913231627-233fca715f49.3(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
+        specifier: 2.2.2-20230913231627-233fca715f49.2
+        version: 2.2.2-20230913231627-233fca715f49.2(@bufbuild/protobuf@2.2.3)
       '@changesets/cli':
         specifier: ^2.27.3
         version: 2.27.7
@@ -163,11 +160,11 @@ importers:
   apps/minifront:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@connectrpc/connect':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)
       '@cosmjs/proto-signing':
         specifier: ^0.32.4
         version: 0.32.4
@@ -236,7 +233,7 @@ importers:
         version: 1.17.1
       '@skip-go/widget':
         specifier: ^3.4.1
-        version: 3.4.1(yljgh6wa5prhsh4o2fqtlwtizy)
+        version: 3.4.1(ppajsz6uflebmtkntfype2ksly)
       '@tanstack/react-query':
         specifier: 5.62.7
         version: 5.62.7(react@18.3.1)
@@ -338,11 +335,11 @@ importers:
   apps/node-status:
     dependencies:
       '@connectrpc/connect':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)
       '@connectrpc/connect-web':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.2.3))
       '@penumbra-zone/crypto-web':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -394,11 +391,11 @@ importers:
   packages/client:
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@connectrpc/connect':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)
       '@penumbra-zone/protobuf':
         specifier: workspace:*
         version: link:../protobuf
@@ -483,8 +480,8 @@ importers:
   packages/getters:
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -506,8 +503,8 @@ importers:
   packages/perspective:
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -524,26 +521,23 @@ importers:
   packages/protobuf:
     devDependencies:
       '@bufbuild/buf':
-        specifier: ^1.0
-        version: 1.35.1
+        specifier: ^1.50.1
+        version: 1.50.1
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@bufbuild/protoc-gen-es':
-        specifier: ^1.10.0
-        version: 1.10.0(@bufbuild/protobuf@1.10.0)
-      '@connectrpc/protoc-gen-connect-es':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protoc-gen-es@1.10.0(@bufbuild/protobuf@1.10.0))(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
+        specifier: ^2.2.2
+        version: 2.2.3(@bufbuild/protobuf@2.2.3)
 
   packages/services:
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@connectrpc/connect':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -575,8 +569,8 @@ importers:
   packages/storage:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -618,11 +612,11 @@ importers:
   packages/transport-chrome:
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@connectrpc/connect':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)
       '@penumbra-zone/transport-dom':
         specifier: workspace:*
         version: link:../transport-dom
@@ -633,11 +627,11 @@ importers:
   packages/transport-dom:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@connectrpc/connect':
-        specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: ^2.0.0
+        version: 2.0.2(@bufbuild/protobuf@2.2.3)
 
   packages/types:
     dependencies:
@@ -658,8 +652,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -743,8 +737,8 @@ importers:
         version: 1.6.0
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@chromatic-com/storybook':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)(storybook@8.4.2(bufferutil@4.0.8)(prettier@3.3.3)(utf-8-validate@5.0.10))
@@ -815,8 +809,8 @@ importers:
   packages/ui-deprecated:
     dependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@emotion/react':
         specifier: ^11.11.4
         version: 11.11.4(@types/react@18.3.12)(react@18.3.1)
@@ -1057,8 +1051,8 @@ importers:
         version: link:../keys
     devDependencies:
       '@bufbuild/protobuf':
-        specifier: ^1.10.0
-        version: 1.10.0
+        specifier: ^2.2.2
+        version: 2.2.3
       '@penumbra-zone/bech32m':
         specifier: workspace:*
         version: link:../bech32m
@@ -1931,77 +1925,76 @@ packages:
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
-  '@buf/connectrpc_eliza.bufbuild_es@1.10.0-20230913231627-233fca715f49.1':
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.bufbuild_es/-/connectrpc_eliza.bufbuild_es-1.10.0-20230913231627-233fca715f49.1.tgz}
+  '@buf/connectrpc_eliza.bufbuild_es@2.2.2-20230913231627-233fca715f49.2':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.bufbuild_es/-/connectrpc_eliza.bufbuild_es-2.2.2-20230913231627-233fca715f49.2.tgz}
     peerDependencies:
-      '@bufbuild/protobuf': ^1.10.0
+      '@bufbuild/protobuf': ^2.2.2
 
-  '@buf/connectrpc_eliza.bufbuild_es@1.7.2-20230913231627-233fca715f49.2':
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.bufbuild_es/-/connectrpc_eliza.bufbuild_es-1.7.2-20230913231627-233fca715f49.2.tgz}
-    peerDependencies:
-      '@bufbuild/protobuf': ^1.7.2
-
-  '@buf/connectrpc_eliza.connectrpc_es@1.4.0-20230913231627-233fca715f49.3':
-    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.connectrpc_es/-/connectrpc_eliza.connectrpc_es-1.4.0-20230913231627-233fca715f49.3.tgz}
-    peerDependencies:
-      '@connectrpc/connect': ^1.4.0
-
-  '@bufbuild/buf-darwin-arm64@1.35.1':
-    resolution: {integrity: sha512-Yy+sk+8sg3LDvMSZLGUIoMCkZajkQSZkdxO96mpqJagKlEYPLGTtakVFCVNX9KgK/sv1bd9sU55iMGXE3+eIYw==}
+  '@bufbuild/buf-darwin-arm64@1.50.1':
+    resolution: {integrity: sha512-uoRLgqucLP5qLIIDovsHN+7QoeBC0fqfZ1LhwZfNUd95py3ymEOmOFmP0JCbW349a8zmH2HhS5yOySe1yXwP2w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
-  '@bufbuild/buf-darwin-x64@1.35.1':
-    resolution: {integrity: sha512-LcscoNTCHFeb5y9sitw4w6HWZtJ4Ja/MDBCUU9A8/OGHJSESV0JjhbvVHGNOIsKUbPq5p/SVjYA/Ab/wlmmpaA==}
+  '@bufbuild/buf-darwin-x64@1.50.1':
+    resolution: {integrity: sha512-b5efryjfQ/rTnftcjcbluAJK1bSHCacSK0O/ldMbNQRUwstUieqX/NHIxdQcrorHqW26VppWmQuB88JYxffABw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
-  '@bufbuild/buf-linux-aarch64@1.35.1':
-    resolution: {integrity: sha512-bPeiSURl8WFxCdawtJjAjUOMqknVTw763NLIDcbYSH1/wTiUbM5QeXCORRlHKXtMGM89SYU5AatcY9UhQ+sn9g==}
+  '@bufbuild/buf-linux-aarch64@1.50.1':
+    resolution: {integrity: sha512-ZE3nfVyENkHNV+lZw9ScjmQnPNlzIZrGLYeqFTQllnbUWehvZACTBY8L4ak5eXf6NRyGIksAEuCPnnrht5WigA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
 
-  '@bufbuild/buf-linux-x64@1.35.1':
-    resolution: {integrity: sha512-n6ziazYjNH9H1JjHiacGi20rIyZuKnsHjF8qWisO8KGajhnS/7tpq0VzYdorqqWyJ1TcnLBWHj+dWYuGay9Nag==}
+  '@bufbuild/buf-linux-armv7@1.50.1':
+    resolution: {integrity: sha512-Bc/V1ySgFIaTa8sdCEwX3Y4vkyULlDeuUKyqUSSQjiVweeuoxOp8jLwQMFoQCdYFwY02yY0MlNR/mhyowGCt9w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@bufbuild/buf-linux-x64@1.50.1':
+    resolution: {integrity: sha512-2aHe+LmsTIaOH3ViH8EcOVx4yStZznJYmZ/NQ/cV5kvD3JAVJv4u5MtTJAd6DDj9BmEhXtjXK9hWtRi7S0vF2w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
-  '@bufbuild/buf-win32-arm64@1.35.1':
-    resolution: {integrity: sha512-3B65+iA1i/LDjJBseEpAvrkEI7VJqrvW39PyYVkIXSHHT917O+n95g74pn38A0XkggN5lEibLEkipBMDUfwMew==}
+  '@bufbuild/buf-win32-arm64@1.50.1':
+    resolution: {integrity: sha512-fqNQ9Ke/arleUulnePEyG2+iW2eB6xO6rcVovFY4EorZUTZ/EzrtdmVn87AfWJle3HxcXcIXP0onrcKBrwXUuQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
 
-  '@bufbuild/buf-win32-x64@1.35.1':
-    resolution: {integrity: sha512-iafrcs+1FMlD+3ZjI1kVBHGOluT6YcoAUETrGMbQjRha6dL5s2Ldr0G7zCKLIT13yEKG5QTyP8z8gVEpk8C8wg==}
+  '@bufbuild/buf-win32-x64@1.50.1':
+    resolution: {integrity: sha512-+jd1Dopk24WQtcSgden+dOtGu/OMAuBtnsfkv59pqbCbdZqNCsqrC7VluJ4/5y5PiNcB7hcA26RETkPtkInluA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
 
-  '@bufbuild/buf@1.35.1':
-    resolution: {integrity: sha512-POtbb4wRhvgCmmClnuaQTpkHL4ukhFItuS/AaD7QDY0kamn4ExNJz4XlHG5jeJODaQ1Wq3f9qn7UIgUr6CUODw==}
+  '@bufbuild/buf@1.50.1':
+    resolution: {integrity: sha512-KVXBUfKe13STjoSZ9VPzomJUwYnJ01c1b54nJf4a90H/tg0Q/K0z0Wxz0Dr43vuuoDvVHAuBOZPs/XIwSH33IQ==}
     engines: {node: '>=12'}
     hasBin: true
 
   '@bufbuild/protobuf@1.10.0':
     resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
 
-  '@bufbuild/protoc-gen-es@1.10.0':
-    resolution: {integrity: sha512-zBYBsVT/ul4uZb6F+kD7/k4sWNHVVbEPfJwKi0FDr+9VJo8MKIofI6pkr5ksBLr4fi/74r+e/75Xi/0clL5dXg==}
+  '@bufbuild/protobuf@2.2.3':
+    resolution: {integrity: sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==}
+
+  '@bufbuild/protoc-gen-es@2.2.3':
+    resolution: {integrity: sha512-hdhIV9NmwXXy24DcbnArauv6L5Dv2PjkO9gz2DUhiZ9HPRpP+rmpT8zo5LohjJiuA7YIQGGKKWSKpRg+xcdLSQ==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
-      '@bufbuild/protobuf': 1.10.0
+      '@bufbuild/protobuf': 2.2.3
     peerDependenciesMeta:
       '@bufbuild/protobuf':
         optional: true
 
-  '@bufbuild/protoplugin@1.10.0':
-    resolution: {integrity: sha512-u6NE4vL0lw1+EK4/PiE/SQB7fKO4LRJNTEScIXVOi2x88K/c8WKc/k0KyEaA0asVBMpwekJQZGnRyj04ZtN5Gg==}
+  '@bufbuild/protoplugin@2.2.3':
+    resolution: {integrity: sha512-UsV7mj6NJTZrqIYJK+jNFnnj5tOS7wgNXKyMjebFEpf+OX6pfXE+nx+QPjumOfu4GxdVPfEDnKuwISgqlXSQqw==}
 
   '@celo/base@3.2.0':
     resolution: {integrity: sha512-9wfZYiYv7dzt17a29fxU6sV7JssyXfpSQ9kPSpfOlsewPICXwfOMQ+25Jn6xZu20Vx9rmKebmLHiQyiuYEDOcQ==}
@@ -2110,29 +2103,21 @@ packages:
     resolution: {integrity: sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==}
     deprecated: Unmaintained. The codebase for this package was moved to https://github.com/cosmos/ics23 but then the JS implementation was removed in https://github.com/cosmos/ics23/pull/353. Please consult the maintainers of https://github.com/cosmos for further assistance.
 
-  '@connectrpc/connect-web@1.4.0':
-    resolution: {integrity: sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==}
+  '@connectrpc/connect-web@2.0.2':
+    resolution: {integrity: sha512-QANMFPiL2o66BdBEctg4TsQLe5ozsBLqcle3dCBp7BwGlNGTY6NnNnqmt+YRnpeMW88GgomJwWNMGCrRD9pRKA==}
     peerDependencies:
-      '@bufbuild/protobuf': ^1.4.2
-      '@connectrpc/connect': 1.4.0
+      '@bufbuild/protobuf': ^2.2.0
+      '@connectrpc/connect': 2.0.2
 
   '@connectrpc/connect@1.4.0':
     resolution: {integrity: sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==}
     peerDependencies:
       '@bufbuild/protobuf': ^1.4.2
 
-  '@connectrpc/protoc-gen-connect-es@1.4.0':
-    resolution: {integrity: sha512-/7vQ8Q7mEBhV8qEVh/eifRQlQnf8EJ6weMwCD2DljVAQRlZYcW9SLxjYZhV1uM1ZZqQC7Cw2vvgXRg2XQswHBg==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
+  '@connectrpc/connect@2.0.2':
+    resolution: {integrity: sha512-xZuylIUNvNlH52e/4eQsZvY4QZyDJRtEFEDnn/yBrv5Xi5ZZI/p8X+GAHH35ucVaBvv9u7OzHZo8+tEh1EFTxA==}
     peerDependencies:
-      '@bufbuild/protoc-gen-es': ^1.7.2
-      '@connectrpc/connect': 1.4.0
-    peerDependenciesMeta:
-      '@bufbuild/protoc-gen-es':
-        optional: true
-      '@connectrpc/connect':
-        optional: true
+      '@bufbuild/protobuf': ^2.2.0
 
   '@cosmjs/amino@0.27.1':
     resolution: {integrity: sha512-w56ar/nK9+qlvWDpBPRmD0Blk2wfkkLqRi1COs1x7Ll1LF0AtkIBUjbRKplENLbNovK0T3h+w8bHiFm+GBGQOA==}
@@ -3351,7 +3336,6 @@ packages:
   '@mui/base@5.0.0-beta.40':
     resolution: {integrity: sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==}
     engines: {node: '>=12.0.0'}
-    deprecated: This package has been replaced by @base-ui-components/react
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
@@ -13946,61 +13930,56 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
     optional: true
 
-  '@buf/connectrpc_eliza.bufbuild_es@1.10.0-20230913231627-233fca715f49.1(@bufbuild/protobuf@1.10.0)':
+  '@buf/connectrpc_eliza.bufbuild_es@2.2.2-20230913231627-233fca715f49.2(@bufbuild/protobuf@2.2.3)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.0
+      '@bufbuild/protobuf': 2.2.3
 
-  '@buf/connectrpc_eliza.bufbuild_es@1.7.2-20230913231627-233fca715f49.2(@bufbuild/protobuf@1.10.0)':
-    dependencies:
-      '@bufbuild/protobuf': 1.10.0
-
-  '@buf/connectrpc_eliza.connectrpc_es@1.4.0-20230913231627-233fca715f49.3(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))':
-    dependencies:
-      '@buf/connectrpc_eliza.bufbuild_es': 1.7.2-20230913231627-233fca715f49.2(@bufbuild/protobuf@1.10.0)
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
-    transitivePeerDependencies:
-      - '@bufbuild/protobuf'
-
-  '@bufbuild/buf-darwin-arm64@1.35.1':
+  '@bufbuild/buf-darwin-arm64@1.50.1':
     optional: true
 
-  '@bufbuild/buf-darwin-x64@1.35.1':
+  '@bufbuild/buf-darwin-x64@1.50.1':
     optional: true
 
-  '@bufbuild/buf-linux-aarch64@1.35.1':
+  '@bufbuild/buf-linux-aarch64@1.50.1':
     optional: true
 
-  '@bufbuild/buf-linux-x64@1.35.1':
+  '@bufbuild/buf-linux-armv7@1.50.1':
     optional: true
 
-  '@bufbuild/buf-win32-arm64@1.35.1':
+  '@bufbuild/buf-linux-x64@1.50.1':
     optional: true
 
-  '@bufbuild/buf-win32-x64@1.35.1':
+  '@bufbuild/buf-win32-arm64@1.50.1':
     optional: true
 
-  '@bufbuild/buf@1.35.1':
+  '@bufbuild/buf-win32-x64@1.50.1':
+    optional: true
+
+  '@bufbuild/buf@1.50.1':
     optionalDependencies:
-      '@bufbuild/buf-darwin-arm64': 1.35.1
-      '@bufbuild/buf-darwin-x64': 1.35.1
-      '@bufbuild/buf-linux-aarch64': 1.35.1
-      '@bufbuild/buf-linux-x64': 1.35.1
-      '@bufbuild/buf-win32-arm64': 1.35.1
-      '@bufbuild/buf-win32-x64': 1.35.1
+      '@bufbuild/buf-darwin-arm64': 1.50.1
+      '@bufbuild/buf-darwin-x64': 1.50.1
+      '@bufbuild/buf-linux-aarch64': 1.50.1
+      '@bufbuild/buf-linux-armv7': 1.50.1
+      '@bufbuild/buf-linux-x64': 1.50.1
+      '@bufbuild/buf-win32-arm64': 1.50.1
+      '@bufbuild/buf-win32-x64': 1.50.1
 
   '@bufbuild/protobuf@1.10.0': {}
 
-  '@bufbuild/protoc-gen-es@1.10.0(@bufbuild/protobuf@1.10.0)':
+  '@bufbuild/protobuf@2.2.3': {}
+
+  '@bufbuild/protoc-gen-es@2.2.3(@bufbuild/protobuf@2.2.3)':
     dependencies:
-      '@bufbuild/protoplugin': 1.10.0
+      '@bufbuild/protoplugin': 2.2.3
     optionalDependencies:
-      '@bufbuild/protobuf': 1.10.0
+      '@bufbuild/protobuf': 2.2.3
     transitivePeerDependencies:
       - supports-color
 
-  '@bufbuild/protoplugin@1.10.0':
+  '@bufbuild/protoplugin@2.2.3':
     dependencies:
-      '@bufbuild/protobuf': 1.10.0
+      '@bufbuild/protobuf': 2.2.3
       '@typescript/vfs': 1.6.0(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -14275,24 +14254,18 @@ snapshots:
       '@noble/hashes': 1.6.1
       protobufjs: 6.11.4
 
-  '@connectrpc/connect-web@1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))':
+  '@connectrpc/connect-web@2.0.2(@bufbuild/protobuf@2.2.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.2.3))':
     dependencies:
-      '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
+      '@bufbuild/protobuf': 2.2.3
+      '@connectrpc/connect': 2.0.2(@bufbuild/protobuf@2.2.3)
 
   '@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
-  '@connectrpc/protoc-gen-connect-es@1.4.0(@bufbuild/protoc-gen-es@1.10.0(@bufbuild/protobuf@1.10.0))(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))':
+  '@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.2.3)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.0
-      '@bufbuild/protoplugin': 1.10.0
-    optionalDependencies:
-      '@bufbuild/protoc-gen-es': 1.10.0(@bufbuild/protobuf@1.10.0)
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@bufbuild/protobuf': 2.2.3
 
   '@cosmjs/amino@0.27.1':
     dependencies:
@@ -17663,21 +17636,21 @@ snapshots:
 
   '@penumbra-labs/registry@12.4.0': {}
 
-  '@penumbra-zone/bech32m@13.0.0(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@1.10.0))':
+  '@penumbra-zone/bech32m@13.0.0(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@2.2.3))':
     dependencies:
-      '@penumbra-zone/protobuf': 7.2.0(@bufbuild/protobuf@1.10.0)
+      '@penumbra-zone/protobuf': 7.2.0(@bufbuild/protobuf@2.2.3)
       bech32: 2.0.0
 
-  '@penumbra-zone/client@24.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.0)':
+  '@penumbra-zone/client@24.0.0(@bufbuild/protobuf@2.2.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.2.3))(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@2.2.3))(@penumbra-zone/transport-dom@7.5.0)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.0
-      '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
-      '@penumbra-zone/protobuf': 7.2.0(@bufbuild/protobuf@1.10.0)
+      '@bufbuild/protobuf': 2.2.3
+      '@connectrpc/connect': 2.0.2(@bufbuild/protobuf@2.2.3)
+      '@penumbra-zone/protobuf': 7.2.0(@bufbuild/protobuf@2.2.3)
       '@penumbra-zone/transport-dom': 7.5.0
 
-  '@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@1.10.0)':
+  '@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@2.2.3)':
     dependencies:
-      '@bufbuild/protobuf': 1.10.0
+      '@bufbuild/protobuf': 2.2.3
 
   '@penumbra-zone/transport-dom@7.5.0':
     dependencies:
@@ -20316,7 +20289,7 @@ snapshots:
       - subscriptions-transport-ws
       - utf-8-validate
 
-  '@skip-go/widget@3.4.1(yljgh6wa5prhsh4o2fqtlwtizy)':
+  '@skip-go/widget@3.4.1(ppajsz6uflebmtkntfype2ksly)':
     dependencies:
       '@amplitude/analytics-browser': 2.11.13
       '@cosmjs/amino': 0.31.3
@@ -20329,9 +20302,9 @@ snapshots:
       '@ebay/nice-modal-react': 1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@eslint/compat': 1.2.4(eslint@9.6.0)
       '@leapwallet/cosmos-social-login-capsule-provider': 0.0.44(@cosmjs/encoding@0.32.4)(@cosmjs/proto-signing@0.32.4)(fp-ts@2.16.9)
-      '@penumbra-zone/bech32m': 13.0.0(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@1.10.0))
-      '@penumbra-zone/client': 24.0.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/transport-dom@7.5.0)
-      '@penumbra-zone/protobuf': 7.2.0(@bufbuild/protobuf@1.10.0)
+      '@penumbra-zone/bech32m': 13.0.0(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@2.2.3))
+      '@penumbra-zone/client': 24.0.0(@bufbuild/protobuf@2.2.3)(@connectrpc/connect@2.0.2(@bufbuild/protobuf@2.2.3))(@penumbra-zone/protobuf@7.2.0(@bufbuild/protobuf@2.2.3))(@penumbra-zone/transport-dom@7.5.0)
+      '@penumbra-zone/protobuf': 7.2.0(@bufbuild/protobuf@2.2.3)
       '@penumbra-zone/transport-dom': 7.5.0
       '@r2wc/react-to-web-component': 2.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/react': 8.55.0(react@18.3.1)
@@ -21685,7 +21658,7 @@ snapshots:
 
   '@typescript/vfs@1.6.0(typescript@5.5.3)':
     dependencies:
-      debug: 4.3.5
+      debug: 4.4.0
       typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Closes #1622 

Upgrades bufbuild and connectrpc libraries to v2.

Steps of this PR:
1. Run `pnpx @connectrpc/connect-migrate@latest` – it updates all dependencies and paths. Didn't commit 200+ files updated by the script, it can always be redone and committed later
2. Updated protobuf generation schema to v2, moved everything to `buf.gen.yaml` file. 
3. Generated new protobufs using `pnpm proto` in the protobuf package
4. Updated protobuf package contents by changing imports from `*_connect.js` to `*_pb.js`. Fixed other issues in the protobuf package like adding Schema suffix to types, changed `ServiceType` to `DescService`
5. Refactored the `create.ts` file in transport-dom and its tests by following this code https://github.com/connectrpc/connect-es/blob/main/packages/connect/src/protocol-grpc/transport.ts

Further work:
1. Refactor the rest of the transport-dom and transport-chrome packages
2. Check other packages for inconsistencies
3. Do `pnpx @connectrpc/connect-migrate@latest` again and commit the changes