### PR TITLE
storage: store incentivized asset id instead of metadata

### DIFF
--- a/.changeset/giant-peas-watch.md
+++ b/.changeset/giant-peas-watch.md
@@ -1,0 +1,7 @@
+---
+'@penumbra-zone/services': minor
+'@penumbra-zone/storage': minor
+'@penumbra-zone/types': minor
+---
+
+use asset id instead of metadata in liquidity tournament idb table

--- a/packages/services/src/view-service/tournament-votes.ts
+++ b/packages/services/src/view-service/tournament-votes.ts
@@ -22,7 +22,7 @@ export const tournamentVotes: Impl['tournamentVotes'] = async function* (req, ct
         vote =>
           new TournamentVotesResponse_Vote({
             transaction: vote.TransactionId,
-            incentivizedAsset: vote.AssetMetadata.penumbraAssetId,
+            incentivizedAsset: vote.incentivizedAsset,
             votePower: vote.VoteValue.amount,
             reward: vote.RewardValue
               ? new Value({
@@ -68,7 +68,7 @@ export const tournamentVotes: Impl['tournamentVotes'] = async function* (req, ct
         bucket.push(
           new TournamentVotesResponse_Vote({
             transaction: vote.TransactionId,
-            incentivizedAsset: vote.AssetMetadata.penumbraAssetId,
+            incentivizedAsset: vote.incentivizedAsset,
             votePower: vote.VoteValue.amount,
             reward: new Value({
               amount: new Amount({

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -433,9 +433,9 @@ export class IndexedDb implements IndexedDbInterface {
     subaccount?: number,
   ): Promise<
     {
+      incentivizedAsset: AssetId;
       epoch: string;
       TransactionId: TransactionId;
-      AssetMetadata: Metadata;
       VoteValue: Value;
       RewardValue: Amount | undefined;
       id: string | undefined;
@@ -453,9 +453,9 @@ export class IndexedDb implements IndexedDbInterface {
       : tournamentVotes;
 
     return filtered.map(tournamentVote => ({
+      incentivizedAsset: AssetId.fromJson(tournamentVote.incentivizedAsset, { typeRegistry }),
       epoch: tournamentVote.epoch,
       TransactionId: TransactionId.fromJson(tournamentVote.TransactionId, { typeRegistry }),
-      AssetMetadata: Metadata.fromJson(tournamentVote.AssetMetadata, { typeRegistry }),
       VoteValue: Value.fromJson(tournamentVote.VoteValue, { typeRegistry }),
       RewardValue: tournamentVote.RewardValue
         ? Amount.fromJson(tournamentVote.RewardValue, { typeRegistry })
@@ -484,9 +484,11 @@ export class IndexedDb implements IndexedDbInterface {
           if (voteEpoch < epoch && voteSubaccount === subaccount) {
             if (cursor.value.RewardValue) {
               cont.enqueue({
+                incentivizedAsset: AssetId.fromJson(cursor.value.incentivizedAsset, {
+                  typeRegistry,
+                }),
                 epoch: cursor.value.epoch,
                 TransactionId: TransactionId.fromJson(cursor.value.TransactionId, { typeRegistry }),
-                AssetMetadata: Metadata.fromJson(cursor.value.AssetMetadata, { typeRegistry }),
                 VoteValue: Value.fromJson(cursor.value.VoteValue, { typeRegistry }),
                 RewardValue: Amount.fromJson(cursor.value.RewardValue, { typeRegistry }),
                 id: cursor.value.id,
@@ -507,9 +509,9 @@ export class IndexedDb implements IndexedDbInterface {
    * Saves historical liquidity tournament votes and rewards for a given epoch.
    */
   async saveLQTHistoricalVote(
+    incentivizedAsset: AssetId,
     epoch: bigint,
     transactionId: TransactionId,
-    assetMetadata: Metadata,
     voteValue: Value,
     rewardValue?: Amount,
     id?: string,
@@ -524,9 +526,9 @@ export class IndexedDb implements IndexedDbInterface {
     // TODO: saving the entire metadata is extraneous, experiment with changing
     // @see https://github.com/penumbra-zone/web/issues/2032.
     const tournamentVote = {
+      incentivizedAsset: incentivizedAsset.toJson({ typeRegistry }) as Jsonified<AssetId>,
       epoch: epoch.toString(),
       TransactionId: transactionId.toJson({ typeRegistry }) as Jsonified<TransactionId>,
-      AssetMetadata: assetMetadata.toJson({ typeRegistry }) as Jsonified<Metadata>,
       VoteValue: voteValue.toJson({ typeRegistry }) as Jsonified<Value>,
       RewardValue: rewardValue ? (rewardValue.toJson({ typeRegistry }) as Jsonified<Amount>) : null,
       id: uniquePrimaryKey,

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -185,9 +185,9 @@ export interface IndexedDbInterface {
   getPosition(positionId: PositionId): Promise<Position | undefined>;
 
   saveLQTHistoricalVote(
+    incentivizedAsset: AssetId,
     epoch: bigint,
     transactionId: TransactionId,
-    assetMetadata: Metadata,
     voteValue: Value,
     rewardValue?: Amount,
     id?: string,
@@ -199,9 +199,9 @@ export interface IndexedDbInterface {
     subaccount?: number,
   ): Promise<
     {
+      incentivizedAsset: AssetId;
       epoch: string;
       TransactionId: TransactionId;
-      AssetMetadata: Metadata;
       VoteValue: Value;
       RewardValue: Amount | undefined;
       id: string | undefined;
@@ -214,9 +214,9 @@ export interface IndexedDbInterface {
     subaccount?: number,
   ): AsyncGenerator<
     {
+      incentivizedAsset: AssetId;
       epoch: string;
       TransactionId: TransactionId;
-      AssetMetadata: Metadata;
       VoteValue: Value;
       RewardValue: Amount;
       id: string | undefined;
@@ -376,10 +376,10 @@ export interface PenumbraDb extends DBSchema {
   LQT_HISTORICAL_VOTES: {
     key: string;
     value: {
+      incentivizedAsset: Jsonified<AssetId>;
       id: string;
       epoch: string;
       TransactionId: Jsonified<TransactionId>;
-      AssetMetadata: Jsonified<Metadata>;
       VoteValue: Jsonified<Value>;
       RewardValue: Jsonified<Amount> | null;
       subaccount?: number;


### PR DESCRIPTION
## Description of Changes

references https://github.com/penumbra-zone/web/blob/main/packages/storage/src/indexed-db/index.ts#L524-L534. Recent registry changes exacerbated this issue by exposing breakage whereby the asset Id used at the time of voting no longer exists in the current registry, preventing metadata (and by extension the vote) from being saved.

pairs with https://github.com/prax-wallet/prax/pull/339

## Related Issue

N/A

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
