### PR TITLE
atomic validator status updates

### DIFF
--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -31,7 +31,10 @@ import {
   FmdParameters,
   Note,
 } from '@penumbra-zone/protobuf/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
-import { ValidatorInfo } from '@penumbra-zone/protobuf/penumbra/core/component/stake/v1/stake_pb';
+import {
+  ValidatorInfo,
+  ValidatorInfoResponse,
+} from '@penumbra-zone/protobuf/penumbra/core/component/stake/v1/stake_pb';
 import { AddressIndex, IdentityKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import {
   Transaction,
@@ -114,7 +117,7 @@ export interface IndexedDbInterface {
   addEpoch(epoch: PlainMessage<Epoch>): Promise<void>;
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
   getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined>;
-  upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;
+  updateValidatorInfo(validatorInfo: AsyncIterable<ValidatorInfoResponse>): Promise<void>;
   iterateValidatorInfos(): AsyncGenerator<ValidatorInfo, void>;
   clearValidatorInfos(): Promise<void>;
   getValidatorInfo(identityKey: IdentityKey): Promise<ValidatorInfo | undefined>;


### PR DESCRIPTION
## Description of Changes

directly lifts only the `updateValidatorInfo` method from https://github.com/penumbra-zone/web/pull/2258. I haven't tested this functionally yet and am not comfortable with merging, but we should proceed to the testing stage. 

question: can this proceed and land after a release that includes the epoch handling work? I think that will be the plan for now, cc @turbocrime 

## Related Issue

complementary to https://github.com/penumbra-zone/web/pull/2242

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
