### PR TITLE
fix: display previous epochs table correctly when not connected

### DIFF
--- a/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
+++ b/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
@@ -85,8 +85,8 @@ const PreviousEpochsRow = observer(
           )}
         </TableCell>
 
-        <TableCell cell loading={isLoading || rewardsLoading}>
-          {connected && (rewardsLoading || reward !== undefined) ? (
+        {connected && (rewardsLoading || reward !== undefined) && (
+          <TableCell cell loading={isLoading || rewardsLoading}>
             <ValueViewComponent
               valueView={
                 new ValueView({
@@ -101,10 +101,8 @@ const PreviousEpochsRow = observer(
               }
               priority='tertiary'
             />
-          ) : (
-            <Text color='text.secondary'>–</Text>
-          )}
-        </TableCell>
+          </TableCell>
+        )}
         <TableCell cell loading={isLoading}>
           <Density slim>
             <Button iconOnly icon={ChevronRight}>


### PR DESCRIPTION
## Description of Changes

We were rendering an extra column for the voting rewards, even when the user is not connected, causing a rendering error.

**Before:**
![image](https://github.com/user-attachments/assets/2eba52c6-e559-41e0-8b58-51166377cba4)
**After:**
![image](https://github.com/user-attachments/assets/3e4153ac-e062-472f-a6ff-43852264239e)

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
