### PR TITLE
fix(veil): #2340: implement better gauge rendering

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-epoch-results.ts
+++ b/apps/veil/src/pages/tournament/api/use-epoch-results.ts
@@ -1,13 +1,26 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/shared/utils/api-fetch';
+import { useRegistryAssets } from '@/shared/api/registry';
 import { useRefetchOnNewBlock } from '@/shared/api/compact-block';
 import { EpochResultsRequest, EpochResultsApiResponse } from '../server/epoch-results';
+import type { MappedGauge } from '@/pages/tournament/server/previous-epochs';
+import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { assetPatterns } from '@penumbra-zone/types/assets';
 
+/**
+ * Requests voting results of a given epoch. Returns percentages of each
+ * asset within the epoch and an array of `assetGauges` – results merged
+ * with registry asset metadata that usually gives an array of asset with 0 votes.
+ */
 export const useEpochResults = (
   name: string,
   params: Partial<EpochResultsRequest>,
   disabled?: boolean,
+  search = '',
 ) => {
+  const { data: assets } = useRegistryAssets();
+
   const query = useQuery({
     queryKey: [name, params.epoch, params.limit, params.page, params.sortKey, params.sortDirection],
     enabled: !!params.epoch && !disabled,
@@ -18,5 +31,47 @@ export const useEpochResults = (
 
   useRefetchOnNewBlock(name, query, disabled);
 
-  return query;
+  // collect all the gauges for the current epoch by the asset denom
+  const gaugeMapByDenom = useMemo(
+    () =>
+      (query.data?.data ?? []).reduce<Map<string, MappedGauge>>((accum, current) => {
+        accum.set(current.asset.base, current);
+        return accum;
+      }, new Map()),
+    [query.data?.data],
+  );
+
+  // filters assets from the registry that are IBC-assets and match the search query
+  const filteredAssets = useMemo<Metadata[]>(() => {
+    return assets.filter(asset => {
+      return (
+        assetPatterns.ibc.matches(asset.base) &&
+        (asset.symbol.toLowerCase().includes(search.toLowerCase()) ||
+          asset.description.toLowerCase().includes(search.toLowerCase()))
+      );
+    });
+  }, [assets, search]);
+
+  // adapts filtered assets to the gauges
+  const assetGauges = useMemo<MappedGauge[]>(() => {
+    return filteredAssets.map(asset => {
+      const fromGauge = gaugeMapByDenom.get(asset.base);
+      if (fromGauge) {
+        return fromGauge;
+      }
+
+      return {
+        asset,
+        epoch: 0,
+        votes: 0,
+        portion: 0,
+        missing_votes: 0,
+      };
+    });
+  }, [filteredAssets, gaugeMapByDenom]);
+
+  return {
+    ...query,
+    assetGauges,
+  };
 };

--- a/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
@@ -25,7 +25,7 @@ export const LandingCard = observer(() => {
   });
 
   const {
-    data: epochGauge,
+    assetGauges,
     isLoading: epochGaugeLoading,
     isPending,
   } = useEpochResults(
@@ -65,7 +65,7 @@ export const LandingCard = observer(() => {
 
           <IncentivePool summary={summary?.[0]} loading={summaryLoading} />
           <TournamentResults
-            results={epochGauge?.data ?? []}
+            results={assetGauges.slice(0, 5)}
             loading={isPending || epochGaugeLoading}
           />
           <VotingInfo />

--- a/apps/veil/src/pages/tournament/ui/landing-card/results.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/results.tsx
@@ -1,13 +1,23 @@
-import { round } from '@penumbra-zone/types/round';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Skeleton } from '@penumbra-zone/ui/Skeleton';
-import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
 import type { MappedGauge } from '../../server/previous-epochs';
+import { getVoteAssetComponents } from '../vote-dialog/vote-dialog-asset';
 
 export interface TournamentResultsProps {
   results: MappedGauge[];
   loading: boolean;
 }
+
+const TournamentResultsAsset = ({ asset }: { asset: MappedGauge }) => {
+  const { icon, content } = getVoteAssetComponents(asset);
+
+  return (
+    <div key={asset.asset.symbol} className='flex gap-3'>
+      {icon}
+      {content}
+    </div>
+  );
+};
 
 export const TournamentResults = ({ loading, results }: TournamentResultsProps) => {
   if (!loading && !results.length) {
@@ -32,28 +42,7 @@ export const TournamentResults = ({ loading, results }: TournamentResultsProps) 
               <Skeleton />
             </div>
           ))
-        : results.map(asset => (
-            <div key={asset.asset.symbol} className='flex gap-3'>
-              <AssetIcon metadata={asset.asset} size='lg' />
-
-              <div className='flex w-full flex-col gap-2'>
-                <div className='flex justify-between w-full'>
-                  <Text technical color='text.primary'>
-                    {asset.asset.symbol}
-                  </Text>
-                  <Text technical color='text.secondary'>
-                    {round({ value: asset.portion * 100, decimals: 0 })}%
-                  </Text>
-                </div>
-                <div className='flex w-full h-[6px] bg-other-tonalFill5 rounded-full overflow-hidden'>
-                  <div
-                    className='h-full bg-secondary-light'
-                    style={{ width: `calc(${asset.portion * 100}% - 1px)` }}
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
+        : results.map(asset => <TournamentResultsAsset asset={asset} key={asset.asset.base} />)}
     </div>
   );
 };

--- a/apps/veil/src/pages/tournament/ui/round/current-voting-results/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/current-voting-results/index.tsx
@@ -11,9 +11,9 @@ import { useSortableTableHeaders } from '../../sortable-table-header';
 import type { EpochResultsSortKey } from '../../../server/epoch-results';
 import type { MappedGauge } from '../../../server/previous-epochs';
 import { useEpochResults } from '../../../api/use-epoch-results';
+import { VOTING_THRESHOLD } from '../../vote-dialog/vote-dialog-asset';
 import { TableRow } from './table-row';
 
-const THRESHOLD = 0.05;
 const BASE_LIMIT = 10;
 
 const TABLE_CLASSES = {
@@ -59,7 +59,7 @@ export const CurrentVotingResults = observer(({ epoch }: CurrentVotingResultsPro
     below: MappedGauge[];
   }>(
     (accum, current) => {
-      if (current.portion >= THRESHOLD) {
+      if (current.portion >= VOTING_THRESHOLD) {
         accum.above.push(current);
       } else {
         accum.below.push(current);
@@ -106,7 +106,7 @@ export const CurrentVotingResults = observer(({ epoch }: CurrentVotingResultsPro
                 <TableCell>
                   <Text technical color='text.secondary'>
                     Below threshold ({'<'}
-                    {THRESHOLD * 100}%)
+                    {VOTING_THRESHOLD * 100}%)
                   </Text>
                 </TableCell>
               </div>

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/index.tsx
@@ -9,10 +9,10 @@ import { Checkbox } from '@penumbra-zone/ui/Checkbox';
 import { TextInput } from '@penumbra-zone/ui/TextInput';
 import { SpendableNoteRecord } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { useSubaccounts } from '@/widgets/header/api/subaccounts';
+import { voteTournament } from '@/entities/tournament/api/vote';
 import { connectionStore } from '@/shared/model/connection';
 import { getAddressIndex } from '@penumbra-zone/getters/address-view';
 import { useLQTNotes } from '../../api/use-voting-notes';
-import { voteTournament } from '../../../../entities/tournament/api/vote';
 import { useCurrentEpoch } from '../../api/use-current-epoch';
 import { useEpochResults } from '../../api/use-epoch-results';
 import { MappedGauge } from '../../server/previous-epochs';
@@ -49,7 +49,11 @@ export const VoteDialogueSelector = observer(
     const { epoch, isLoading: epochLoading } = useCurrentEpoch();
 
     const { data: notes } = useLQTNotes(subaccount, epoch);
-    const { data: assets, isLoading } = useEpochResults(
+    const {
+      data: assetsData,
+      isLoading,
+      assetGauges,
+    } = useEpochResults(
       'epoch-results-vote-dialog',
       {
         epoch,
@@ -57,7 +61,18 @@ export const VoteDialogueSelector = observer(
         page: 1,
       },
       !isOpen && epochLoading,
+      searchQuery,
     );
+
+    // Collect an array of minium 5 items. If there are more than 5 voted assets, return all of them.
+    // If less than 5, firstly return all voted assets, and then fill the rest with non-voted assets.
+    const assets = assetsData?.data ?? [];
+    const selectorAssets = [
+      ...assets,
+      ...((assets.length || 5) < 5
+        ? assetGauges.slice(assets.length, assets.length + 5 - assets.length)
+        : []),
+    ];
 
     const handleVoteSubmit = async () => {
       if (!selectedAsset) {
@@ -161,7 +176,7 @@ export const VoteDialogueSelector = observer(
               <VotingAssetSelector
                 selectedAsset={selectedAsset}
                 loading={isLoading}
-                gauge={assets?.data ?? []}
+                gauge={selectorAssets}
                 onSelect={onSearchSelect}
               />
             )}
@@ -169,8 +184,7 @@ export const VoteDialogueSelector = observer(
             {isSearchOpen && (
               <VoteDialogSearchResults
                 value={selectedAsset?.asset.base}
-                gauge={assets?.data ?? []}
-                search={searchQuery}
+                gauge={assetGauges}
                 onSelect={onSearchSelect}
               />
             )}

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/search-results.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/search-results.tsx
@@ -1,80 +1,31 @@
-import { useMemo } from 'react';
-import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { assetPatterns } from '@penumbra-zone/types/assets';
 import { Dialog } from '@penumbra-zone/ui/Dialog';
 import { Text } from '@penumbra-zone/ui/Text';
-import { useRegistryAssets } from '@/shared/api/registry';
 import type { MappedGauge } from '../../server/previous-epochs';
-import { LoadingVoteAsset } from './loading-vote-asset';
 import { VoteDialogAsset } from './vote-dialog-asset';
 import { VotingDialogNoResults } from './no-results';
 
 export interface VoteDialogSearchResultsProps {
   value: string | undefined;
   gauge: MappedGauge[];
-  search: string;
   onSelect: (asset: MappedGauge) => void;
 }
 
 export const VoteDialogSearchResults = ({
   value,
   gauge,
-  search,
   onSelect,
 }: VoteDialogSearchResultsProps) => {
-  const { data: assets } = useRegistryAssets();
-
-  const gaugeMapByDenom = useMemo(
-    () =>
-      gauge.reduce<Map<string, MappedGauge>>((accum, current) => {
-        accum.set(current.asset.base, current);
-        return accum;
-      }, new Map()),
-    [gauge],
-  );
-
-  const filteredAssets = useMemo<Metadata[]>(() => {
-    return assets.filter(asset => {
-      return (
-        assetPatterns.ibc.matches(asset.base) &&
-        (asset.symbol.toLowerCase().includes(search.toLowerCase()) ||
-          asset.description.toLowerCase().includes(search.toLowerCase()))
-      );
-    });
-  }, [assets, search]);
-
-  const mappedAssets = useMemo<MappedGauge[]>(() => {
-    return filteredAssets.map(asset => {
-      const fromGauge = gaugeMapByDenom.get(asset.base);
-      if (fromGauge) {
-        return fromGauge;
-      }
-
-      return {
-        asset,
-        epoch: 0,
-        votes: 0,
-        portion: 0,
-        missing_votes: 0,
-      };
-    });
-  }, [filteredAssets, gaugeMapByDenom]);
-
   return (
     <div className='flex flex-col gap-2'>
       <Text small color='text.secondary'>
         Search results
       </Text>
 
-      {!mappedAssets.length && <VotingDialogNoResults />}
+      {!gauge.length && <VotingDialogNoResults />}
 
       <Dialog.RadioGroup value={value}>
         <div className='flex flex-col gap-1'>
-          {new Array(5).fill({}).map((_, index) => (
-            <LoadingVoteAsset key={index} />
-          ))}
-
-          {mappedAssets.map(asset => (
+          {gauge.map(asset => (
             <VoteDialogAsset
               key={asset.asset.base}
               asset={asset}

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
@@ -1,18 +1,61 @@
 import cn from 'clsx';
 import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
+import { round } from '@penumbra-zone/types/round';
 import { Dialog } from '@penumbra-zone/ui/Dialog';
 import { Text } from '@penumbra-zone/ui/Text';
 import type { MappedGauge } from '../../server/previous-epochs';
 
-const VOTING_THRESHOLD = 0.05;
+export const VOTING_THRESHOLD = 0.05;
 
 export interface VoteDialogAssetProps {
   asset: MappedGauge;
   onSelect: VoidFunction;
 }
 
-export const VoteDialogAsset = ({ asset, onSelect }: VoteDialogAssetProps) => {
+export const getVoteAssetComponents = (asset: MappedGauge) => {
   const isSecondary = asset.portion < VOTING_THRESHOLD;
+
+  let percentage = round({ value: asset.portion * 100, decimals: 0 });
+  if (asset.portion < 0.01) {
+    percentage = '<1';
+  }
+  if (asset.portion === 0) {
+    percentage = '0';
+  }
+
+  return {
+    icon: (
+      <div className={cn('min-w-8', isSecondary && 'grayscale')}>
+        <AssetIcon size='lg' metadata={asset.asset} />
+      </div>
+    ),
+    content: (
+      <div className='grow flex flex-col gap-1 ml-1'>
+        <div className='flex w-full justify-between gap-1'>
+          <Text technical color='text.primary'>
+            {asset.asset.symbol}
+          </Text>
+          <Text technical color={isSecondary ? 'neutral.light' : 'text.primary'}>
+            {percentage}%
+          </Text>
+        </div>
+
+        <div className='flex w-full h-1 bg-other-tonalFill5 rounded-full'>
+          <div
+            className={cn(
+              'h-full rounded-full',
+              isSecondary ? 'bg-neutral-light' : 'bg-secondary-light',
+            )}
+            style={{ width: `${asset.portion * 100}%` }}
+          />
+        </div>
+      </div>
+    ),
+  };
+};
+
+export const VoteDialogAsset = ({ asset, onSelect }: VoteDialogAssetProps) => {
+  const { icon, content } = getVoteAssetComponents(asset);
 
   return (
     <Dialog.RadioItem
@@ -20,29 +63,8 @@ export const VoteDialogAsset = ({ asset, onSelect }: VoteDialogAssetProps) => {
       key={asset.asset.base}
       value={asset.asset.base}
       onSelect={onSelect}
-      startAdornment={<AssetIcon size='lg' metadata={asset.asset} />}
-      endAdornment={
-        <div className='grow flex flex-col gap-1 ml-1'>
-          <div className='flex w-full justify-between gap-1'>
-            <Text technical color='text.primary'>
-              {asset.asset.symbol}
-            </Text>
-            <Text technical color={isSecondary ? 'neutral.light' : 'text.primary'}>
-              {asset.portion * 100}%
-            </Text>
-          </div>
-
-          <div className='flex w-full h-[6px] bg-other-tonalFill5 rounded-full'>
-            <div
-              className={cn(
-                'h-full rounded-full',
-                isSecondary ? 'bg-[#888888]' : 'bg-secondary-light',
-              )}
-              style={{ width: `${asset.portion * 100}%` }}
-            />
-          </div>
-        </div>
-      }
+      startAdornment={icon}
+      endAdornment={content}
     />
   );
 };


### PR DESCRIPTION
Closes #2340 

Now, current results on the landing tournament page will always contain 5 assets. Also, improved and reused voted assets rendering between the mentioned component and the voting dialog. Assets below the threshold are now grayscaled. If the percentage is less than 1 but not 0, it renders as "<1%".