### PR TITLE
services: make tests use type-correct idb mock

### DIFF
--- a/.changeset/brown-waves-pick.md
+++ b/.changeset/brown-waves-pick.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/services': patch
+---
+
+use type-correct mock in tests

--- a/packages/services/src/sct-service/epoch-by-height.test.ts
+++ b/packages/services/src/sct-service/epoch-by-height.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { epochByHeight } from './epoch-by-height.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { SctService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
@@ -12,15 +12,12 @@ import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('EpochByHeight request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
     vi.resetAllMocks();
 
-    mockIndexedDb = {
-      getEpochByHeight: vi.fn(),
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -41,7 +38,7 @@ describe('EpochByHeight request handler', () => {
   it('returns an `EpochByHeightResponse` with the result of the database query', async () => {
     const expected = new Epoch({ startHeight: 0n, index: 0n });
 
-    mockIndexedDb.getEpochByHeight?.mockResolvedValue(expected);
+    mockIndexedDb.getEpochByHeight.mockResolvedValue(expected);
     const req = new EpochByHeightRequest({ height: 0n });
 
     const result = await epochByHeight(req, mockCtx);

--- a/packages/services/src/stake-service/get-validator-info.test.ts
+++ b/packages/services/src/stake-service/get-validator-info.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { StakeService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
@@ -13,7 +13,7 @@ import { getValidatorInfo } from './get-validator-info.js';
 
 describe('GetValidatorInfo request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockStakingQuerierValidatorInfo: Mock;
   let mockCtx: HandlerContext;
   let req: GetValidatorInfoRequest;
@@ -26,10 +26,6 @@ describe('GetValidatorInfo request handler', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    mockIndexedDb = {
-      getValidatorInfo: vi.fn(),
-    };
 
     mockStakingQuerierValidatorInfo = vi.fn();
 
@@ -66,7 +62,7 @@ describe('GetValidatorInfo request handler', () => {
   });
 
   it('should successfully return validator info when idb has them', async () => {
-    mockIndexedDb.getValidatorInfo?.mockResolvedValueOnce(
+    mockIndexedDb.getValidatorInfo.mockResolvedValueOnce(
       mockGetValidatorInfoResponse.validatorInfo,
     );
 

--- a/packages/services/src/stake-service/validator-info.test.ts
+++ b/packages/services/src/stake-service/validator-info.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { validatorInfo } from './validator-info.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { StakeService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
@@ -14,7 +14,7 @@ import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('ValidatorInfo request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
   const mockValidatorInfoResponse1 = new ValidatorInfoResponse({
     validatorInfo: {
@@ -44,9 +44,6 @@ describe('ValidatorInfo request handler', () => {
     });
     mockIterateValidatorInfos.next.mockResolvedValueOnce({ done: true });
 
-    mockIndexedDb = {
-      iterateValidatorInfos: () => mockIterateValidatorInfos,
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),

--- a/packages/services/src/stake-service/validator-info.test.ts
+++ b/packages/services/src/stake-service/validator-info.test.ts
@@ -32,17 +32,12 @@ describe('ValidatorInfo request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateValidatorInfos = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateValidatorInfos,
-    };
-    mockIterateValidatorInfos.next.mockResolvedValueOnce({
-      value: mockValidatorInfoResponse1.validatorInfo,
+    mockIndexedDb.iterateValidatorInfos.mockImplementation(async function* () {
+      yield* await Promise.resolve([
+        mockValidatorInfoResponse1.validatorInfo!,
+        mockValidatorInfoResponse2.validatorInfo!,
+      ]);
     });
-    mockIterateValidatorInfos.next.mockResolvedValueOnce({
-      value: mockValidatorInfoResponse2.validatorInfo,
-    });
-    mockIterateValidatorInfos.next.mockResolvedValueOnce({ done: true });
 
     mockServices = {
       getWalletServices: vi.fn(() =>

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -1,85 +1,100 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call -- test utils */
+/* eslint-disable @typescript-eslint/no-unsafe-argument -- test utils */
 /* eslint-disable @typescript-eslint/no-explicit-any -- test utils */
 /* eslint-disable @typescript-eslint/require-await -- test utils */
-
-import { Mock, Mocked, vi } from 'vitest';
-import { FullViewingKey, SpendKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { fullViewingKeyFromBech32m } from '@penumbra-zone/bech32m/penumbrafullviewingkey';
-import { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';
 import { AssetId } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { FullViewingKey, SpendKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
+import {
+  IdbUpdate,
+  IndexedDbInterface,
+  PenumbraDb,
+  PenumbraStoreNames,
+} from '@penumbra-zone/types/indexed-db';
+import { expect, Mock, Mocked, vi } from 'vitest';
+
+export async function* mockSubscriptionData<T extends PenumbraStoreNames>(
+  table: T,
+  data: PenumbraDb[T]['value'][],
+): AsyncGenerator<IdbUpdate<PenumbraDb, T>> {
+  for (const value of data) {
+    yield { value, table };
+  }
+}
+
+const mockDisabled: any = () =>
+  expect.unreachable("Mock disabled! Use this mock's `mockImplementation` method to configure it.");
+
+export const mockStakingTokenAssetId = vi.fn(
+  (): AssetId =>
+    expect.unreachable(
+      'Test should not get stakingTokenAssetId. Import `mockStakingTokenAssetId.mockReturnedValue` to configure this mock.',
+    ),
+);
 
 export const mockIndexedDb: Mocked<IndexedDbInterface> = {
-  addAuctionOutstandingReserves: vi.fn(),
-  addEpoch: vi.fn(),
-  addPosition: vi.fn(),
-  clear: vi.fn(),
-  clearSwapBasedPrices: vi.fn(),
-  clearValidatorInfos: vi.fn(),
-  constants: vi.fn(),
-  deleteAuctionOutstandingReserves: vi.fn(),
-  getAltGasPrices: vi.fn(),
-  getAppParams: vi.fn(),
-  getAssetsMetadata: vi.fn(),
-  getAuction: vi.fn(),
-  getAuctionOutstandingReserves: vi.fn(),
-  getEpochByHeight: vi.fn(),
-  getEpochByIndex: vi.fn(),
-  getFmdParams: vi.fn(),
-  getFullSyncHeight: vi.fn(),
-  getLQTHistoricalVotes: vi.fn(),
-  getNativeGasPrices: vi.fn(),
-  getNotesForVoting: vi.fn(),
-  getOwnedPositionIds: vi.fn(async function* (..._) {
-    yield* [] as any[];
-  }),
-  getPosition: vi.fn(),
-  getPricesForAsset: vi.fn(),
-  getSpendableNoteByCommitment: vi.fn(),
-  getSpendableNoteByNullifier: vi.fn(),
-  getStateCommitmentTree: vi.fn(),
-  getSwapByCommitment: vi.fn(),
-  getSwapByNullifier: vi.fn(),
-  getTransaction: vi.fn(),
-  getTransactionInfo: vi.fn(),
-  getValidatorInfo: vi.fn(),
-  hasTokenBalance: vi.fn(),
-  iterateAssetsMetadata: vi.fn(async function* () {
-    yield* [] as any[];
-  }),
-  iterateLQTVotes: vi.fn(async function* (..._) {
-    yield* [] as any[];
-  }),
-  iterateSpendableNotes: vi.fn(async function* () {
-    yield* [] as any[];
-  }),
-  iterateSwaps: vi.fn(async function* () {
-    yield* [] as any[];
-  }),
-  iterateTransactions: vi.fn(async function* () {
-    yield* [] as any[];
-  }),
-  iterateValidatorInfos: vi.fn(async function* () {
-    yield* [] as any[];
-  }),
-  saveAppParams: vi.fn(),
-  saveAssetsMetadata: vi.fn(),
-  saveFmdParams: vi.fn(),
-  saveFullSyncHeight: vi.fn(),
-  saveGasPrices: vi.fn(),
-  saveLQTHistoricalVote: vi.fn(),
-  saveScanResult: vi.fn(),
-  saveSpendableNote: vi.fn(),
-  saveSwap: vi.fn(),
-  saveTransaction: vi.fn(),
-  saveTransactionInfo: vi.fn(),
-  stakingTokenAssetId: new AssetId({}),
+  get stakingTokenAssetId(): AssetId {
+    return mockStakingTokenAssetId();
+  },
+
   subscribe: vi.fn(async function* (_) {
-    yield* [] as any[];
+    yield mockDisabled();
   }),
-  totalNoteBalance: vi.fn(),
-  updatePosition: vi.fn(),
-  updatePrice: vi.fn(),
-  upsertAuction: vi.fn(),
-  upsertValidatorInfo: vi.fn(),
+
+  addAuctionOutstandingReserves: vi.fn(mockDisabled),
+  addEpoch: vi.fn(mockDisabled),
+  addPosition: vi.fn(mockDisabled),
+  clear: vi.fn(mockDisabled),
+  clearSwapBasedPrices: vi.fn(mockDisabled),
+  clearValidatorInfos: vi.fn(mockDisabled),
+  constants: vi.fn(mockDisabled),
+  deleteAuctionOutstandingReserves: vi.fn(mockDisabled),
+  getAltGasPrices: vi.fn(mockDisabled),
+  getAppParams: vi.fn(mockDisabled),
+  getAssetsMetadata: vi.fn(mockDisabled),
+  getAuction: vi.fn(mockDisabled),
+  getAuctionOutstandingReserves: vi.fn(mockDisabled),
+  getEpochByIndex: vi.fn(mockDisabled),
+  getEpochByHeight: vi.fn(mockDisabled),
+  getFmdParams: vi.fn(mockDisabled),
+  getFullSyncHeight: vi.fn(mockDisabled),
+  getLQTHistoricalVotes: vi.fn(mockDisabled),
+  getNativeGasPrices: vi.fn(mockDisabled),
+  getNotesForVoting: vi.fn(mockDisabled),
+  getOwnedPositionIds: vi.fn(mockDisabled),
+  getPosition: vi.fn(mockDisabled),
+  getPricesForAsset: vi.fn(mockDisabled),
+  getSpendableNoteByCommitment: vi.fn(mockDisabled),
+  getSpendableNoteByNullifier: vi.fn(mockDisabled),
+  getStateCommitmentTree: vi.fn(mockDisabled),
+  getSwapByCommitment: vi.fn(mockDisabled),
+  getSwapByNullifier: vi.fn(mockDisabled),
+  getTransaction: vi.fn(mockDisabled),
+  getTransactionInfo: vi.fn(mockDisabled),
+  getValidatorInfo: vi.fn(mockDisabled),
+  hasTokenBalance: vi.fn(mockDisabled),
+  iterateAssetsMetadata: vi.fn(mockDisabled),
+  iterateLQTVotes: vi.fn(mockDisabled),
+  iterateSpendableNotes: vi.fn(mockDisabled),
+  iterateSwaps: vi.fn(mockDisabled),
+  iterateTransactions: vi.fn(mockDisabled),
+  iterateValidatorInfos: vi.fn(mockDisabled),
+  saveAppParams: vi.fn(mockDisabled),
+  saveAssetsMetadata: vi.fn(mockDisabled),
+  saveFmdParams: vi.fn(mockDisabled),
+  saveFullSyncHeight: vi.fn(mockDisabled),
+  saveGasPrices: vi.fn(mockDisabled),
+  saveLQTHistoricalVote: vi.fn(mockDisabled),
+  saveScanResult: vi.fn(mockDisabled),
+  saveSpendableNote: vi.fn(mockDisabled),
+  saveSwap: vi.fn(mockDisabled),
+  saveTransaction: vi.fn(mockDisabled),
+  saveTransactionInfo: vi.fn(mockDisabled),
+  totalNoteBalance: vi.fn(mockDisabled),
+  updatePosition: vi.fn(mockDisabled),
+  updatePrice: vi.fn(mockDisabled),
+  upsertAuction: vi.fn(mockDisabled),
+  upsertValidatorInfo: vi.fn(mockDisabled),
 };
 
 export interface AuctionMock {

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -1,46 +1,86 @@
-import { Mock } from 'vitest';
+/* eslint-disable @typescript-eslint/no-explicit-any -- test utils */
+/* eslint-disable @typescript-eslint/require-await -- test utils */
+
+import { Mock, Mocked, vi } from 'vitest';
 import { FullViewingKey, SpendKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { fullViewingKeyFromBech32m } from '@penumbra-zone/bech32m/penumbrafullviewingkey';
+import { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';
+import { AssetId } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 
-export interface IndexedDbMock {
-  constants?: Mock;
-  getAppParams?: Mock;
-  getAssetsMetadata?: Mock;
-  getNativeGasPrices?: Mock;
-  getAltGasPrices?: Mock;
-  getFmdParams?: Mock;
-  getFullSyncHeight?: Mock;
-  getNotesForVoting?: Mock;
-  getOwnedPositionIds?: () => Partial<AsyncIterable<Mock>>;
-  getSpendableNoteByCommitment?: Mock;
-  getSpendableNoteByNullifier?: Mock;
-  getStateCommitmentTree?: Mock;
-  getSwapByNullifier?: Mock;
-  getTransaction?: Mock;
-  iterateAssetsMetadata?: () => Partial<AsyncIterable<Mock>>;
-  iterateSpendableNotes?: () => Partial<AsyncIterable<Mock>>;
-  iterateSwaps?: () => Partial<AsyncIterable<Mock>>;
-  iterateTransactions?: () => Partial<AsyncIterable<Mock>>;
-  iterateValidatorInfos?: () => Partial<AsyncIterable<Mock>>;
-  getValidatorInfo?: Mock;
-  subscribe?: (table: string) => Partial<AsyncIterable<Mock>>;
-  getSwapByCommitment?: Mock;
-  getEpochByHeight?: Mock;
-  saveAssetsMetadata?: Mock;
-  getPricesForAsset?: Mock;
-  getAuction?: Mock;
-  getAuctionOutstandingReserves?: Mock;
-  stakingTokenAssetId?: Mock;
-  upsertAuction?: Mock;
-  hasTokenBalance?: Mock;
-  saveGasPrices?: Mock;
-  saveTransactionInfo?: Mock;
-  getTransactionInfo?: Mock;
-  getEpochByIndex?: Mock;
-  saveLQTHistoricalVote?: Mock;
-  getLQTHistoricalVotes?: Mock;
-  iterateLQTVotes?: Mock;
-}
+export const mockIndexedDb: Mocked<IndexedDbInterface> = {
+  addAuctionOutstandingReserves: vi.fn(),
+  addEpoch: vi.fn(),
+  addPosition: vi.fn(),
+  clear: vi.fn(),
+  clearSwapBasedPrices: vi.fn(),
+  clearValidatorInfos: vi.fn(),
+  constants: vi.fn(),
+  deleteAuctionOutstandingReserves: vi.fn(),
+  getAltGasPrices: vi.fn(),
+  getAppParams: vi.fn(),
+  getAssetsMetadata: vi.fn(),
+  getAuction: vi.fn(),
+  getAuctionOutstandingReserves: vi.fn(),
+  getEpochByHeight: vi.fn(),
+  getEpochByIndex: vi.fn(),
+  getFmdParams: vi.fn(),
+  getFullSyncHeight: vi.fn(),
+  getLQTHistoricalVotes: vi.fn(),
+  getNativeGasPrices: vi.fn(),
+  getNotesForVoting: vi.fn(),
+  getOwnedPositionIds: vi.fn(async function* (..._) {
+    yield* [] as any[];
+  }),
+  getPosition: vi.fn(),
+  getPricesForAsset: vi.fn(),
+  getSpendableNoteByCommitment: vi.fn(),
+  getSpendableNoteByNullifier: vi.fn(),
+  getStateCommitmentTree: vi.fn(),
+  getSwapByCommitment: vi.fn(),
+  getSwapByNullifier: vi.fn(),
+  getTransaction: vi.fn(),
+  getTransactionInfo: vi.fn(),
+  getValidatorInfo: vi.fn(),
+  hasTokenBalance: vi.fn(),
+  iterateAssetsMetadata: vi.fn(async function* () {
+    yield* [] as any[];
+  }),
+  iterateLQTVotes: vi.fn(async function* (..._) {
+    yield* [] as any[];
+  }),
+  iterateSpendableNotes: vi.fn(async function* () {
+    yield* [] as any[];
+  }),
+  iterateSwaps: vi.fn(async function* () {
+    yield* [] as any[];
+  }),
+  iterateTransactions: vi.fn(async function* () {
+    yield* [] as any[];
+  }),
+  iterateValidatorInfos: vi.fn(async function* () {
+    yield* [] as any[];
+  }),
+  saveAppParams: vi.fn(),
+  saveAssetsMetadata: vi.fn(),
+  saveFmdParams: vi.fn(),
+  saveFullSyncHeight: vi.fn(),
+  saveGasPrices: vi.fn(),
+  saveLQTHistoricalVote: vi.fn(),
+  saveScanResult: vi.fn(),
+  saveSpendableNote: vi.fn(),
+  saveSwap: vi.fn(),
+  saveTransaction: vi.fn(),
+  saveTransactionInfo: vi.fn(),
+  stakingTokenAssetId: new AssetId({}),
+  subscribe: vi.fn(async function* (_) {
+    yield* [] as any[];
+  }),
+  totalNoteBalance: vi.fn(),
+  updatePosition: vi.fn(),
+  updatePrice: vi.fn(),
+  upsertAuction: vi.fn(),
+  upsertValidatorInfo: vi.fn(),
+};
 
 export interface AuctionMock {
   auctionStateById: Mock;
@@ -83,7 +123,7 @@ export interface StakeMock {
 }
 
 interface MockServicesInner {
-  indexedDb?: IndexedDbMock;
+  indexedDb?: Mocked<IndexedDbInterface>;
   viewServer?: ViewServerMock;
   querier?: MockQuerier;
 }

--- a/packages/services/src/test-utils.ts
+++ b/packages/services/src/test-utils.ts
@@ -29,6 +29,8 @@ export async function* createUpdates<
   for await (const value of data) {
     yield { value: value as PenumbraDb[T]['value'], table };
   }
+  // subscriptions don't end
+  yield await new Promise<never>(() => void null);
 }
 
 const mockDisabled: any = () =>

--- a/packages/services/src/view-service/app-parameters.test.ts
+++ b/packages/services/src/view-service/app-parameters.test.ts
@@ -8,12 +8,12 @@ import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 import { appParameters } from './app-parameters.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('AppParameters request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
   let apSubNext: Mock;
 
@@ -25,16 +25,6 @@ describe('AppParameters request handler', () => {
     const mockAppParametersSubscription = {
       next: apSubNext,
       [Symbol.asyncIterator]: () => mockAppParametersSubscription,
-    };
-
-    mockIndexedDb = {
-      getAppParams: vi.fn(),
-      subscribe: (table: string) => {
-        if (table === 'APP_PARAMETERS') {
-          return mockAppParametersSubscription;
-        }
-        throw new Error('Table not supported');
-      },
     };
 
     mockServices = {
@@ -55,7 +45,7 @@ describe('AppParameters request handler', () => {
   });
 
   test('should successfully get appParameters when idb has them', async () => {
-    mockIndexedDb.getAppParams?.mockResolvedValue(testData);
+    mockIndexedDb.getAppParams.mockResolvedValue(testData);
     const appParameterResponse = new AppParametersResponse(
       await appParameters(new AppParametersRequest(), mockCtx),
     );
@@ -63,7 +53,7 @@ describe('AppParameters request handler', () => {
   });
 
   test('should wait for appParameters when idb has none', async () => {
-    mockIndexedDb.getAppParams?.mockResolvedValue(undefined);
+    mockIndexedDb.getAppParams.mockResolvedValue(undefined);
     apSubNext.mockResolvedValueOnce({
       value: { value: new AppParametersRequest(), table: 'APP_PARAMETERS' },
     });

--- a/packages/services/src/view-service/app-parameters.test.ts
+++ b/packages/services/src/view-service/app-parameters.test.ts
@@ -8,9 +8,8 @@ import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 import { appParameters } from './app-parameters.js';
-import { mockIndexedDb, MockServices, mockSubscriptionData } from '../test-utils.js';
+import { mockIndexedDb, MockServices, createUpdates } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
-import { JsonObject } from '@bufbuild/protobuf';
 
 describe('AppParameters request handler', () => {
   let mockServices: MockServices;
@@ -49,10 +48,12 @@ describe('AppParameters request handler', () => {
     mockIndexedDb.getAppParams.mockResolvedValue(undefined);
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      if (table === 'APP_PARAMETERS') {
-        yield* mockSubscriptionData(table, [new AppParametersRequest().toJson()] as JsonObject[]);
-      } else {
-        expect.unreachable('Test should only subscribe to APP_PARAMETERS');
+      switch (table) {
+        case 'APP_PARAMETERS':
+          yield* createUpdates(table, [new AppParametersRequest().toJson()]);
+          break;
+        default:
+          expect.unreachable(`Test should not subscribe to ${table}`);
       }
     });
 

--- a/packages/services/src/view-service/app-parameters.test.ts
+++ b/packages/services/src/view-service/app-parameters.test.ts
@@ -1,4 +1,4 @@
-import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   AppParametersRequest,
   AppParametersResponse,
@@ -8,24 +8,17 @@ import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
 import { appParameters } from './app-parameters.js';
-import { mockIndexedDb, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices, mockSubscriptionData } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
+import { JsonObject } from '@bufbuild/protobuf';
 
 describe('AppParameters request handler', () => {
   let mockServices: MockServices;
 
   let mockCtx: HandlerContext;
-  let apSubNext: Mock;
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    apSubNext = vi.fn();
-
-    const mockAppParametersSubscription = {
-      next: apSubNext,
-      [Symbol.asyncIterator]: () => mockAppParametersSubscription,
-    };
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -54,9 +47,15 @@ describe('AppParameters request handler', () => {
 
   test('should wait for appParameters when idb has none', async () => {
     mockIndexedDb.getAppParams.mockResolvedValue(undefined);
-    apSubNext.mockResolvedValueOnce({
-      value: { value: new AppParametersRequest(), table: 'APP_PARAMETERS' },
+
+    mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
+      if (table === 'APP_PARAMETERS') {
+        yield* mockSubscriptionData(table, [new AppParametersRequest().toJson()] as JsonObject[]);
+      } else {
+        expect.unreachable('Test should only subscribe to APP_PARAMETERS');
+      }
     });
+
     await expect(appParameters(new AppParametersRequest(), mockCtx)).resolves.toBeTruthy();
   });
 });

--- a/packages/services/src/view-service/asset-metadata-by-id.test.ts
+++ b/packages/services/src/view-service/asset-metadata-by-id.test.ts
@@ -6,14 +6,14 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices, ShieldedPoolMock } from '../test-utils.js';
+import { mockIndexedDb, MockServices, ShieldedPoolMock } from '../test-utils.js';
 import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { assetMetadataById } from './asset-metadata-by-id.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('AssetMetadataById request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
   let mockShieldedPool: ShieldedPoolMock;
   let request: AssetMetadataByIdRequest;
@@ -21,10 +21,6 @@ describe('AssetMetadataById request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    mockIndexedDb = {
-      getAssetsMetadata: vi.fn(),
-      saveAssetsMetadata: vi.fn(),
-    };
     mockShieldedPool = {
       assetMetadataById: vi.fn(),
     };
@@ -55,7 +51,7 @@ describe('AssetMetadataById request handler', () => {
   });
 
   test('should successfully respond with metadata when idb record is present', async () => {
-    mockIndexedDb.getAssetsMetadata?.mockResolvedValue(metadataFromIdb);
+    mockIndexedDb.getAssetsMetadata.mockResolvedValue(metadataFromIdb);
     const metadataByIdResponse = new AssetMetadataByIdResponse(
       await assetMetadataById(request, mockCtx),
     );
@@ -63,7 +59,7 @@ describe('AssetMetadataById request handler', () => {
   });
 
   test('should successfully respond with metadata when idb record is absent, but metadata is available from remote rpc', async () => {
-    mockIndexedDb.getAssetsMetadata?.mockResolvedValue(undefined);
+    mockIndexedDb.getAssetsMetadata.mockResolvedValue(undefined);
     mockShieldedPool.assetMetadataById.mockResolvedValueOnce(metadataFromNode);
     const metadataByIdResponse = new AssetMetadataByIdResponse(
       await assetMetadataById(request, mockCtx),
@@ -72,7 +68,7 @@ describe('AssetMetadataById request handler', () => {
   });
 
   test('should customize symbols', async () => {
-    mockIndexedDb.getAssetsMetadata?.mockResolvedValue(undefined);
+    mockIndexedDb.getAssetsMetadata.mockResolvedValue(undefined);
     mockShieldedPool.assetMetadataById.mockResolvedValueOnce(delegationMetadata);
     const metadataByIdResponse = new AssetMetadataByIdResponse(
       await assetMetadataById(request, mockCtx),
@@ -83,7 +79,7 @@ describe('AssetMetadataById request handler', () => {
   });
 
   test('should successfully respond even when no metadata is available', async () => {
-    mockIndexedDb.getAssetsMetadata?.mockResolvedValue(undefined);
+    mockIndexedDb.getAssetsMetadata.mockResolvedValue(undefined);
     mockShieldedPool.assetMetadataById.mockResolvedValueOnce(undefined);
     const metadataByIdResponse = new AssetMetadataByIdResponse(
       await assetMetadataById(request, mockCtx),

--- a/packages/services/src/view-service/assets.test.ts
+++ b/packages/services/src/view-service/assets.test.ts
@@ -17,10 +17,9 @@ describe('Assets request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateMetadata = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateMetadata,
-    };
+    mockIndexedDb.iterateAssetsMetadata.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve(testData);
+    });
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -37,15 +36,6 @@ describe('Assets request handler', () => {
       contextValues: createContextValues().set(servicesCtx, () =>
         Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
-    });
-
-    for (const record of testData) {
-      mockIterateMetadata.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIterateMetadata.next.mockResolvedValueOnce({
-      done: true,
     });
     req = new AssetsRequest({});
   });

--- a/packages/services/src/view-service/assets.test.ts
+++ b/packages/services/src/view-service/assets.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { servicesCtx } from '../ctx/prax.js';
 import { assets } from './assets.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { UM_METADATA } from './util/data.js';
 
 describe('Assets request handler', () => {
@@ -20,10 +20,6 @@ describe('Assets request handler', () => {
     const mockIterateMetadata = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIterateMetadata,
-    };
-
-    const mockIndexedDb: IndexedDbMock = {
-      iterateAssetsMetadata: () => mockIterateMetadata,
     };
 
     mockServices = {

--- a/packages/services/src/view-service/balances.test.ts
+++ b/packages/services/src/view-service/balances.test.ts
@@ -13,7 +13,7 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
-import { IndexedDbMock, MockServices, TendermintMock, testFullViewingKey } from '../test-utils.js';
+import { mockIndexedDb, MockServices, TendermintMock, testFullViewingKey } from '../test-utils.js';
 import {
   AssetId,
   EquivalentValue,
@@ -48,7 +48,7 @@ describe('Balances request handler', () => {
   let req: BalancesRequest;
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockTendermint: TendermintMock;
 
   beforeEach(() => {
@@ -57,14 +57,6 @@ describe('Balances request handler', () => {
     const mockIterateSpendableNotes = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIterateSpendableNotes,
-    };
-
-    mockIndexedDb = {
-      getAppParams: vi.fn(),
-      getAssetsMetadata: vi.fn(),
-      getPricesForAsset: vi.fn(),
-      getFullSyncHeight: vi.fn(() => Promise.resolve()),
-      iterateSpendableNotes: () => mockIterateSpendableNotes,
     };
 
     const mockShieldedPool = {
@@ -108,7 +100,7 @@ describe('Balances request handler', () => {
       done: true,
     });
 
-    mockIndexedDb.getAssetsMetadata?.mockImplementation((assetId: AssetId) => {
+    mockIndexedDb.getAssetsMetadata.mockImplementation((assetId: AssetId) => {
       return Promise.resolve(
         new Metadata({
           penumbraAssetId: assetId,
@@ -116,7 +108,7 @@ describe('Balances request handler', () => {
       );
     });
 
-    mockIndexedDb.getPricesForAsset?.mockImplementation(() => Promise.resolve([]));
+    mockIndexedDb.getPricesForAsset.mockImplementation(() => Promise.resolve([]));
     req = new BalancesRequest();
   });
 
@@ -175,7 +167,7 @@ describe('Balances request handler', () => {
     const pricedAsset = new AssetId({ inner: new Uint8Array([5, 6, 7, 8]) });
     const mockNumerairePerUnit = 2.5;
 
-    mockIndexedDb.getAppParams?.mockResolvedValue(
+    mockIndexedDb.getAppParams.mockResolvedValue(
       new AppParameters({
         sctParams: {
           epochDuration: 719n,
@@ -184,7 +176,7 @@ describe('Balances request handler', () => {
     );
     // We'll just mock the same response for every call -- we're just testing
     // that the equivalent prices get included in the RPC response.
-    mockIndexedDb.getPricesForAsset?.mockResolvedValue([
+    mockIndexedDb.getPricesForAsset.mockResolvedValue([
       new EstimatedPrice({
         asOfHeight: 123n,
         numerairePerUnit: mockNumerairePerUnit,

--- a/packages/services/src/view-service/balances.test.ts
+++ b/packages/services/src/view-service/balances.test.ts
@@ -54,10 +54,9 @@ describe('Balances request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateSpendableNotes = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateSpendableNotes,
-    };
+    mockIndexedDb.iterateSpendableNotes.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve(testData);
+    });
 
     const mockShieldedPool = {
       assetMetadata: vi.fn(),
@@ -89,15 +88,6 @@ describe('Balances request handler', () => {
       contextValues: createContextValues()
         .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
         .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
-    });
-
-    for (const record of testData) {
-      mockIterateSpendableNotes.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIterateSpendableNotes.next.mockResolvedValueOnce({
-      done: true,
     });
 
     mockIndexedDb.getAssetsMetadata.mockImplementation((assetId: AssetId) => {

--- a/packages/services/src/view-service/broadcast-transaction.test.ts
+++ b/packages/services/src/view-service/broadcast-transaction.test.ts
@@ -11,7 +11,7 @@ import { Transaction } from '@penumbra-zone/protobuf/penumbra/core/transaction/v
 import { broadcastTransaction } from './broadcast-transaction.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
-import { IndexedDbMock, MockServices, TendermintMock } from '../test-utils.js';
+import { mockIndexedDb, MockServices, TendermintMock } from '../test-utils.js';
 
 const mockSha256 = vi.hoisted(() => vi.fn());
 vi.mock('@penumbra-zone/crypto-web/sha256', () => ({
@@ -21,7 +21,7 @@ vi.mock('@penumbra-zone/crypto-web/sha256', () => ({
 describe('BroadcastTransaction request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockTendermint: TendermintMock;
   let txSubNext: Mock;
   let broadcastTransactionRequest: BroadcastTransactionRequest;
@@ -41,14 +41,6 @@ describe('BroadcastTransaction request handler', () => {
       [Symbol.asyncIterator]: () => mockTransactionInfoSubscription,
     };
 
-    mockIndexedDb = {
-      subscribe: (table: string) => {
-        if (table === 'TRANSACTIONS') {
-          return mockTransactionInfoSubscription;
-        }
-        throw new Error('Table not supported');
-      },
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({

--- a/packages/services/src/view-service/broadcast-transaction.test.ts
+++ b/packages/services/src/view-service/broadcast-transaction.test.ts
@@ -85,8 +85,6 @@ describe('BroadcastTransaction request handler', () => {
       switch (table) {
         case 'TRANSACTIONS':
           yield* createUpdates(table, [txRecord.toJson()]);
-          // don't end the stream
-          yield await new Promise<never>(() => {});
           break;
         default:
           expect.unreachable(`Test should not subscribe to ${table}`);

--- a/packages/services/src/view-service/fees.test.ts
+++ b/packages/services/src/view-service/fees.test.ts
@@ -15,27 +15,15 @@ import {
 } from '@penumbra-zone/protobuf/penumbra/core/component/auction/v1/auction_pb';
 import { extractAltFee } from './fees.js';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
-import { IndexedDbMock } from '../test-utils.js';
 import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
 import { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';
 import { GasPrices } from '@penumbra-zone/protobuf/penumbra/core/component/fee/v1/fee_pb';
 import { AddressIndex } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
+import { mockIndexedDb } from '../test-utils.js';
 
 describe('extractAltFee', () => {
-  let mockIndexedDb: IndexedDbMock;
-
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockIndexedDb = {
-      getSwapByCommitment: vi.fn(),
-      upsertAuction: vi.fn(),
-      saveAssetsMetadata: vi.fn(),
-      getAuction: vi.fn(),
-      saveGasPrices: vi.fn(),
-      getAltGasPrices: vi.fn(),
-      hasTokenBalance: vi.fn(),
-    };
   });
 
   it('extracts the alternative asset fee from outputs', async () => {
@@ -64,9 +52,8 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -99,9 +86,8 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -153,16 +139,15 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(outputAssetId)).toBeTruthy();
   });
 
   it('extracts the staking asset fee from swaps', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(mockSwapNativeStakingToken);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(mockSwapNativeStakingToken);
 
     const inputAssetId = new AssetId({
       inner: new Uint8Array([
@@ -189,16 +174,15 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
   });
 
   it('extracts the alternative asset fee from swaps', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(mockSwapAlternativeToken);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(mockSwapAlternativeToken);
 
     const inputAssetId = new AssetId({
       inner: new Uint8Array([
@@ -225,16 +209,15 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
   });
 
   it('extracts the staking asset fee from swap claims', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(mockSwapNativeStakingToken);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(mockSwapNativeStakingToken);
 
     const inputAssetId = new AssetId({
       inner: new Uint8Array([
@@ -257,7 +240,7 @@ describe('extractAltFee', () => {
   });
 
   it('extracts the alternative asset fee from swap claims', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(mockSwapAlternativeToken);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(mockSwapAlternativeToken);
 
     const inputAssetId = new AssetId({
       inner: new Uint8Array([
@@ -311,9 +294,8 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -333,13 +315,13 @@ describe('extractAltFee', () => {
       },
     });
 
-    mockIndexedDb.getAuction?.mockResolvedValueOnce({
+    mockIndexedDb.getAuction.mockResolvedValueOnce({
       auction,
       noteCommitment: mockAuctionEndCommitment,
       seqNum: 0n,
     });
 
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true);
+    mockIndexedDb.hasTokenBalance.mockResolvedValueOnce(true);
 
     const request = new TransactionPlannerRequest({
       dutchAuctionEndActions: [
@@ -360,9 +342,8 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const result = await extractAltFee(request, mockIndexedDb as unknown as IndexedDbInterface);
     expect(result.equals(inputAssetId)).toBeTruthy();
@@ -382,7 +363,7 @@ describe('extractAltFee', () => {
       },
     });
 
-    mockIndexedDb.getAuction?.mockResolvedValueOnce({
+    mockIndexedDb.getAuction.mockResolvedValueOnce({
       auction,
       noteCommitment: mockAuctionEndCommitment,
       seqNum: 0n,
@@ -403,12 +384,11 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValue(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
 
     // Mock hasTokenBalance twice to control its behavior in the function
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(false); // For the specificAssetId check
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true); // For the altGasPrices check
+    mockIndexedDb.hasTokenBalance.mockResolvedValueOnce(false); // For the specificAssetId check
+    mockIndexedDb.hasTokenBalance.mockResolvedValueOnce(true); // For the altGasPrices check
 
     const request = new TransactionPlannerRequest({
       dutchAuctionEndActions: [
@@ -437,7 +417,7 @@ describe('extractAltFee', () => {
       },
     });
 
-    mockIndexedDb.getAuction?.mockResolvedValueOnce({
+    mockIndexedDb.getAuction.mockResolvedValueOnce({
       auction,
       noteCommitment: mockAuctionEndCommitment,
       seqNum: 0n,
@@ -453,9 +433,8 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValue(true);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.hasTokenBalance.mockResolvedValue(true);
 
     const request = new TransactionPlannerRequest({
       dutchAuctionWithdrawActions: [
@@ -484,7 +463,7 @@ describe('extractAltFee', () => {
       },
     });
 
-    mockIndexedDb.getAuction?.mockResolvedValueOnce({
+    mockIndexedDb.getAuction.mockResolvedValueOnce({
       auction,
       noteCommitment: mockAuctionEndCommitment,
       seqNum: 0n,
@@ -505,12 +484,11 @@ describe('extractAltFee', () => {
       }),
     ];
 
-    mockIndexedDb.saveGasPrices?.mockResolvedValue(gasPrices);
-    mockIndexedDb.getAltGasPrices?.mockResolvedValueOnce(gasPrices);
+    mockIndexedDb.getAltGasPrices.mockResolvedValueOnce(gasPrices);
 
     // Mock hasTokenBalance twice to control its behavior in the function
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(false); // For the specificAssetId check
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true); // For the altGasPrices check
+    mockIndexedDb.hasTokenBalance.mockResolvedValueOnce(false); // For the specificAssetId check
+    mockIndexedDb.hasTokenBalance.mockResolvedValueOnce(true); // For the altGasPrices check
 
     const request = new TransactionPlannerRequest({
       dutchAuctionWithdrawActions: [

--- a/packages/services/src/view-service/fees.test.ts
+++ b/packages/services/src/view-service/fees.test.ts
@@ -15,11 +15,11 @@ import {
 } from '@penumbra-zone/protobuf/penumbra/core/component/auction/v1/auction_pb';
 import { extractAltFee } from './fees.js';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
+import { mockIndexedDb } from '../test-utils.js';
 import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
 import { IndexedDbInterface } from '@penumbra-zone/types/indexed-db';
 import { GasPrices } from '@penumbra-zone/protobuf/penumbra/core/component/fee/v1/fee_pb';
 import { AddressIndex } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
-import { mockIndexedDb } from '../test-utils.js';
 
 describe('extractAltFee', () => {
   beforeEach(() => {

--- a/packages/services/src/view-service/fmd-parameters.test.ts
+++ b/packages/services/src/view-service/fmd-parameters.test.ts
@@ -6,22 +6,19 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { FmdParameters } from '@penumbra-zone/protobuf/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
 import { fMDParameters } from './fmd-parameters.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('FmdParameters request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
     vi.resetAllMocks();
 
-    mockIndexedDb = {
-      getFmdParams: vi.fn(),
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -40,7 +37,7 @@ describe('FmdParameters request handler', () => {
   });
 
   test('should successfully get fmdParameters when idb has them', async () => {
-    mockIndexedDb.getFmdParams?.mockResolvedValue(testData);
+    mockIndexedDb.getFmdParams.mockResolvedValue(testData);
     const fmdParameterResponse = new FMDParametersResponse(
       await fMDParameters(new FMDParametersRequest(), mockCtx),
     );
@@ -48,7 +45,7 @@ describe('FmdParameters request handler', () => {
   });
 
   test('should fail to get fmdParameters when idb has none', async () => {
-    mockIndexedDb.getFmdParams?.mockResolvedValue(undefined);
+    mockIndexedDb.getFmdParams.mockResolvedValue(undefined);
     await expect(fMDParameters(new FMDParametersRequest(), mockCtx)).rejects.toThrow();
   });
 });

--- a/packages/services/src/view-service/gas-prices.test.ts
+++ b/packages/services/src/view-service/gas-prices.test.ts
@@ -6,23 +6,19 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { GasPrices } from '@penumbra-zone/protobuf/penumbra/core/component/fee/v1/fee_pb';
 import { gasPrices } from './gas-prices.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('GasPrices request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
     vi.resetAllMocks();
 
-    mockIndexedDb = {
-      getNativeGasPrices: vi.fn(),
-      getAltGasPrices: vi.fn(),
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -41,7 +37,7 @@ describe('GasPrices request handler', () => {
   });
 
   test('should successfully get gas prices when idb has them', async () => {
-    mockIndexedDb.getNativeGasPrices?.mockResolvedValue(testData);
+    mockIndexedDb.getNativeGasPrices.mockResolvedValue(testData);
     const gasPricesResponse = new GasPricesResponse(
       await gasPrices(new GasPricesRequest(), mockCtx),
     );
@@ -49,7 +45,7 @@ describe('GasPrices request handler', () => {
   });
 
   test('should fail to get gas prices when idb has none', async () => {
-    mockIndexedDb.getNativeGasPrices?.mockResolvedValue(undefined);
+    mockIndexedDb.getNativeGasPrices.mockResolvedValue(undefined);
     await expect(gasPrices(new GasPricesRequest(), mockCtx)).rejects.toThrow(
       'Gas prices is not available',
     );

--- a/packages/services/src/view-service/latest-swaps.test.ts
+++ b/packages/services/src/view-service/latest-swaps.test.ts
@@ -11,7 +11,7 @@ import {
   LatestSwapsResponse,
   SwapRecord,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices, testFullViewingKey } from '../test-utils.js';
+import { mockIndexedDb, MockServices, testFullViewingKey } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { latestSwaps } from './latest-swaps.js';
 import { CommitmentSource } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
@@ -26,7 +26,7 @@ import { DirectedTradingPair } from '@penumbra-zone/protobuf/penumbra/core/compo
 describe('LatestSwaps request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
+
   let fillDB: (data: SwapRecord[]) => void;
 
   const request = async (req: LatestSwapsRequest): Promise<LatestSwapsResponse[]> => {
@@ -45,10 +45,6 @@ describe('LatestSwaps request handler', () => {
     const mockIterateSwaps = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIterateSwaps,
-    };
-
-    mockIndexedDb = {
-      iterateSwaps: () => mockIterateSwaps,
     };
 
     mockServices = {

--- a/packages/services/src/view-service/latest-swaps.test.ts
+++ b/packages/services/src/view-service/latest-swaps.test.ts
@@ -56,12 +56,6 @@ describe('LatestSwaps request handler', () => {
         .set(servicesCtx, () => Promise.resolve(mockServices as unknown as ServicesInterface))
         .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
-
-    /*
-      mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () { yield* await Promise.resolve([
-
-      ]); });
-      */
   });
 
   it('collects swaps with "transaction" source only', async () => {

--- a/packages/services/src/view-service/latest-swaps.test.ts
+++ b/packages/services/src/view-service/latest-swaps.test.ts
@@ -27,8 +27,6 @@ describe('LatestSwaps request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
 
-  let fillDB: (data: SwapRecord[]) => void;
-
   const request = async (req: LatestSwapsRequest): Promise<LatestSwapsResponse[]> => {
     const responses: LatestSwapsResponse[] = [];
 
@@ -41,11 +39,6 @@ describe('LatestSwaps request handler', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    const mockIterateSwaps = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateSwaps,
-    };
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -64,38 +57,35 @@ describe('LatestSwaps request handler', () => {
         .set(fvkCtx, () => Promise.resolve(testFullViewingKey)),
     });
 
-    fillDB = (data: SwapRecord[]) => {
-      for (const record of data) {
-        mockIterateSwaps.next.mockResolvedValueOnce({
-          value: record,
-        });
-      }
-      mockIterateSwaps.next.mockResolvedValueOnce({
-        done: true,
-      });
-    };
+    /*
+      mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () { yield* await Promise.resolve([
+
+      ]); });
+      */
   });
 
   it('collects swaps with "transaction" source only', async () => {
-    fillDB([
-      IRRELEVANT_SWAP,
-      getSwap({
-        height: 100,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 9,
-        account: 1,
-        from: UM_METADATA,
-        to: SHITMOS_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-    ]);
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([
+        IRRELEVANT_SWAP,
+        getSwap({
+          height: 100,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 9,
+          account: 1,
+          from: UM_METADATA,
+          to: SHITMOS_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+      ]);
+    });
 
     const res = await request(new LatestSwapsRequest({}));
 
@@ -106,24 +96,26 @@ describe('LatestSwaps request handler', () => {
   });
 
   it('applies `responseLimit` filter correctly', async () => {
-    fillDB([
-      getSwap({
-        height: 100,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 9,
-        account: 1,
-        from: UM_METADATA,
-        to: SHITMOS_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-    ]);
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([
+        getSwap({
+          height: 100,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 9,
+          account: 1,
+          from: UM_METADATA,
+          to: SHITMOS_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+      ]);
+    });
 
     const res = await request(
       new LatestSwapsRequest({
@@ -136,24 +128,26 @@ describe('LatestSwaps request handler', () => {
   });
 
   it('applies `afterHeight` filter correctly', async () => {
-    fillDB([
-      getSwap({
-        height: 100,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 9,
-        account: 1,
-        from: UM_METADATA,
-        to: SHITMOS_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-    ]);
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([
+        getSwap({
+          height: 100,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 9,
+          account: 1,
+          from: UM_METADATA,
+          to: SHITMOS_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+      ]);
+    });
 
     const res = await request(
       new LatestSwapsRequest({
@@ -166,24 +160,26 @@ describe('LatestSwaps request handler', () => {
   });
 
   it('applies `accountFilter` filter correctly', async () => {
-    fillDB([
-      getSwap({
-        height: 100,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 9,
-        account: 1,
-        from: UM_METADATA,
-        to: SHITMOS_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-    ]);
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([
+        getSwap({
+          height: 100,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 9,
+          account: 1,
+          from: UM_METADATA,
+          to: SHITMOS_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+      ]);
+    });
 
     const res = await request(
       new LatestSwapsRequest({
@@ -195,24 +191,26 @@ describe('LatestSwaps request handler', () => {
   });
 
   it('applies `pair` filter correctly', async () => {
-    fillDB([
-      getSwap({
-        height: 100,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 9,
-        account: 1,
-        from: UM_METADATA,
-        to: SHITMOS_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-    ]);
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([
+        getSwap({
+          height: 100,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 9,
+          account: 1,
+          from: UM_METADATA,
+          to: SHITMOS_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+      ]);
+    });
 
     const res = await request(
       new LatestSwapsRequest({
@@ -229,49 +227,51 @@ describe('LatestSwaps request handler', () => {
   });
 
   it('applies all filters together correctly', async () => {
-    fillDB([
-      IRRELEVANT_SWAP,
-      getSwap({
-        height: 0,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 99,
-        account: 0,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 100,
-        account: 1,
-        from: UM_METADATA,
-        to: SHITMOS_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 101,
-        account: 1,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-      getSwap({
-        height: 102,
-        account: 1,
-        from: UM_METADATA,
-        to: USDC_METADATA,
-        input: 100n,
-        output: 110n,
-      }),
-    ]);
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([
+        IRRELEVANT_SWAP,
+        getSwap({
+          height: 0,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 99,
+          account: 0,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 100,
+          account: 1,
+          from: UM_METADATA,
+          to: SHITMOS_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 101,
+          account: 1,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+        getSwap({
+          height: 102,
+          account: 1,
+          from: UM_METADATA,
+          to: USDC_METADATA,
+          input: 100n,
+          output: 110n,
+        }),
+      ]);
+    });
 
     const res = await request(
       new LatestSwapsRequest({

--- a/packages/services/src/view-service/lqt-voting-notes.test.ts
+++ b/packages/services/src/view-service/lqt-voting-notes.test.ts
@@ -8,7 +8,7 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockQuerier, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockQuerier, MockServices } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { lqtVotingNotes } from './lqt-voting-notes.js';
 import { Epoch } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
@@ -17,19 +17,12 @@ import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/t
 
 describe('lqtVotingNotes request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockQuerier: MockQuerier;
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    mockIndexedDb = {
-      getLQTHistoricalVotes: vi.fn(),
-      iterateLQTVotes: vi.fn(),
-      getEpochByIndex: vi.fn(),
-      getNotesForVoting: vi.fn(),
-    };
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -52,8 +45,8 @@ describe('lqtVotingNotes request handler', () => {
   test('returns no voting notes if the nullifier has already been used for voting in the current epoch', async () => {
     // voting notes mocked with static data, and the mock bypasses the logic in the real implementation,
     // but that's fine.
-    mockIndexedDb.getNotesForVoting?.mockResolvedValueOnce(testData);
-    mockIndexedDb.getEpochByIndex?.mockResolvedValueOnce(epoch);
+    mockIndexedDb.getNotesForVoting.mockResolvedValueOnce(testData);
+    mockIndexedDb.getEpochByIndex.mockResolvedValueOnce(epoch);
 
     mockQuerier = {
       funding: {
@@ -87,8 +80,8 @@ describe('lqtVotingNotes request handler', () => {
   });
 
   test('returns voting notes when the nullifier has not been used for voting in the current epoch', async () => {
-    mockIndexedDb.getNotesForVoting?.mockResolvedValueOnce(testData);
-    mockIndexedDb.getEpochByIndex?.mockResolvedValueOnce(epoch);
+    mockIndexedDb.getNotesForVoting.mockResolvedValueOnce(testData);
+    mockIndexedDb.getEpochByIndex.mockResolvedValueOnce(epoch);
 
     mockQuerier = {
       funding: {

--- a/packages/services/src/view-service/note-by-commitment.test.ts
+++ b/packages/services/src/view-service/note-by-commitment.test.ts
@@ -7,11 +7,10 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { mockIndexedDb, MockServices, mockSubscriptionData } from '../test-utils.js';
+import { mockIndexedDb, MockServices, createUpdates } from '../test-utils.js';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import { noteByCommitment } from './note-by-commitment.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
-import { JsonObject } from '@bufbuild/protobuf';
 
 describe('NoteByCommitment request handler', () => {
   let mockServices: MockServices;
@@ -66,10 +65,12 @@ describe('NoteByCommitment request handler', () => {
     request.awaitDetection = true;
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      if (table === 'SPENDABLE_NOTES') {
-        yield* mockSubscriptionData(table, [testNote.toJson()] as JsonObject[]);
-      } else {
-        expect.unreachable('Test should only subscribe to SPENDABLE_NOTES');
+      switch (table) {
+        case 'SPENDABLE_NOTES':
+          yield* createUpdates(table, [testNote.toJson()]);
+          break;
+        default:
+          expect.unreachable(`Test should not subscribe to ${table}`);
       }
     });
 
@@ -84,10 +85,12 @@ describe('NoteByCommitment request handler', () => {
     request.awaitDetection = true;
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      if (table === 'SPENDABLE_NOTES') {
-        yield* mockSubscriptionData(table, [noteWithAnotherCommitment.toJson()] as JsonObject[]);
-      } else {
-        expect.unreachable('Test should only subscribe to SPENDABLE_NOTES');
+      switch (table) {
+        case 'SPENDABLE_NOTES':
+          yield* createUpdates(table, [noteWithAnotherCommitment.toJson()]);
+          break;
+        default:
+          expect.unreachable(`Test should not subscribe to ${table}`);
       }
     });
 

--- a/packages/services/src/view-service/note-by-commitment.test.ts
+++ b/packages/services/src/view-service/note-by-commitment.test.ts
@@ -60,14 +60,14 @@ describe('NoteByCommitment request handler', () => {
     await expect(noteByCommitment(request, mockCtx)).rejects.toThrow('Note not found');
   });
 
-  test('should get note if note is not found in idb, but awaitDetection is true, and has been detected', async () => {
+  test('should get note if note is not found in idb, but awaitDetection is true, and then it is detected', async () => {
     mockIndexedDb.getSpendableNoteByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = true;
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
       switch (table) {
         case 'SPENDABLE_NOTES':
-          yield* createUpdates(table, [testNote.toJson()]);
+          yield* createUpdates(table, [noteWithAnotherCommitment.toJson(), testNote.toJson()]);
           break;
         default:
           expect.unreachable(`Test should not subscribe to ${table}`);
@@ -78,23 +78,6 @@ describe('NoteByCommitment request handler', () => {
       await noteByCommitment(request, mockCtx),
     );
     expect(noteByCommitmentResponse.spendableNote?.equals(testNote)).toBeTruthy();
-  });
-
-  test('should throw error if note is not found in idb, and has not been detected', async () => {
-    mockIndexedDb.getSpendableNoteByCommitment.mockResolvedValue(undefined);
-    request.awaitDetection = true;
-
-    mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      switch (table) {
-        case 'SPENDABLE_NOTES':
-          yield* createUpdates(table, [noteWithAnotherCommitment.toJson()]);
-          break;
-        default:
-          expect.unreachable(`Test should not subscribe to ${table}`);
-      }
-    });
-
-    await expect(noteByCommitment(request, mockCtx)).rejects.toThrow('Note not found');
   });
 });
 

--- a/packages/services/src/view-service/note-by-commitment.test.ts
+++ b/packages/services/src/view-service/note-by-commitment.test.ts
@@ -7,14 +7,14 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import { noteByCommitment } from './note-by-commitment.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('NoteByCommitment request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
   let request: NoteByCommitmentRequest;
   let noteSubNext: Mock;
@@ -28,10 +28,6 @@ describe('NoteByCommitment request handler', () => {
       [Symbol.asyncIterator]: () => mockNoteSubscription,
     };
 
-    mockIndexedDb = {
-      getSpendableNoteByCommitment: vi.fn(),
-      subscribe: () => mockNoteSubscription,
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -52,7 +48,7 @@ describe('NoteByCommitment request handler', () => {
   });
 
   test('should successfully get note by commitment when idb has them', async () => {
-    mockIndexedDb.getSpendableNoteByCommitment?.mockResolvedValue(testNote);
+    mockIndexedDb.getSpendableNoteByCommitment.mockResolvedValue(testNote);
     const noteByCommitmentResponse = new NoteByCommitmentResponse(
       await noteByCommitment(request, mockCtx),
     );
@@ -66,13 +62,13 @@ describe('NoteByCommitment request handler', () => {
   });
 
   test('should throw an error if note  no found in idb and awaitDetection is false', async () => {
-    mockIndexedDb.getSpendableNoteByCommitment?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = false;
     await expect(noteByCommitment(request, mockCtx)).rejects.toThrow('Note not found');
   });
 
   test('should get note if note is not found in idb, but awaitDetection is true, and has been detected', async () => {
-    mockIndexedDb.getSpendableNoteByCommitment?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = true;
     noteSubNext.mockResolvedValueOnce({
       value: { value: testNote.toJson() },
@@ -84,7 +80,7 @@ describe('NoteByCommitment request handler', () => {
   });
 
   test('should throw error if note is not found in idb, and has not been detected', async () => {
-    mockIndexedDb.getSpendableNoteByCommitment?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = true;
 
     noteSubNext.mockResolvedValueOnce({

--- a/packages/services/src/view-service/notes-for-voting.test.ts
+++ b/packages/services/src/view-service/notes-for-voting.test.ts
@@ -6,21 +6,18 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { notesForVoting } from './notes-for-voting.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('NotesForVoting request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
     vi.resetAllMocks();
 
-    mockIndexedDb = {
-      getNotesForVoting: vi.fn(),
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -39,7 +36,7 @@ describe('NotesForVoting request handler', () => {
   });
 
   test('should successfully get notes for voting', async () => {
-    mockIndexedDb.getNotesForVoting?.mockResolvedValueOnce(testData);
+    mockIndexedDb.getNotesForVoting.mockResolvedValueOnce(testData);
     const responses: NotesForVotingResponse[] = [];
     const req = new NotesForVotingRequest({});
     for await (const res of notesForVoting(req, mockCtx)) {

--- a/packages/services/src/view-service/notes.test.ts
+++ b/packages/services/src/view-service/notes.test.ts
@@ -24,10 +24,9 @@ describe('Notes request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateSpendableNotes = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateSpendableNotes,
-    };
+    mockIndexedDb.iterateSpendableNotes.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve(testData);
+    });
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -44,15 +43,6 @@ describe('Notes request handler', () => {
       contextValues: createContextValues().set(servicesCtx, () =>
         Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
-    });
-
-    for (const record of testData) {
-      mockIterateSpendableNotes.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIterateSpendableNotes.next.mockResolvedValueOnce({
-      done: true,
     });
   });
 

--- a/packages/services/src/view-service/notes.test.ts
+++ b/packages/services/src/view-service/notes.test.ts
@@ -14,13 +14,12 @@ import {
   NotesResponse,
   SpendableNoteRecord,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('Notes request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -28,10 +27,6 @@ describe('Notes request handler', () => {
     const mockIterateSpendableNotes = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIterateSpendableNotes,
-    };
-
-    mockIndexedDb = {
-      iterateSpendableNotes: () => mockIterateSpendableNotes,
     };
 
     mockServices = {

--- a/packages/services/src/view-service/nullifier-status.test.ts
+++ b/packages/services/src/view-service/nullifier-status.test.ts
@@ -141,8 +141,6 @@ describe('nullifierStatus', () => {
             nonMatchingSwap.toJson(),
             nonMatchingSwap.toJson(),
           ]);
-          // don't end the stream
-          yield await new Promise<never>(() => {});
           break;
         case 'SPENDABLE_NOTES':
           // Incoming notes with the last one being the match
@@ -151,8 +149,6 @@ describe('nullifierStatus', () => {
             matchingNoteNotSpent.toJson(),
             matchingNoteSpent.toJson(),
           ]);
-          // don't end the stream
-          yield await new Promise<never>(() => {});
           break;
         default:
           expect.unreachable(`Test should not subscribe to ${table}`);

--- a/packages/services/src/view-service/nullifier-status.test.ts
+++ b/packages/services/src/view-service/nullifier-status.test.ts
@@ -14,12 +14,11 @@ import {
   SpendableNoteRecord,
   SwapRecord,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { stringToUint8Array } from '@penumbra-zone/types/string';
 
 describe('nullifierStatus', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
   let mockCtx: HandlerContext;
   let noteSubNext: Mock;
   let swapSubNext: Mock;
@@ -39,19 +38,6 @@ describe('nullifierStatus', () => {
       [Symbol.asyncIterator]: () => mockSwapSubscription,
     };
 
-    mockIndexedDb = {
-      getSpendableNoteByNullifier: vi.fn(),
-      getSwapByNullifier: vi.fn(),
-      subscribe: (table: string) => {
-        if (table === 'SPENDABLE_NOTES') {
-          return mockNoteSubscription;
-        }
-        if (table === 'SWAPS') {
-          return mockSwapSubscription;
-        }
-        throw new Error('Table not supported');
-      },
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -80,8 +66,8 @@ describe('nullifierStatus', () => {
       nullifier: new Nullifier({ inner: stringToUint8Array('nullifier_abc') }),
     });
 
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(undefined);
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(undefined);
 
     const res = await nullifierStatus(req, mockCtx);
     expect(res.spent).toBe(false);
@@ -92,8 +78,8 @@ describe('nullifierStatus', () => {
       nullifier: new Nullifier({ inner: stringToUint8Array('nullifier_abc') }),
     });
 
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(undefined);
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(new SwapRecord({ heightClaimed: 324234n }));
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(new SwapRecord({ heightClaimed: 324234n }));
 
     const res = await nullifierStatus(req, mockCtx);
     expect(res.spent).toBe(true);
@@ -104,8 +90,8 @@ describe('nullifierStatus', () => {
       nullifier: new Nullifier({ inner: stringToUint8Array('nullifier_abc') }),
     });
 
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(undefined);
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(new SwapRecord());
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(new SwapRecord());
 
     const res = await nullifierStatus(req, mockCtx);
     expect(res.spent).toBe(false);
@@ -116,10 +102,10 @@ describe('nullifierStatus', () => {
       nullifier: new Nullifier({ inner: stringToUint8Array('nullifier_abc') }),
     });
 
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(
       new SpendableNoteRecord({ heightSpent: 324234n }),
     );
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(undefined);
 
     const res = await nullifierStatus(req, mockCtx);
     expect(res.spent).toBe(true);
@@ -130,16 +116,16 @@ describe('nullifierStatus', () => {
       nullifier: new Nullifier({ inner: stringToUint8Array('nullifier_abc') }),
     });
 
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(new SpendableNoteRecord());
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(new SpendableNoteRecord());
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(undefined);
 
     const res = await nullifierStatus(req, mockCtx);
     expect(res.spent).toBe(false);
   });
 
   test('await detect corresponding note', async () => {
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(undefined);
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(undefined);
 
     const matchingNullifier = new Nullifier({ inner: stringToUint8Array('nullifier_abc') });
 
@@ -194,8 +180,8 @@ describe('nullifierStatus', () => {
   });
 
   test('await detect corresponding swap', async () => {
-    mockIndexedDb.getSpendableNoteByNullifier?.mockResolvedValue(undefined);
-    mockIndexedDb.getSwapByNullifier?.mockResolvedValue(undefined);
+    mockIndexedDb.getSpendableNoteByNullifier.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByNullifier.mockResolvedValue(undefined);
 
     const matchingNullifier = new Nullifier({ inner: stringToUint8Array('nullifier_abc') });
 

--- a/packages/services/src/view-service/owned-position-ids.test.ts
+++ b/packages/services/src/view-service/owned-position-ids.test.ts
@@ -9,7 +9,7 @@ import {
   OwnedPositionIdsRequest,
   OwnedPositionIdsResponse,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { PositionId } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { ownedPositionIds } from './owned-position-ids.js';
@@ -17,7 +17,6 @@ import { ownedPositionIds } from './owned-position-ids.js';
 describe('OwnedPositionIds request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
   let req: OwnedPositionIdsRequest;
 
   beforeEach(() => {
@@ -26,10 +25,6 @@ describe('OwnedPositionIds request handler', () => {
     const mockIteratePositions = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIteratePositions,
-    };
-
-    mockIndexedDb = {
-      getOwnedPositionIds: () => mockIteratePositions,
     };
 
     mockServices = {

--- a/packages/services/src/view-service/owned-position-ids.test.ts
+++ b/packages/services/src/view-service/owned-position-ids.test.ts
@@ -22,10 +22,9 @@ describe('OwnedPositionIds request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIteratePositions = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIteratePositions,
-    };
+    mockIndexedDb.getOwnedPositionIds.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve(testData);
+    });
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -42,15 +41,6 @@ describe('OwnedPositionIds request handler', () => {
       contextValues: createContextValues().set(servicesCtx, () =>
         Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
-    });
-
-    for (const record of testData) {
-      mockIteratePositions.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIteratePositions.next.mockResolvedValueOnce({
-      done: true,
     });
     req = new OwnedPositionIdsRequest();
   });

--- a/packages/services/src/view-service/status-stream.test.ts
+++ b/packages/services/src/view-service/status-stream.test.ts
@@ -6,13 +6,12 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices, TendermintMock } from '../test-utils.js';
+import { mockIndexedDb, MockServices, TendermintMock } from '../test-utils.js';
 import { statusStream } from './status-stream.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('Status stream request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
   let mockCtx: HandlerContext;
   let mockTendermint: TendermintMock;
   let lastBlockSubNext: Mock;
@@ -25,10 +24,6 @@ describe('Status stream request handler', () => {
     const mockLastBlockSubscription = {
       next: lastBlockSubNext,
       [Symbol.asyncIterator]: () => mockLastBlockSubscription,
-    };
-
-    mockIndexedDb = {
-      subscribe: () => mockLastBlockSubscription,
     };
 
     mockTendermint = {

--- a/packages/services/src/view-service/status.test.ts
+++ b/packages/services/src/view-service/status.test.ts
@@ -3,22 +3,18 @@ import { StatusRequest, StatusResponse } from '@penumbra-zone/protobuf/penumbra/
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices, TendermintMock } from '../test-utils.js';
+import { mockIndexedDb, MockServices, TendermintMock } from '../test-utils.js';
 import { status } from './status.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('Status request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
+
   let mockCtx: HandlerContext;
   let mockTendermint: TendermintMock;
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    mockIndexedDb = {
-      getFullSyncHeight: vi.fn(),
-    };
 
     mockTendermint = {
       latestBlockHeight: vi.fn(),
@@ -48,7 +44,7 @@ describe('Status request handler', () => {
   });
 
   test('should get status when view service is synchronized with last known block in tendermint', async () => {
-    mockIndexedDb.getFullSyncHeight?.mockResolvedValue(222n);
+    mockIndexedDb.getFullSyncHeight.mockResolvedValue(222n);
     mockTendermint.latestBlockHeight?.mockResolvedValue(222n);
     const statusResponse = new StatusResponse(await status(new StatusRequest(), mockCtx));
     expect(statusResponse.catchingUp).toBe(false);
@@ -56,7 +52,7 @@ describe('Status request handler', () => {
   });
 
   test('should receive status when view service synchronizes and lags behind last known block in tendermint', async () => {
-    mockIndexedDb.getFullSyncHeight?.mockResolvedValue(111n);
+    mockIndexedDb.getFullSyncHeight.mockResolvedValue(111n);
     mockTendermint.latestBlockHeight?.mockResolvedValue(222n);
     const statusResponse = new StatusResponse(await status(new StatusRequest(), mockCtx));
     expect(statusResponse.catchingUp).toBe(true);

--- a/packages/services/src/view-service/swap-by-commitment.test.ts
+++ b/packages/services/src/view-service/swap-by-commitment.test.ts
@@ -59,14 +59,14 @@ describe('SwapByCommitment request handler', () => {
     await expect(swapByCommitment(request, mockCtx)).rejects.toThrow('Swap not found');
   });
 
-  test('should get swap if swap is not found in idb, but awaitDetection is true, and has been detected', async () => {
+  test('should get swap if swap is not found in idb, but awaitDetection is true, and then it is detected', async () => {
     mockIndexedDb.getSwapByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = true;
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
       switch (table) {
         case 'SWAPS':
-          yield* createUpdates(table, [testSwap.toJson()]);
+          yield* createUpdates(table, [swapWithAnotherCommitment.toJson(), testSwap.toJson()]);
           break;
         default:
           expect.unreachable(`Test should not subscribe to ${table}`);
@@ -77,23 +77,6 @@ describe('SwapByCommitment request handler', () => {
       await swapByCommitment(request, mockCtx),
     );
     expect(swapByCommitmentResponse.swap?.equals(testSwap)).toBeTruthy();
-  });
-
-  test('should throw error if swap is not found in idb, and has not been detected', async () => {
-    mockIndexedDb.getSwapByCommitment.mockResolvedValue(undefined);
-    request.awaitDetection = true;
-
-    mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      switch (table) {
-        case 'SWAPS':
-          yield* createUpdates(table, [swapWithAnotherCommitment.toJson()]);
-          break;
-        default:
-          expect.unreachable(`Test should not subscribe to ${table}`);
-      }
-    });
-
-    await expect(swapByCommitment(request, mockCtx)).rejects.toThrow('Swap not found');
   });
 });
 

--- a/packages/services/src/view-service/swap-by-commitment.test.ts
+++ b/packages/services/src/view-service/swap-by-commitment.test.ts
@@ -7,14 +7,13 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import { swapByCommitment } from './swap-by-commitment.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('SwapByCommitment request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
   let mockCtx: HandlerContext;
   let request: SwapByCommitmentRequest;
   let swapSubNext: Mock;
@@ -28,10 +27,6 @@ describe('SwapByCommitment request handler', () => {
       [Symbol.asyncIterator]: () => mockSwapSubscription,
     };
 
-    mockIndexedDb = {
-      getSwapByCommitment: vi.fn(),
-      subscribe: () => mockSwapSubscription,
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -52,7 +47,7 @@ describe('SwapByCommitment request handler', () => {
   });
 
   test('should successfully get swap by commitment when idb has them', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(testSwap);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(testSwap);
     const swapByCommitmentResponse = new SwapByCommitmentResponse(
       await swapByCommitment(request, mockCtx),
     );
@@ -66,13 +61,13 @@ describe('SwapByCommitment request handler', () => {
   });
 
   test('should throw an error if swap  no found in idb and awaitDetection is false', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = false;
     await expect(swapByCommitment(request, mockCtx)).rejects.toThrow('Swap not found');
   });
 
   test('should get swap if swap is not found in idb, but awaitDetection is true, and has been detected', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = true;
     swapSubNext.mockResolvedValueOnce({
       value: { value: testSwap.toJson() },
@@ -84,7 +79,7 @@ describe('SwapByCommitment request handler', () => {
   });
 
   test('should throw error if swap is not found in idb, and has not been detected', async () => {
-    mockIndexedDb.getSwapByCommitment?.mockResolvedValue(undefined);
+    mockIndexedDb.getSwapByCommitment.mockResolvedValue(undefined);
     request.awaitDetection = true;
 
     swapSubNext.mockResolvedValueOnce({

--- a/packages/services/src/view-service/swap-by-commitment.test.ts
+++ b/packages/services/src/view-service/swap-by-commitment.test.ts
@@ -7,11 +7,10 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { mockIndexedDb, MockServices, mockSubscriptionData } from '../test-utils.js';
+import { mockIndexedDb, MockServices, createUpdates } from '../test-utils.js';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import { swapByCommitment } from './swap-by-commitment.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
-import { JsonObject } from '@bufbuild/protobuf';
 
 describe('SwapByCommitment request handler', () => {
   let mockServices: MockServices;
@@ -65,10 +64,12 @@ describe('SwapByCommitment request handler', () => {
     request.awaitDetection = true;
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      if (table === 'SWAPS') {
-        yield* mockSubscriptionData(table, [testSwap.toJson()] as JsonObject[]);
-      } else {
-        expect.unreachable('Test should only subscribe to SWAPS');
+      switch (table) {
+        case 'SWAPS':
+          yield* createUpdates(table, [testSwap.toJson()]);
+          break;
+        default:
+          expect.unreachable(`Test should not subscribe to ${table}`);
       }
     });
 
@@ -83,10 +84,12 @@ describe('SwapByCommitment request handler', () => {
     request.awaitDetection = true;
 
     mockIndexedDb.subscribe.mockImplementationOnce(async function* (table) {
-      if (table === 'SWAPS') {
-        yield* mockSubscriptionData(table, [swapWithAnotherCommitment.toJson()] as JsonObject[]);
-      } else {
-        expect.unreachable('Test should only subscribe to SWAPS');
+      switch (table) {
+        case 'SWAPS':
+          yield* createUpdates(table, [swapWithAnotherCommitment.toJson()]);
+          break;
+        default:
+          expect.unreachable(`Test should not subscribe to ${table}`);
       }
     });
 

--- a/packages/services/src/view-service/tournament-votes.test.ts
+++ b/packages/services/src/view-service/tournament-votes.test.ts
@@ -6,28 +6,20 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { Epoch } from '@penumbra-zone/protobuf/penumbra/core/component/sct/v1/sct_pb';
 import { tournamentVotes } from './tournament-votes.js';
 import { Amount } from '@penumbra-zone/protobuf/penumbra/core/num/v1/num_pb';
-import { Value } from '@bufbuild/protobuf';
+import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { TransactionId } from '@penumbra-zone/protobuf/penumbra/core/txhash/v1/txhash_pb';
 
 describe('tournamentVotes request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
   let mockCtx: HandlerContext;
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    mockIndexedDb = {
-      getLQTHistoricalVotes: vi.fn(),
-      iterateLQTVotes: vi.fn(),
-      saveLQTHistoricalVote: vi.fn(),
-      getEpochByIndex: vi.fn(),
-      getNotesForVoting: vi.fn(),
-    };
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -48,10 +40,11 @@ describe('tournamentVotes request handler', () => {
   });
 
   test('returns historical liquidity tournament votes that have been previously been saved to storage', async () => {
-    mockIndexedDb.getEpochByIndex?.mockResolvedValueOnce(epoch);
-    mockIndexedDb.saveLQTHistoricalVote?.mockResolvedValueOnce(mockVote);
-    mockIndexedDb.getLQTHistoricalVotes?.mockResolvedValueOnce([mockVote]);
-    mockIndexedDb.iterateLQTVotes?.mockResolvedValueOnce([mockVote]);
+    mockIndexedDb.getEpochByIndex.mockResolvedValueOnce(epoch);
+    mockIndexedDb.getLQTHistoricalVotes.mockResolvedValueOnce([mockVote]);
+    mockIndexedDb.iterateLQTVotes.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve([mockVote]);
+    });
 
     const res: TournamentVotesResponse_Vote[] = [];
     const req = new TournamentVotesRequest({ epochIndex: epoch.index });
@@ -74,11 +67,12 @@ const epoch = new Epoch({
 });
 
 const mockVote = {
+  incentivizedAsset: new AssetId({}),
   id: 'test-uuid-or-any-string',
-  epoch: 100n,
-  TransactionId: {
+  epoch: '100',
+  TransactionId: new TransactionId({
     inner: new Uint8Array([1, 2, 3, 4]),
-  },
+  }),
   AssetMetadata: {
     penumbraAssetId: {
       inner: new Uint8Array(new Array(32).fill(1)),

--- a/packages/services/src/view-service/transaction-info.test.ts
+++ b/packages/services/src/view-service/transaction-info.test.ts
@@ -32,10 +32,9 @@ describe('TransactionInfo request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateTransactionInfo = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateTransactionInfo,
-    };
+    mockIndexedDb.iterateTransactions.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve(testData);
+    });
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -57,15 +56,6 @@ describe('TransactionInfo request handler', () => {
     mockTransactionInfo.mockReturnValue({
       txp: {},
       txv: {},
-    });
-
-    for (const record of testData) {
-      mockIterateTransactionInfo.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIterateTransactionInfo.next.mockResolvedValueOnce({
-      done: true,
     });
     req = new TransactionInfoRequest();
   });

--- a/packages/services/src/view-service/transaction-info.test.ts
+++ b/packages/services/src/view-service/transaction-info.test.ts
@@ -10,7 +10,7 @@ import {
   TransactionInfoRequest,
   TransactionInfoResponse,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices, testFullViewingKey } from '../test-utils.js';
+import { mockIndexedDb, MockServices, testFullViewingKey } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { transactionInfo } from './transaction-info.js';
 import { fvkCtx } from '../ctx/full-viewing-key.js';
@@ -27,7 +27,6 @@ vi.mock('@penumbra-zone/wasm/transaction', () => ({
 describe('TransactionInfo request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
   let req: TransactionInfoRequest;
 
   beforeEach(() => {
@@ -36,17 +35,6 @@ describe('TransactionInfo request handler', () => {
     const mockIterateTransactionInfo = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIterateTransactionInfo,
-    };
-
-    mockIndexedDb = {
-      iterateTransactions: () => mockIterateTransactionInfo,
-      constants: vi.fn(),
-      getTransactionInfo: vi.fn().mockResolvedValue({
-        txp: {},
-        txv: {},
-        summary: {},
-      }),
-      saveTransactionInfo: vi.fn().mockResolvedValue(undefined),
     };
 
     mockServices = {

--- a/packages/services/src/view-service/transaction-planner/index.test.ts
+++ b/packages/services/src/view-service/transaction-planner/index.test.ts
@@ -6,7 +6,7 @@ import {
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../../ctx/prax.js';
-import { IndexedDbMock, MockServices, testFullViewingKey } from '../../test-utils.js';
+import { mockIndexedDb, MockServices, testFullViewingKey } from '../../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { FmdParameters } from '@penumbra-zone/protobuf/penumbra/core/component/shielded_pool/v1/shielded_pool_pb';
 import { AppParameters } from '@penumbra-zone/protobuf/penumbra/core/app/v1/app_pb';
@@ -24,20 +24,11 @@ vi.mock('@penumbra-zone/wasm/planner', () => ({
 }));
 describe('TransactionPlanner request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
   let mockCtx: HandlerContext;
   let req: TransactionPlannerRequest;
 
   beforeEach(() => {
     vi.resetAllMocks();
-
-    mockIndexedDb = {
-      getFmdParams: vi.fn(),
-      getAppParams: vi.fn(),
-      getNativeGasPrices: vi.fn(),
-      constants: vi.fn(),
-      hasTokenBalance: vi.fn(),
-    };
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -78,13 +69,13 @@ describe('TransactionPlanner request handler', () => {
   });
 
   test('should create a transaction plan if all necessary data exists in indexed-db', async () => {
-    mockIndexedDb.getFmdParams?.mockResolvedValueOnce(
+    mockIndexedDb.getFmdParams.mockResolvedValueOnce(
       new FmdParameters({
         precisionBits: 12,
         asOfBlockHeight: 2n,
       }),
     );
-    mockIndexedDb.getAppParams?.mockResolvedValueOnce(
+    mockIndexedDb.getAppParams.mockResolvedValueOnce(
       new AppParameters({
         chainId: 'penumbra-testnet-mock',
         sctParams: new SctParameters({
@@ -92,7 +83,7 @@ describe('TransactionPlanner request handler', () => {
         }),
       }),
     );
-    mockIndexedDb.getNativeGasPrices?.mockResolvedValueOnce(
+    mockIndexedDb.getNativeGasPrices.mockResolvedValueOnce(
       new GasPrices({
         verificationPrice: 22n,
         executionPrice: 222n,
@@ -101,8 +92,7 @@ describe('TransactionPlanner request handler', () => {
       }),
     );
 
-    mockIndexedDb.stakingTokenAssetId?.mockResolvedValueOnce(true);
-    mockIndexedDb.hasTokenBalance?.mockResolvedValueOnce(true);
+    mockIndexedDb.hasTokenBalance.mockResolvedValueOnce(true);
 
     mockPlanTransaction.mockResolvedValueOnce(
       new TransactionPlan({

--- a/packages/services/src/view-service/unclaimed-swaps.test.ts
+++ b/packages/services/src/view-service/unclaimed-swaps.test.ts
@@ -10,14 +10,13 @@ import {
   UnclaimedSwapsRequest,
   UnclaimedSwapsResponse,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import type { ServicesInterface } from '@penumbra-zone/types/services';
 import { unclaimedSwaps } from './unclaimed-swaps.js';
 
 describe('UnclaimedSwaps request handler', () => {
   let mockServices: MockServices;
   let mockCtx: HandlerContext;
-  let mockIndexedDb: IndexedDbMock;
   let req: UnclaimedSwapsRequest;
 
   beforeEach(() => {
@@ -26,10 +25,6 @@ describe('UnclaimedSwaps request handler', () => {
     const mockIterateSwaps = {
       next: vi.fn(),
       [Symbol.asyncIterator]: () => mockIterateSwaps,
-    };
-
-    mockIndexedDb = {
-      iterateSwaps: () => mockIterateSwaps,
     };
 
     mockServices = {

--- a/packages/services/src/view-service/unclaimed-swaps.test.ts
+++ b/packages/services/src/view-service/unclaimed-swaps.test.ts
@@ -22,10 +22,9 @@ describe('UnclaimedSwaps request handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
-    const mockIterateSwaps = {
-      next: vi.fn(),
-      [Symbol.asyncIterator]: () => mockIterateSwaps,
-    };
+    mockIndexedDb.iterateSwaps.mockImplementationOnce(async function* () {
+      yield* await Promise.resolve(testData);
+    });
 
     mockServices = {
       getWalletServices: vi.fn(() =>
@@ -42,15 +41,6 @@ describe('UnclaimedSwaps request handler', () => {
       contextValues: createContextValues().set(servicesCtx, () =>
         Promise.resolve(mockServices as unknown as ServicesInterface),
       ),
-    });
-
-    for (const record of testData) {
-      mockIterateSwaps.next.mockResolvedValueOnce({
-        value: record,
-      });
-    }
-    mockIterateSwaps.next.mockResolvedValueOnce({
-      done: true,
     });
     req = new UnclaimedSwapsRequest();
   });

--- a/packages/services/src/view-service/witness.test.ts
+++ b/packages/services/src/view-service/witness.test.ts
@@ -3,7 +3,7 @@ import { WitnessRequest, WitnessResponse } from '@penumbra-zone/protobuf/penumbr
 import { createContextValues, createHandlerContext, HandlerContext } from '@connectrpc/connect';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { servicesCtx } from '../ctx/prax.js';
-import { IndexedDbMock, MockServices } from '../test-utils.js';
+import { mockIndexedDb, MockServices } from '../test-utils.js';
 import { witness } from './witness.js';
 import {
   TransactionPlan,
@@ -13,16 +13,12 @@ import type { ServicesInterface } from '@penumbra-zone/types/services';
 
 describe('Witness request handler', () => {
   let mockServices: MockServices;
-  let mockIndexedDb: IndexedDbMock;
   let mockCtx: HandlerContext;
   let req: WitnessRequest;
 
   beforeEach(() => {
     vi.resetAllMocks();
 
-    mockIndexedDb = {
-      getStateCommitmentTree: vi.fn(),
-    };
     mockServices = {
       getWalletServices: vi.fn(() =>
         Promise.resolve({ indexedDb: mockIndexedDb }),
@@ -44,7 +40,7 @@ describe('Witness request handler', () => {
   });
 
   test('should successfully create witness data', async () => {
-    mockIndexedDb.getStateCommitmentTree?.mockResolvedValue(testSct);
+    mockIndexedDb.getStateCommitmentTree.mockResolvedValue(testSct);
     const witnessResponse = new WitnessResponse(await witness(req, mockCtx));
     expect(witnessResponse.witnessData).instanceof(WitnessData);
   });


### PR DESCRIPTION
Replaces the arbitrarily-declared `IndexedDbMock` in the services package with a preconstructed mock object that enforces the actual interface type.

This still isn't ideal, because it's still not using a real database underneath. But, this change creates no functional diff.

This is important because now the mock no longer has to be manually maintained in parallel to the storage interface - it updates automatically when the type updates, requiring the tests to also update.