### PR TITLE
fix(veil): #2387: "ends in" clock fix

### DIFF
--- a/apps/veil/src/shared/utils/format-time.ts
+++ b/apps/veil/src/shared/utils/format-time.ts
@@ -1,9 +1,17 @@
+import { pluralize } from '@/shared/utils/pluralize';
+
 export const formatTimeRemaining = (seconds: number): string => {
   // Convert to switch state to include hour and day states
   if (seconds < 60) {
-    return `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`;
-  } else {
+    return pluralize(seconds, 'second', 'seconds');
+  } else if (seconds < 3600) {
     const minutes = Math.floor(seconds / 60);
-    return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+    return pluralize(minutes, 'minute', 'minutes');
+  } else if (seconds < 86400) {
+    const hours = Math.floor(seconds / 3600);
+    return pluralize(hours, 'hour', 'hours');
+  } else {
+    const days = Math.floor(seconds / 86400);
+    return pluralize(days, 'day', 'days');
   }
 };


### PR DESCRIPTION
Closes #2387 

Adds support for hours and days in the `formatTimeRemaining` function