### PR TITLE
Order form: Set max decimals of input to exponent

### DIFF
--- a/apps/veil/src/pages/trade/ui/order-form/store/LimitOrderFormStore.ts
+++ b/apps/veil/src/pages/trade/ui/order-form/store/LimitOrderFormStore.ts
@@ -4,7 +4,7 @@ import { limitOrderPosition } from '@/shared/math/position';
 import { makeAutoObservable, reaction } from 'mobx';
 import { AssetInfo } from '@/pages/trade/model/AssetInfo';
 import { parseNumber } from '@/shared/utils/num';
-
+import { round } from '@penumbra-zone/types/round';
 export type Direction = 'buy' | 'sell';
 
 export enum SellLimitOrderOptions {
@@ -73,7 +73,9 @@ export class LimitOrderFormStore {
   }
 
   get baseInput(): string {
-    return this._input.inputA;
+    return this._input.inputA.length
+      ? round({ value: Number(this._input.inputA), decimals: this._baseAsset?.exponent ?? 6 })
+      : '';
   }
 
   setBaseInput = (x: string) => {
@@ -81,7 +83,9 @@ export class LimitOrderFormStore {
   };
 
   get quoteInput(): string {
-    return this._input.inputB;
+    return this._input.inputB.length
+      ? round({ value: Number(this._input.inputB), decimals: this._quoteAsset?.exponent ?? 6 })
+      : '';
   }
 
   setQuoteInput = (x: string) => {
@@ -89,7 +93,9 @@ export class LimitOrderFormStore {
   };
 
   get priceInput(): string {
-    return this._priceInput;
+    return this._priceInput.length
+      ? round({ value: Number(this._priceInput), decimals: this._quoteAsset?.exponent ?? 6 })
+      : '';
   }
 
   get priceInputOption(): SellLimitOrderOptions | BuyLimitOrderOptions | undefined {

--- a/apps/veil/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
+++ b/apps/veil/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
@@ -8,6 +8,7 @@ import { estimateAmount } from './estimate-amount';
 import { formatNumber } from '@penumbra-zone/types/amount';
 import { getMetadata } from '@penumbra-zone/getters/value-view';
 import { Direction } from './types';
+import { round } from '@penumbra-zone/types/round';
 
 export type LastEdited = 'Base' | 'Quote';
 
@@ -114,7 +115,9 @@ export class MarketOrderFormStore {
   };
 
   get baseInput(): string {
-    return this._baseAssetInput;
+    return this._baseAssetInput.length
+      ? round({ value: Number(this._baseAssetInput), decimals: this._baseAsset?.exponent ?? 6 })
+      : '';
   }
 
   setBaseInput = (x: string) => {
@@ -123,7 +126,9 @@ export class MarketOrderFormStore {
   };
 
   get quoteInput(): string {
-    return this._quoteAssetInput;
+    return this._quoteAssetInput.length
+      ? round({ value: Number(this._quoteAssetInput), decimals: this._quoteAsset?.exponent ?? 6 })
+      : '';
   }
 
   setQuoteInput = (x: string) => {

--- a/apps/veil/src/pages/trade/ui/order-form/store/RangeOrderFormStore.ts
+++ b/apps/veil/src/pages/trade/ui/order-form/store/RangeOrderFormStore.ts
@@ -3,6 +3,7 @@ import { rangeLiquidityPositions } from '@/shared/math/position';
 import { parseNumber } from '@/shared/utils/num';
 import { Position } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { pnum } from '@penumbra-zone/types/pnum';
+import { round } from '@penumbra-zone/types/round';
 import { makeAutoObservable } from 'mobx';
 
 export enum UpperBoundOptions {
@@ -65,9 +66,9 @@ export const MAX_POSITION_COUNT = 15;
 export class RangeOrderFormStore {
   private _baseAsset?: AssetInfo;
   private _quoteAsset?: AssetInfo;
-  liquidityTargetInput = '';
-  upperPriceInput = '';
-  lowerPriceInput = '';
+  private _liquidityTargetInput = '';
+  private _upperPriceInput = '';
+  private _lowerPriceInput = '';
   upperPriceInputOption: UpperBoundOptions | undefined;
   lowerPriceInputOption: LowerBoundOptions | undefined;
   feeTierPercentInput = '';
@@ -89,19 +90,34 @@ export class RangeOrderFormStore {
   }
 
   get liquidityTarget(): number | undefined {
-    return parseNumber(this.liquidityTargetInput);
+    return parseNumber(this._liquidityTargetInput);
+  }
+
+  get liquidityTargetInput(): string {
+    return this._liquidityTargetInput.length
+      ? round({
+          value: Number(this._liquidityTargetInput),
+          decimals: this._baseAsset?.exponent ?? 6,
+        })
+      : '';
   }
 
   setLiquidityTargetInput = (x: string) => {
-    this.liquidityTargetInput = x;
+    this._liquidityTargetInput = x;
   };
 
   get upperPrice(): number | undefined {
-    return parseNumber(this.upperPriceInput);
+    return parseNumber(this._upperPriceInput);
+  }
+
+  get upperPriceInput(): string {
+    return this._upperPriceInput.length
+      ? round({ value: Number(this._upperPriceInput), decimals: this._quoteAsset?.exponent ?? 6 })
+      : '';
   }
 
   setUpperPriceInput = (x: string, fromOption = false) => {
-    this.upperPriceInput = x;
+    this._upperPriceInput = x;
     if (!fromOption) {
       this.upperPriceInputOption = undefined;
     }
@@ -123,8 +139,14 @@ export class RangeOrderFormStore {
     return parseNumber(this.lowerPriceInput);
   }
 
+  get lowerPriceInput(): string {
+    return this._lowerPriceInput.length
+      ? round({ value: Number(this._lowerPriceInput), decimals: this._quoteAsset?.exponent ?? 6 })
+      : '';
+  }
+
   setLowerPriceInput = (x: string, fromOption = false) => {
-    this.lowerPriceInput = x;
+    this._lowerPriceInput = x;
     if (!fromOption) {
       this.lowerPriceInputOption = undefined;
     }
@@ -229,8 +251,8 @@ export class RangeOrderFormStore {
     this._baseAsset = base;
     this._quoteAsset = quote;
     if (resetInputs) {
-      this.liquidityTargetInput = '';
-      this.upperPriceInput = '';
+      this._liquidityTargetInput = '';
+      this._upperPriceInput = '';
       this.upperPriceInputOption = undefined;
       this.lowerPriceInput = '';
       this.lowerPriceInputOption = undefined;

--- a/apps/veil/src/pages/trade/ui/order-form/store/RangeOrderFormStore.ts
+++ b/apps/veil/src/pages/trade/ui/order-form/store/RangeOrderFormStore.ts
@@ -254,7 +254,7 @@ export class RangeOrderFormStore {
       this._liquidityTargetInput = '';
       this._upperPriceInput = '';
       this.upperPriceInputOption = undefined;
-      this.lowerPriceInput = '';
+      this._lowerPriceInput = '';
       this.lowerPriceInputOption = undefined;
       this.feeTierPercentInput = '';
       this._positionCountInput = '10';


### PR DESCRIPTION
## Description of Changes

Implements https://github.com/penumbra-zone/web/issues/2163 and https://github.com/penumbra-zone/web/issues/2164

- Sets the max decimals of an input to the assets exponent

https://github.com/user-attachments/assets/f0fddf31-c9b2-4111-92ce-3cee6ef9d0b8

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
