### PR TITLE
storage: store remote epoch

### DIFF
--- a/.changeset/shaggy-adults-jam.md
+++ b/.changeset/shaggy-adults-jam.md
@@ -1,0 +1,6 @@
+---
+'@penumbra-zone/storage': minor
+'@penumbra-zone/types': minor
+---
+
+storage helper to save remote epoch

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -36,7 +36,7 @@ export interface IndexedDbMock {
   saveGasPrices?: Mock;
   saveTransactionInfo?: Mock;
   getTransactionInfo?: Mock;
-  getBlockHeightByEpoch?: Mock;
+  getEpochByIndex?: Mock;
   saveLQTHistoricalVote?: Mock;
   getLQTHistoricalVotes?: Mock;
   iterateLQTVotes?: Mock;

--- a/packages/services/src/view-service/lqt-voting-notes.test.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.test.ts
@@ -27,7 +27,7 @@ describe('lqtVotingNotes request handler', () => {
     mockIndexedDb = {
       getLQTHistoricalVotes: vi.fn(),
       iterateLQTVotes: vi.fn(),
-      getBlockHeightByEpoch: vi.fn(),
+      getEpochByIndex: vi.fn(),
       getNotesForVoting: vi.fn(),
     };
 
@@ -53,7 +53,7 @@ describe('lqtVotingNotes request handler', () => {
     // voting notes mocked with static data, and the mock bypasses the logic in the real implementation,
     // but that's fine.
     mockIndexedDb.getNotesForVoting?.mockResolvedValueOnce(testData);
-    mockIndexedDb.getBlockHeightByEpoch?.mockResolvedValueOnce(epoch);
+    mockIndexedDb.getEpochByIndex?.mockResolvedValueOnce(epoch);
 
     mockQuerier = {
       funding: {
@@ -88,7 +88,7 @@ describe('lqtVotingNotes request handler', () => {
 
   test('returns voting notes when the nullifier has not been used for voting in the current epoch', async () => {
     mockIndexedDb.getNotesForVoting?.mockResolvedValueOnce(testData);
-    mockIndexedDb.getBlockHeightByEpoch?.mockResolvedValueOnce(epoch);
+    mockIndexedDb.getEpochByIndex?.mockResolvedValueOnce(epoch);
 
     mockQuerier = {
       funding: {

--- a/packages/services/src/view-service/lqt-voting-notes.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.ts
@@ -13,7 +13,7 @@ export const lqtVotingNotes: Impl['lqtVotingNotes'] = async function* (req, ctx)
   const { indexedDb, querier } = await services.getWalletServices();
 
   // Get the starting block height for the corresponding epoch index.
-  const epoch = await indexedDb.getBlockHeightByEpoch(req.epochIndex);
+  const epoch = await indexedDb.getEpochByIndex(req.epochIndex);
 
   // Retrieve SNRs from storage ('ASSETS' in IndexedDB) for the specified subaccount that are eligible for voting
   // at the start height of the current epoch. Alternatively, a wasm helper `get_voting_notes` can be used to

--- a/packages/services/src/view-service/tournament-votes.test.ts
+++ b/packages/services/src/view-service/tournament-votes.test.ts
@@ -25,7 +25,7 @@ describe('tournamentVotes request handler', () => {
       getLQTHistoricalVotes: vi.fn(),
       iterateLQTVotes: vi.fn(),
       saveLQTHistoricalVote: vi.fn(),
-      getBlockHeightByEpoch: vi.fn(),
+      getEpochByIndex: vi.fn(),
       getNotesForVoting: vi.fn(),
     };
 
@@ -48,7 +48,7 @@ describe('tournamentVotes request handler', () => {
   });
 
   test('returns historical liquidity tournament votes that have been previously been saved to storage', async () => {
-    mockIndexedDb.getBlockHeightByEpoch?.mockResolvedValueOnce(epoch);
+    mockIndexedDb.getEpochByIndex?.mockResolvedValueOnce(epoch);
     mockIndexedDb.saveLQTHistoricalVote?.mockResolvedValueOnce(mockVote);
     mockIndexedDb.getLQTHistoricalVotes?.mockResolvedValueOnce([mockVote]);
     mockIndexedDb.iterateLQTVotes?.mockResolvedValueOnce([mockVote]);

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -820,6 +820,21 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   /**
+   * Adds a new remote epoch from full node with the given start height.
+   */
+  async addRemoteEpoch(startHeight: bigint, epochIndex: bigint): Promise<void> {
+    const remoteEpoch = {
+      startHeight: startHeight.toString(),
+      index: epochIndex.toString(),
+    };
+
+    await this.u.update({
+      table: 'EPOCHS',
+      value: remoteEpoch,
+    });
+  }
+
+  /**
    * Adds a new epoch with the given start height. Automatically sets the epoch
    * index by finding the previous epoch index, and adding 1n.
    */

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -529,6 +529,7 @@ export class IndexedDb implements IndexedDbInterface {
 
     // This is a unique identifier to force unique primary keys. If the field isn't provided,
     // a random one is generated and used to store an object.
+    // emulating unllifier uniqueness
     const uniquePrimaryKey = id ?? crypto.randomUUID();
 
     // TODO: saving the entire metadata is extraneous, experiment with changing
@@ -835,28 +836,18 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   /**
-   * Adds a new epoch with the given start height. Automatically sets the epoch
-   * index by finding the previous epoch index, and adding 1n.
+   * Adds a new epoch with start height and epoch index.
    */
-  async addEpoch(startHeight: bigint): Promise<void> {
-    const cursor = await this.db.transaction('EPOCHS', 'readonly').store.openCursor(null, 'prev');
-    const previousEpoch = cursor?.value ? Epoch.fromJson(cursor.value) : undefined;
-    const index = previousEpoch?.index !== undefined ? previousEpoch.index + 1n : 0n;
+  async addEpoch(startHeight: bigint, epochIndex: bigint): Promise<void> {
+    const tx = this.db.transaction('EPOCHS', 'readwrite');
 
-    // avoid saving the same epoch twice
-    if (previousEpoch?.startHeight === startHeight) {
-      return;
-    }
-
-    const newEpoch = {
-      startHeight: startHeight.toString(),
-      index: index.toString(),
-    };
-
-    await this.u.update({
-      table: 'EPOCHS',
-      value: newEpoch,
-    });
+    await tx.store.put(
+      {
+        startHeight: startHeight.toString(),
+        index: epochIndex.toString(),
+      },
+      Number(epochIndex),
+    );
   }
 
   /**
@@ -897,21 +888,17 @@ export class IndexedDb implements IndexedDbInterface {
   }
 
   /**
-   * Get the block height for the correspinding epoch index.
+   * Get the epoch identified by the given epoch index.
    */
-  async getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined> {
-    let epoch: Epoch | undefined;
-
+  async getEpochByIndex(epochIndex: bigint): Promise<Epoch | undefined> {
     // Iterate over epochs and return the one with the matching epoch index.
-    for await (const cursor of this.db.transaction('EPOCHS', 'readonly').store) {
-      const currentEpoch = Epoch.fromJson(cursor.value);
-      if (currentEpoch.index === epoch_index) {
-        epoch = currentEpoch;
-        break;
+    for await (const cursor of this.db.transaction('EPOCHS').store.iterate(null, 'prev')) {
+      const epoch = Epoch.fromJson(cursor.value);
+      if (epoch.index === epochIndex) {
+        return epoch;
       }
     }
-
-    return epoch;
+    return;
   }
 
   /**

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -111,8 +111,7 @@ export interface IndexedDbInterface {
     newState: PositionState,
     subaccount?: AddressIndex,
   ): Promise<void>;
-  addRemoteEpoch(startHeight: bigint, epochIndex: bigint): Promise<void>;
-  addEpoch(startHeight: bigint): Promise<void>;
+  addEpoch(startHeight: bigint, epochIndex: bigint): Promise<void>;
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
   getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined>;
   upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -113,7 +113,7 @@ export interface IndexedDbInterface {
   ): Promise<void>;
   addEpoch(startHeight: bigint, epochIndex: bigint): Promise<void>;
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
-  getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined>;
+  getEpochByIndex(epochIndex: bigint): Promise<Epoch | undefined>;
   upsertValidatorInfo(validatorInfo: ValidatorInfo): Promise<void>;
   iterateValidatorInfos(): AsyncGenerator<ValidatorInfo, void>;
   clearValidatorInfos(): Promise<void>;

--- a/packages/types/src/indexed-db.ts
+++ b/packages/types/src/indexed-db.ts
@@ -111,6 +111,7 @@ export interface IndexedDbInterface {
     newState: PositionState,
     subaccount?: AddressIndex,
   ): Promise<void>;
+  addRemoteEpoch(startHeight: bigint, epochIndex: bigint): Promise<void>;
   addEpoch(startHeight: bigint): Promise<void>;
   getEpochByHeight(height: bigint): Promise<Epoch | undefined>;
   getBlockHeightByEpoch(epoch_index: bigint): Promise<Epoch | undefined>;


### PR DESCRIPTION
## Description of Changes

Fresh wallets leverage instant sync by consuming the latest frontier, and therefore need to persist the latest remote epoch fetched from the full node. This provides an auxiliary helper storage method to do that. 

## Related Issue

pairs with https://github.com/prax-wallet/prax/pull/346

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
