### PR TITLE
use node setup action in workflows

### DIFF
--- a/.github/workflows/deploy-ui-preview-main.yml
+++ b/.github/workflows/deploy-ui-preview-main.yml
@@ -14,6 +14,11 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/deploy-ui-release.yml
+++ b/.github/workflows/deploy-ui-release.yml
@@ -16,6 +16,11 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
use node setup action in deploy-ui workflows, to match others. these workflows broke recently due to new engine requirements in veil.

should probably centralize tool-versions with something like mise.

https://github.com/penumbra-zone/web/actions/runs/14231070370/job/39914124285