### PR TITLE
fix(perspective): #2280: tx summary swap rendering

### DIFF
--- a/.changeset/thick-flowers-knock.md
+++ b/.changeset/thick-flowers-knock.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/perspective': patch
+---
+
+Fix transaction classification for swap and swap claim actions

--- a/packages/perspective/src/action-view/relevant-assets.ts
+++ b/packages/perspective/src/action-view/relevant-assets.ts
@@ -5,10 +5,10 @@ import {
   getAsset2Metadata,
   getDelta2IFromSwapView,
 } from '@penumbra-zone/getters/swap-view';
-import { getOutputData } from '@penumbra-zone/getters/swap-claim-view';
+import { getOutput1Value, getOutput2Value } from '@penumbra-zone/getters/swap-claim-view';
 import { getNote as getSpendNote } from '@penumbra-zone/getters/spend-view';
 import { getNote as getOutputNote } from '@penumbra-zone/getters/output-view';
-import { getMetadata } from '@penumbra-zone/getters/value-view';
+import { getMetadata, getAmount } from '@penumbra-zone/getters/value-view';
 import { bech32mIdentityKey } from '@penumbra-zone/bech32m/penumbravalid';
 
 export type RelevantAsset = AssetId | Metadata;
@@ -58,7 +58,7 @@ export const findRelevantAssets = (action?: ActionView): RelevantAsset[] => {
     const metadata1 = getAsset1Metadata.optional(view.value);
     const metadata2 = getAsset2Metadata.optional(view.value);
     const delta2 = getDelta2IFromSwapView(view.value);
-    const isDelta2Zero = delta2.lo === 0n && delta2.hi === 0n;
+    const isDelta2Zero = !(delta2.lo > 0n || delta2.hi > 0n);
     const inputMetadata = isDelta2Zero ? metadata1 : metadata2;
     const outputMetadata = isDelta2Zero ? metadata2 : metadata1;
 
@@ -66,8 +66,20 @@ export const findRelevantAssets = (action?: ActionView): RelevantAsset[] => {
   }
 
   if (view.case === 'swapClaim') {
-    const bsod = getOutputData.optional(view.value);
-    return returnAssets([bsod?.tradingPair?.asset1, bsod?.tradingPair?.asset2]);
+    const value1 = getOutput1Value.optional(view.value);
+    const value2 = getOutput2Value.optional(view.value);
+    let inputMetadata = getMetadata.optional(value1);
+    let outputMetadata = getMetadata.optional(value2);
+
+    // find correct swap claim sides
+    const amount1 = getAmount.optional(value1);
+    const isAmount1NotZero = amount1 && (amount1.lo > 0n || amount1.hi > 0n);
+    if (isAmount1NotZero) {
+      inputMetadata = getMetadata.optional(value2);
+      outputMetadata = getMetadata.optional(value1);
+    }
+
+    return returnAssets([inputMetadata, outputMetadata]);
   }
 
   if (view.case === 'positionOpen') {


### PR DESCRIPTION
Closes #2280

Applies correct sides to assets of swap and swap claim action views to transaction summary component, as the issue suggests.

Doesn't do anything with issue's claim of "the swap only shows input amount and no output amount" – that's an expected behavior of the swap view – output amount is shown in the swap claim summary.