### PR TITLE
fix(types, ui): better swap getters

### DIFF
--- a/.changeset/stupid-groups-bet.md
+++ b/.changeset/stupid-groups-bet.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/types': patch
+'@penumbra-zone/ui': patch
+---
+
+Fix Swap getters for ActionViews

--- a/packages/types/src/swap.ts
+++ b/packages/types/src/swap.ts
@@ -75,26 +75,49 @@ export const getOneWaySwapValues = (
   const delta1I = getDelta1IFromSwapView(swapView);
   const delta2I = getDelta2IFromSwapView(swapView);
 
-  const input = new ValueView({
-    valueView: {
-      case: 'knownAssetId',
-      value: {
-        amount: isZero(delta2I) ? delta1I : delta2I,
-        metadata: isZero(delta2I) ? getAsset1Metadata(swapView) : getAsset2Metadata(swapView),
-      },
-    },
-  });
+  const metadata1 = getAsset1Metadata.optional(swapView);
+  const metadata2 = getAsset2Metadata.optional(swapView);
+  const inputMetadata = isZero(delta2I) ? metadata1 : metadata2;
+  const outputMetadata = isZero(delta2I) ? metadata2 : metadata1;
+
+  const input = inputMetadata
+    ? new ValueView({
+        valueView: {
+          case: 'knownAssetId',
+          value: {
+            amount: isZero(delta2I) ? delta1I : delta2I,
+            metadata: inputMetadata,
+          },
+        },
+      })
+    : new ValueView({
+        valueView: {
+          case: 'unknownAssetId',
+          value: {
+            amount: isZero(delta2I) ? delta1I : delta2I,
+          },
+        },
+      });
 
   let output = isZero(delta2I) ? output2 : output1;
 
-  output ??= new ValueView({
-    valueView: {
-      case: 'knownAssetId',
-      value: {
-        metadata: isZero(delta2I) ? getAsset2Metadata(swapView) : getAsset1Metadata(swapView),
-      },
-    },
-  });
+  output ??= outputMetadata
+    ? new ValueView({
+        valueView: {
+          case: 'knownAssetId',
+          value: {
+            metadata: outputMetadata,
+          },
+        },
+      })
+    : new ValueView({
+        valueView: {
+          case: 'unknownAssetId',
+          value: {
+            amount: isZero(delta2I) ? delta1I : delta2I,
+          },
+        },
+      });
 
   return {
     input,

--- a/packages/ui/src/ActionView/swap/swap.tsx
+++ b/packages/ui/src/ActionView/swap/swap.tsx
@@ -29,7 +29,8 @@ export const SwapAction = ({ value, getMetadata }: SwapActionProps) => {
 
   const isOneWay = isOneWaySwap(value);
   const swap = isOneWay ? getOneWaySwapValues(value) : undefined;
-  const showOutput = !!getAmount.optional(swap?.output) && !isZero(getAmount(swap?.output));
+  const swapOutputAmount = getAmount.optional(swap?.output);
+  const showOutput = !!swapOutputAmount && !isZero(swapOutputAmount);
   const isVisible = value.swapView.case === 'visible';
 
   const unfilled = useMemo(() => {


### PR DESCRIPTION
Fixes the issue with certain swap ActionViews that don't have metadata inside them, usually in opaque views.

<img width="846" alt="image" src="https://github.com/user-attachments/assets/3e0d40b7-0869-40b5-b810-764a4835cd08" />
