### PR TITLE
ci: leverage turborepo caching

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -4,7 +4,7 @@ inputs:
   primary-key:
     description: Primary key for the cache
     required: false
-    default: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+    default: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
   restore-prefix:
     description: Restore prefix for the cache
     required: false
@@ -18,11 +18,16 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: nixbuild/nix-quick-install-action@v28
+      uses: nixbuild/nix-quick-install-action@v30
 
     - name: Setup Nix Cache
-      uses: nix-community/cache-nix-action@v5
+      uses: nix-community/cache-nix-action@v6
       with:
         primary-key: ${{ inputs.primary-key }}
         restore-prefixes-first-match: ${{ inputs.restore-prefix }}
         backend: ${{ inputs.backend }}
+
+    - name: Pre-build development shell
+      shell: bash
+      run: |
+        nix develop --command echo "devshell built and cached"

--- a/.github/actions/setup-turbo/action.yml
+++ b/.github/actions/setup-turbo/action.yml
@@ -1,0 +1,32 @@
+name: 'Setup Turbo'
+description: 'Handles cache-wrangling for turborepo setup, including node and rust deps'
+inputs:
+  primary-key:
+    description: Primary key for the cache
+    required: false
+    default: turbo-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+  restore-prefix:
+    description: Restore prefix for the cache
+    required: false
+    default: turbo-${{ runner.os }}-
+  backend:
+    description: Backend to use for caching
+    required: false
+    default: buildjet
+
+runs:
+  using: composite
+  steps:
+    - name: Setup turbo cache
+      uses: buildjet/cache@v4
+      with:
+        path: |
+          .turbo
+          node_modules
+        key: ${{ inputs.primary-key }}
+
+    - name: Install node deps
+      shell: bash
+      # We assume that the "setup-nix" step has already been run,
+      # so that `pnpm` is on the path.
+      run: nix develop --command just install

--- a/.github/workflows/compile-wasm.yml
+++ b/.github/workflows/compile-wasm.yml
@@ -9,25 +9,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - id: compiled
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}
-
       - name: setup nix
         uses: ./.github/actions/setup-nix
         # Optional: override default parameters
         # with:
         #   backend: 'github'
+      #
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
 
-      - name: compile wasm code
-        run: nix develop --command just wasm
+      - name: build the project
+        run: nix develop --command just build
 
       - name: Verify no unexpected file changes (like cargo.lock change)
         run: git diff --exit-code
-        working-directory: packages/wasm/crate
 
       - name: dump rust dependencies for debugging, only on failure
         run: nix develop --command cargo tree --invert penumbra-wasm --edges features

--- a/.github/workflows/deploy-dex-explorer.yml
+++ b/.github/workflows/deploy-dex-explorer.yml
@@ -65,19 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install nix
-        uses: nixbuild/nix-quick-install-action@v28
-
-      - name: setup nix cache
-        uses: nix-community/cache-nix-action@v5
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          backend: buildjet
-
-      # Confirm that the nix devshell is buildable and runs at all.
-      - name: validate nix env
-        run: nix develop --command echo hello
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
 
       - name: save DigitalOcean kubeconfig with short-lived credentials
         run: >

--- a/.github/workflows/deploy-ui-preview-main.yml
+++ b/.github/workflows/deploy-ui-preview-main.yml
@@ -7,37 +7,22 @@ on:
     branches:
       - main
 jobs:
-  turbo-compile:
-    name: Compile
-    uses: ./.github/workflows/compile-wasm.yml
-
   build_and_deploy:
-    needs: turbo-compile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - id: built
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-built
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
 
-      - uses: pnpm/action-setup@v4
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build all packages that UI depends on
-        run: pnpm exec turbo build --cache-dir=.turbo --filter=./packages/ui
+      - name: build all packages, including ui
+        run: nix develop --command just build
 
       - name: Build static site
-        run: pnpm build-storybook
+        run: nix develop --command pnpm build-storybook
         working-directory: packages/ui
 
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/deploy-ui-preview-pr.yml
+++ b/.github/workflows/deploy-ui-preview-pr.yml
@@ -14,33 +14,22 @@ permissions:
   pull-requests: write
 
 jobs:
-  turbo-compile:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    name: Compile
-    uses: ./.github/workflows/compile-wasm.yml
-
   build_and_preview:
     runs-on: ubuntu-latest
