### PR TITLE
fix: Previous Epochs table, again (woops)

### DIFF
--- a/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
+++ b/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { ChevronRight } from 'lucide-react';
-import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { ValueViewComponent } from '@penumbra-zone/ui/ValueView';
 import { Pagination } from '@penumbra-zone/ui/Pagination';
 import { TableCell } from '@penumbra-zone/ui/TableCell';
@@ -18,7 +17,7 @@ import type { PreviousEpochData } from '../server/previous-epochs';
 import { useSortableTableHeaders } from './sortable-table-header';
 import { usePersonalRewards } from '../api/use-personal-rewards';
 import { Vote } from './vote';
-import { pnum } from '@penumbra-zone/types/pnum';
+import { toValueView } from '@/shared/utils/value-view';
 
 const TABLE_CLASSES = {
   table: {
@@ -85,22 +84,16 @@ const PreviousEpochsRow = observer(
           )}
         </TableCell>
 
-        {connected && (rewardsLoading || reward !== undefined) && (
+        {connected && (
           <TableCell cell loading={isLoading || rewardsLoading}>
-            <ValueViewComponent
-              valueView={
-                new ValueView({
-                  valueView: {
-                    case: 'knownAssetId',
-                    value: {
-                      amount: pnum(reward?.reward).toAmount(),
-                      metadata: stakingToken,
-                    },
-                  },
-                })
-              }
-              priority='tertiary'
-            />
+            {reward !== undefined ? (
+              <ValueViewComponent
+                valueView={toValueView({ amount: reward.reward, metadata: stakingToken })}
+                priority='tertiary'
+              />
+            ) : (
+              '-'
+            )}
           </TableCell>
         )}
         <TableCell cell loading={isLoading}>


### PR DESCRIPTION
This now makes the previous epochs table work for both connected and not-connected states

now:
![image](https://github.com/user-attachments/assets/fb90f0d2-3b3e-4a35-854e-2077dc678407)
before:
![image](https://github.com/user-attachments/assets/1a728789-7295-4338-ac0f-37c7958e11f9)

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
