### PR TITLE
fix(veil): #2437: vote percentage round

### DIFF
--- a/apps/veil/src/pages/tournament/ui/lp-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/lp-rewards.tsx
@@ -1,6 +1,6 @@
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { observer } from 'mobx-react-lite';
-import { useRouter } from 'next/navigation';
 import { ChevronRight, ExternalLink } from 'lucide-react';
 import { bech32mPositionId } from '@penumbra-zone/bech32m/plpid';
 import { ValueViewComponent } from '@penumbra-zone/ui/ValueView';
@@ -30,15 +30,12 @@ interface LpRewardRowData extends LpReward {
 }
 
 function LpRewardRow({ lpReward, padStart }: { lpReward: LpRewardRowData; padStart?: number }) {
-  const router = useRouter();
   const id = bech32mPositionId(lpReward.positionId);
 
   return (
-    <div
-      onClick={() => {
-        router.push(`/inspect/lp/${id}`);
-      }}
+    <Link
       className='grid grid-cols-subgrid col-span-5 hover:bg-action-hoverOverlay transition-colors cursor-pointer'
+      href={`/inspect/lp/${id}`}
     >
       <TableCell cell>#{lpReward.epoch}</TableCell>
       <TableCell cell>
@@ -85,7 +82,7 @@ function LpRewardRow({ lpReward, padStart }: { lpReward: LpRewardRowData; padSta
           </Button>
         </Density>
       </TableCell>
-    </div>
+    </Link>
   );
 }
 

--- a/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
@@ -44,7 +44,7 @@ const VotingRewardsRow = ({ row, padStart }: VotingRewardsRowProps) => {
         <span className='font-mono whitespace-pre'>
           {round({
             value: (row.power / row.summary.total_voting_power) * 100,
-            decimals: 2,
+            decimals: 3,
           }).padStart(6, '\u00A0')}
           % for
         </span>

--- a/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
+++ b/apps/veil/src/pages/tournament/ui/total-delegator-rewards.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { ChevronRight } from 'lucide-react';
@@ -34,7 +35,10 @@ interface VotingRewardsRowProps {
 
 const VotingRewardsRow = ({ row, padStart }: VotingRewardsRowProps) => {
   return (
-    <div className='grid grid-cols-subgrid col-span-4'>
+    <Link
+      className='grid grid-cols-subgrid col-span-4 hover:bg-action-hoverOverlay'
+      href={`/tournament/${row.epoch}`}
+    >
       <TableCell cell>{`Epoch #${row.epoch}`}</TableCell>
       <TableCell cell>
         <span className='font-mono whitespace-pre'>
@@ -65,7 +69,7 @@ const VotingRewardsRow = ({ row, padStart }: VotingRewardsRowProps) => {
           </Button>
         </Density>
       </TableCell>
-    </div>
+    </Link>
   );
 };
 
@@ -149,7 +153,7 @@ export const VotingRewards = observer(() => {
   return (
     <>
       <Density compact>
-        <div className='grid grid-cols-[auto_1fr_1fr_32px]'>
+        <div className='grid grid-cols-[auto_1fr_1fr_48px]'>
           <div className='grid grid-cols-subgrid col-span-4'>
             {getTableHeader('epoch', 'Epoch')}
             <TableCell heading>Casted Vote</TableCell>

--- a/apps/veil/src/pages/tournament/ui/vote.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
 import { Text } from '@penumbra-zone/ui/Text';
+import { round } from '@penumbra-zone/types/round';
 
 export interface VoteProps {
   asset: Metadata;
@@ -13,7 +14,7 @@ export const Vote = ({ asset, percent, hideFor }: VoteProps) => {
     <div className='flex items-center gap-1'>
       <AssetIcon metadata={asset} />
       <Text smallTechnical color='text.primary'>
-        {percent * 100}% {hideFor ? '' : 'for'}
+        {round({ value: percent * 100, decimals: 2 })}% {hideFor ? '' : 'for'}
       </Text>
       <Text smallTechnical color='text.secondary'>
         {asset.symbol}

--- a/apps/veil/src/pages/tournament/ui/vote.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote.tsx
@@ -14,7 +14,7 @@ export const Vote = ({ asset, percent, hideFor }: VoteProps) => {
     <div className='flex items-center gap-1'>
       <AssetIcon metadata={asset} />
       <Text smallTechnical color='text.primary'>
-        {round({ value: percent * 100, decimals: 2 })}% {hideFor ? '' : 'for'}
+        {round({ value: percent * 100, decimals: 3 })}% {hideFor ? '' : 'for'}
       </Text>
       <Text smallTechnical color='text.secondary'>
         {asset.symbol}


### PR DESCRIPTION
Closes #2437 

Additionally, this PR uses Link component instead of programmatic routing in delegator history tables and fixes asset icon display in delegator voting rewards. Previously, all assets were unknown like here:

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/4ed05a26-557d-4c37-83c6-d45961328ec3" />

Now, it renders like this:

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/022a04a7-dab7-4b2d-9787-1e298dfe62ea" />

Some old assets are undefined. I think it was before the switch to phobos-3 chainId, – all assets had different ids