### PR TITLE
IBC: fix manual flow for shielding assets

### DIFF
--- a/apps/minifront/src/components/ibc/deposit-manual/assets-table.tsx
+++ b/apps/minifront/src/components/ibc/deposit-manual/assets-table.tsx
@@ -45,7 +45,7 @@ export const AssetsTable = () => {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className='w-[100px]'>Denom</TableHead>
+            <TableHead className='w-[100px]'>Asset</TableHead>
             <TableHead className='text-right'>Amount</TableHead>
           </TableRow>
         </TableHeader>

--- a/apps/minifront/src/components/ibc/deposit-manual/chain-dropdown.tsx
+++ b/apps/minifront/src/components/ibc/deposit-manual/chain-dropdown.tsx
@@ -71,7 +71,7 @@ export const ChainDropdown = () => {
               <span className='mt-0.5'>{selected?.label}</span>
             </div>
           ) : (
-            'Shield assets from'
+            'Select Source Chain'
           )}
           <ChevronsUpDown className='ml-2 size-4 shrink-0 opacity-50' />
         </Button>

--- a/apps/minifront/src/components/ibc/deposit-manual/ibc-in-request.tsx
+++ b/apps/minifront/src/components/ibc/deposit-manual/ibc-in-request.tsx
@@ -38,7 +38,7 @@ export const IbcInRequest = () => {
 
   return (
     <div className='flex flex-col items-center gap-2'>
-      <div className='font-bold text-white'>Issue Ibc-in Request</div>
+      <div className='font-bold text-white'>Initiate Shielding Transfer</div>
       {isUnsupportedAsset && (
         <div className='justify-center rounded bg-amber-200 p-2 text-center italic text-stone-700'>
           Note: only <b>native</b> assets at this time are eligible for ibc&apos;ing in. Unwind them
@@ -53,12 +53,14 @@ export const IbcInRequest = () => {
           <SelectContent className='max-w-52 bg-white text-stone-700'>
             {data.map(b => (
               <SelectItem value={b.displayDenom} key={b.displayDenom}>
-                <div className='flex items-center gap-2 text-stone-700'>
+                <div className='flex items-center gap-2 text-stone-700 max-w-[180px]'>
                   <Avatar className='size-6'>
                     <AvatarImage src={getIconWithUmFallback(b)} />
                     <Identicon uniqueIdentifier={b.displayDenom} type='gradient' size={22} />
                   </Avatar>
-                  <span className=''>{b.displayDenom}</span>
+                  <span className='truncate text-sm' title={b.displayDenom}>
+                    {b.displayDenom}
+                  </span>
                 </div>
               </SelectItem>
             ))}

--- a/apps/minifront/src/components/ibc/tabs.ts
+++ b/apps/minifront/src/components/ibc/tabs.ts
@@ -3,7 +3,7 @@ import { PagePath } from '../metadata/paths.ts';
 export type ShieldTab = PagePath.DEPOSIT_SKIP | PagePath.DEPOSIT_MANUAL | PagePath.WITHDRAW;
 
 export const shieldTabs = [
-  { title: 'Deposit (Skip)', href: PagePath.DEPOSIT_SKIP, enabled: true },
-  { title: 'Deposit (Manual)', href: PagePath.DEPOSIT_MANUAL, enabled: true },
-  { title: 'Withdraw', href: PagePath.WITHDRAW, enabled: true },
+  { title: 'Deposit with Skip', href: PagePath.DEPOSIT_SKIP, enabled: true },
+  { title: 'Manual Deposit', href: PagePath.DEPOSIT_MANUAL, enabled: true },
+  { title: 'Withdraw Funds', href: PagePath.WITHDRAW, enabled: true },
 ];

--- a/packages/ui-deprecated/components/ui/button/index.tsx
+++ b/packages/ui-deprecated/components/ui/button/index.tsx
@@ -50,10 +50,14 @@ export interface ButtonProps
 }
 
 // Converted from forwardRef to regular component
-const Button = ({ className, variant, size, asChild = false, ref, ...props }: ButtonProps) => {
-  const Comp = asChild ? Slot : 'button';
-  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
-};
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />
+    );
+  },
+);
 Button.displayName = 'Button';
 
 export { Button, buttonVariants };

--- a/packages/ui-deprecated/components/ui/command/index.tsx
+++ b/packages/ui-deprecated/components/ui/command/index.tsx
@@ -11,16 +11,12 @@ export interface CommandProps extends React.ComponentPropsWithoutRef<typeof Comm
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const Command = ({ className, ref, ...props }: CommandProps) => (
-  <CommandPrimitive
-    ref={ref}
-    className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
-      className,
-    )}
-    {...props}
-  />
-);
+const Command = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive ref={ref} className={cn('...', className)} {...props} />
+));
 Command.displayName = CommandPrimitive.displayName;
 
 type CommandDialogProps = DialogProps;
@@ -42,20 +38,22 @@ export interface CommandInputProps
   ref?: React.Ref<HTMLInputElement>;
 }
 
-const CommandInput = ({ className, ref, ...props }: CommandInputProps) => (
-  // eslint-disable-next-line react/no-unknown-property -- TODO: justify
+const CommandInput = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
   <div className='flex items-center border-b px-3' cmdk-input-wrapper=''>
     <Search className='mr-2 size-4 shrink-0 opacity-50' />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        'flex h-11 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground',
         className,
       )}
       {...props}
     />
   </div>
-);
+));
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 export interface CommandListProps
@@ -63,13 +61,16 @@ export interface CommandListProps
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const CommandList = ({ className, ref, ...props }: CommandListProps) => (
+const CommandList = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
     className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
     {...props}
   />
-);
+));
 CommandList.displayName = CommandPrimitive.List.displayName;
 
 export interface CommandEmptyProps
@@ -91,16 +92,16 @@ export interface CommandGroupProps
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const CommandGroup = ({ className, ref, ...props }: CommandGroupProps) => (
+const CommandGroup = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
     ref={ref}
-    className={cn(
-      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
-      className,
-    )}
+    className={cn('overflow-hidden p-1 text-foreground', className)}
     {...props}
   />
-);
+));
 CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 export interface CommandSeparatorProps
@@ -122,16 +123,19 @@ export interface CommandItemProps
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const CommandItem = ({ className, ref, ...props }: CommandItemProps) => (
+const CommandItem = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground',
       className,
     )}
     {...props}
   />
-);
+));
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {


### PR DESCRIPTION
## Description of Changes

- fixes side-effect of some breakage from https://github.com/penumbra-zone/web/issues/2420 where assets couldn't be selected when manually shielding,
- truncates overflow IBC asset id for manual deposits 

## Related Issue

https://github.com/penumbra-zone/web/issues/2420 and https://github.com/penumbra-zone/web/issues/2382

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
