### PR TITLE
bump wasm deps

### DIFF
--- a/.changeset/wicked-rings-grow.md
+++ b/.changeset/wicked-rings-grow.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/wasm': minor
+---
+
+bump wasm deps to latest tagged release

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -816,8 +816,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -830,8 +830,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -2080,8 +2080,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2119,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2164,8 +2164,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2194,8 +2194,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2225,8 +2225,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2278,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2294,8 +2294,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2318,8 +2318,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -2349,8 +2349,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2398,8 +2398,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2433,8 +2433,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "aes",
  "anyhow",
@@ -2477,8 +2477,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2513,8 +2513,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2538,8 +2538,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2565,8 +2565,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2599,8 +2599,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2650,8 +2650,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2691,8 +2691,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2720,8 +2720,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2772,8 +2772,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ae2300bce202a7d429727f1340e7412d3b9f810c#ae2300bce202a7d429727f1340e7412d3b9f810c"
+version = "2.0.0-alpha.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.4#2c98fa10f927e458ded2f352dc9bf95e7837f3d9"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -14,23 +14,22 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-# Update to tag dependency once https://github.com/penumbra-zone/penumbra/tree/protocol/lqt_branch is in a release
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-transaction", default-features = false }
-penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ae2300bce202a7d429727f1340e7412d3b9f810c", package = "penumbra-sdk-funding", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-transaction", default-features = false }
+penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.4", package = "penumbra-sdk-funding", default-features = false }
 
 anyhow = "1.0.89"
 ark-ff = { version = "0.4.2", features = ["std"] }


### PR DESCRIPTION
## Description of Changes

bumps wasm deps to the latest tagged release, `v2.0.0-alpha.4`

## Related Issue

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
