### PR TITLE
ci: use nix devshell for workflows

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,28 @@
+name: 'Setup Nix Environment'
+description: 'Installs Nix and configures the cache'
+inputs:
+  primary-key:
+    description: Primary key for the cache
+    required: false
+    default: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+  restore-prefix:
+    description: Restore prefix for the cache
+    required: false
+    default: nix-${{ runner.os }}-
+  backend:
+    description: Backend to use for caching
+    required: false
+    default: buildjet
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: nixbuild/nix-quick-install-action@v28
+
+    - name: Setup Nix Cache
+      uses: nix-community/cache-nix-action@v5
+      with:
+        primary-key: ${{ inputs.primary-key }}
+        restore-prefixes-first-match: ${{ inputs.restore-prefix }}
+        backend: ${{ inputs.backend }}

--- a/.github/workflows/compile-wasm.yml
+++ b/.github/workflows/compile-wasm.yml
@@ -8,29 +8,28 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
+
       - id: compiled
         uses: buildjet/cache@v4
         with:
           path: .turbo
           key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
           restore-keys: ${{ hashFiles('**/Cargo.lock') }}
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm turbo telemetry disable
-      - uses: dtolnay/rust-toolchain@stable # rust only on buildjet
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: jetli/wasm-pack-action@v0.4.0 # preinstall wasm-pack
-        with:
-          version: 'latest'
-      - run: pnpm turbo compile --cache-dir=.turbo # compile wasm
+
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+        # Optional: override default parameters
+        # with:
+        #   backend: 'github'
+
+      - name: compile wasm code
+        run: nix develop --command just wasm
+
       - name: Verify no unexpected file changes (like cargo.lock change)
         run: git diff --exit-code
         working-directory: packages/wasm/crate
-      - run: cargo tree --invert penumbra-wasm --edges features # debug tree
+
+      - name: dump rust dependencies for debugging, only on failure
+        run: nix develop --command cargo tree --invert penumbra-wasm --edges features
         if: failure()
         working-directory: packages/wasm/crate

--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -34,20 +34,19 @@ jobs:
     needs: turbo-compile
     steps:
       - uses: actions/checkout@v4
+
       - id: built
         uses: buildjet/cache@v4
         with:
           path: .turbo
           key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-built
           restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm turbo telemetry disable
-      - run: pnpm turbo build --cache-dir=.turbo
+
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+
+      - name: run build
+        run: nix develop --command just build
 
   turbo-lint:
     name: Lint
@@ -55,20 +54,19 @@ jobs:
     needs: turbo-build
     steps:
       - uses: actions/checkout@v4
+
       - id: lint
         uses: buildjet/cache@v4
         with:
           path: .turbo
           key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-lint
           restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm turbo telemetry disable
-      - run: pnpm turbo lint:strict --cache-dir=.turbo
+
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+
+      - name: lint turbo
+        run: nix develop --command just lint-turbo
 
   turbo-test:
     name: test
@@ -76,17 +74,21 @@ jobs:
     needs: turbo-build
     steps:
       - uses: actions/checkout@v4
+
       - id: tested
         uses: buildjet/cache@v4
         with:
           path: .turbo
           key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-test
           restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
+
+      # TODO: update nix devshell to support playwright
       - uses: pnpm/action-setup@v4
       - uses: buildjet/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo telemetry disable
       - run: pnpm playwright install --with-deps chromium
@@ -98,23 +100,19 @@ jobs:
     needs: turbo-compile
     steps:
       - uses: actions/checkout@v4
+
       - id: rust-linted
         uses: buildjet/cache@v4
         with:
           path: .turbo
           key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-lint:rust
           restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - run: pnpm turbo telemetry disable
-      - run: pnpm turbo lint:rust --cache-dir=.turbo
+
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+
+      - name: lint rust
+        run: nix develop --command just lint-rust
 
   turbo-test-rust:
     name: test:wasm
@@ -128,19 +126,12 @@ jobs:
           path: .turbo
           key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-test:wasm
           restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: 'latest'
