### PR TITLE
veil: make voting button not load forever

### DIFF
--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -34,7 +34,7 @@ export const useVotingInfo = (defaultEpoch?: number) => {
     isEnded || !!notes?.length,
   );
 
-  const isLoading = loadingEpoch || loadingNotes || loadingVotes || delegationsLoading;
+  const isLoading = loadingEpoch || loadingNotes || delegationsLoading;
   const isVoted = !!votes?.length;
   const isDelegated = !!delegations?.length;
 
@@ -95,6 +95,7 @@ export const useVotingInfo = (defaultEpoch?: number) => {
     connected,
     isEnded,
     isLoading,
+    loadingVotes,
     isVoted,
     votedFor,
     isDelegated,


### PR DESCRIPTION
## Description of Changes

Alternate approach to #2327, with a more minimal change.

I think the hook for getting your votes is broken right now, which is the real source of the issues. This kind of papers over that, so we should open a subsequent issue to track.

Closes #2326.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
