### PR TITLE
bug(veil): add connection status check to rewards card

### DIFF
--- a/apps/veil/src/pages/tournament/ui/delegator-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/delegator-rewards.tsx
@@ -21,7 +21,17 @@ import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_
 import { pnum } from '@penumbra-zone/types/pnum';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
 
+// Outer component that handles the connection check. If the wallet isn't connected,
+// the parent hook won't execute, and the component won't render.
 export const DelegatorRewards = observer(() => {
+  if (!connectionStore.connected) {
+    return null;
+  }
+
+  return <DelegatorTotalRewards />;
+});
+
+export const DelegatorTotalRewards = observer(() => {
   const { subaccount } = connectionStore;
 
   const { epoch } = useCurrentEpoch();


### PR DESCRIPTION
## Description of Changes

created `DelegatorRewards` parent react component that wraps `DelegatorTotalRewards`, and lifted connection check into the parent. The child component now conditionally renders when the wallet is connected, avoiding unnecessary hook execution. 

react v19 warnings are [separate](https://github.com/penumbra-zone/web/issues/2296)

----------

https://github.com/user-attachments/assets/a8b84111-b902-4d19-9f2f-9c9a23dc9ebd

## Related Issue

https://github.com/penumbra-zone/web/issues/2294

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