-      - uses: browser-actions/setup-firefox@v1
-      - run: pnpm turbo telemetry disable
-      - run: pnpm turbo test:wasm --cache-dir=.turbo
-      - run: pnpm turbo test:cargo --cache-dir=.turbo
+
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+
+      - name: install firefox browser
+        uses: browser-actions/setup-firefox@v1
+
+      - name: run rust tests
+        run: nix develop --command just test-rust

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+flake.lock
 pnpm-lock.yaml
 packages/wasm/crate
 packages/wasm/wasm

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1745454774,
+        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,8 +51,30 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745894113,
+        "narHash": "sha256-dxO3caQZMv/pMtcuXdi+SnAtyki6HFbSf1IpgQPXZYc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e552fe1b16ffafd678ebe061c22b117e050769ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,69 @@
 {
   description = "Dev shell for Penumbra web development";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    # nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane, rust-overlay }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system}; in
-      {
-        devShells.default = pkgs.mkShell {
-          name = "devShell";
-          nativeBuildInputs = [ pkgs.bashInteractive ];
-          buildInputs = with pkgs; [
-            fd
-            file
-            jq
-            just
-            pnpm_10
-            nodejs_22
-            postgresql
-            wasm-pack
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./packages/wasm/crate/rust-toolchain.toml;
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+      in with pkgs; with pkgs.lib; let
+        # Common development packages for all shells
+        commonDevPackages = [
+          fd
+          file
+          jq
+          just
+          pnpm_10
+          nodejs_22
+          postgresql
+          wasm-pack
 
-            # for deployment/ci
-            doctl
-            kubectl
-          ];
+          # for deployment/ci
+          doctl
+          kubectl
+        ];
+        # Common shell hook content
+        commonShellHook = ''
+          export RUST_LOG="penumbra=debug"
+          export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc} # Required for rust-analyzer
+          export NEXT_TELEMETRY_DISABLED=1
+          export TURBO_TELEMETRY_DISABLED=1
+        '';
+      in
+      {
+        devShells = {
+          default = craneLib.devShell {
+            name = "penumbra-web devShell";
+            packages = commonDevPackages;
+            shellHook = ''
+              ${commonShellHook}
+            '';
+          };
+
+          # Separate opt-in devshell that excludes rust tooling.
+          minimal = pkgs.mkShell {
+            name = "minimal penumbra-web devShell";
+            packages = commonDevPackages;
+            shellHook = ''
+              ${commonShellHook}
+            '';
+          };
         };
-      });
+      }
+    );
 }

--- a/justfile
+++ b/justfile
@@ -1,3 +1,32 @@
+# Install npm dependencies
+install:
+  pnpm install
+
+# Build the apps via turbo
+build: install
+  pnpm turbo build --cache-dir=.turbo
+
+# Compile the WASM dependencies via turbo
+wasm: install
+  pnpm turbo compile --cache-dir=.turbo
+
+# Compile the WASM dependencies via turbo (alias)
+compile: install
+  @just wasm
+
+# Wrapper for all linting targets
+lint:
+  @just lint-turbo
+  @just lint-rust
+
+# Lint the turbo resources
+lint-turbo: install
+  pnpm turbo lint:strict --cache-dir=.turbo
+
+# List Rust code
+lint-rust: install
+  pnpm turbo lint:rust --cache-dir=.turbo
+
 # Build top-level debug container
 container:
   fd -t d node_modules --no-ignore -X rm -r
@@ -12,3 +41,16 @@ veil:
 # Build container for Veil app
 veil-container:
   cd ./apps/veil && just container
+
+# Configure OS deps for Playwright tests
+install-playwright: install
+  pnpm playwright install --with-deps chromium
+
+# Run the turbo test suite
+test-turbo: install
+   pnpm turbo test --cache-dir=.turbo
+
+# Run the Rust test suite
+test-rust: install
+   pnpm turbo test:wasm --cache-dir=.turbo
+   pnpm turbo test:cargo --cache-dir=.turbo


### PR DESCRIPTION
## Description of Changes

We want a single declaration of tooling dependencies required to work on
the apps in the web monorepo. Extending the nix flake so that it's used
in CI, as well, ensuring that CI failures are easily replicable.

There's a single omission, for the sake of velocity: I haven't ported
the playwright tests to use the nix env. That'll take another pass, but
punting on it for now, so that we have green CI again on the web
monorepo.

## Related Issue

Refs #2290.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.

No changes to app code, this is just CI-wrangling.
