### PR TITLE
bug(veil): fetch registry object unconditionally

### DIFF
--- a/apps/veil/src/pages/tournament/ui/delegator-leaderboard.tsx
+++ b/apps/veil/src/pages/tournament/ui/delegator-leaderboard.tsx
@@ -24,6 +24,7 @@ import { useDelegatorLeaderboard, BASE_PAGE, BASE_LIMIT } from '../api/use-deleg
 import { useSortableTableHeaders } from './sortable-table-header';
 import { useIndexByAddress } from '../api/use-index-by-address';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
+import { Skeleton } from '@penumbra-zone/ui/Skeleton';
 
 const LeaderboardRow = observer(
   ({ row, loading }: { row: DelegatorLeaderboardData; loading: boolean }) => {
@@ -110,9 +111,11 @@ const LeaderboardRow = observer(
           {row.streak}
         </TableCell>
         <TableCell cell loading={loading}>
-          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- required to ensure staking token is loaded before rendering */}
-          {row.total_rewards && stakingToken && !stakingLoading && (
-            <ValueViewComponent valueView={totalRewards} priority='tertiary' />
+          {stakingLoading ? (
+            <Skeleton />
+          ) : (
+            row.total_rewards &&
+            stakingToken && <ValueViewComponent valueView={totalRewards} priority='tertiary' />
           )}
         </TableCell>
         <TableCell cell loading={loading}>

--- a/apps/veil/src/pages/tournament/ui/delegator-leaderboard.tsx
+++ b/apps/veil/src/pages/tournament/ui/delegator-leaderboard.tsx
@@ -29,7 +29,7 @@ const LeaderboardRow = observer(
   ({ row, loading }: { row: DelegatorLeaderboardData; loading: boolean }) => {
     const { connected } = connectionStore;
     const { data: subaccountIndex, isLoading: indexLoading } = useIndexByAddress(row.address);
-    const { data: stakingToken } = useStakingTokenMetadata();
+    const { data: stakingToken, isLoading: stakingLoading } = useStakingTokenMetadata();
 
     const addressLink = useMemo(() => {
       if (loading) {
@@ -61,7 +61,7 @@ const LeaderboardRow = observer(
     }, [row.address, subaccountIndex, connected]);
 
     const totalRewards = useMemo(() => {
-      if (loading) {
+      if (loading || stakingLoading || !stakingToken) {
         return undefined;
       }
 
@@ -74,7 +74,7 @@ const LeaderboardRow = observer(
           },
         },
       });
-    }, [loading, row.total_rewards, stakingToken]);
+    }, [loading, stakingLoading, row.total_rewards, stakingToken]);
 
     return (
       <Link
@@ -89,7 +89,7 @@ const LeaderboardRow = observer(
           {row.place}
         </TableCell>
         <TableCell cell loading={loading || indexLoading}>
-          {!loading && !indexLoading && (
+          {!loading && !indexLoading && !stakingLoading && (
             <>
               <AddressViewComponent
                 truncate
@@ -110,7 +110,9 @@ const LeaderboardRow = observer(
           {row.streak}
         </TableCell>
         <TableCell cell loading={loading}>
-          {row.total_rewards && <ValueViewComponent valueView={totalRewards} priority='tertiary' />}
+          {row.total_rewards && stakingToken && !stakingLoading && (
+            <ValueViewComponent valueView={totalRewards} priority='tertiary' />
+          )}
         </TableCell>
         <TableCell cell loading={loading}>
           <Density slim>

--- a/apps/veil/src/pages/tournament/ui/delegator-leaderboard.tsx
+++ b/apps/veil/src/pages/tournament/ui/delegator-leaderboard.tsx
@@ -110,6 +110,7 @@ const LeaderboardRow = observer(
           {row.streak}
         </TableCell>
         <TableCell cell loading={loading}>
+          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- required to ensure staking token is loaded before rendering */}
           {row.total_rewards && stakingToken && !stakingLoading && (
             <ValueViewComponent valueView={totalRewards} priority='tertiary' />
           )}

--- a/apps/veil/src/shared/api/registry.ts
+++ b/apps/veil/src/shared/api/registry.ts
@@ -2,7 +2,6 @@ import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { useQuery } from '@tanstack/react-query';
 import { envQueryFn } from './env/env';
 import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { getAssetMetadataById } from './metadata';
 
 export const chainRegistryClient = new ChainRegistryClient();
 
@@ -15,8 +14,10 @@ export const useStakingTokenMetadata = () => {
   return useQuery({
     queryKey: ['stakingTokenMetadata'],
     queryFn: async (): Promise<Metadata> => {
+      const registry = await registryQueryFn();
       const { stakingAssetId } = chainRegistryClient.bundled.globals();
-      const stakingAssetsMetadata = await getAssetMetadataById(stakingAssetId);
+      const stakingAssetsMetadata = registry.getMetadata(stakingAssetId);
+
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- staking token exists in registry
       return stakingAssetsMetadata!;
     },

--- a/apps/veil/src/shared/api/registry.ts
+++ b/apps/veil/src/shared/api/registry.ts
@@ -18,8 +18,7 @@ export const useStakingTokenMetadata = () => {
       const { stakingAssetId } = chainRegistryClient.bundled.globals();
       const stakingAssetsMetadata = registry.getMetadata(stakingAssetId);
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- staking token exists in registry
-      return stakingAssetsMetadata!;
+      return stakingAssetsMetadata;
     },
     staleTime: Infinity,
   });


### PR DESCRIPTION
## Description of Changes

the `useStakingTokenMetadata` hook was originally calling into [getAssetMetadataById](https://github.com/penumbra-zone/web/blob/main/apps/veil/src/shared/api/metadata.ts#L20-L24), which attempts to fetch the metadata from the view service (in-memory registry cache). However, if the wallet wasn't connected and the remote registry hadn't been fetched yet, this would return undefined and display unknown assets.

this updates the hook to explicitly call `registryQueryFn`, which pays a one-time cost to fetch the full remote registry when the wallet isn't connected. Then it calls the registry helper `getMetadata` to retrieve the staking token metadata. React query then caches subsequent hook invocations. 

additionally, adds more stringent `isLoading` checks to the reward cell within `LeaderboardRow` to make sure rewards are only rendered when metadata is fully loaded.

----------------

https://github.com/user-attachments/assets/7b3fad3a-eaf6-4141-a620-2c25a5a246bd


## Related Issue

https://github.com/penumbra-zone/web/issues/2287 (_related_ to motivation in https://github.com/penumbra-zone/web/issues/2295, but doesn't close it)

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
