### PR TITLE
fix(veil): #2153: consistent x axis

### DIFF
--- a/apps/veil/src/pages/trade/ui/chart.tsx
+++ b/apps/veil/src/pages/trade/ui/chart.tsx
@@ -149,6 +149,7 @@ const ChartData = observer(({ candles }: { candles: CandleWithVolume[] }) => {
         timeScale: {
           timeVisible: true,
           secondsVisible: false,
+          uniformDistribution: true,
         },
       });
 
@@ -196,8 +197,6 @@ const ChartData = observer(({ candles }: { candles: CandleWithVolume[] }) => {
               : theme.color.destructive.light + '80',
         })),
       );
-
-      chartRef.current.timeScale().fitContent();
     }
 
     return () => {
@@ -225,20 +224,8 @@ const ChartData = observer(({ candles }: { candles: CandleWithVolume[] }) => {
               : theme.color.destructive.light + '80',
         })),
       );
-      chartRef.current?.timeScale().fitContent();
     }
   }, [candles]);
-
-  // Handle window resize to re-fit content
-  useEffect(() => {
-    const handleResize = () => {
-      if (chartRef.current) {
-        chartRef.current.timeScale().fitContent();
-      }
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   return <div className='h-full w-full' ref={chartElRef} />;
 });


### PR DESCRIPTION
Closes #2153 

The default Trading View behavior without using `.fitContent()` appears to be just what we need. Time frames like '1m', '15m', '1h', '4h', '1d' look very good with consistent bar width. The '1w' and '1mo` time frames lack data a little, but generally good to look consistent.