### PR TITLE
dev: support nix env for playwright tests

### DIFF
--- a/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
+++ b/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
@@ -124,7 +124,6 @@ Join now 👇`;
                 Copy Image
               </Button>
               <Button actionType='accent' onClick={() => shareToX(text, url)}>
-                {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Xcom */}
                 <Icon IconComponent={Xcom} size='sm' />
                 Share
               </Button>

--- a/apps/veil/tsconfig.json
+++ b/apps/veil/tsconfig.json
@@ -23,12 +23,14 @@
   },
   "extends": ["@tsconfig/strictest/tsconfig.json", "@tsconfig/vite-react/tsconfig.json"],
   "include": [
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "global.d.ts",
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
     "styles/styles.d.ts",
-    "global.d.ts"
+    ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/flake.nix
+++ b/flake.nix
@@ -21,45 +21,113 @@
         pkgs = import nixpkgs { inherit system overlays; };
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./packages/wasm/crate/rust-toolchain.toml;
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        # We need to handle `harfbuzz` delicately, otherwise libpango complains:
+        # `libpango-1.0.so.0: undefined symbol: hb_ot_color_has_paint`
+        # So we create a binding here and reference it within the playwright deps.
+        harfbuzz = pkgs.harfbuzz;
+
+        # OS dependencies for web browsers, used by playwright integration tests.
+        # Each nixpkg is annotated with the shared object it provides.
+        playwrightLibs = with pkgs; [
+          glib                  # libglib-2.0.so.0, libgio-2.0.so.0
+          glib.out              # Additional search path
+          gobject-introspection # libgobject-2.0.so.0
+          nss                   # libnss3.so, libnssutil3.so
+          nspr                  # libnspr4.so
+          dbus                  # libdbus-1.so.3
+          atk                   # libatk-1.0.so.0
+          at-spi2-atk           # libatk-bridge-2.0.so.0
+          at-spi2-core          # libatspi.so.0
+          expat                 # libexpat.so.1
+          xorg.libX11           # libX11.so.6
+          xorg.libXcomposite    # libXcomposite.so.1
+          xorg.libXdamage       # libXdamage.so.1
+          xorg.libXext          # libXext.so.6
+          xorg.libXfixes        # libXfixes.so.3
+          xorg.libXrandr        # libXrandr.so.2
+          mesa                  # libgbm.so.1
+          xorg.libxcb           # libxcb.so.1
+          libxkbcommon          # libxkbcommon.so.0
+          udev                  # libudev.so.1
+          alsa-lib              # libasound.so.2
+
+          # Additional dependencies that Playwright wants.
+          cups
+          gtk3
+          # Declare harfbuzz dependency prior to pango, so its libs are available for pango.
+          harfbuzz
+          pango
+          cairo
+          freetype
+          fontconfig
+          libdrm
+          libva
+          pipewire
+        ];
+
+        # Additional packages for the dev environment
+        playwrightPackages = with pkgs; [
+          playwright-driver.browsers
+          chromium
+          xvfb-run
+          harfbuzz
+        ];
+
       in with pkgs; with pkgs.lib; let
         # Common development packages for all shells
         commonDevPackages = [
           fd
           file
           firefox
+          gum
+          hyperfine
           jq
           just
+          libuuid
           nodejs_22
           pnpm_10
           postgresql
-          libuuid
           wasm-pack
 
           # for deployment/ci
           doctl
           kubectl
-        ];
+        ] ++ playwrightPackages;
+
+        # The uuid lib is required for social card support.
+        uuidLibPath = pkgs.lib.makeLibraryPath [pkgs.libuuid];
+
         # Common shell hook content
         commonShellHook = ''
           export RUST_LOG="penumbra=debug"
           export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc} # Required for rust-analyzer
           export NEXT_TELEMETRY_DISABLED=1
           export TURBO_TELEMETRY_DISABLED=1
+
           # Override libpath so that builds succeed
-          export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [pkgs.libuuid]}:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="${uuidLibPath}:$LD_LIBRARY_PATH"
+
+          # Export the playwright browsers path, to aid in setting up CI.
+          export _PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+
+          # If this is the first time activating the dev shell, install pnpm
+          if ! test -d node_modules ; then
+            >&2 echo "Local ./node_modules not found, run 'pnpm install'"
+          fi
         '';
       in
       {
         devShells = {
           default = craneLib.devShell {
             name = "penumbra-web devShell";
-            packages = commonDevPackages;
+            packages = commonDevPackages ++ playwrightLibs;
             shellHook = ''
               ${commonShellHook}
             '';
           };
 
-          # Separate opt-in devshell that excludes rust tooling.
+          # Separate opt-in devshell that excludes rust tooling & playwright browsers.
           minimal = pkgs.mkShell {
             name = "minimal penumbra-web devShell";
             packages = commonDevPackages;

--- a/justfile
+++ b/justfile
@@ -22,8 +22,6 @@ clean:
   rm -rf .turbo
   fd -t d node_modules --no-ignore -X rm -r
   fd -t d target --no-ignore -X rm -r
-  fd -t f tsconfig.tsbuildinfo --no-ignore -X rm
-  fd -t d flake-inputs --no-ignore --hidden -X rm -r
 
 # Wrapper for all linting targets
 lint:
@@ -63,13 +61,13 @@ test:
   @just test-turbo
 
 # Run the turbo test suite
-test-turbo:
-   pnpm turbo test
+test-turbo: install
+   pnpm turbo test --cache-dir=.turbo
 
 # Run the Rust test suite
-test-rust:
-   pnpm turbo test:cargo
-   pnpm turbo test:wasm
+test-rust: install
+   pnpm turbo test:cargo --cache-dir=.turbo
+   pnpm turbo test:wasm --cache-dir=.turbo
 
 # Run test suites locally and gather timing information
 benchmark-tests:

--- a/justfile
+++ b/justfile
@@ -16,9 +16,14 @@ compile: install
 
 # Remove all cached build artifacts
 clean:
+  pnpm clean
+  pnpm clean:modules
+  pnpm clean:vitest-mjs
   rm -rf .turbo
   fd -t d node_modules --no-ignore -X rm -r
   fd -t d target --no-ignore -X rm -r
+  fd -t f tsconfig.tsbuildinfo --no-ignore -X rm
+  fd -t d flake-inputs --no-ignore --hidden -X rm -r
 
 # Wrapper for all linting targets
 lint:
@@ -46,15 +51,26 @@ veil:
 veil-container:
   cd ./apps/veil && just container
 
-# Configure OS deps for Playwright tests
-install-playwright: install
-  pnpm playwright install --with-deps chromium
+# Configure Playwright for current nix devshell
+playwright-setup:
+  ./scripts/playwright-setup
+
+# Run all test suites
+test:
+  # Run rust tests
+  @just test-rust
+  # Run turbo playwright tests
+  @just test-turbo
 
 # Run the turbo test suite
-test-turbo: install
-   pnpm turbo test --cache-dir=.turbo
+test-turbo:
+   pnpm turbo test
 
 # Run the Rust test suite
-test-rust: install
-   pnpm turbo test:wasm --cache-dir=.turbo
-   pnpm turbo test:cargo --cache-dir=.turbo
+test-rust:
+   pnpm turbo test:cargo
+   pnpm turbo test:wasm
+
+# Run test suites locally and gather timing information
+benchmark-tests:
+  ./scripts/benchmark-tests

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:strict": "turbo lint:strict",
     "lint:syncpack": "syncpack lint",
     "postinstall": "syncpack list-mismatches",
-    "pretest": "playwright install",
+    "pretest": "./scripts/playwright-setup",
     "test": "turbo test",
     "test:wasm": "turbo test:wasm"
   },

--- a/scripts/benchmark-tests
+++ b/scripts/benchmark-tests
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Developer script to benchmark running the test suite and gather some timing info,
+# to aid in optimizing CI runtimes. Running multiple times illustrates "warm cache"
+# behavior.
+set -euo pipefail
+
+
+# The lint task passes completely, or has at least once. Let's focus on tests for now.
+hyperfine --setup "pnpm install && pnpm build" --warmup 1 --runs 5 \
+  "just lint-rust" \
+  "just lint-turbo" \
+  "just test-rust" \
+  "just test-turbo"
+  "pnpm run all-check"

--- a/scripts/benchmark-tests
+++ b/scripts/benchmark-tests
@@ -6,9 +6,9 @@ set -euo pipefail
 
 
 # The lint task passes completely, or has at least once. Let's focus on tests for now.
-hyperfine --setup "pnpm install && pnpm build" --warmup 1 --runs 5 \
+hyperfine --setup "just clean && pnpm install && pnpm build" --warmup 1 --runs 5 \
   "just lint-rust" \
   "just lint-turbo" \
   "just test-rust" \
-  "just test-turbo"
+  "just test-turbo" \
   "pnpm run all-check"

--- a/scripts/playwright-setup
+++ b/scripts/playwright-setup
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Build script to handle configuring Playwright for running integration tests,
+# both as a "pretest" hook in `package.json` and via manual invocation in CI.
+#
+# By default this will run `pnpm exec playwright install` because that's the sane thing to do,
+# and will work on most normal computers, such as macOS. The bulk of the logic is to handle
+# special cases like non-Playwright-supported Linux distributes, such as Fedora Workstation.
+# Additionally, the special-case logic *only* applies if the script is being run from within
+# a nix devShell. So if you're not using nix, no problem, you don't have to. But if you are, this script
+# will wire up integration testing via Playwright by committing some grave sins in symlink form.
+#
+# Specifically, it will inspect the contents of `~/.cache/ms-playwright`, which is a directory
+# that Playwright will *always* check for browsers. If it finds pre-existing Playwright data,
+# it'll preserve it and emit a warning about tests maybe not working right. If no prior Playwright
+# data exists, it'll configure the symlinks, so that when playwright looks for a headless chromium,
+# it'll find the nix-installed version that's present in the build store.
+set -euo pipefail
+
+# This is a hardcoded value that matches exactly the path Playwright
+# will check within its browser cache dir. This value must be updated
+# whenever the `playwright` npm dependency is changed. If it breaks, mention @conorsch.
+_PLAYWRIGHT_CHROMIUM_HEADLESS_VERSION="1169"
+
+
+# If we're not in a nix shell, then just do the simple thing:
+# defer to playwright docs on default setup strategy.
+if [[ -z "${IN_NIX_SHELL:-}" ]] ; then
+  >&2 echo "Installing playwright..."
+  pnpm exec playwright install
+  exit 0
+fi
+
+# The nix devshell should export this env var; fail if not.
+if [[ -z "$_PLAYWRIGHT_BROWSERS_PATH" ]] ; then
+  gum log --level error --time datetime "_PLAYWRIGHT_BROWSERS_PATH not set"
+  exit 1
+fi
+
+# Make sure we have a target browser to link Playwright to
+nix_chromium_dir="$(fd headless_shell "$_PLAYWRIGHT_BROWSERS_PATH" --follow -t d)"
+
+if [[ -z "$nix_chromium_dir" ]] ; then
+  gum log --level error --time datetime "failed to find chromium headless installation in nix env"
+  exit 2
+fi
+
+# Playwright will *always* check this dir, regardless of env vars like PLAYWRIGHT_BROWSERS_PATH.
+playwright_cache_dir="${HOME:?}/.cache/ms-playwright"
+playwright_chromium_dir="${playwright_cache_dir}/chromium_headless_shell-${_PLAYWRIGHT_CHROMIUM_HEADLESS_VERSION}"
+
+# Create a textbox for displaying a readable message.
+# Also theme it kinda like Penumbra.
+function format_message() {
+  local s
+  s="${1:-}"
+  shift 1
+  gum style \
+    --background "#000000" \
+    --foreground "#FFFFFF" \
+    --border "rounded" \
+    --border-foreground "#FFA500" \
+    --padding "1 2" \
+    --align center \
+    --margin "1" \
+    "$s"
+}
+
+# Inform the user that there's pre-existing Playwright state
+# that we don't want to mess with.
+function display_user_warning() {
+    # Declare message as a heredoc, store it in a var.
+    msg="$(cat <<EOM
+
+Found pre-existing data in Playwright cache dir: $playwright_cache_dir
+The integration testing config for this repo will try to overwrite that content.
+If you don't care about prior Playwright browser cache, remove the directory and rerun the tests:
+
+  rm -r "$playwright_cache_dir"
+
+Otherwise, move the dir aside and re-run the tests:
+
+  mv "$playwright_cache_dir{,.bak}"
+
+Doing so will re-initialize Playwright for specifically this git repo.
+You'll need to remove the dir before setting up Playwright with a different project,
+via 'pnpm playwright install' or similar.
+
+EOM
+)"
+  format_message "$msg"
+}
+
+# Create symlink so that the browser path Playwright uses refers to a browser
+# within the nix-installed package store.
+function setup_playwright_symlink() {
+  gum log --level info --time datetime "Creating browser symlink for playwright to use a nix-managed browser"
+  mkdir -p "$playwright_cache_dir"
+  rm -f "$playwright_chromium_dir"
+  ln -sf "$nix_chromium_dir" -v "$playwright_chromium_dir"
+}
+
+# If we're in CI, it's OK to shove things around.
+if [[ -n "${CI:-}" ]] ; then
+  gum log --level=info --time datetime "Detected CI environment, configuring Playwright for nix devshell"
+  # Clobber the local config
+  mkdir -p "$playwright_cache_dir"
+  gum log --level=debug "Linking '$nix_chromium_dir' -> '$playwright_chromium_dir'"
+  setup_playwright_symlink
+# Handle the Playwright cache dir gently, if we're on a developer machine.
+else
+  gum log --level=debug --time datetime "'CI' env var not set; assuming developer workstation; proceeding carefully"
+  # If the cache dir exists
+  if [[ -e "$playwright_cache_dir" ]] ; then
+    # We check for what exactly matches our expectations:
+    # only one entry, and it's a symlink.
+    playwright_cache_dir_contents="$(fd . "$playwright_cache_dir")"
+    # If the playwright dir has only one entry, and it's a symlink
+    if [[ "$(wc -l <<< "$playwright_cache_dir_contents")" -eq 1 ]] && [[ -L "$playwright_cache_dir_contents" ]] ; then
+      # If we got this far, it's ok to manage and clobber.
+      # Check if anything needs to be done.
+      target="$(readlink "$playwright_cache_dir_contents")"
+      if [[ "$playwright_cache_dir_contents" = "$playwright_chromium_dir" ]] && [[ "$target" = "$nix_chromium_dir" ]] ; then
+        gum log --level debug --time datetime "Playwright setup looks good, making no changes"
+        exit 0
+      else
+        gum log --level debug --time datetime "Found pre-existing single symlink in playwright cache, clobbering"
+        setup_playwright_symlink
+      fi
+    # If the cache dir exists and has multiple entries, then prior Playwright initialization
+    #
+    # was performed, so let's preserve the state and warn.
+    else
+      display_user_warning
+      # Sleep briefly so as not to jerk the UX, given that a large message was displayed.
+      sleep 5
+      # Sleep to ensure warning is visible; presumably we're calling this script in dev tooling,
+      # immediately preceding a scrollback-destroyingly verbose test run.
+      sleep_duration_seconds="20"
+      for i in $(seq 0 "$sleep_duration_seconds") ; do
+          printf '\rResuming script in %s... ' "$(( sleep_duration_seconds - i ))"
+          sleep 1
+      done
+      gum log --level=warn --time datetime "Resuming; integration tests may not work correctly!"
+      exit 0
+    fi
+  # If no prior state was found, OK to set it up!
+  else
+    setup_playwright_symlink
+  fi
+fi

--- a/turbo.json
+++ b/turbo.json
@@ -84,10 +84,12 @@
       "dependsOn": ["build"]
     },
     "test:wasm": {
+      "cache": false,
       "dependsOn": ["compile"],
       "inputs": ["crate/src/**", "crate/Cargo.toml", "crate/Cargo.lock", "crate/tests/**"]
     },
     "test:cargo": {
+      "cache": false,
       "dependsOn": ["^keys"],
       "inputs": ["crate/src/**", "crate/Cargo.toml", "crate/Cargo.lock", "crate/tests/**"]
     }


### PR DESCRIPTION
## Description of Changes

It's somewhat cursed what I'm doing here, but the goal was:

* get playwright tests running under linux, so i can run them locally
* use the nix env to provide tooling
* ergo: run the playwright tests within the devshell

Surprisingly difficult! Playwright demands binaries in a very specific location, and the binaries it downloads are dynamically linked, to paths that will be filtered out of the nix devshell's LD_LIBRARY_PATH, and therefore the browsers won't run. Even if we override the devshell's library path, we'd still be referencing incompatible shared objects.

We can instead install suitable browsers within nix and cache them, although instructing Playwright to use them is actually quite difficult. So we cheat, and create symlinks at the paths Playwright watches, pointing to the nix-downloaded browsers.

Cursed? You bet. Does it work? It does! Although it'll break whenever the `playwright` node deps are bumped. Made top-level var in the wrapper script so that updating the playwright browser version string is straightforward.

## Related Issue

Closes #2411. Refs #2410. 

## Testing and reviewing

In this changeset I've _avoided_ updating the behavior of CI, as assurance that the changes I've made don't break the existing playwright tests. In future work (#2410) I'll revisit CI and pull this logic in. 

If you're reviewing this PR on a mac, verify that nothing in it affects you. If you're reviewing this PR and you use a non-[Playwright-supported Linux distro](https://playwright.dev/docs/intro#system-requirements), and you feel comfortable using a nix devshell, go ahead and blast `just test` and see how it treats you. 

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.

I've not done so, but was careful not to alter actual app code when preparing the diff. 