### PR TITLE
feat(ui): #2124: pagination

### DIFF
--- a/.changeset/cold-feet-live.md
+++ b/.changeset/cold-feet-live.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': minor
+---
+
+Add Pagination UI component

--- a/packages/ui/src/Pagination/index.stories.tsx
+++ b/packages/ui/src/Pagination/index.stories.tsx
@@ -10,14 +10,45 @@ const meta: Meta<typeof Pagination> = {
 
 export default meta;
 
+const ArrayList = ({ array }: { array: number[] }) => {
+  if (array.length < 10) {
+    return (
+      <ol className='text-text-secondary'>
+        {array.map(v => (
+          <li className='text-xs' key={v}>
+            {v}
+          </li>
+        ))}
+      </ol>
+    );
+  }
+
+  return (
+    <ol className='text-text-secondary'>
+      {array.slice(0, 3).map(v => (
+        <li className='text-xs' key={v}>
+          {v}
+        </li>
+      ))}
+      <li key='...' className='text-xs'>
+        ...
+      </li>
+      {array.slice(-3).map(v => (
+        <li className='text-xs' key={v}>
+          {v}
+        </li>
+      ))}
+    </ol>
+  );
+};
+
 export const Basic: StoryObj<typeof Pagination> = {
   render: args => {
     const [value, setValue] = useState(args.value);
     const [limit, setLimit] = useState<number>(args.limit);
 
-    const array = Array.from({ length: 300 }, (_, i) => i + 1);
+    const array = Array.from({ length: 305 }, (_, i) => i + 1);
     const values = array.slice(limit * (value - 1), limit * value);
-    const pages = Math.ceil(array.length / limit);
 
     const onLimit = (limit: number) => {
       setLimit(limit);
@@ -28,28 +59,13 @@ export const Basic: StoryObj<typeof Pagination> = {
       <div className='flex flex-col gap-2'>
         <Pagination
           {...args}
-          pages={pages}
+          totalItems={array.length}
           value={value}
           onChange={setValue}
-          limit={args.limit}
+          limit={limit}
           onLimitChange={onLimit}
         />
-
-        <ol className='text-text-secondary'>
-          {values.slice(0, 3).map(v => (
-            <li className='text-xs' key={v}>
-              {v}
-            </li>
-          ))}
-          <li key='...' className='text-xs'>
-            ...
-          </li>
-          {values.slice(-3).map(v => (
-            <li className='text-xs' key={v}>
-              {v}
-            </li>
-          ))}
-        </ol>
+        <ArrayList array={values} />
       </div>
     );
   },
@@ -64,29 +80,19 @@ export const Short: StoryObj<typeof Pagination> = {
     const [value, setValue] = useState(args.value);
 
     const limit = args.limit;
-    const array = Array.from({ length: 300 }, (_, i) => i + 1);
+    const array = Array.from({ length: 305 }, (_, i) => i + 1);
     const values = array.slice(limit * (value - 1), limit * value);
-    const pages = Math.ceil(array.length / limit);
 
     return (
       <div className='flex flex-col gap-2'>
-        <Pagination {...args} pages={pages} value={value} onChange={setValue} limit={limit} />
-
-        <ol className='text-text-secondary'>
-          {values.slice(0, 3).map(v => (
-            <li className='text-xs' key={v}>
-              {v}
-            </li>
-          ))}
-          <li key='...' className='text-xs'>
-            ...
-          </li>
-          {values.slice(-3).map(v => (
-            <li className='text-xs' key={v}>
-              {v}
-            </li>
-          ))}
-        </ol>
+        <Pagination
+          {...args}
+          totalItems={array.length}
+          value={value}
+          onChange={setValue}
+          limit={limit}
+        />
+        <ArrayList array={values} />
       </div>
     );
   },

--- a/packages/ui/src/Pagination/index.stories.tsx
+++ b/packages/ui/src/Pagination/index.stories.tsx
@@ -1,0 +1,100 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Pagination } from '.';
+import { useState } from 'react';
+
+const meta: Meta<typeof Pagination> = {
+  component: Pagination,
+  tags: ['autodocs', '!dev'],
+};
+
+export default meta;
+
+export const Basic: StoryObj<typeof Pagination> = {
+  render: args => {
+    const [value, setValue] = useState(args.value);
+    const [limit, setLimit] = useState<number>(args.limit);
+
+    const array = Array.from({ length: 300 }, (_, i) => i + 1);
+    const values = array.slice(limit * (value - 1), limit * value);
+    const pages = Math.ceil(array.length / limit);
+
+    const onLimit = (limit: number) => {
+      setLimit(limit);
+      setValue(1);
+    };
+
+    return (
+      <div className='flex flex-col gap-2'>
+        <Pagination
+          {...args}
+          pages={pages}
+          value={value}
+          onChange={setValue}
+          limit={args.limit}
+          onLimitChange={onLimit}
+        />
+
+        <ol className='text-text-secondary'>
+          {values.slice(0, 3).map(v => (
+            <li className='text-xs' key={v}>
+              {v}
+            </li>
+          ))}
+          <li key='...' className='text-xs'>
+            ...
+          </li>
+          {values.slice(-3).map(v => (
+            <li className='text-xs' key={v}>
+              {v}
+            </li>
+          ))}
+        </ol>
+      </div>
+    );
+  },
+  args: {
+    value: 1,
+    limit: 30,
+  },
+};
+
+export const Short: StoryObj<typeof Pagination> = {
+  render: args => {
+    const [value, setValue] = useState(args.value);
+
+    const limit = args.limit;
+    const array = Array.from({ length: 300 }, (_, i) => i + 1);
+    const values = array.slice(limit * (value - 1), limit * value);
+    const pages = Math.ceil(array.length / limit);
+
+    return (
+      <div className='flex flex-col gap-2'>
+        <Pagination {...args} pages={pages} value={value} onChange={setValue} limit={limit} />
+
+        <ol className='text-text-secondary'>
+          {values.slice(0, 3).map(v => (
+            <li className='text-xs' key={v}>
+              {v}
+            </li>
+          ))}
+          <li key='...' className='text-xs'>
+            ...
+          </li>
+          {values.slice(-3).map(v => (
+            <li className='text-xs' key={v}>
+              {v}
+            </li>
+          ))}
+        </ol>
+      </div>
+    );
+  },
+  args: {
+    value: 1,
+    limit: 30,
+    hideLimitSelector: true,
+    hidePageButtons: true,
+    hidePageInfo: true,
+  },
+};

--- a/packages/ui/src/Pagination/index.tsx
+++ b/packages/ui/src/Pagination/index.tsx
@@ -22,8 +22,8 @@ export interface PaginationProps {
   onChange: (value: number) => void;
   /** The number of items per page. If 0 or less, doesn't render the limit selector */
   limit: number;
-  /** The total number of pages */
-  pages: number;
+  /** The total number of items. If provided, will be used to calculate the total number of pages */
+  totalItems: number;
   /** Callback function to update the number of items per page */
   onLimitChange?: (limit: number) => void;
   /** The available options list for the limit */
@@ -52,9 +52,6 @@ export interface PaginationProps {
  *   const array = Array.from({ length: 300 }, (_, i) => i + 1);
  *   const values = array.slice(limit * (value - 1), limit * value);
  *
- *   // Calculate the total number of pages
- *   const pages = Math.ceil(array.length / limit);
- *
  *   // Reset the page value when the limit changes
  *   const onLimit = (limit: number) => {
  *     setLimit(limit);
@@ -64,7 +61,7 @@ export interface PaginationProps {
  *   return (
  *     <div className='flex flex-col gap-2'>
  *       <Pagination
- *         pages={pages}
+ *         totalItems={array.length}
  *         value={value}
  *         onChange={setValue}
  *         limit={limit}
@@ -87,7 +84,7 @@ export const Pagination = ({
   as: Container = 'div',
   value,
   onChange,
-  pages,
+  totalItems,
   hidePageInfo,
   hidePageButtons,
   hideLimitSelector,
@@ -97,6 +94,9 @@ export const Pagination = ({
 }: PaginationProps) => {
   const selectId = useId();
   const selectEl = useRef<HTMLSelectElement>(null);
+  const pages = useMemo(() => {
+    return Math.ceil((totalItems < 1 ? 1 : totalItems) / limit);
+  }, [limit, totalItems]);
 
   const limitOptionsSet = useMemo(() => {
     const options = limitOptions ?? LIMIT_OPTIONS;
@@ -167,14 +167,6 @@ export const Pagination = ({
     onLimitChange?.(parseInt(event.target.value));
   };
 
-  const pageInfo = pages ? (
-    <Text small>
-      {value} out of {pages}
-    </Text>
-  ) : (
-    <Text small>Page {value}</Text>
-  );
-
   return (
     <Container
       className={cn(
@@ -184,7 +176,11 @@ export const Pagination = ({
       )}
     >
       <div className='col-start-1 row-start-1 whitespace-nowrap'>
-        {hidePageInfo ? null : pageInfo}
+        {hidePageInfo ? null : (
+          <Text small>
+            {limit} out of {totalItems}
+          </Text>
+        )}
       </div>
 
       <nav
@@ -200,7 +196,9 @@ export const Pagination = ({
         </Density>
 
         {hidePageButtons ? (
-          pageInfo
+          <Text small>
+            {value} of {pages}
+          </Text>
         ) : (
           <div className='flex items-center tablet:gap-3'>
             {buttons.map((key, index) => (
@@ -242,6 +240,7 @@ export const Pagination = ({
             <select
               ref={selectEl}
               id={selectId}
+              value={limit}
               onChange={onSelect}
               className='invisible absolute left-0 top-0'
             >

--- a/packages/ui/src/Pagination/index.tsx
+++ b/packages/ui/src/Pagination/index.tsx
@@ -1,0 +1,259 @@
+import {
+  ChangeEventHandler,
+  ElementType,
+  KeyboardEventHandler,
+  useId,
+  useMemo,
+  useRef,
+} from 'react';
+import cn from 'clsx';
+import { ChevronsUpDown } from 'lucide-react';
+import { Text } from '../Text';
+import { Density } from '../Density';
+import { Button } from '../Button';
+import { ELLIPSIS_KEY, PaginationButton } from './pagination-button';
+
+const LIMIT_OPTIONS = [10, 20, 50, 100];
+
+export interface PaginationProps {
+  /** The current page value */
+  value: number;
+  /** Callback function to update the current page value */
+  onChange: (value: number) => void;
+  /** The number of items per page. If 0 or less, doesn't render the limit selector */
+  limit: number;
+  /** The total number of pages */
+  pages: number;
+  /** Callback function to update the number of items per page */
+  onLimitChange?: (limit: number) => void;
+  /** The available options list for the limit */
+  limitOptions?: number[];
+  /** If true, hides the left pagination info block that usually says "{currentPage} out of {totalPages}" */
+  hidePageInfo?: boolean;
+  /** If true, hides all buttons that help select a certain page, leaves only "prev" and "next" */
+  hidePageButtons?: boolean;
+  /** If true, hides the limit selector */
+  hideLimitSelector?: boolean;
+  as?: ElementType;
+}
+
+/**
+ * Table pagination component. Displays buttons to navigate between pages
+ * and a page limit selector.
+ *
+ * Example usage:
+ *
+ * ```tsx
+ * const TableDemo = () => {
+ *   const [value, setValue] = useState(1);
+ *   const [limit, setLimit] = useState<number>(20);
+ *
+ *   // Generate an array of 300 elements and slice it based on the current page and limit values
+ *   const array = Array.from({ length: 300 }, (_, i) => i + 1);
+ *   const values = array.slice(limit * (value - 1), limit * value);
+ *
+ *   // Calculate the total number of pages
+ *   const pages = Math.ceil(array.length / limit);
+ *
+ *   // Reset the page value when the limit changes
+ *   const onLimit = (limit: number) => {
+ *     setLimit(limit);
+ *     setValue(1);
+ *   };
+ *
+ *   return (
+ *     <div className='flex flex-col gap-2'>
+ *       <Pagination
+ *         pages={pages}
+ *         value={value}
+ *         onChange={setValue}
+ *         limit={limit}
+ *         onLimitChange={onLimit}
+ *       />
+ *
+ *       <ul className='text-text-secondary'>
+ *         {values.map(v => (
+ *           <li className='text-xs' key={v}>
+ *             {v}
+ *           </li>
+ *         ))}
+ *       </ol>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export const Pagination = ({
+  as: Container = 'div',
+  value,
+  onChange,
+  pages,
+  hidePageInfo,
+  hidePageButtons,
+  hideLimitSelector,
+  limitOptions,
+  limit,
+  onLimitChange,
+}: PaginationProps) => {
+  const selectId = useId();
+  const selectEl = useRef<HTMLSelectElement>(null);
+
+  const limitOptionsSet = useMemo(() => {
+    const options = limitOptions ?? LIMIT_OPTIONS;
+    if (!options.includes(limit)) {
+      options.push(limit);
+    }
+    options.sort((a, b) => a - b);
+    return options;
+  }, [limit, limitOptions]);
+
+  // Calculates which buttons to show. The first, last and current page are always shown
+  const maxVisible = 3;
+  const buttons = useMemo(() => {
+    if (pages < 2) {
+      return [1];
+    }
+
+    if (pages <= 5) {
+      return Array.from({ length: pages }, (_, i) => i + 1);
+    }
+
+    const arr: (number | typeof ELLIPSIS_KEY)[] = [];
+
+    // Always show the first page
+    arr.push(1);
+
+    if (value > maxVisible) {
+      arr.push(ELLIPSIS_KEY);
+    }
+
+    // Show pages around the current page
+    const startPage = Math.max(2, value - 1);
+    const endPage = Math.min(pages - 1, value + 1);
+    for (let i = startPage; i <= endPage; i++) {
+      arr.push(i);
+    }
+
+    if (value < pages - maxVisible) {
+      arr.push(ELLIPSIS_KEY);
+    }
+
+    // Always show the last page
+    arr.push(pages);
+
+    return arr;
+  }, [pages, value]);
+
+  const onLabelClick = () => {
+    selectEl.current?.showPicker();
+  };
+
+  const onLabelEnter: KeyboardEventHandler<HTMLLabelElement> = event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      selectEl.current?.showPicker();
+    }
+  };
+
+  const onPrev = () => {
+    onChange(value - 1 <= 1 ? 1 : value - 1);
+  };
+
+  const onNext = () => {
+    onChange(value + 1 >= pages ? pages : value + 1);
+  };
+
+  const onSelect: ChangeEventHandler<HTMLSelectElement> = event => {
+    onLimitChange?.(parseInt(event.target.value));
+  };
+
+  const pageInfo = pages ? (
+    <Text small>
+      {value} out of {pages}
+    </Text>
+  ) : (
+    <Text small>Page {value}</Text>
+  );
+
+  return (
+    <Container
+      className={cn(
+        'w-full grid items-center gap-x-6 gap-y-2 text-text-secondary',
+        'grid-rows-2 grid-cols-2',
+        'tablet:grid-rows-1 tablet:grid-cols-[auto_1fr_auto]',
+      )}
+    >
+      <div className='col-start-1 row-start-1 whitespace-nowrap'>
+        {hidePageInfo ? null : pageInfo}
+      </div>
+
+      <nav
+        className={cn(
+          'flex items-center justify-center gap-1 tablet:gap-3',
+          'col-span-2 row-start-2 tablet:col-span-1 tablet:col-start-2 tablet:row-start-1',
+        )}
+      >
+        <Density compact>
+          <Button priority='primary' disabled={value <= 1} onClick={onPrev}>
+            Prev
+          </Button>
+        </Density>
+
+        {hidePageButtons ? (
+          pageInfo
+        ) : (
+          <div className='flex items-center tablet:gap-3'>
+            {buttons.map((key, index) => (
+              <PaginationButton
+                key={index}
+                value={key}
+                active={value === key}
+                onClick={() => typeof key === 'number' && onChange(key)}
+              />
+            ))}
+          </div>
+        )}
+
+        <Density compact>
+          <Button priority='primary' disabled={!!pages && value >= pages} onClick={onNext}>
+            Next
+          </Button>
+        </Density>
+      </nav>
+
+      <div className='relative col-start-2 row-start-1 tablet:col-start-3'>
+        {!hideLimitSelector && limit > 0 && (
+          <>
+            <label
+              role='button'
+              className='flex cursor-pointer items-center justify-end gap-1 whitespace-nowrap text-text-secondary'
+              htmlFor={selectId}
+              aria-haspopup='listbox'
+              tabIndex={0}
+              onClick={onLabelClick}
+              onKeyDown={onLabelEnter}
+            >
+              <Text small>Show {limit}</Text>
+              <i className='flex size-4 items-center justify-center text-neutral-light'>
+                <ChevronsUpDown className='size-3' />
+              </i>
+            </label>
+
+            <select
+              ref={selectEl}
+              id={selectId}
+              onChange={onSelect}
+              className='invisible absolute left-0 top-0'
+            >
+              {limitOptionsSet.map(option => (
+                <option key={option.toString()} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+      </div>
+    </Container>
+  );
+};

--- a/packages/ui/src/Pagination/pagination-button.tsx
+++ b/packages/ui/src/Pagination/pagination-button.tsx
@@ -1,0 +1,35 @@
+import cn from 'clsx';
+import { Text } from '../Text';
+
+export const ELLIPSIS_KEY = '...';
+
+interface PaginationButtonProps {
+  value: number | typeof ELLIPSIS_KEY;
+  onClick: VoidFunction;
+  active?: boolean;
+}
+
+export const PaginationButton = ({ value, onClick, active }: PaginationButtonProps) => {
+  const disabled = value === ELLIPSIS_KEY;
+
+  let color = active
+    ? cn('text-text-primary bg-other-tonalFill10')
+    : cn('text-text-secondary hover:text-text-primary focus:text-text-primary');
+  if (disabled) {
+    color = cn('text-text-muted');
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={() => onClick()}
+      className={cn(
+        'size-8 min-w-8 rounded-full border-none transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-action-neutralFocusOutline',
+        color,
+      )}
+      disabled={disabled}
+    >
+      <Text small>{value}</Text>
+    </button>
+  );
+};


### PR DESCRIPTION
Closes #2124 

Add Pagination UI component with many props controlling its behavior. Implements this design: https://www.figma.com/design/QSiF2XSvHAWwzBJS5C3f4S/Penumbra-Web-UI?node-id=1030-51107&m=dev. However, goes further and makes it look fine on mobile screens.

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/8f36d41b-b0cc-4eb8-a85d-5955e16455ef" />


