### PR TITLE
middleware routing: redirect to portfolio page as default route

### DIFF
--- a/apps/veil/src/shared/api/middleware.ts
+++ b/apps/veil/src/shared/api/middleware.ts
@@ -7,9 +7,8 @@ export const routingMiddleware = async (request: NextRequest) => {
   const { pathname } = request.nextUrl;
 
   if (pathname === '/') {
-    // Redirect the default homepage to the 'explore' page.
-    // TODO: Replace this with a path to a fully designed landing page.
-    return NextResponse.redirect(new URL(`/explore`, request.url));
+    // Redirect the default homepage to the 'portfolio' page.
+    return NextResponse.redirect(new URL(`/portfolio`, request.url));
   }
 
   // Otherwise, route to the default trading pair on the trading page.

--- a/apps/veil/src/widgets/header/ui/links.ts
+++ b/apps/veil/src/widgets/header/ui/links.ts
@@ -5,16 +5,16 @@ import { PagePath } from '@/shared/const/pages';
 export const HEADER_LINKS = [
   {
     as: Link,
-    tabProps: { href: PagePath.Explore },
-    label: 'Explore',
-    value: PagePath.Explore,
+    tabProps: { href: PagePath.Portfolio },
+    label: 'Portfolio',
+    value: PagePath.Portfolio,
     icon: Coins,
   },
   {
     as: Link,
-    tabProps: { href: PagePath.Portfolio },
-    label: 'Portfolio',
-    value: PagePath.Portfolio,
+    tabProps: { href: PagePath.Explore },
+    label: 'Explore',
+    value: PagePath.Explore,
     icon: Coins,
   },
   {


### PR DESCRIPTION
## Description of Changes

- Redirects to the portfolio page as the default route after onboarding,
- Took creative liberty to reorder header tabs to place portfolio first (seems more natural?),
- As a side-effect, the "Manage Portfolio" button in Prax will now redirect to the portfolio page by default, unless the user selects a different minifront frontend, in which case it will redirect to the assets page as before.

Notably, this _doesn't_ require any changes to prax onboarding since we already set the default frontend to veil in extension LS. 

## Related Issue

N/A

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
