### PR TITLE
fix(veil): #2350: personal rewards tables

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-personal-rewards.ts
+++ b/apps/veil/src/pages/tournament/api/use-personal-rewards.ts
@@ -15,6 +15,7 @@ import {
   AddressByIndexResponse,
   TournamentVotesResponse,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
+import { bech32mAddress } from '@penumbra-zone/bech32m/penumbra';
 
 export const BASE_LIMIT = 10;
 export const BASE_PAGE = 1;
@@ -69,8 +70,7 @@ const fetchRewards = async (
       '/api/tournament/delegator-history',
       {
         epochs: Array.from(epochs),
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- address is defined
-        address: { inner: Array.from(address!.inner) },
+        address: address ? bech32mAddress(address) : '',
         page,
         limit,
         sortKey,

--- a/apps/veil/src/pages/tournament/server/delegator-history.ts
+++ b/apps/veil/src/pages/tournament/server/delegator-history.ts
@@ -48,9 +48,7 @@ export const getBodyParams = async (
   const sortDirection =
     sortDirectionParam && DIRECTIONS.includes(sortDirectionParam) ? sortDirectionParam : 'desc';
 
-  const epochs = Array.isArray(body.epochs)
-    ? body.epochs.filter(epoch => typeof epoch === 'string')
-    : [];
+  const epochs = Array.isArray(body.epochs) ? body.epochs : [];
 
   if (!isAddress(body.address)) {
     return 'Invalid address';

--- a/apps/veil/src/pages/tournament/ui/lp-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/lp-rewards.tsx
@@ -1,86 +1,77 @@
 import { useState } from 'react';
 import { observer } from 'mobx-react-lite';
+import { useRouter } from 'next/navigation';
 import { ChevronRight, ExternalLink } from 'lucide-react';
 import { bech32mPositionId } from '@penumbra-zone/bech32m/plpid';
+import { ValueViewComponent } from '@penumbra-zone/ui/ValueView';
 import { Pagination } from '@penumbra-zone/ui/Pagination';
 import { TableCell } from '@penumbra-zone/ui/TableCell';
-import { ValueViewComponent } from '@penumbra-zone/ui/ValueView';
-import { Button } from '@penumbra-zone/ui/Button';
 import { Density } from '@penumbra-zone/ui/Density';
-import { withdrawPositions } from '@/entities/position/api/withdraw-positions';
+import { Button } from '@penumbra-zone/ui/Button';
+import { pnum } from '@penumbra-zone/types/pnum';
+import { ValueView, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import {
   useLpRewards,
   BASE_LIMIT,
   BASE_PAGE,
   LpReward,
 } from '@/pages/tournament/api/use-lp-rewards';
-import { useSortableTableHeaders } from '@/pages/tournament/ui/sortable-table-header';
+import { withdrawPositions } from '@/entities/position/api/withdraw-positions';
 import { connectionStore } from '@/shared/model/connection';
-import { useRouter } from 'next/navigation';
-import { LpRewardsSortKey } from '../server/lp-rewards';
-import { ValueView, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { pnum } from '@penumbra-zone/types/pnum';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
+import { LpRewardsSortKey } from '../server/lp-rewards';
+import { useSortableTableHeaders } from './sortable-table-header';
 
-function LoadingRows() {
-  return (
-    <>
-      {new Array(5).map((_, x) => (
-        <div key={x}>
-          <TableCell cell loading>
-            null
-          </TableCell>
-          <TableCell cell loading>
-            null
-          </TableCell>
-          <TableCell cell loading>
-            null
-          </TableCell>
-          <TableCell cell loading>
-            null
-          </TableCell>
-          <TableCell cell loading>
-            null
-          </TableCell>
-        </div>
-      ))}
-    </>
-  );
-}
-
-function LpRewardRow({ lpReward, umMetadata }: { lpReward: LpReward; umMetadata: Metadata }) {
+function LpRewardRow({
+  lpReward,
+  umMetadata,
+  loading,
+}: {
+  lpReward: LpReward;
+  umMetadata: Metadata;
+  loading?: boolean;
+}) {
   const router = useRouter();
+  const id = !loading ? bech32mPositionId(lpReward.positionId) : '';
 
   return (
     <div
       onClick={() => {
-        router.push(`/inspect/lp/${bech32mPositionId(lpReward.positionId)}`);
+        router.push(`/inspect/lp/${id}`);
       }}
       className='grid grid-cols-subgrid col-span-5 hover:bg-action-hoverOverlay transition-colors cursor-pointer'
     >
-      <TableCell cell>#{lpReward.epoch}</TableCell>
-      <TableCell cell>
-        <div className='max-w-[370px] truncate'>{bech32mPositionId(lpReward.positionId)}</div>
-        <ExternalLink className='size-3 min-w-3 text-neutral-light' />
+      <TableCell cell loading={loading}>
+        #{lpReward.epoch}
       </TableCell>
-      <TableCell cell>
-        <ValueViewComponent
-          valueView={
-            new ValueView({
-              valueView: {
-                case: 'knownAssetId',
-                value: {
-                  amount: pnum(lpReward.rewards).toAmount(),
-                  metadata: umMetadata,
+      <TableCell cell loading={loading}>
+        {!loading && (
+          <>
+            <div className='max-w-[370px] truncate'>{id}</div>
+            <ExternalLink className='size-3 min-w-3 text-neutral-light' />
+          </>
+        )}
+      </TableCell>
+      <TableCell cell loading={loading}>
+        {!loading && (
+          <ValueViewComponent
+            valueView={
+              new ValueView({
+                valueView: {
+                  case: 'knownAssetId',
+                  value: {
+                    amount: pnum(lpReward.rewards).toAmount(),
+                    metadata: umMetadata,
+                  },
                 },
-              },
-            })
-          }
-          priority='tertiary'
-        />
+              })
+            }
+            priority='tertiary'
+          />
+        )}
       </TableCell>
-      <TableCell cell>
-        {(lpReward.isWithdrawable || lpReward.isWithdrawn) && (
+      <TableCell cell loading={loading}>
+        {!loading && (lpReward.isWithdrawable || lpReward.isWithdrawn) && (
           <Density slim>
             <div>
               <Button
@@ -104,7 +95,7 @@ function LpRewardRow({ lpReward, umMetadata }: { lpReward: LpReward; umMetadata:
           </Density>
         )}
       </TableCell>
-      <TableCell cell>
+      <TableCell cell loading={loading}>
         <Density slim>
           <Button iconOnly icon={ChevronRight}>
             Go to position information
@@ -122,17 +113,18 @@ export const LpRewards = observer(() => {
   const { getTableHeader, sortBy } = useSortableTableHeaders<keyof LpReward>('epoch');
   const { data: umMetadata } = useStakingTokenMetadata();
 
-  const query = useLpRewards(
+  const { data, isPending } = useLpRewards(
     subaccount,
     page,
     limit,
     sortBy.key as LpRewardsSortKey,
     sortBy.direction,
   );
-  const { data: queryData, isPending } = query;
-  const { data, total } = queryData ?? { data: [], total: 0 };
+
   const loading = isPending;
-  const rewards = data;
+  const loadingArr = new Array(BASE_LIMIT).fill({}) as LpReward[];
+  const rewards = data?.data ?? loadingArr;
+  const total = data?.total ?? 0;
 
   const onLimitChange = (newLimit: number) => {
     setLimit(newLimit);
@@ -151,13 +143,20 @@ export const LpRewards = observer(() => {
             <TableCell heading> </TableCell>
           </div>
 
-          {loading ? (
-            <LoadingRows />
-          ) : (
-            rewards.map((lpReward, index) => (
-              <LpRewardRow key={index} lpReward={lpReward} umMetadata={umMetadata} />
-            ))
+          {!loading && !total && (
+            <div className='col-span-5 text-sm text-muted-foreground py-4'>
+              No LP rewards found for this account.
+            </div>
           )}
+
+          {rewards.map((lpReward, index) => (
+            <LpRewardRow
+              key={index}
+              lpReward={lpReward}
+              umMetadata={umMetadata}
+              loading={loading}
+            />
+          ))}
         </div>
       </Density>
 

--- a/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
+++ b/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
@@ -44,7 +44,7 @@ const PreviousEpochsRow = observer(
     const {
       data: rewards,
       query: { isLoading: rewardsLoading },
-    } = usePersonalRewards(subaccount, row.epoch);
+    } = usePersonalRewards(subaccount, row.epoch, false, 1, 1);
     const { data: stakingToken } = useStakingTokenMetadata();
     const reward = rewards.get(row.epoch);
 
@@ -84,26 +84,27 @@ const PreviousEpochsRow = observer(
             </Tooltip>
           )}
         </TableCell>
-        {connected && (rewardsLoading || reward !== undefined) && (
-          <TableCell cell loading={isLoading || rewardsLoading}>
-            {
-              <ValueViewComponent
-                valueView={
-                  new ValueView({
-                    valueView: {
-                      case: 'knownAssetId',
-                      value: {
-                        amount: pnum(reward?.reward).toAmount(),
-                        metadata: stakingToken,
-                      },
+
+        <TableCell cell loading={isLoading || rewardsLoading}>
+          {connected && (rewardsLoading || reward !== undefined) ? (
+            <ValueViewComponent
+              valueView={
+                new ValueView({
+                  valueView: {
+                    case: 'knownAssetId',
+                    value: {
+                      amount: pnum(reward?.reward).toAmount(),
+                      metadata: stakingToken,
                     },
-                  })
-                }
-                priority='tertiary'
-              />
-            }
-          </TableCell>
-        )}
+                  },
+                })
+              }
+              priority='tertiary'
+            />
+          ) : (
+            <Text color='text.secondary'>–</Text>
+          )}
+        </TableCell>
         <TableCell cell loading={isLoading}>
           <Density slim>
             <Button iconOnly icon={ChevronRight}>

--- a/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
@@ -104,7 +104,7 @@ export const VotingRewards = observer(() => {
     epochStatus !== 'success',
     page,
     limit,
-    sortBy.key,
+    sortBy.key as DelegatorHistorySortKey,
     sortBy.direction,
   );
 

--- a/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
@@ -10,6 +10,7 @@ import { connectionStore } from '@/shared/model/connection';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
 import { Pagination } from '@penumbra-zone/ui/Pagination';
 import { LqtSummary } from '@/shared/database/schema';
+import { LoadingRow } from '@/shared/ui/loading-row';
 import { useGetMetadata } from '@/shared/api/assets';
 import { toValueView } from '@/shared/utils/value-view';
 import { useCurrentEpoch } from '../api/use-current-epoch';
@@ -17,17 +18,6 @@ import { usePersonalRewards, BASE_LIMIT, BASE_PAGE } from '../api/use-personal-r
 import { DelegatorHistorySortKey, LqtDelegatorHistoryData } from '../server/delegator-history';
 import { useTournamentSummary } from '../api/use-tournament-summary';
 import { useSortableTableHeaders } from './sortable-table-header';
-
-const LoadingRow = () => {
-  return (
-    <div className='grid grid-cols-subgrid col-span-4'>
-      <TableCell loading>–</TableCell>
-      <TableCell loading>–</TableCell>
-      <TableCell loading>–</TableCell>
-      <TableCell loading>–</TableCell>
-    </div>
-  );
-};
 
 interface VotingRewardsRowProps {
   epoch: number;
@@ -113,6 +103,8 @@ export const VotingRewards = observer(() => {
   const { data: rawSummary } = useTournamentSummary(
     {
       epochs: epochs.length > 0 ? epochs : undefined,
+      limit,
+      page,
     },
     epochs.length === 0,
   );
@@ -136,7 +128,8 @@ export const VotingRewards = observer(() => {
             <TableCell heading> </TableCell>
           </div>
 
-          {loading && new Array(BASE_LIMIT).fill({}).map((_, index) => <LoadingRow key={index} />)}
+          {loading &&
+            new Array(BASE_LIMIT).fill({}).map((_, index) => <LoadingRow cells={4} key={index} />)}
 
           {!loading && !total && (
             <div className='col-span-4 text-sm text-muted-foreground py-4'>

--- a/apps/veil/src/shared/ui/loading-row.tsx
+++ b/apps/veil/src/shared/ui/loading-row.tsx
@@ -1,0 +1,36 @@
+import { TableCell, TableCellVariant } from '@penumbra-zone/ui/TableCell';
+import cn from 'clsx';
+
+const COLSPAN_CLASSES: Record<number, string> = {
+  1: 'col-span-1',
+  2: 'col-span-2',
+  3: 'col-span-3',
+  4: 'col-span-4',
+  5: 'col-span-5',
+  6: 'col-span-6',
+  7: 'col-span-7',
+  8: 'col-span-8',
+};
+
+export interface LoadingRowProps {
+  /** The amount of cells in a loading row */
+  cells: number;
+  cellVariant?: TableCellVariant;
+  className?: string;
+}
+
+/**
+ * A component that simplifies creation of loading rows
+ * within a standard table using TableCell
+ */
+export const LoadingRow = ({ cells, className, cellVariant = 'cell' }: LoadingRowProps) => {
+  return (
+    <div className={cn('grid grid-cols-subgrid', COLSPAN_CLASSES[cells], className)}>
+      {new Array(cells).fill({}).map((_, index) => (
+        <TableCell key={index} variant={cellVariant} loading>
+          undefined
+        </TableCell>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #2350 

In this PR:
1. Fix: Returned correct loading and empty states to "LPs rewards" and "Voting rewards" tables within the tournament landing page, as the issue suggests
2. Feat: added sorting by rewards, not only by epoch to "Voting rewards" table. Previously, only sorting by epoch was supported
3. Refactor: removed all JS-based rewards and power calculation from the server, delegated this logic to SQL. Works faster now, easier to maintain and read. Tested that the result is the same as it was before.
4. Fixed a bug of pagination limit not being correctly applied in the voting rewards table

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/cb845e9e-5209-4ac6-b5b9-81f6edcf4b18" />
