### PR TITLE
Fix recipient variable naming in liquidity-tournament-vote.tsx

### DIFF
--- a/packages/ui/src/ActionView/actions/liquidity-tournament-vote.tsx
+++ b/packages/ui/src/ActionView/actions/liquidity-tournament-vote.tsx
@@ -79,18 +79,18 @@ export const LiquidityTournamentVoteAction = ({
   }, [value]);
 
   const recipientAddress = useMemo(() => {
-    const receipient = vote?.body?.rewardsRecipient;
+    const recipient = vote?.body?.rewardsRecipient;
     const defaultAddress = new AddressView({
       addressView: {
         case: 'opaque',
         value: {
-          address: receipient,
+          address: recipient,
         },
       },
     });
 
     const visible = spendAddress?.addressView.value?.address;
-    if (visible && receipient && visible.equals(receipient)) {
+    if (visible && recipient && visible.equals(recipient)) {
       return spendAddress;
     }
 


### PR DESCRIPTION


**Description:**
This PR updates the variable naming in the liquidity tournament vote action to maintain consistency:
- Renames `receipient` to `recipient` to fix typo
- Updates variable references throughout the file to match the corrected naming
- Maintains the same functionality while improving code clarity

The changes affect the address comparison logic in the tournament vote handling code.

