### PR TITLE
Order form: Set max decimals of input to exponent

### DIFF
--- a/apps/veil/src/pages/trade/ui/order-form/order-form-limit.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-limit.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
+import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
@@ -14,7 +15,7 @@ import { BuyLimitOrderOptions, SellLimitOrderOptions } from './store/LimitOrderF
 
 export const LimitOrderForm = observer(({ parentStore }: { parentStore: OrderFormStore }) => {
   const { connected } = connectionStore;
-  const store = parentStore.limitForm;
+  const { defaultDecimals, limitForm: store } = parentStore;
 
   const isBuy = store.direction === 'buy';
 
@@ -25,7 +26,10 @@ export const LimitOrderForm = observer(({ parentStore }: { parentStore: OrderFor
         <div className='mb-2'>
           <OrderInput
             label={`When ${store.baseAsset?.symbol} is`}
-            value={store.priceInput}
+            value={round({
+              value: store.priceInput,
+              decimals: store.quoteAsset?.exponent ?? defaultDecimals,
+            })}
             onChange={price => store.setPriceInput(price)}
             denominator={store.quoteAsset?.symbol}
           />
@@ -41,7 +45,10 @@ export const LimitOrderForm = observer(({ parentStore }: { parentStore: OrderFor
       <div className='mb-4'>
         <OrderInput
           label={isBuy ? 'Buy' : 'Sell'}
-          value={store.baseInput}
+          value={round({
+            value: store.baseInput,
+            decimals: store.baseAsset?.exponent ?? defaultDecimals,
+          })}
           onChange={store.setBaseInput}
           denominator={store.baseAsset?.symbol}
         />
@@ -49,7 +56,10 @@ export const LimitOrderForm = observer(({ parentStore }: { parentStore: OrderFor
       <div className='mb-4'>
         <OrderInput
           label={isBuy ? 'Pay with' : 'Receive'}
-          value={store.quoteInput}
+          value={round({
+            value: store.quoteInput,
+            decimals: store.quoteAsset?.exponent ?? defaultDecimals,
+          })}
           onChange={store.setQuoteInput}
           denominator={store.quoteAsset?.symbol}
         />

--- a/apps/veil/src/pages/trade/ui/order-form/order-form-market.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-market.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
+import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
@@ -55,7 +56,7 @@ const Slider = observer(
 
 export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFormStore }) => {
   const { connected } = connectionStore;
-  const store = parentStore.marketForm;
+  const { defaultDecimals, marketForm: store } = parentStore;
 
   const isBuy = store.direction === 'buy';
 
@@ -65,7 +66,10 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
       <div className='mb-4'>
         <OrderInput
           label={isBuy ? 'Buy' : 'Sell'}
-          value={store.baseInput}
+          value={round({
+            value: store.baseInput,
+            decimals: store.baseAsset?.exponent ?? defaultDecimals,
+          })}
           onChange={store.setBaseInput}
           isEstimating={store.baseEstimating}
           isApproximately={isBuy && store.baseInputAmount !== 0}
@@ -75,7 +79,10 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
       <div className='mb-4'>
         <OrderInput
           label={isBuy ? 'Pay with' : 'Receive'}
-          value={store.quoteInput}
+          value={round({
+            value: store.quoteInput,
+            decimals: store.quoteAsset?.exponent ?? defaultDecimals,
+          })}
           onChange={store.setQuoteInput}
           isEstimating={store.quoteEstimating}
           isApproximately={!isBuy && store.quoteInputAmount !== 0}

--- a/apps/veil/src/pages/trade/ui/order-form/order-form-range-liquidity.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-range-liquidity.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
+import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
@@ -20,7 +21,7 @@ import {
 export const RangeLiquidityOrderForm = observer(
   ({ parentStore }: { parentStore: OrderFormStore }) => {
     const { connected } = connectionStore;
-    const store = parentStore.rangeForm;
+    const { defaultDecimals, rangeForm: store } = parentStore;
 
     return (
       <div className='p-4'>
@@ -28,7 +29,10 @@ export const RangeLiquidityOrderForm = observer(
           <div className='mb-1'>
             <OrderInput
               label='Liquidity Target'
-              value={store.liquidityTargetInput}
+              value={round({
+                value: store.liquidityTargetInput,
+                decimals: store.quoteAsset?.exponent ?? defaultDecimals,
+              })}
               onChange={store.setLiquidityTargetInput}
               denominator={store.quoteAsset?.symbol}
             />
@@ -66,7 +70,10 @@ export const RangeLiquidityOrderForm = observer(
           <div className='mb-2'>
             <OrderInput
               label='Upper Price Bound'
-              value={store.upperPriceInput}
+              value={round({
+                value: store.upperPriceInput,
+                decimals: store.quoteAsset?.exponent ?? defaultDecimals,
+              })}
               onChange={price => store.setUpperPriceInput(price)}
               denominator={store.quoteAsset?.symbol}
             />
@@ -81,7 +88,10 @@ export const RangeLiquidityOrderForm = observer(
           <div className='mb-2'>
             <OrderInput
               label='Lower Price Bound'
-              value={store.lowerPriceInput}
+              value={round({
+                value: store.lowerPriceInput,
+                decimals: store.quoteAsset?.exponent ?? defaultDecimals,
+              })}
               onChange={price => store.setLowerPriceInput(price)}
               denominator={store.quoteAsset?.symbol}
             />

--- a/apps/veil/src/pages/trade/ui/order-form/store/OrderFormStore.ts
+++ b/apps/veil/src/pages/trade/ui/order-form/store/OrderFormStore.ts
@@ -54,6 +54,7 @@ export class OrderFormStore {
   private _feeAsset?: AssetInfo;
   private _gasFee: { symbol: string; display: string } = { symbol: 'UM', display: '--' };
   private _gasFeeLoading = false;
+  defaultDecimals = 6;
 
   constructor() {
     makeAutoObservable(this);


### PR DESCRIPTION
## Description of Changes

Implements https://github.com/penumbra-zone/web/issues/2163 and https://github.com/penumbra-zone/web/issues/2164

Sets the max decimals of an input to the assets exponent

## Related Issue

Replacement of https://github.com/penumbra-zone/web/pull/2223
Depends on https://github.com/penumbra-zone/web/pull/2237

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
