### PR TITLE
feat(veil): #2119: previous epochs

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-previous-epochs.ts
+++ b/apps/veil/src/pages/tournament/api/use-previous-epochs.ts
@@ -1,0 +1,83 @@
+import orderBy from 'lodash/orderBy';
+import { useQuery } from '@tanstack/react-query';
+import { connectionStore } from '@/shared/model/connection';
+import { DUMMY_UM_METADATA, DUMMY_USDC_METADATA } from './dummy';
+import { LQTVote } from './use-voting-rewards';
+
+export const BASE_LIMIT = 10;
+export const BASE_PAGE = 1;
+
+export interface EpochVote {
+  epoch: number;
+  votes: LQTVote[];
+  sort?: {
+    epoch: number;
+  };
+}
+
+const DUMMY_PREVIOUS_EPOCHS: EpochVote[] = Array.from({ length: 55 }, (_, i) => ({
+  epoch: i + 1,
+  votes: [
+    {
+      percent: Math.floor(Math.random() * 100 + 1),
+      asset: Math.random() > 0.5 ? DUMMY_UM_METADATA : DUMMY_USDC_METADATA,
+    },
+    {
+      percent: Math.floor(Math.random() * 100 + 1),
+      asset: Math.random() > 0.5 ? DUMMY_UM_METADATA : DUMMY_USDC_METADATA,
+    },
+    {
+      percent: Math.floor(Math.random() * 100 + 1),
+      asset: Math.random() > 0.5 ? DUMMY_UM_METADATA : DUMMY_USDC_METADATA,
+    },
+    {
+      percent: Math.floor(Math.random() * 100 + 1),
+      asset: Math.random() > 0.5 ? DUMMY_UM_METADATA : DUMMY_USDC_METADATA,
+    },
+    {
+      percent: Math.floor(Math.random() * 100 + 1),
+      asset: Math.random() > 0.5 ? DUMMY_UM_METADATA : DUMMY_USDC_METADATA,
+    },
+  ],
+}));
+
+const addSortToEpochVotes = (epochVote: EpochVote): Required<EpochVote> => {
+  const sortedVotes = [...epochVote.votes].sort((a, b) => a.percent - b.percent);
+  return {
+    ...epochVote,
+    votes: sortedVotes,
+    sort: {
+      epoch: epochVote.epoch,
+    },
+  };
+};
+
+export const usePreviousEpochs = (
+  page = BASE_PAGE,
+  limit = BASE_LIMIT,
+  sortKey?: keyof Required<EpochVote>['sort'] | '',
+  sortDirection?: 'asc' | 'desc',
+) => {
+  const query = useQuery<Required<EpochVote>[]>({
+    queryKey: ['previous-epochs', page, limit, sortKey, sortDirection],
+    enabled: connectionStore.connected,
+    queryFn: async () => {
+      // TODO: use backend API to fetch, filter, and sort previous epochs
+      return new Promise(resolve => {
+        setTimeout(() => {
+          const data = DUMMY_PREVIOUS_EPOCHS;
+          const mapped = data.map(addSortToEpochVotes);
+          const sorted =
+            sortKey && sortDirection ? orderBy(mapped, `sort.${sortKey}`, sortDirection) : mapped;
+          const limited = sorted.slice(limit * (page - 1), limit * page);
+          resolve(limited);
+        }, 1000);
+      });
+    },
+  });
+
+  return {
+    query,
+    total: DUMMY_PREVIOUS_EPOCHS.length,
+  };
+};

--- a/apps/veil/src/pages/tournament/api/use-voting-rewards.ts
+++ b/apps/veil/src/pages/tournament/api/use-voting-rewards.ts
@@ -9,13 +9,15 @@ import { DUMMY_VALUE_VIEW, DUMMY_UM_METADATA, DUMMY_USDC_METADATA } from './dumm
 export const BASE_LIMIT = 10;
 export const BASE_PAGE = 1;
 
