### PR TITLE
fix: unbonding penalty calculation

### DIFF
--- a/.changeset/forty-laws-refuse.md
+++ b/.changeset/forty-laws-refuse.md
@@ -1,0 +1,5 @@
+---
+'minifront': minor
+---
+
+fix unbonding penalty range calculation

--- a/.changeset/slow-wings-glow.md
+++ b/.changeset/slow-wings-glow.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/types': minor
+---
+
+remove `getUnbondingStartHeight` export from assets regex module

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -88,7 +88,7 @@ const getUnbondingEndHeight = ({
   );
 };
 
-const assembleUndelegateClaimPlan = async ({
+const assembleUndelegationClaim = async ({
   currentHeight,
   appUnbondingDelay,
   unbondingToken,
@@ -151,7 +151,7 @@ export const assembleUndelegateClaimRequest = async ({
 
   const undelegationClaims = await Promise.all(
     unbondingTokens.map(unbondingToken =>
-      assembleUndelegateClaimPlan({
+      assembleUndelegationClaim({
         currentHeight: fullSyncHeight,
         appUnbondingDelay: unbondingDelay,
         unbondingToken,

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -135,10 +135,9 @@ export const assembleUndelegateClaimRequest = async ({
 }: {
   account: number;
   unbondingTokens: ValueView[];
-}) => {
+}): Promise<TransactionPlannerRequest> => {
   const appClient = penumbra.service(AppService);
   const viewClient = penumbra.service(ViewService);
-  const sctClient = penumbra.service(SctService);
 
   const { appParameters } = await appClient.appParameters({});
   if (!appParameters?.stakeParams?.unbondingDelay) {
@@ -149,11 +148,6 @@ export const assembleUndelegateClaimRequest = async ({
   const { unbondingDelay } = appParameters.stakeParams;
 
   const { fullSyncHeight } = await viewClient.status({});
-
-  const { epoch: presentEpoch } = await sctClient.epochByHeight({ height: fullSyncHeight });
-  if (!presentEpoch?.index) {
-    return;
-  }
 
   const undelegationClaims = await Promise.all(
     unbondingTokens.map(unbondingToken =>

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -9,31 +9,125 @@ import {
   getValidatorIdentityKeyFromValueView,
   getMetadata,
 } from '@penumbra-zone/getters/value-view';
-import { getUnbondingStartHeight } from '@penumbra-zone/types/assets';
+import { getBondingState } from '@penumbra-zone/getters/validator-status';
 import { penumbra } from '../../penumbra';
-import { SctService, StakeService, ViewService } from '@penumbra-zone/protobuf';
+import { AppService, SctService, StakeService, ViewService } from '@penumbra-zone/protobuf';
+import { assetPatterns } from '@penumbra-zone/types/assets';
+import {
+  BondingState,
+  BondingState_BondingStateEnum,
+} from '@penumbra-zone/protobuf/penumbra/core/component/stake/v1/stake_pb';
 
-const getUndelegateClaimPlannerRequest =
-  (endEpochIndex: bigint) => async (unbondingToken: ValueView) => {
-    const unbondingStartHeight = getUnbondingStartHeight(getMetadata(unbondingToken));
-    const identityKey = getValidatorIdentityKeyFromValueView(unbondingToken);
-    const { epoch: startEpoch } = await penumbra
-      .service(SctService)
-      .epochByHeight({ height: unbondingStartHeight });
+/**
+ * Get the unbonding start height index from the `ValueView` of an unbonding token
+ * -- that is, the block height at which unbonding started.
+ */
+const getUnbondingStartHeight = (unbondingToken: ValueView): bigint => {
+  const unbondingMetadata = getMetadata(unbondingToken);
 
-    const { penalty } = await penumbra.service(StakeService).validatorPenalty({
-      startEpochIndex: startEpoch?.index,
-      endEpochIndex,
-      identityKey,
+  const unbondingMatch = assetPatterns.unbondingToken.capture(unbondingMetadata.display);
+  if (!unbondingMatch?.startAt) {
+    throw TypeError('Not an unbonding token', { cause: unbondingMetadata });
+  }
+
+  return BigInt(unbondingMatch.startAt);
+};
+
+/**
+ * Calculate the unbonding end height for a particular token, based on present
+ * state of the validator.
+ *
+ * @see https://github.com/penumbra-zone/penumbra/pull/5084
+ */
+const getUnbondingEndHeight = ({
+  currentHeight,
+  appUnbondingDelay,
+  startHeight,
+  bondingState,
+}: {
+  currentHeight: bigint;
+  appUnbondingDelay: bigint;
+  startHeight: bigint;
+  bondingState: BondingState;
+}) => {
+  if (!bondingState.state) {
+    throw new ReferenceError('Validator bonding state must be available and specified', {
+      cause: bondingState,
     });
+  }
+  const { state: validatorState, unbondsAtHeight: validatorUnbondingHeight } = bondingState;
 
-    return new TransactionPlannerRequest_UndelegateClaim({
-      validatorIdentity: identityKey,
-      unbondingStartHeight,
-      penalty,
-      unbondingAmount: getAmount(unbondingToken),
-    });
-  };
+  const appDelayHeight = startHeight + appUnbondingDelay;
+
+  let endHeight: bigint;
+  switch (validatorState) {
+    case BondingState_BondingStateEnum.BONDED:
+      endHeight = appDelayHeight;
+      break;
+    case BondingState_BondingStateEnum.UNBONDING:
+      if (validatorUnbondingHeight > startHeight) {
+        endHeight =
+          // if the validator height exceeds the app delay height
+          validatorUnbondingHeight > appDelayHeight
+            ? appDelayHeight //  clamp to the app delay height
+            : validatorUnbondingHeight;
+      } else {
+        endHeight = currentHeight;
+      }
+      break;
+    case BondingState_BondingStateEnum.UNBONDED:
+      endHeight = currentHeight;
+      break;
+  }
+
+  return (
+    // if the calculated height is in the future
+    endHeight > currentHeight
+      ? currentHeight // clamp to the current height
+      : endHeight
+  );
+};
+
+const assembleUndelegateClaimPlan = async ({
+  currentHeight,
+  appUnbondingDelay,
+  unbondingToken,
+}: {
+  currentHeight: bigint;
+  appUnbondingDelay: bigint;
+  unbondingToken: ValueView;
+}): Promise<TransactionPlannerRequest_UndelegateClaim> => {
+  const sctClient = penumbra.service(SctService);
+  const stakeClient = penumbra.service(StakeService);
+
+  const identityKey = getValidatorIdentityKeyFromValueView(unbondingToken);
+
+  const startHeight = getUnbondingStartHeight(unbondingToken);
+  const { epoch: startEpoch } = await sctClient.epochByHeight({ height: startHeight });
+
+  const { status: validatorStatus } = await stakeClient.validatorStatus({ identityKey });
+
+  const endHeight = getUnbondingEndHeight({
+    currentHeight,
+    appUnbondingDelay,
+    startHeight,
+    bondingState: getBondingState(validatorStatus),
+  });
+  const { epoch: endEpoch } = await sctClient.epochByHeight({ height: endHeight });
+
+  const { penalty } = await stakeClient.validatorPenalty({
+    identityKey,
+    startEpochIndex: startEpoch?.index,
+    endEpochIndex: endEpoch?.index,
+  });
+
+  return new TransactionPlannerRequest_UndelegateClaim({
+    validatorIdentity: identityKey,
+    unbondingStartHeight: startHeight,
+    unbondingAmount: getAmount(unbondingToken),
+    penalty,
+  });
+};
 
 export const assembleUndelegateClaimRequest = async ({
   account,
@@ -42,17 +136,37 @@ export const assembleUndelegateClaimRequest = async ({
   account: number;
   unbondingTokens: ValueView[];
 }) => {
-  const { fullSyncHeight } = await penumbra.service(ViewService).status({});
-  const { epoch } = await penumbra.service(SctService).epochByHeight({ height: fullSyncHeight });
-  const endEpochIndex = epoch?.index;
-  if (!endEpochIndex) {
+  const appClient = penumbra.service(AppService);
+  const viewClient = penumbra.service(ViewService);
+  const sctClient = penumbra.service(SctService);
+
+  const { appParameters } = await appClient.appParameters({});
+  if (!appParameters?.stakeParams?.unbondingDelay) {
+    throw new ReferenceError('Unbonding delay must be available', {
+      cause: appParameters?.stakeParams,
+    });
+  }
+  const { unbondingDelay } = appParameters.stakeParams;
+
+  const { fullSyncHeight } = await viewClient.status({});
+
+  const { epoch: presentEpoch } = await sctClient.epochByHeight({ height: fullSyncHeight });
+  if (!presentEpoch?.index) {
     return;
   }
 
-  return new TransactionPlannerRequest({
-    undelegationClaims: await Promise.all(
-      unbondingTokens.map(getUndelegateClaimPlannerRequest(endEpochIndex)),
+  const undelegationClaims = await Promise.all(
+    unbondingTokens.map(unbondingToken =>
+      assembleUndelegateClaimPlan({
+        currentHeight: fullSyncHeight,
+        appUnbondingDelay: unbondingDelay,
+        unbondingToken,
+      }),
     ),
+  );
+
+  return new TransactionPlannerRequest({
+    undelegationClaims,
     source: { account },
   });
 };

--- a/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
+++ b/apps/minifront/src/state/staking/assemble-undelegate-claim-request.ts
@@ -19,10 +19,9 @@ import {
 } from '@penumbra-zone/protobuf/penumbra/core/component/stake/v1/stake_pb';
 
 /**
- * Get the unbonding start height index from the `ValueView` of an unbonding token
- * -- that is, the block height at which unbonding started.
+ * Parse the value's denom for its embedded unbonding start height.
  */
-const getUnbondingStartHeight = (unbondingToken: ValueView): bigint => {
+const parseUnbondingStartHeight = (unbondingToken: ValueView): bigint => {
   const unbondingMetadata = getMetadata(unbondingToken);
 
   const unbondingMatch = assetPatterns.unbondingToken.capture(unbondingMetadata.display);
@@ -102,7 +101,7 @@ const assembleUndelegationClaim = async ({
 
   const identityKey = getValidatorIdentityKeyFromValueView(unbondingToken);
 
-  const startHeight = getUnbondingStartHeight(unbondingToken);
+  const startHeight = parseUnbondingStartHeight(unbondingToken);
   const { epoch: startEpoch } = await sctClient.epochByHeight({ height: startHeight });
 
   const { status: validatorStatus } = await stakeClient.validatorStatus({ identityKey });

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -345,9 +345,6 @@ export const createStakingSlice = (): SliceCreator<StakingSlice> => (set, get) =
 
     try {
       const req = await assembleUndelegateClaimRequest({ account, unbondingTokens });
-      if (!req) {
-        return;
-      }
 
       await planBuildBroadcast('undelegateClaim', req);
 

--- a/packages/types/src/assets.test.ts
+++ b/packages/types/src/assets.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { assetPatterns, getUnbondingStartHeight, RegexMatcher } from './assets.js';
-import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { assetPatterns, RegexMatcher } from './assets.js';
 
 describe('assetPatterns', () => {
   describe('auctionNft', () => {
@@ -155,23 +154,5 @@ describe('RegexMatcher', () => {
       subject: 'world',
     };
     expect(matcher.capture('hello world')).toEqual(expected);
-  });
-});
-
-describe('getUnbondingStartHeight()', () => {
-  it("gets the unbonding start height, coerced to a `BigInt`, from an unbonding token's asset ID", () => {
-    const metadata = new Metadata({ display: 'unbonding_start_at_123_penumbravalid1abc123' });
-
-    expect(getUnbondingStartHeight(metadata)).toBe(123n);
-  });
-
-  it("returns `undefined` for a non-unbonding token's metadata", () => {
-    const metadata = new Metadata({ display: 'penumbra' });
-
-    expect(getUnbondingStartHeight(metadata)).toBeUndefined();
-  });
-
-  it('returns `undefined` for undefined metadata', () => {
-    expect(getUnbondingStartHeight(undefined)).toBeUndefined();
   });
 });

--- a/packages/types/src/assets.ts
+++ b/packages/types/src/assets.ts
@@ -1,5 +1,3 @@
-import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-
 // PRICE_RELEVANCE_THRESHOLDS defines how long prices for different asset types remain relevant (in blocks)
 // 1 block = 5 seconds, 200 blocks approximately equals 17 minutes
 export const PRICE_RELEVANCE_THRESHOLDS = {
@@ -91,25 +89,4 @@ export const assetPatterns: AssetPatterns = {
   ),
   votingReceipt: new RegexMatcher(/^voted_on_/),
   ibc: new RegexMatcher(/^transfer\/(?<channel>channel-\d+)\/(?<denom>.*)/),
-};
-
-/**
- * Get the unbonding start height index from the metadata of an unbonding token
- * -- that is, the block height at which unbonding started.
- *
- * For metadata of a non-unbonding token, will return `undefined`.
- */
-export const getUnbondingStartHeight = (metadata?: Metadata) => {
-  if (!metadata) {
-    return undefined;
-  }
-
-  const unbondingMatch = assetPatterns.unbondingToken.capture(metadata.display);
-
-  if (unbondingMatch) {
-    const { startAt } = unbondingMatch;
-    return BigInt(startAt);
-  }
-
-  return undefined;
 };


### PR DESCRIPTION
## Description of Changes

Port of pcli fix https://github.com/penumbra-zone/penumbra/pull/5084 to the minifront planning UI

>This fixes an edge-case in pcli tx undelegate-claim that would compute an invalid penalty range for dated delegation tokens.

>Instead of using the current epoch as the end of the penalty range, we compute a more precise bound using the block delay chain parameter. This fixes processing old delegation tokens bound to a validator that transitioned in and out of penalty states.

## Related Issue

https://github.com/penumbra-zone/penumbra/pull/5084

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
