### PR TITLE
skip widget config

### DIFF
--- a/apps/minifront/src/components/ibc/deposit-skip/index.tsx
+++ b/apps/minifront/src/components/ibc/deposit-skip/index.tsx
@@ -47,5 +47,12 @@ const theme = {
 };
 
 export const DepositSkip = () => {
-  return <Widget defaultRoute={defaultRoute} filter={filter} theme={theme} />;
+  return (
+    <Widget
+      defaultRoute={defaultRoute}
+      filter={filter}
+      theme={theme}
+      enableAmplitudeAnalytics={false}
+    />
+  );
 };


### PR DESCRIPTION
## Description of Changes

_explicitly_ disables analytics rather than relying on the default behavior, even though skip-go appears to not enable analytics by default

## Related Issue

https://github.com/penumbra-zone/web/issues/2212

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
