### PR TITLE
LQT: generalize view service response

### DIFF
--- a/.changeset/happy-sites-sink.md
+++ b/.changeset/happy-sites-sink.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/services': minor
+---
+
+add 'already_voted' field to LQT view service implementation

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -16,7 +16,7 @@
     "gen:ibc": "buf generate buf.build/cosmos/ibc:7ab44ae956a0488ea04e04511efa5f70",
     "gen:ics23": "buf generate buf.build/cosmos/ics23:55085f7c710a45f58fa09947208eb70b",
     "gen:noble": "buf generate buf.build/noble-assets/forwarding:5a8609a6772d417584a9c60cd8b80881",
-    "gen:penumbra": "buf generate buf.build/penumbra-zone/penumbra:f6682d4ef839bb06e2da4fae487eb9d565ea04d6",
+    "gen:penumbra": "buf generate buf.build/penumbra-zone/penumbra:783aa7661fb11ad8248153d6b71475b89158c64d",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",

--- a/packages/services/src/view-service/lqt-voting-notes.test.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.test.ts
@@ -3,6 +3,7 @@ import {
   LqtVotingNotesRequest,
   LqtVotingNotesResponse,
   NotesForVotingResponse,
+  SpendableNoteRecord,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
@@ -73,10 +74,12 @@ describe('lqtVotingNotes request handler', () => {
       ) as MockServices['getWalletServices'],
     };
 
-    const responses: LqtVotingNotesResponse[] = [];
+    const responses: SpendableNoteRecord[] = [];
     const req = new LqtVotingNotesRequest({});
-    for await (const res of lqtVotingNotes(req, mockCtx)) {
-      responses.push(new LqtVotingNotesResponse(res));
+    for await (const {noteRecord, alreadyVoted} of lqtVotingNotes(req, mockCtx)) {
+      if (!alreadyVoted) {
+        responses.push(noteRecord as SpendableNoteRecord);
+      }
     }
 
     expect(responses.length).toBe(0);

--- a/packages/services/src/view-service/lqt-voting-notes.test.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.test.ts
@@ -76,7 +76,7 @@ describe('lqtVotingNotes request handler', () => {
 
     const responses: SpendableNoteRecord[] = [];
     const req = new LqtVotingNotesRequest({});
-    for await (const {noteRecord, alreadyVoted} of lqtVotingNotes(req, mockCtx)) {
+    for await (const { noteRecord, alreadyVoted } of lqtVotingNotes(req, mockCtx)) {
       if (!alreadyVoted) {
         responses.push(noteRecord as SpendableNoteRecord);
       }

--- a/packages/services/src/view-service/lqt-voting-notes.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.ts
@@ -38,11 +38,11 @@ export const lqtVotingNotes: Impl['lqtVotingNotes'] = async function* (req, ctx)
     const alreadyVoted = lqtCheckNullifierResponse.alreadyVoted;
     const noteRecord = votingNote.noteRecord as SpendableNoteRecord;
 
-    // Rather than treating this view service implementation as a filtering 
+    // Rather than treating this view service implementation as a filtering
     // service that yields SNRs that haven't been used for voting yet, we
     // return a mapping of 'all' potentially eligible delegation note records
-    // and a a flag indicating whether each note was already used for voting
-    // in the current epoch. 
+    // and a flag indicating whether each note was already used for voting
+    // in the current epoch.
     yield new LqtVotingNotesResponse({ noteRecord, alreadyVoted });
   }
 };

--- a/packages/services/src/view-service/lqt-voting-notes.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.ts
@@ -34,13 +34,15 @@ export const lqtVotingNotes: Impl['lqtVotingNotes'] = async function* (req, ctx)
       epoch.index,
       votingNote.noteRecord.nullifier as Nullifier,
     );
-    if (lqtCheckNullifierResponse.alreadyVoted) {
-      continue;
-    }
 
+    const alreadyVoted = lqtCheckNullifierResponse.alreadyVoted;
     const noteRecord = votingNote.noteRecord as SpendableNoteRecord;
 
-    // Yield the SNRs that haven't been used for voting yet.
-    yield new LqtVotingNotesResponse({ noteRecord });
+    // Rather than treating this view service implementation as a filtering 
+    // service that yields SNRs that haven't been used for voting yet, we
+    // return a mapping of 'all' potentially eligible delegation note records
+    // and a a flag indicating whether each note was already used for voting
+    // in the current epoch. 
+    yield new LqtVotingNotesResponse({ noteRecord, alreadyVoted });
   }
 };


### PR DESCRIPTION
## Description of Changes

pairs with https://github.com/penumbra-zone/penumbra/pull/5158 – a more amenable way for consumers of the view service impl to determine whether LQT notes have already been used to vote in the current epoch.

requires associated proto changes before merging

## Related Issue

N/A

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
