### PR TITLE
veil: bug: make useGetMetadata hook actually fallible

### DIFF
--- a/apps/veil/src/shared/api/assets.ts
+++ b/apps/veil/src/shared/api/assets.ts
@@ -19,5 +19,5 @@ export const isDenom = (value?: Denom | AssetId): value is Denom =>
  */
 export const useGetMetadata = (): GetMetadata => {
   const registry = useRegistry().data;
-  return x => x && registry.getMetadata(x);
+  return x => x && registry.tryGetMetadata(x);
 };


### PR DESCRIPTION
We were using getMetadata, which throws, instead of tryGetMetadata, which doesn't throw

This causes a runtime error, instead of being gracefully handleable.

Link to the issue this PR addresses.

references https://github.com/penumbra-zone/web/issues/2352

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