-    needs: turbo-compile
     steps:
       - uses: actions/checkout@v4
-      - id: built
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-built
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
 
-      - uses: pnpm/action-setup@v4
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
 
-      - name: Install dependencies
-        run: pnpm install
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
 
-      - name: Build all packages that UI depends on
-        run: pnpm exec turbo build --cache-dir=.turbo --filter=./packages/ui
+      - name: build all packages, including ui
+        run: nix develop --command just build
 
       - name: Build static site
-        run: pnpm build-storybook
+        run: nix develop --command pnpm build-storybook
         working-directory: packages/ui
 
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/deploy-ui-release.yml
+++ b/.github/workflows/deploy-ui-release.yml
@@ -9,37 +9,22 @@ on:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
 jobs:
-  turbo-compile:
-    name: Compile
-    uses: ./.github/workflows/compile-wasm.yml
-
   build_and_deploy:
     runs-on: ubuntu-latest
-    needs: turbo-compile
     steps:
       - uses: actions/checkout@v4
-      - id: built
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-built
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
 
-      - uses: pnpm/action-setup@v4
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build all packages that UI depends on
-        run: pnpm exec turbo build --cache-dir=.turbo --filter=./packages/ui
+      - name: build all packages, including ui
+        run: nix develop --command just build
 
       - name: Build static site
-        run: pnpm build-storybook
+        run: nix develop --command pnpm build-storybook
         working-directory: packages/ui
 
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/packages-release.yml
+++ b/.github/workflows/packages-release.yml
@@ -8,35 +8,17 @@ on:
       - main
 
 jobs:
-  turbo-compile:
-    name: Compile
-    uses: ./.github/workflows/compile-wasm.yml
-
   publish:
     name: Packages Release
     runs-on: buildjet-16vcpu-ubuntu-2204
-    needs: turbo-compile
-
     steps:
       - uses: actions/checkout@v4
-      - id: built
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-built
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm turbo telemetry disable
-      - run: pnpm turbo lint:strict --cache-dir=.turbo
-      - run: pnpm turbo build --cache-dir=.turbo
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
 
       # If there are changesets, this action will create a PR on the repo to version packages
       # If there are none, it will publish newer-versioned public packages to npm
@@ -44,7 +26,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          publish: nix develop --command pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/turbo-ci.yml
+++ b/.github/workflows/turbo-ci.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # this is pretty verbose and repetitive, but github workflows require it
 # the first action is commented, most of those comments apply to all actions
@@ -24,117 +24,57 @@ concurrency:
 # rust cache only used in rust jobs
 
 jobs:
-  turbo-compile:
-    name: Compile
+  turbo-build:
     uses: ./.github/workflows/compile-wasm.yml
 
-  turbo-build:
-    name: Build
+  lint:
     runs-on: buildjet-8vcpu-ubuntu-2204
-    needs: turbo-compile
+    # needs: turbo-build
     steps:
       - uses: actions/checkout@v4
-
-      - id: built
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-built
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
 
       - name: setup nix
         uses: ./.github/actions/setup-nix
 
-      - name: run build
-        run: nix develop --command just build
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
 
-  turbo-lint:
-    name: Lint
-    runs-on: buildjet-8vcpu-ubuntu-2204
-    needs: turbo-build
-    steps:
-      - uses: actions/checkout@v4
+      - name: run all linters
+        run: nix develop --command just lint
 
-      - id: lint
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-lint
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-
-      - name: setup nix
-        uses: ./.github/actions/setup-nix
-
-      - name: lint turbo
-        run: nix develop --command just lint-turbo
-
-  turbo-test:
+  test:
     name: test
-    runs-on: buildjet-8vcpu-ubuntu-2204
-    needs: turbo-build
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: tested
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-test
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-
-      - name: setup playwright cache
-        uses: buildjet/cache@v4
-        with:
-          path: /home/runner/.cache/ms-playwright/
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      # TODO: update nix devshell to support playwright
-      - uses: pnpm/action-setup@v4
-      - uses: buildjet/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm turbo telemetry disable
-      - run: pnpm playwright install --with-deps chromium
-      - run: pnpm turbo test --cache-dir=.turbo
-
-  turbo-lint-rust:
-    name: lint:rust
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    needs: turbo-compile
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: rust-linted
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-lint:rust
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
-
-      - name: setup nix
-        uses: ./.github/actions/setup-nix
-
-      - name: lint rust
-        run: nix develop --command just lint-rust
-
-  turbo-test-rust:
-    name: test:wasm
     runs-on: buildjet-16vcpu-ubuntu-2204
