### PR TITLE
fix: action view swap bugs

### DIFF
--- a/.changeset/sharp-doors-remain.md
+++ b/.changeset/sharp-doors-remain.md
@@ -1,0 +1,7 @@
+---
+'@penumbra-zone/getters': patch
+'@penumbra-zone/types': patch
+'@penumbra-zone/ui': patch
+---
+
+Fix swap ActionViews not rendering values correctly

--- a/packages/getters/src/swap-view.ts
+++ b/packages/getters/src/swap-view.ts
@@ -76,6 +76,10 @@ export const getAsset1Metadata = createGetter((swapView?: SwapView) =>
     : undefined,
 );
 
+export const getTradingPair = createGetter(
+  (swapView?: SwapView) => swapView?.swapView.value?.swap?.body?.tradingPair,
+);
+
 // Generic getter function for 'Asset2Metadata'
 export const getAsset2Metadata = createGetter((swapView?: SwapView) =>
   swapView?.swapView.case === 'visible' || swapView?.swapView.case === 'opaque'

--- a/packages/types/src/pnum.ts
+++ b/packages/types/src/pnum.ts
@@ -40,8 +40,8 @@ function pnum(
     'valueView' in input &&
     typeof input.valueView === 'object'
   ) {
-    const amount = getAmount(input);
-    value = new BigNumber(joinLoHi(amount.lo, amount.hi).toString());
+    const amount = getAmount.optional(input);
+    value = new BigNumber(joinLoHi(amount?.lo, amount?.hi).toString());
     exponent =
       input.valueView.case === 'knownAssetId'
         ? (getDisplayDenomExponentFromValueView.optional(input) ?? 0)

--- a/packages/ui/src/ActionView/actions/ics-20-withdrawal.tsx
+++ b/packages/ui/src/ActionView/actions/ics-20-withdrawal.tsx
@@ -85,6 +85,7 @@ export const Ics20WithdrawalAction = ({ value, getMetadata }: Ics20WithdrawalAct
         receiverView && (
           <Density slim>
             <ActionRow
+              key='receiver'
               label='Receiver'
               info={<AddressViewComponent addressView={receiverView} external copyable truncate />}
             />

--- a/packages/ui/src/ActionView/actions/liquidity-tournament-vote.tsx
+++ b/packages/ui/src/ActionView/actions/liquidity-tournament-vote.tsx
@@ -109,6 +109,7 @@ export const LiquidityTournamentVoteAction = ({
         !!epoch && <ActionRow label='Epoch' info={`#${epoch.toString()}`} />,
         !!voteValue && (
           <ActionRow
+            key='voting-power'
             label='Voting Power'
             info={
               <Density slim>

--- a/packages/ui/src/ActionView/position/position-close.tsx
+++ b/packages/ui/src/ActionView/position/position-close.tsx
@@ -17,6 +17,7 @@ export const PositionCloseAction = ({ value }: PositionCloseActionProps) => {
         <>
           {value.positionId && (
             <ActionRow
+              key='position-id'
               label='Position ID'
               info={shorten(bech32mPositionId(value.positionId), 8)}
               copyText={bech32mPositionId(value.positionId)}

--- a/packages/ui/src/ActionView/position/position-open.tsx
+++ b/packages/ui/src/ActionView/position/position-open.tsx
@@ -81,17 +81,19 @@ export const PositionOpenAction = ({ value, getMetadata }: PositionOpenActionPro
       title='Position Open'
       infoRows={
         <>
-          {positionId && <ActionRow label='Position ID' info={positionId} />}
+          {positionId && <ActionRow key='position-id' label='Position ID' info={positionId} />}
 
           <Density slim>
             {r1 && (
               <ActionRow
+                key='r1'
                 label='Reserves'
                 info={<ValueViewComponent valueView={r1} priority='tertiary' showIcon={false} />}
               />
             )}
             {r2 && (
               <ActionRow
+                key='r2'
                 label='Reserves'
                 info={<ValueViewComponent valueView={r2} priority='tertiary' showIcon={false} />}
               />
@@ -99,7 +101,7 @@ export const PositionOpenAction = ({ value, getMetadata }: PositionOpenActionPro
           </Density>
 
           {!!value.position?.phi?.component?.fee && (
-            <ActionRow label='Fee' info={value.position.phi.component.fee} />
+            <ActionRow key='fee' label='Fee' info={value.position.phi.component.fee} />
           )}
         </>
       }

--- a/packages/ui/src/ActionView/position/position-reward-claim.tsx
+++ b/packages/ui/src/ActionView/position/position-reward-claim.tsx
@@ -16,6 +16,7 @@ export const PositionRewardClaimAction = ({ value }: PositionRewardClaimActionPr
         <>
           {value.positionId && (
             <ActionRow
+              key='position-id'
               label='Position ID'
               info={shorten(bech32mPositionId(value.positionId), 8)}
               copyText={bech32mPositionId(value.positionId)}

--- a/packages/ui/src/ActionView/position/position-withdraw.tsx
+++ b/packages/ui/src/ActionView/position/position-withdraw.tsx
@@ -16,6 +16,7 @@ export const PositionWithdrawAction = ({ value }: PositionWithdrawActionProps) =
         <>
           {value.positionId && (
             <ActionRow
+              key='position-id'
               label='Position ID'
               info={shorten(bech32mPositionId(value.positionId), 8)}
               copyText={bech32mPositionId(value.positionId)}

--- a/packages/ui/src/ActionView/swap/swap-claim.tsx
+++ b/packages/ui/src/ActionView/swap/swap-claim.tsx
@@ -119,8 +119,15 @@ export const SwapClaimAction = ({ value, getMetadata }: SwapClaimActionProps) =>
       opaque={value.swapClaimView.case === 'opaque'}
       infoRows={
         <>
-          {!!fee && <ActionRow label='Swap Claim Fee' info={fee} />}
-          {!!txId && <ActionRow label='Swap Transaction' info={shorten(txId, 8)} copyText={txId} />}
+          {!!fee && <ActionRow key='claim-fee' label='Swap Claim Fee' info={fee} />}
+          {!!txId && (
+            <ActionRow
+              key='swap-tx'
+              label='Swap Transaction'
+              info={shorten(txId, 8)}
+              copyText={txId}
+            />
+          )}
         </>
       }
     >

--- a/packages/ui/src/ActionView/swap/swap.tsx
+++ b/packages/ui/src/ActionView/swap/swap.tsx
@@ -28,7 +28,7 @@ export const SwapAction = ({ value, getMetadata }: SwapActionProps) => {
   const density = useDensity();
 
   const isOneWay = isOneWaySwap(value);
-  const swap = isOneWay ? getOneWaySwapValues(value) : undefined;
+  const swap = isOneWay ? getOneWaySwapValues(value, getMetadata) : undefined;
   const swapOutputAmount = getAmount.optional(swap?.output);
   const showOutput = !!swapOutputAmount && !isZero(swapOutputAmount);
   const isVisible = value.swapView.case === 'visible';
@@ -66,11 +66,16 @@ export const SwapAction = ({ value, getMetadata }: SwapActionProps) => {
       infoRows={
         isVisible && (
           <>
-            {!!fee && <ActionRow label='Swap Claim Fee' info={fee} />}
+            {!!fee && <ActionRow key='claim-fee' label='Swap Claim Fee' info={fee} />}
             {!!txId && (
-              <ActionRow label='Swap Claim Transaction' info={shorten(txId, 8)} copyText={txId} />
+              <ActionRow
+                key='claim-tx'
+                label='Swap Claim Transaction'
+                info={shorten(txId, 8)}
+                copyText={txId}
+              />
             )}
-            {unfilled && <ActionRow label='Unfilled Amount' info={unfilled} />}
+            {unfilled && <ActionRow key='unfilled' label='Unfilled Amount' info={unfilled} />}
           </>
         )
       }


### PR DESCRIPTION
The bug is specific to opaque swap views, it was following us from the first versions of the ActionView UI component.

Before (notice how the amounts are duplicated for both input and output):

<img width="850" alt="image" src="https://github.com/user-attachments/assets/16cd96d5-7a53-414a-ba71-69d02ed69a1d" />

After:

<img width="845" alt="image" src="https://github.com/user-attachments/assets/8524376d-6191-467f-bcf3-f41e54c0c635" />
