### PR TITLE
veil: bug: distinguish no lp rewards and loading

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-lp-rewards.ts
+++ b/apps/veil/src/pages/tournament/api/use-lp-rewards.ts
@@ -84,6 +84,9 @@ export const useLpRewards = (
     // but it's fine to let people reload the page to see that.
     staleTime: Infinity,
     queryFn: async () => {
+      if (!positionIds?.length) {
+        return { data: [], total: 0, totalRewards: 0 };
+      }
       return apiPostFetch<LpRewardsApiResponse>('/api/tournament/lp-rewards', {
         positionIds,
         page,
@@ -92,11 +95,10 @@ export const useLpRewards = (
         sortDirection,
       } as LpRewardsRequest).then(async resp => ({
         ...resp,
-        data: resp.data.length ? await enrichLpRewards(resp.data) : [],
+        data: await enrichLpRewards(resp.data),
       }));
     },
-    // Also handles the case where we have an empty array
-    enabled: !!positionIds,
+    enabled: positionIds !== undefined,
   });
 
   return query;

--- a/apps/veil/src/pages/tournament/ui/lp-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/lp-rewards.tsx
@@ -25,7 +25,7 @@ import { useStakingTokenMetadata } from '@/shared/api/registry';
 function LoadingRows() {
   return (
     <>
-      {new Array(5).map(x => (
+      {new Array(5).map((_, x) => (
         <div key={x}>
           <TableCell cell loading>
             null


### PR DESCRIPTION
The bug here is that we were treating the case where we knew the user had no positions and the case where we were waiting to learn if the user had any positions identically, causing an infinite load.

## Description of Changes

This handles things correctly now, returning an empty rewards response when you have no positions.

Closes #2348.
## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
