### PR TITLE
stub skip-go dep

### DIFF
--- a/.changeset/old-frogs-flash.md
+++ b/.changeset/old-frogs-flash.md
@@ -1,0 +1,5 @@
+---
+'@repo/stubs': major
+---
+
+introduce stubs

--- a/apps/minifront-v2/package.json
+++ b/apps/minifront-v2/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@chain-registry/types": "^0.50.93",
     "@eslint/compat": "^1.1.0",
+    "@repo/stubs": "workspace:*",
     "@storybook/react": "^8.4.2",
     "@types/chrome": "^0.0.268",
     "@types/lodash": "^4.17.13",

--- a/apps/minifront-v2/vite.config.ts
+++ b/apps/minifront-v2/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import react from '@vitejs/plugin-react-swc';
 import polyfillNode from 'vite-plugin-node-stdlib-browser';
 import svgr from 'vite-plugin-svgr';
+import url from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,6 +23,9 @@ export default defineConfig(({ mode }) => {
         '@entities': path.resolve(__dirname, 'entities'),
         '@features': path.resolve(__dirname, 'features'),
         '@widgets': path.resolve(__dirname, 'widgets'),
+        '@amplitude/analytics-browser': url.fileURLToPath(
+          import.meta.resolve('@repo/stubs/amplitude-analytics-browser'),
+        ),
       },
     },
     plugins: [

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@chain-registry/types": "^0.50.93",
     "@eslint/compat": "^1.1.0",
+    "@repo/stubs": "workspace:*",
     "@storybook/react": "^8.4.2",
     "@types/chrome": "^0.0.268",
     "@types/lodash": "^4.17.13",

--- a/apps/minifront/vite.config.ts
+++ b/apps/minifront/vite.config.ts
@@ -5,12 +5,20 @@ import react from '@vitejs/plugin-react-swc';
 import { commitInfoPlugin } from './src/utils/commit-info-vite-plugin';
 import polyfillNode from 'vite-plugin-node-stdlib-browser';
 import svgr from 'vite-plugin-svgr';
+import url from 'node:url';
 
 export default defineConfig(({ mode }) => {
   return {
     define: { 'globalThis.__DEV__': mode !== 'production' },
     clearScreen: false,
     base: './',
+    resolve: {
+      alias: {
+        '@amplitude/analytics-browser': url.fileURLToPath(
+          import.meta.resolve('@repo/stubs/amplitude-analytics-browser'),
+        ),
+      },
+    },
     plugins: [
       polyfillNode(),
       react(),

--- a/apps/veil/next.config.mjs
+++ b/apps/veil/next.config.mjs
@@ -20,6 +20,9 @@ const nextConfig = {
   webpack: config => {
     config.externals.push('pino-pretty');
 
+    config.resolve.alias['@amplitude/analytics-browser'] =
+      '@repo/stubs/amplitude-analytics-browser';
+
     config.module.rules.push({
       test: /\.svg$/i,
       issuer: /\.[jt]sx?$/,

--- a/apps/veil/package.json
+++ b/apps/veil/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "add:tgz": "tsx scripts/add-tgz.ts",
     "build": "next build",
+    "clean": "rm -rfv *.tsbuildinfo",
     "dev": "next dev",
+    "dev:app": "next dev",
     "format": "prettier --write .",
     "generate-pindexer-schema": "tsx ./scripts/generate-pindexer-schema.ts",
     "lint": "eslint src",
@@ -76,6 +78,7 @@
   "devDependencies": {
     "@eslint/js": "^9.16.0",
     "@next/bundle-analyzer": "15.2.4",
+    "@repo/stubs": "workspace:*",
     "@svgr/webpack": "^8.1.0",
     "@types/chrome": "^0.0.268",
     "@types/lodash": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "overrides": {
       "typescript": "5.5.3",
       "cosmos-kit": "^2.21.1",
-      "@hexxagon/feather.js": "npm:@terra-money/feather.js@1.0.9"
+      "@hexxagon/feather.js": "npm:@terra-money/feather.js@1.0.9",
+      "@amplitude/analytics-browser": "./packages/stubs"
     }
   },
   "devDependencies": {

--- a/packages/stubs/package.json
+++ b/packages/stubs/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@repo/stubs",
+  "version": "0.0.1",
+  "private": true,
+  "license": "(MIT OR Apache-2.0)",
+  "description": "Stubs for some third-party packages",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --build --verbose",
+    "clean": "rm -rfv dist *.tsbuildinfo",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "lint:strict": "tsc --noEmit && eslint src --max-warnings 0"
+  },
+  "exports": {
+    "./amplitude-analytics-browser": {
+      "types": "./dist/amplitude-analytics-browser.d.cts",
+      "default": "./dist/amplitude-analytics-browser.cjs"
+    }
+  }
+}

--- a/packages/stubs/src/amplitude-analytics-browser.cts
+++ b/packages/stubs/src/amplitude-analytics-browser.cts
@@ -1,0 +1,7 @@
+const stub = (name: string) =>
+  globalThis.__DEV__ ? console.warn.bind(console, 'stub', name) : () => void null;
+
+export const add = stub('add');
+export const init = stub('init');
+export const setUserId = stub('setUserId');
+export const track = stub('track');

--- a/packages/stubs/src/global.d.ts
+++ b/packages/stubs/src/global.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  // eslint-disable-next-line no-var -- global dev mode flag
+  var __DEV__: boolean | undefined;
+}
+
+export {};

--- a/packages/stubs/tsconfig.json
+++ b/packages/stubs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["@tsconfig/strictest/tsconfig.json"],
+  "include": ["./src"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,9 @@ importers:
       '@eslint/compat':
         specifier: ^1.1.0
         version: 1.2.9(eslint@9.27.0(jiti@1.21.7))
+      '@repo/stubs':
+        specifier: workspace:*
+        version: link:../../packages/stubs
       '@storybook/react':
         specifier: ^8.4.2
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(bufferutil@4.0.9)(prettier@3.5.3)(utf-8-validate@5.0.10)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(bufferutil@4.0.9)(prettier@3.5.3)(utf-8-validate@5.0.10))(typescript@5.5.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   typescript: 5.5.3
   cosmos-kit: ^2.21.1
   '@hexxagon/feather.js': npm:@terra-money/feather.js@1.0.9
+  '@amplitude/analytics-browser': ./packages/stubs
 
 importers:
 
@@ -317,6 +318,9 @@ importers:
       '@eslint/compat':
         specifier: ^1.1.0
         version: 1.2.9(eslint@9.27.0(jiti@1.21.7))
+      '@repo/stubs':
+        specifier: workspace:*
+        version: link:../../packages/stubs
       '@storybook/react':
         specifier: ^8.4.2
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(bufferutil@4.0.9)(prettier@3.5.3)(utf-8-validate@5.0.10)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(bufferutil@4.0.9)(prettier@3.5.3)(utf-8-validate@5.0.10))(typescript@5.5.3)
@@ -704,6 +708,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: 15.2.4
         version: 15.2.4(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@repo/stubs':
+        specifier: workspace:*
+        version: link:../../packages/stubs
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.5.3)
@@ -989,6 +996,8 @@ importers:
       fetch-mock:
         specifier: 10.0.7
         version: 10.0.7
+
+  packages/stubs: {}
 
   packages/tailwind-config:
     dependencies:
@@ -1508,12 +1517,6 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@amplitude/analytics-browser@2.17.6':
-    resolution: {integrity: sha512-1Lbm5KNXG/6Zpg1Zr0qAmft562kXWGIXZ1ah12oEf6Wcp2ePxIPlbkKgagOTzeS8hwOlfuKVeBy9oCuOdf8yFw==}
-
-  '@amplitude/analytics-client-common@2.3.21':
-    resolution: {integrity: sha512-7KfSIr9d+Dnn+jW3UxQS/VlTaWpQz0nxX4LCi006x7YtjFgReFU2dxwB/48ZkfORLBEQokhm7cKilvD+JZveeg==}
-
   '@amplitude/analytics-connector@1.6.4':
     resolution: {integrity: sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==}
 
@@ -1523,26 +1526,11 @@ packages:
   '@amplitude/analytics-core@2.12.0':
     resolution: {integrity: sha512-mfA6J2krFionypPHka65fK13eFi058EjSpLk8XgGmGS6Yvw+eidkgHvbouNDKwxBkhQFDH7cY8vOZeIAdkrktw==}
 
-  '@amplitude/analytics-remote-config@0.4.1':
-    resolution: {integrity: sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==}
-
   '@amplitude/analytics-remote-config@0.6.2':
     resolution: {integrity: sha512-TsJ8u/R1Yi+Q+pEb4xi3Y5C2V4+1zHS0BjmbpS94fnCG7mkSIKp4O4c23rQlyBGyCddrYZbWnZnMdKSUmFKpcA==}
 
   '@amplitude/analytics-types@1.3.5':
     resolution: {integrity: sha512-IpncCNTZZ6VoGe4fNwTTZtpi+ZNm3mtsocdbCHtIwmKg2wmOF2E09CAwvyF7mK5aRlMIrSAKQyR3GwraATghSw==}
-
-  '@amplitude/analytics-types@2.9.2':
-    resolution: {integrity: sha512-juhTz396dDP/jLJYP9zDOEAZBtJM0JVvP8G10p1OxUDBVwVIprpQL598F9GRQwVFyqV4CEhDmNyAY0HqqU5bhA==}
-
-  '@amplitude/plugin-autocapture-browser@1.2.6':
-    resolution: {integrity: sha512-+WB6DSGrKOxWC0muT/z0bcc5ftzjPY9L1D3CB5nHIHJTHAzxkTuc1+TFRtjc8L5Tdly9h2YADPNo1H8dkWNOkg==}
-
-  '@amplitude/plugin-network-capture-browser@1.1.6':
-    resolution: {integrity: sha512-Ck39vvvizJ7qlBUxkOqq8k4/hrD9yCdvceBpSDfCr9jGzd3R3VisYUHsChOVChHd1fOoLtpoKF+HsgfrXmn17g==}
-
-  '@amplitude/plugin-page-view-tracking-browser@2.3.27':
-    resolution: {integrity: sha512-iJeuCn+jvBymQwV2EEkZhmJg+bitpZulubCxRMI0ihIdh/Nvk1XWhwmSfcgKaxMdk2qpa9CYXD9/pDewI88IDg==}
 
   '@amplitude/plugin-session-replay-browser@1.16.9':
     resolution: {integrity: sha512-TjAShrBGwAdVDjnlYeskvgmp7gyvOvEfft8uWsw8WGqm2m3Nze+P3lBfql7OdlZwLsbNSm0HGkBCsbn0jwAulg==}
@@ -13102,22 +13090,6 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@amplitude/analytics-browser@2.17.6':
-    dependencies:
-      '@amplitude/analytics-core': 2.12.0
-      '@amplitude/analytics-remote-config': 0.4.1
-      '@amplitude/plugin-autocapture-browser': 1.2.6
-      '@amplitude/plugin-network-capture-browser': 1.1.6
-      '@amplitude/plugin-page-view-tracking-browser': 2.3.27
-      tslib: 2.8.1
-
-  '@amplitude/analytics-client-common@2.3.21':
-    dependencies:
-      '@amplitude/analytics-connector': 1.6.4
-      '@amplitude/analytics-core': 2.12.0
-      '@amplitude/analytics-types': 2.9.2
-      tslib: 2.8.1
-
   '@amplitude/analytics-connector@1.6.4': {}
 
   '@amplitude/analytics-core@1.2.7':
@@ -13130,13 +13102,6 @@ snapshots:
       '@amplitude/analytics-connector': 1.6.4
       tslib: 2.8.1
 
-  '@amplitude/analytics-remote-config@0.4.1':
-    dependencies:
-      '@amplitude/analytics-client-common': 2.3.21
-      '@amplitude/analytics-core': 2.12.0
-      '@amplitude/analytics-types': 2.9.2
-      tslib: 2.8.1
-
   '@amplitude/analytics-remote-config@0.6.2':
     dependencies:
       '@amplitude/analytics-core': 1.2.7
@@ -13144,26 +13109,6 @@ snapshots:
       tslib: 2.8.1
 
   '@amplitude/analytics-types@1.3.5': {}
-
-  '@amplitude/analytics-types@2.9.2': {}
-
-  '@amplitude/plugin-autocapture-browser@1.2.6':
-    dependencies:
-      '@amplitude/analytics-core': 2.12.0
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  '@amplitude/plugin-network-capture-browser@1.1.6':
-    dependencies:
-      '@amplitude/analytics-core': 2.12.0
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  '@amplitude/plugin-page-view-tracking-browser@2.3.27':
-    dependencies:
-      '@amplitude/analytics-client-common': 2.3.21
-      '@amplitude/analytics-types': 2.9.2
-      tslib: 2.8.1
 
   '@amplitude/plugin-session-replay-browser@1.16.9(rollup@4.41.0)':
     dependencies:
@@ -20045,7 +19990,7 @@ snapshots:
 
   '@skip-go/widget@3.10.2(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@solana/wallet-adapter-base@0.9.26(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.5.3)(utf-8-validate@5.0.10)))(@tanstack/react-query@5.62.7(react@19.1.0))(@types/react@19.0.12)(bufferutil@4.0.9)(eslint@9.27.0(jiti@1.21.7))(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.41.0)(starknet@6.24.1)(typescript@5.5.3)(use-sync-external-store@1.4.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.5.3)(utf-8-validate@5.0.10)(zod@3.25.17))(wagmi@2.15.4(@tanstack/query-core@5.76.0)(@tanstack/react-query@5.62.7(react@19.1.0))(@types/react@19.0.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.5.3)(utf-8-validate@5.0.10)(zod@3.25.17))(zod@3.25.17))':
     dependencies:
-      '@amplitude/analytics-browser': 2.17.6
+      '@amplitude/analytics-browser': link:packages/stubs
       '@amplitude/plugin-session-replay-browser': 1.16.9(rollup@4.41.0)
       '@cosmjs/amino': 0.33.1
       '@cosmjs/cosmwasm-stargate': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -20133,7 +20078,7 @@ snapshots:
 
   '@skip-go/widget@3.10.2(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.1))(@solana/wallet-adapter-base@0.9.26(@solana/web3.js@1.98.2(bufferutil@4.0.9)(typescript@5.5.3)(utf-8-validate@5.0.10)))(@tanstack/react-query@5.62.7(react@19.1.0))(@types/react@19.0.12)(bufferutil@4.0.9)(eslint@9.27.0(jiti@1.21.7))(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.41.0)(starknet@6.24.1)(typescript@5.5.3)(use-sync-external-store@1.5.0(react@19.1.0))(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.5.3)(utf-8-validate@5.0.10)(zod@3.25.17))(wagmi@2.15.4(@tanstack/query-core@5.76.0)(@tanstack/react-query@5.62.7(react@19.1.0))(@types/react@19.0.12)(bufferutil@4.0.9)(immer@10.1.1)(react@19.1.0)(typescript@5.5.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.5.3)(utf-8-validate@5.0.10)(zod@3.25.17))(zod@3.25.17))':
     dependencies:
-      '@amplitude/analytics-browser': 2.17.6
+      '@amplitude/analytics-browser': link:packages/stubs
       '@amplitude/plugin-session-replay-browser': 1.16.9(rollup@4.41.0)
       '@cosmjs/amino': 0.33.1
       '@cosmjs/cosmwasm-stargate': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)


### PR DESCRIPTION
Provides an empty package to override `@amplitude/analytics-browser` and stubs for `@skip-go/widget` imports from `@amplitude/analytics-browser` to completely omit the package from build output

references https://github.com/penumbra-zone/web/issues/2212