### PR TITLE
fix: minifront-v2 avoid dev server port contention

### DIFF
--- a/apps/minifront-v2/package.json
+++ b/apps/minifront-v2/package.json
@@ -5,7 +5,7 @@
   "license": "(MIT OR Apache-2.0)",
   "type": "module",
   "scripts": {
-    "dev:app": "vite --port 5173"
+    "dev:app": "vite --port 5175"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",


### PR DESCRIPTION
provides a port number for `minifront-v2`'s `dev:app` script that is not in use by another `dev:app` script