### PR TITLE
fix(ui, veil): #2141: transaction-related bug fixes

### DIFF
--- a/.changeset/eighty-areas-fry.md
+++ b/.changeset/eighty-areas-fry.md
@@ -1,0 +1,8 @@
+---
+'@penumbra-zone/ui-deprecated': patch
+'minifront': patch
+'@penumbra-zone/ui': patch
+'penumbra-veil': patch
+---
+
+Fix bugs related to transaction history and transaction/action views

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -58,7 +58,7 @@
     "react-helmet": "^6.1.0",
     "react-loader-spinner": "^6.1.6",
     "react-router-dom": "^6.23.1",
-    "sonner": "1.4.3",
+    "sonner": "^2.0.3",
     "tailwindcss": "^3.4.16",
     "viem": "^2.21.54",
     "wagmi": "^2.14.0",

--- a/apps/veil/src/entities/transaction/api/plan-build-broadcast.tsx
+++ b/apps/veil/src/entities/transaction/api/plan-build-broadcast.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { TransactionPlannerRequest } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
@@ -79,7 +80,10 @@ export const planBuildBroadcast = async (
       type: 'success',
       message: `${label} transaction succeeded! 🎉`,
       description: `Transaction ${shortenedTxHash} appeared on chain${detectionHeight ? ` at height ${detectionHeight}` : ''}.`,
-      // action: <Link to={`/tx/${this._txHash}`}>See details</Link>
+      action: {
+        label: <Link href={`/inspect/tx/${txHash}`}>See details</Link>,
+        onClick: () => {},
+      },
       dismissible: true,
       persistent: false,
     });

