### PR TITLE
Handle vote revelation correctly

### DIFF
--- a/.changeset/beige-cloths-try.md
+++ b/.changeset/beige-cloths-try.md
@@ -1,0 +1,11 @@
+---
+'@penumbra-zone/wasm': major
+'@penumbra-zone/services': patch
+---
+
+Make the view service request for mapping indices to addresses take the randomizer into account.
+
+The WASM package has a breaking change in that the `get_address_by_index` function now
+_requires_ you to pass a randomizer.
+This can be an empty slice, indicating a randomizer consistent of all 0s.
+Clients should upgrade by adding a `&[]` parameter, which will preserve their current behavior.

--- a/packages/services/src/view-service/address-by-index.ts
+++ b/packages/services/src/view-service/address-by-index.ts
@@ -5,6 +5,10 @@ import { fvkCtx } from '../ctx/full-viewing-key.js';
 
 export const addressByIndex: Impl['addressByIndex'] = async (req, ctx) => {
   const fvk = ctx.values.get(fvkCtx);
-  const address = getAddressByIndex(await fvk(), req.addressIndex?.account ?? 0);
+  const address = getAddressByIndex(
+    await fvk(),
+    req.addressIndex?.account ?? 0,
+    req.addressIndex?.randomizer,
+  );
   return { address };
 };

--- a/packages/types/src/address.ts
+++ b/packages/types/src/address.ts
@@ -1,10 +1,32 @@
-import { Address } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
+import { Address, AddressIndex } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { addressFromBech32m } from '@penumbra-zone/bech32m/penumbra';
 import { compatAddressFromBech32, isCompatAddress } from '@penumbra-zone/bech32m/penumbracompat1';
+import { hexToUint8Array } from './hex.js';
 
 export const parseIntoAddr = (addrStr: string): Address => {
   if (isCompatAddress(addrStr)) {
     return new Address(compatAddressFromBech32(addrStr));
   }
   return new Address(addressFromBech32m(addrStr));
+};
+
+// First 12 bytes of SHA-256('lqt')
+const LQT_RANDOMIZER = hexToUint8Array('46c31be31ea4ae13bb68cfaa');
+
+/** Create the LQT Address Index for a given account. */
+export const lqtAddressIndex = (account: number): AddressIndex => {
+  return new AddressIndex({ account, randomizer: LQT_RANDOMIZER });
+};
+
+/** Check if an address index is the LQT address index. */
+export const isLqtAddressIndex = (index: AddressIndex): boolean => {
+  if (index.randomizer.length !== LQT_RANDOMIZER.length) {
+    return false;
+  }
+  for (let i = 0; i < LQT_RANDOMIZER.length; ++i) {
+    if (index.randomizer[i] !== LQT_RANDOMIZER[i]) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/ui/src/AddressView/index.tsx
+++ b/packages/ui/src/AddressView/index.tsx
@@ -7,6 +7,7 @@ import { AddressIcon } from './AddressIcon';
 import { Text } from '../Text';
 import { TextVariant } from '../Text/types';
 import { useDensity, Density as DensityType } from '../utils/density';
+import { isLqtAddressIndex } from '@penumbra-zone/types/address';
 import { Density } from '../Density';
 
 const textVariantByDensity = (density: DensityType): TextVariant => {
@@ -47,7 +48,8 @@ export const AddressViewComponent = ({
   const addressIndex = getAddressIndex.optional(addressView);
 
   // A randomized index has nonzero randomizer bytes
-  const isRandomized = addressIndex?.randomizer.some(v => v);
+  const isLqt = addressIndex && isLqtAddressIndex(addressIndex);
+  const isRandomized = !isLqt && addressIndex?.randomizer.some(v => v);
 
   const encodedAddress = external ? address.altBech32m : bech32mAddress(address);
 
@@ -67,6 +69,7 @@ export const AddressViewComponent = ({
         {addressIndex ? (
           <Text variant={textVariantByDensity(density)} truncate={truncate}>
             {isRandomized && 'IBC Deposit Address for '}
+            {isLqt && 'Tournament Address for '}
             {getAccountLabel(addressIndex.account)}
           </Text>
         ) : (

--- a/packages/wasm/crate/src/keys.rs
+++ b/packages/wasm/crate/src/keys.rs
@@ -80,14 +80,23 @@ pub fn get_wallet_id(full_viewing_key: &[u8]) -> WasmResult<Vec<u8>> {
 /// get address by index using FVK
 /// Arguments:
 ///     full_viewing_key: `byte representation inner FullViewingKey`
-///     index: `u32`
+///     account: `u32`
+///     randomizer: `12 bytes, with 0 bytes representing all 0s implicitly`
 /// Returns: `Uint8Array representing inner Address`
 #[wasm_bindgen]
-pub fn get_address_by_index(full_viewing_key: &[u8], index: u32) -> WasmResult<Vec<u8>> {
+pub fn get_address_by_index(
+    full_viewing_key: &[u8],
+    account: u32,
+    randomizer: &[u8],
+) -> WasmResult<Vec<u8>> {
     utils::set_panic_hook();
 
     let fvk: FullViewingKey = FullViewingKey::decode(full_viewing_key)?;
-    let (address, _dtk) = fvk.incoming().payment_address(index.into());
+    let randomizer: [u8; 12] = randomizer.try_into().unwrap_or_default();
+    let (address, _dtk) = fvk.incoming().payment_address(AddressIndex {
+        account,
+        randomizer,
+    });
     Ok(address.encode_to_vec())
 }
 

--- a/packages/wasm/crate/tests/test_keys.rs
+++ b/packages/wasm/crate/tests/test_keys.rs
@@ -51,7 +51,7 @@ fn generates_wallet_id() {
 fn gets_address_by_index() {
     let spend_key = generate_spend_key(TEST_SEED_PHRASE).unwrap();
     let fvk_bytes = get_full_viewing_key(spend_key.as_slice()).unwrap();
-    let address_bytes = get_address_by_index(fvk_bytes.as_slice(), 0).unwrap();
+    let address_bytes = get_address_by_index(fvk_bytes.as_slice(), 0, &[]).unwrap();
     let address = Address::decode(address_bytes.as_slice()).unwrap();
     assert_eq!(
         address.to_string(),

--- a/packages/wasm/src/keys.ts
+++ b/packages/wasm/src/keys.ts
@@ -21,8 +21,16 @@ export const generateSpendKey = (seedPhrase: string) =>
 export const getFullViewingKey = (spendKey: SpendKey) =>
   FullViewingKey.fromBinary(get_full_viewing_key(spendKey.toBinary()));
 
-export const getAddressByIndex = (fullViewingKey: FullViewingKey, index: number) => {
-  const bytes = get_address_by_index(fullViewingKey.toBinary(), index);
+export const getAddressByIndex = (
+  fullViewingKey: FullViewingKey,
+  account: number,
+  randomizer?: Uint8Array,
+) => {
+  const bytes = get_address_by_index(
+    fullViewingKey.toBinary(),
+    account,
+    randomizer ?? new Uint8Array(),
+  );
   return Address.fromBinary(bytes);
 };
 


### PR DESCRIPTION
## Description of Changes

- Uses a specific LQT randomizer if vote is revealed.
- Adjusts UI components to render it correctly.
- Uses an ephemeral randomizer if vote is not revealed.
- Fixes a bug in the view service where getting the address by index would ignore the randomizer.

## Related Issue

Closes #2266.
Closes #2333.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
