### PR TITLE
CI runner for package release workflow

### DIFF
--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -35,6 +35,9 @@ jobs:
       - run: pnpm turbo lint:strict --cache-dir=.turbo
       - run: pnpm turbo build --cache-dir=.turbo
 
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
       # If there are changesets, this action will create a PR on the repo to version packages
       # If there are none, it will publish newer-versioned public packages to npm
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
## Description of Changes

For manual package releases, ensure wasm-pack is installed to avoid build failures. relevant failure in https://github.com/penumbra-zone/web/pull/2377 cc @conorsch 

<img width="1417" alt="Screenshot 2025-05-15 at 10 38 44 PM" src="https://github.com/user-attachments/assets/2654f9ae-5384-4562-ac5a-cf7314a0c2b7" />

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