--- a/apps/veil/src/pages/inspect/tx/ui/tx-viewer.tsx
+++ b/apps/veil/src/pages/inspect/tx/ui/tx-viewer.tsx
@@ -147,9 +147,11 @@ export const TxViewer = observer(({ txInfo }: { txInfo?: TransactionInfo }) => {
           {txv?.bodyView?.actionViews.map((action, index) => (
             <Fragment key={index}>
               <ActionView action={action} getMetadata={getMetadata} />
-              <div className='h-2 w-full px-5'>
-                <div className='h-full w-px border-l border-solid border-l-other-tonalStroke' />
-              </div>
+              {index !== (txv.bodyView?.actionViews.length ?? 1) - 1 && (
+                <div className='h-2 w-full px-5'>
+                  <div className='h-full w-px border-l border-solid border-l-other-tonalStroke' />
+                </div>
+              )}
             </Fragment>
           ))}
         </div>

--- a/apps/veil/src/pages/inspect/tx/ui/tx-viewer.tsx
+++ b/apps/veil/src/pages/inspect/tx/ui/tx-viewer.tsx
@@ -119,6 +119,7 @@ export const TxViewer = observer(({ txInfo }: { txInfo?: TransactionInfo }) => {
                 info={
                   <Density slim>
                     <AddressViewComponent
+                      truncate
                       addressView={txv.bodyView.memoView.memoView.value.plaintext.returnAddress}
                     />
                   </Density>

--- a/apps/veil/src/pages/portfolio/api/use-transactions.ts
+++ b/apps/veil/src/pages/portfolio/api/use-transactions.ts
@@ -18,7 +18,7 @@ export const useTransactions = (subaccount = 0) => {
       const res = await Array.fromAsync(penumbra.service(ViewService).transactionInfo({}));
 
       // Filters and maps the array at the same time
-      const reduced = res.reduce<TransactionInfo[]>((accum, tx) => {
+      let reduced = res.reduce<TransactionInfo[]>((accum, tx) => {
         const addresses = tx.txInfo?.perspective?.addressViews;
 
         if (
@@ -42,7 +42,7 @@ export const useTransactions = (subaccount = 0) => {
       }, []);
 
       // TODO: implement sorting by height in the ViewService, and use `limitAsync` here after it
-      reduced.sort((a, b) => Number(a.height - b.height));
+      reduced = reduced.sort((a, b) => Number(b.height) - Number(a.height));
 
       const offset = BASE_LIMIT * (pageParam as number);
       return reduced.slice(offset, offset + BASE_LIMIT);

--- a/packages/ui-deprecated/package.json
+++ b/packages/ui-deprecated/package.json
@@ -102,7 +102,7 @@
     "react-dom": "^18.3.1",
     "react-loader-spinner": "^6.1.6",
     "react-router-dom": "^6.23.1",
-    "sonner": "1.4.3",
+    "sonner": "^2.0.3",
     "styled-components": "^6.1.13",
     "tailwind-merge": "^3.0.1",
     "tinycolor2": "^1.6.0",

--- a/packages/ui-deprecated/src/Toast/provider.tsx
+++ b/packages/ui-deprecated/src/Toast/provider.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from 'sonner';
+import { Toaster, ToasterProps } from 'sonner';
 
 /**
  * If `<ToastProvider />` exists in the document, you can call `openToast` function to open a toast with provided type and options.
@@ -36,6 +36,6 @@ import { Toaster } from 'sonner';
  * };
  * ```
  */
-export const ToastProvider: typeof Toaster = ({ ...props }) => {
+export const ToastProvider = ({ ...props }: ToasterProps) => {
   return <Toaster theme='dark' richColors expand {...props} />;
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,7 +49,7 @@
     "murmurhash3js": "^3.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sonner": "1.4.3",
+    "sonner": "^2.0.3",
     "tinycolor2": "^1.6.0"
   },
   "devDependencies": {

--- a/packages/ui/src/ActionView/actions/output.tsx
+++ b/packages/ui/src/ActionView/actions/output.tsx
@@ -23,7 +23,7 @@ export const OutputAction = ({ value }: OutputActionProps) => {
             priority={density === 'sparse' ? 'primary' : 'tertiary'}
             valueView={getNote(value).value}
           />
-          <AddressViewComponent addressView={getAddress(getNote(value))} />
+          <AddressViewComponent addressView={getAddress(getNote(value))} truncate />
         </Density>
       )}
     </ActionWrapper>

--- a/packages/ui/src/ActionView/actions/spend.tsx
+++ b/packages/ui/src/ActionView/actions/spend.tsx
@@ -21,7 +21,7 @@ export const SpendAction = ({ value }: SpendActionProps) => {
             priority={density === 'sparse' ? 'primary' : 'tertiary'}
             valueView={value.spendView.value.note?.value}
           />
-          <AddressViewComponent addressView={value.spendView.value.note?.address} />
+          <AddressViewComponent truncate addressView={value.spendView.value.note?.address} />
         </Density>
       )}
     </ActionWrapper>

--- a/packages/ui/src/Toast/provider.tsx
+++ b/packages/ui/src/Toast/provider.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from 'sonner';
+import { Toaster, ToasterProps } from 'sonner';
 
 /**
  * If `<ToastProvider />` exists in the document, you can call `openToast` function to open a toast with provided type and options.
@@ -36,6 +36,6 @@ import { Toaster } from 'sonner';
  * };
  * ```
  */
-export const ToastProvider: typeof Toaster = ({ ...props }) => {
+export const ToastProvider = ({ ...props }: ToasterProps) => {
   return <Toaster theme='dark' richColors expand {...props} />;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
         specifier: ^6.23.1
         version: 6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
-        specifier: 1.4.3
-        version: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.17(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.13)(typescript@5.5.3))
@@ -972,8 +972,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       sonner:
-        specifier: 1.4.3
-        version: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinycolor2:
         specifier: ^1.6.0
         version: 1.6.0
@@ -1192,8 +1192,8 @@ importers:
         specifier: ^6.23.1
         version: 6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
-        specifier: 1.4.3
-        version: 1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-components:
         specifier: ^6.1.13
         version: 6.1.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11451,11 +11451,11 @@ packages:
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
 
-  sonner@1.4.3:
-    resolution: {integrity: sha512-SArYlHbkjqRuLiR0iGY2ZSr09oOrxw081ZZkQPfXrs8aZQLIBOLOdzTYxGJB5yIZ7qL56UEPmrX1YqbODwG0Lw==}
+  sonner@2.0.3:
+    resolution: {integrity: sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==}
     peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -29743,7 +29743,7 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
-  sonner@1.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  sonner@2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
Closes #2142 

Closes #2141 

Closes #2140 

Fixes:
- Updated Sonner to v2.0.3 and tested that it doesn't break nor Veil, nor Minifront
- Added a link to the inspect page in transaction success toast
- Truncated addresses correctly in action and transaction views
- Reversed transaction order in Veil portfolio page