+export interface LQTVote {
+  percent: number;
+  asset: Metadata;
+}
+
 export interface VotingReward {
   epoch: number;
   reward: ValueView;
-  vote: {
-    percent: number;
-    asset: Metadata;
-  };
+  vote: LQTVote;
   sort?: {
     epoch: number;
     reward: number;

--- a/apps/veil/src/pages/tournament/ui/page.tsx
+++ b/apps/veil/src/pages/tournament/ui/page.tsx
@@ -3,6 +3,7 @@
 import { PenumbraWaves } from '@/pages/explore/ui/waves';
 import { MyRewards } from './my-rewards';
 import { LandingCard } from './landing-card';
+import { PreviousEpochs } from './previous-epochs';
 
 export const TournamentPage = () => {
   return (
@@ -10,6 +11,8 @@ export const TournamentPage = () => {
       <PenumbraWaves />
       <LandingCard />
       <MyRewards />
+
+      <PreviousEpochs />
     </section>
   );
 };

--- a/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
+++ b/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+import { useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { ChevronRight } from 'lucide-react';
+import { Pagination } from '@penumbra-zone/ui/Pagination';
+import { TableCell } from '@penumbra-zone/ui/TableCell';
+import { Tooltip } from '@penumbra-zone/ui/Tooltip';
+import { Density } from '@penumbra-zone/ui/Density';
+import { Button } from '@penumbra-zone/ui/Button';
+import { Text } from '@penumbra-zone/ui/Text';
+import { usePreviousEpochs, BASE_PAGE, BASE_LIMIT, EpochVote } from '../api/use-previous-epochs';
+import { useSortableTableHeaders } from './sortable-table-header';
+import { Vote } from './vote';
+
+export const PreviousEpochs = observer(() => {
+  const [page, setPage] = useState(BASE_PAGE);
+  const [limit, setLimit] = useState(BASE_LIMIT);
+  const { getTableHeader, sortBy } = useSortableTableHeaders<keyof Required<EpochVote>['sort']>();
+
+  const {
+    query: { data, isLoading },
+    total,
+  } = usePreviousEpochs(page, limit, sortBy.key, sortBy.direction);
+
+  const loadingArr = new Array(10).fill({ votes: [] }) as EpochVote[];
+  const epochs = data ?? loadingArr;
+
+  const onLimitChange = (newLimit: number) => {
+    setLimit(newLimit);
+    setPage(BASE_PAGE);
+  };
+
+  return (
+    <div className='flex flex-col gap-6 p-6 w-full rounded-lg bg-other-tonalFill5 backdrop-blur-lg'>
+      <Text xxl color='text.primary'>
+        Previous epochs
+      </Text>
+      <Density compact>
+        <div className='grid grid-cols-[200px_1fr_48px]'>
+          <div className='grid grid-cols-subgrid col-span-3'>
+            {getTableHeader('epoch', 'Epoch')}
+            <TableCell heading>Votes Summary</TableCell>
+            <TableCell heading> </TableCell>
+          </div>
+
+          {epochs.map((epoch, index) => (
+            <Link
+              href={isLoading ? '' : `/tournament/${epoch.epoch}`}
+              key={index}
+              className='grid grid-cols-subgrid col-span-3 hover:bg-action-hoverOverlay transition-colors cursor-pointer'
+            >
+              <TableCell cell loading={isLoading}>
+                Epoch #{epoch.epoch}
+              </TableCell>
+              <TableCell cell loading={isLoading}>
+                {!isLoading &&
+                  epoch.votes.slice(0, 3).map((vote, index) => (
+                    <div key={index} className='flex items-center justify-start min-w-[88px] px-1'>
+                      <Vote asset={vote.asset} percent={vote.percent} hideFor />
+                    </div>
+                  ))}
+                {!isLoading && epoch.votes.length > 3 && (
+                  <Tooltip
+                    message={
+                      <div className='flex flex-col gap-2'>
+                        {epoch.votes.slice(3).map((vote, index) => (
+                          <Vote key={index} asset={vote.asset} percent={vote.percent} hideFor />
+                        ))}
+                      </div>
+                    }
+                  >
+                    <div className='flex items-center justify-start px-3 text-text-primary'>
+                      <Text smallTechnical>+{epoch.votes.length - 3}</Text>
+                    </div>
+                  </Tooltip>
+                )}
+              </TableCell>
+              <TableCell cell loading={isLoading}>
+                <Density slim>
+                  <Button iconOnly icon={ChevronRight}>
+                    Go to voting reward information
+                  </Button>
+                </Density>
+              </TableCell>
+            </Link>
+          ))}
+        </div>
+      </Density>
+
+      {!isLoading && total >= BASE_LIMIT && (
+        <Pagination
+          totalItems={total}
+          visibleItems={epochs.length}
+          value={page}
+          limit={limit}
+          onChange={setPage}
+          onLimitChange={onLimitChange}
+        />
+      )}
+    </div>
+  );
+});

--- a/apps/veil/src/pages/tournament/ui/vote.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote.tsx
@@ -5,14 +5,15 @@ import { Text } from '@penumbra-zone/ui/Text';
 export interface VoteProps {
   asset: Metadata;
   percent: number;
+  hideFor?: boolean;
 }
 
-export const Vote = ({ asset, percent }: VoteProps) => {
+export const Vote = ({ asset, percent, hideFor }: VoteProps) => {
   return (
     <div className='flex items-center gap-1'>
       <AssetIcon metadata={asset} />
       <Text smallTechnical color='text.primary'>
-        {percent}% for
+        {percent}% {hideFor ? '' : 'for'}
       </Text>
       <Text smallTechnical color='text.secondary'>
         {asset.symbol}


### PR DESCRIPTION
Closes #2119

Previous epochs table with dummy data. For connected to wallet state shows 5 columns, for disconnected – 3 columns. Navigates user to the epoch detail page.

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/1e4f4392-ecd4-42b1-bbf0-b01626644023" />
