### PR TITLE
fix(veil): apply figma comments

### DIFF
--- a/apps/veil/src/pages/explore/ui/waves.tsx
+++ b/apps/veil/src/pages/explore/ui/waves.tsx
@@ -7,7 +7,8 @@ export const PenumbraWaves = () => {
   return (
     <Waves
       className={cn(
-        'display-none absolute scale-90 w-[1200px] top-[-800px] left-[25%]  z-[-30] opacity-90',
+        'w-screen h-[100vw] fixed top-0 left-0 -z-[1] -translate-y-[70%] scale-150 pointer-events-none',
+        'desktop:scale-100 desktop:w-[80vw] desktop:h-[80vw] desktop:-translate-y-3/4 desktop:left-[10vw]',
       )}
     />
   );

--- a/apps/veil/src/pages/tournament/ui/delegator-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/delegator-rewards.tsx
@@ -10,6 +10,7 @@ import { getAmount } from '@penumbra-zone/getters/value-view';
 import { Skeleton } from '@penumbra-zone/ui/Skeleton';
 import { isZero } from '@penumbra-zone/types/amount';
 import { Density } from '@penumbra-zone/ui/Density';
+import { Tooltip } from '@penumbra-zone/ui/Tooltip';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { connectionStore } from '@/shared/model/connection';
@@ -94,7 +95,7 @@ export const DelegatorTotalRewards = observer(() => {
       <div className='flex justify-between items-center'>
         <div className='flex flex-col gap-1'>
           <Text xxl color='text.primary'>
-            My Total Rewards
+            My Total Tournament Rewards
           </Text>
           <Text small color='text.secondary'>
             Cumulative rewards from all epochs, voting and LPs rewards
@@ -107,14 +108,16 @@ export const DelegatorTotalRewards = observer(() => {
           </div>
         ) : (
           <div className='flex items-center gap-4 [&_span]:font-mono [&_span]:text-3xl'>
-            {rewardView ? (
+            {rewardView && !isTotalZero ? (
               <Density sparse>
                 <ValueViewComponent valueView={rewardView} priority='tertiary' />
               </Density>
             ) : (
-              <Text xxl color='text.primary'>
-                0.00 UM
-              </Text>
+              <Tooltip message='Participate in the tournament to earn rewards'>
+                <Text xxl color='text.primary'>
+                  0.00 UM
+                </Text>
+              </Tooltip>
             )}
             <Density compact>
               {!isTotalZero && (


### PR DESCRIPTION
Implements Figma comments:
1. Add a tooltip to zero-balance rewards: https://www.figma.com/design/QSQzywrHh5M6dGdVtFOY5j?node-id=601-220343&m=dev#1208168955
2. Change title in the total rewards section: https://www.figma.com/design/QSQzywrHh5M6dGdVtFOY5j?node-id=601-222608&m=dev#1203576816
3. Not from Figma. Tournament & Explore & Portfolio pages used to have horizontal scroll because of changes to Penumbra Waves component. This PR fixes the component and removes annoying horizontal scroll.