### PR TITLE
hotfix: veil

### DIFF
--- a/.changeset/silver-things-bet.md
+++ b/.changeset/silver-things-bet.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Fix styles build

--- a/apps/veil/src/pages/trade/ui/order-form/store/OrderFormStore.ts
+++ b/apps/veil/src/pages/trade/ui/order-form/store/OrderFormStore.ts
@@ -344,7 +344,7 @@ export const useOrderFormStore = () => {
         return false;
       }
 
-      return isMetadataEqual(metadata, asset) && addressIndex.equals(address);
+      return isMetadataEqual(metadata, asset) && addressIndex.account === address.account;
     },
     [addressIndex],
   );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "vite build && pnpm run build:css && pnpm run build:css:prefixed",
+    "build": "vite build && pnpm run build:css:prefixed",
     "build-storybook": "storybook build",
     "build:css": "pnpm exec tailwindcss -c ./tailwind.config.ts -i ./src/styles/main.css -o ./dist/style.css --minify",
     "build:css:prefixed": "pnpm exec tailwindcss -c ./tailwind.config.prefixed.ts -i ./src/styles/main.css -o ./dist/style-prefixed.css --minify",


### PR DESCRIPTION
1. Correct account index comparison in Veil order form
2. CSS build correction for Veil – as a result breaks Minifront pages related to v2 only, so no users will be affected. Will revisit this later