### PR TITLE
Fix Perpetual Voting Buttons Loading state

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-current-epoch.ts
+++ b/apps/veil/src/pages/tournament/api/use-current-epoch.ts
@@ -5,6 +5,7 @@ export const useCurrentEpoch = (onChange?: (newEpoch: number) => void) => {
   const {
     data: summary,
     isLoading,
+    isFetched,
     status,
   } = useTournamentSummary({
     limit: 1,
@@ -27,5 +28,6 @@ export const useCurrentEpoch = (onChange?: (newEpoch: number) => void) => {
     epoch: summary?.[0]?.epoch,
     isLoading,
     status,
+    isFetched,
   };
 };

--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -24,17 +24,30 @@ export const useVotingInfo = (defaultEpoch?: number) => {
   const { connected, subaccount } = connectionStore;
   const getMetadata = useGetMetadata();
 
-  const { epoch: currentEpoch, isLoading: loadingEpoch } = useCurrentEpoch();
+  const {
+    epoch: currentEpoch,
+    isLoading: loadingEpoch,
+    isFetched: epochFetched,
+  } = useCurrentEpoch();
   const epoch = defaultEpoch ?? currentEpoch;
   const isEnded = !currentEpoch || !epoch || epoch !== currentEpoch || loadingEpoch;
 
-  const { data: notes, isLoading: loadingNotes } = useLQTNotes(subaccount, epoch, isEnded);
+  const {
+    data: notes,
+    isLoading: loadingNotes,
+    isFetched: notesFetched,
+  } = useLQTNotes(subaccount, epoch, isEnded);
   const { data: votes, isLoading: loadingVotes } = useTournamentVotes(epoch, isEnded);
-  const { data: delegations, isLoading: delegationsLoading } = useAccountDelegations(
-    isEnded || !!notes?.length,
-  );
+  const {
+    data: delegations,
+    isLoading: delegationsLoading,
+    isFetched: delegationsFetched,
+  } = useAccountDelegations(isEnded || !!notes?.length);
 
-  const isLoading = loadingEpoch || loadingNotes || delegationsLoading;
+  const isLoading =
+    (loadingEpoch && !epochFetched) ||
+    (loadingNotes && !notesFetched) ||
+    (delegationsLoading && !delegationsFetched);
   const isVoted = !!votes?.length;
   const isDelegated = !!delegations?.length;
 


### PR DESCRIPTION
## Description of Changes

Closes: https://github.com/penumbra-zone/web/issues/2386

Solution is to only render the loading state when the requests haven't been called yet using the `isFetched` prop.

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