-    needs: turbo-compile
+    # TEMPORARY: dont wait on dependency step, just run it
+    # needs: turbo-build
     steps:
       - uses: actions/checkout@v4
-      - id: tested
-        uses: buildjet/cache@v4
-        with:
-          path: .turbo
-          key: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-test:wasm
-          restore-keys: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.ref }}-${{ github.sha }}-compiled
 
       - name: setup nix
         uses: ./.github/actions/setup-nix
+
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
+
+      - name: install playwright deps
+        run: nix develop --command just playwright-setup
 
       - name: run rust tests
         run: nix develop --command just test-rust
+
+      - name: run turbo tests
+        run: nix develop --command just test-turbo
+
+  all-check:
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup nix
+        uses: ./.github/actions/setup-nix
+
+      - name: setup turbo
+        uses: ./.github/actions/setup-turbo
+
+      - name: run all checks
+        run: nix develop --command pnpm all-check

--- a/justfile
+++ b/justfile
@@ -3,15 +3,15 @@ install:
   pnpm install
 
 # Build the apps via turbo
-build: install
-  pnpm turbo build --cache-dir=.turbo
+build:
+  pnpm turbo build
 
 # Compile the WASM dependencies via turbo
-wasm: install
-  pnpm turbo compile --cache-dir=.turbo
+wasm:
+  pnpm turbo compile
 
 # Compile the WASM dependencies via turbo (alias)
-compile: install
+compile:
   @just wasm
 
 # Remove all cached build artifacts
@@ -29,12 +29,12 @@ lint:
   @just lint-rust
 
 # Lint the turbo resources
-lint-turbo: install
-  pnpm turbo lint:strict --cache-dir=.turbo
+lint-turbo:
+  pnpm turbo lint:strict
 
 # List Rust code
-lint-rust: install
-  pnpm turbo lint:rust --cache-dir=.turbo
+lint-rust:
+  pnpm turbo lint:rust
 
 # Build top-level debug container
 container: clean
@@ -54,20 +54,20 @@ playwright-setup:
   ./scripts/playwright-setup
 
 # Run all test suites
-test:
+test: playwright-setup
   # Run rust tests
   @just test-rust
   # Run turbo playwright tests
   @just test-turbo
 
 # Run the turbo test suite
-test-turbo: install
-   pnpm turbo test --cache-dir=.turbo
+test-turbo: playwright-setup
+   pnpm turbo test
 
 # Run the Rust test suite
-test-rust: install
-   pnpm turbo test:cargo --cache-dir=.turbo
-   pnpm turbo test:wasm --cache-dir=.turbo
+test-rust: playwright-setup
+   pnpm turbo test:cargo
+   pnpm turbo test:wasm
 
 # Run test suites locally and gather timing information
 benchmark-tests:


### PR DESCRIPTION
## Description of Changes

Reduces CI runtime on the primary "Turbo CI" workflow, by:

1. careful management of nix devshell for tooling
2. careful management of `.turbo/` directory for turbo cache
3. removing unnecessary workflow serialization

Rerunning the "Turbo CI" workflow on this changeset shows a 2-3x reduction in wall time:

* [Run 1](https://github.com/penumbra-zone/web/actions/runs/15219766711), 6m5s
* [Run 2](https://github.com/penumbra-zone/web/actions/runs/15219872779), 6m23s
* [Run 3](https://github.com/penumbra-zone/web/actions/runs/15220037312), 6m11s

Whereas previous runs were clocking in at ~15-20m. See more detailed timing info in #2410.

## Related Issue

Closes #2410. 

## Testing and review

First, review and merge https://github.com/penumbra-zone/web/pull/2419, since this PR includes that changeset, as well. Once that PR is merged, the diff here will appear much smaller.

It's worth pointing out there there's still a lot of duplicative work done in the parallel CI jobs, but I'm fine with that: CI minutes are cheap, and preserving the UX of distinct lint and test jobs strikes me as beneficial during a period of heavy churn on this repo.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.

No, I've not done that, but the bulk of this diff applies to CI, so I'm not worried about breakage. 
