### PR TITLE
docs: fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,28 +56,49 @@ General documentation is available in [docs/README.md](docs/README.md). Package-
 
 ### Prerequisites
 
-- [Install Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) (probably with rustup)
-- [Install Wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
-- Install [cargo-watch](https://crates.io/crates/cargo-watch): `cargo install cargo-watch`
-- [Install Node.js](https://nodejs.org/en/download/package-manager) however you like (at least version 20)
-- [Install pnpm](https://pnpm.io/installation) (probably via corepack)
-- Install Google Chrome
+Make sure you have the following tools installed:
+
+- [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) – Recommended via [rustup](https://rustup.rs/)
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) – For building WebAssembly components
+- [cargo-watch](https://crates.io/crates/cargo-watch) – Utility that automatically rebuilds and restarts your project.
+- [Node.js](https://nodejs.org/en/download/package-manager) – Recommended via [nvm](https://github.com/nvm-sh/nvm)
+- [pnpm](https://pnpm.io/installation) – Package manager, recommended via [corepack](https://pnpm.io/installation#using-corepack)
+- Google Chrome installation
 
 ### Building
 
-Once you have all these tools, you can
+#### Install all workspace dependencies:
 
 ```sh
 git clone https://github.com/penumbra-zone/web
 cd web
-pnpm i
-pnpm dev
+pnpm install
+```
+
+#### Build shared packages and watch for changes:
+
+```sh
+pnpm build && pnpm dev:pack
+```
+
+#### In a new terminal, run the minifront app:
+
+```sh
+cd apps/minifront
+pnpm dev:build && pnpm dev:app
+```
+
+#### Alternatively, in a new terminal, run the veil app:
+
+```sh
+cd apps/veil
+pnpm install && pnpm dev
 ```
 
 You now have a local copy of Minifront available at
-[`https://localhost:5173`](https://localhost:5173).
+[`https://localhost:5173`](https://localhost:5173) or Veil available at [`https://localhost:3000`](https://localhost:3000).
 
-Minifront will hot-reload.
+Minifront and Veil will hot-reload.
 
 ## Security
 

--- a/apps/minifront/README.md
+++ b/apps/minifront/README.md
@@ -74,10 +74,11 @@ Prerequisites:
 - Install [pnpm](https://pnpm.io/installation)
 
 ```shell
-pnpm install
-pnpm dev
-# Will be live at https://localhost:5173/
+pnpm install && pnpm dev:build && pnpm dev:app
 ```
+
+You now have a local copy of Minifront available at
+[`https://localhost:5173`](https://localhost:5173).
 
 ## Technologies Used
 

--- a/apps/minifront/package.json
+++ b/apps/minifront/package.json
@@ -8,6 +8,7 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "clean": "rm -rfv dist *.tsbuildinfo",
     "dev:app": "vite --port 5173",
+    "dev:build": "pnpm --filter @penumbra-zone/ui run build",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "lint:strict": "tsc --noEmit && eslint src --max-warnings 0",

--- a/apps/veil/README.md
+++ b/apps/veil/README.md
@@ -1,4 +1,4 @@
-# DEX explorer for Penumbra
+# Veil
 
 A DEX explorer for [Penumbra](https://penumbra.zone/).
 
@@ -53,9 +53,19 @@ you'll want to set are:
 - `PENUMBRA_CHAIN_ID`: the chain id for the network being indexed, controls asset-registry lookups
 - `PENUMBRA_CUILOA_URL`: the URL for a block-explorer application, for generating URLs for more block/transaction info
 
-## Name
+## Build locally
 
-It'd be nice to have a cool name for the DEX explorer. We don't have one yet.
+Prerequisites:
+
+- Install [nodejs](https://nodejs.org/)
+- Install [pnpm](https://pnpm.io/installation)
+
+```shell
+pnpm install && pnpm dev
+```
+
+You now have a local copy of Veil available at
+[`https://localhost:3000`](https://localhost:3000).
 
 ## Proto Generation
 


### PR DESCRIPTION
## Description of Changes

- Updates our build instructions after https://github.com/penumbra-zone/web/pull/2409 to include the required `pnpm dev:build` step in minifront to ensure proper consumption of CSS deps,
- Adds build instructions for Veil in the web root,
- Renames all instances of "dex-explorer" to Veil 

## Related Issue

pairs with https://github.com/prax-wallet/prax/pull/355

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
