### PR TITLE
Fix My LP tab loading states

### DIFF
--- a/apps/veil/src/entities/leaderboard/api/use-my-lp-leaderboard.ts
+++ b/apps/veil/src/entities/leaderboard/api/use-my-lp-leaderboard.ts
@@ -4,7 +4,6 @@ import { apiPostFetch } from '@/shared/utils/api-fetch';
 import { penumbra } from '@/shared/const/penumbra';
 import { AddressIndex } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { ViewService } from '@penumbra-zone/protobuf/penumbra/view/v1/view_connect';
-import { statusStore } from '@/shared/model/status';
 import { useCurrentEpoch } from '@/pages/tournament/api/use-current-epoch';
 import {
   LpLeaderboardRequest,
@@ -35,7 +34,6 @@ export const useMyLpLeaderboard = ({
   isActive: boolean;
   assetId: string | undefined;
 }): UseQueryResult<LpLeaderboardResponse> => {
-  const { latestKnownBlockHeight } = statusStore;
   const { epoch: currentEpoch } = useCurrentEpoch();
 
   const { data: positionIds } = useQuery({
@@ -67,7 +65,6 @@ export const useMyLpLeaderboard = ({
       sortKey,
       sortDirection,
       assetId,
-      ...(epoch === currentEpoch ? [Number(latestKnownBlockHeight)] : []),
     ],
     staleTime: Infinity,
     queryFn: async () => {
@@ -85,11 +82,8 @@ export const useMyLpLeaderboard = ({
         assetId,
       } as LpLeaderboardRequest);
     },
-    enabled:
-      typeof epoch === 'number' &&
-      positionIds !== undefined &&
-      isActive &&
-      (epoch === currentEpoch ? !!latestKnownBlockHeight : true),
+    enabled: typeof epoch === 'number' && positionIds !== undefined && isActive,
+    refetchInterval: epoch === currentEpoch ? 10000 : false,
   });
 
   return query;


### PR DESCRIPTION
## Description of Changes

Closes https://github.com/penumbra-zone/web/issues/2399

Caused by updating blockHeights which was part of the query keys. The fix is to use a different approach that keeps the keys the same while refreshing.

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
