### PR TITLE
build: support build-time BASE_URL

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,7 +16,7 @@ on:
   # Temporary: build on PRs, to make sure workflow succeeds
   pull_request:
 jobs:
-  veil:
+  veil-testnet:
     runs-on: buildjet-16vcpu-ubuntu-2204
     permissions:
       contents: read
@@ -52,5 +52,52 @@ jobs:
           platforms: linux/amd64
           file: ci/containerfiles/Containerfile-veil
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ghcr.io/penumbra-zone/veil:testnet
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_URL=https://dex-explorer.testnet.plinfra.net
+
+  veil-mainnet:
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Docker Hub container registry (for pulls)
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the GitHub container registry (for pushes)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/penumbra-zone/veil
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          file: ci/containerfiles/Containerfile-veil
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ghcr.io/penumbra-zone/veil:mainnet
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_URL=https://dex-explorer.mainnet.plinfra.net

--- a/ci/containerfiles/Containerfile-veil
+++ b/ci/containerfiles/Containerfile-veil
@@ -1,3 +1,7 @@
+# The full URL of the site where veil will be hosted,
+# e.g. `https://dex.penumbra.zone`.
+ARG BASE_URL="http://localhost:3000"
+
 # Container image for Veil, a block explorer for Penumbra.
 ARG NODE_MAJOR_VERSION=22
 FROM docker.io/library/node:${NODE_MAJOR_VERSION} AS base
@@ -37,6 +41,10 @@ RUN pnpm install --frozen-lockfile
 # build command. TODO: use `prebuild` steps in the dep packages
 # to ensure a clean dependency graph.
 RUN pnpm build
+
+# Reference the build arg to set NEXT_PUBLIC_BASE_URL, which the NextJS build process
+# will respect, and bake into the emitted docroot.
+ENV NEXT_PUBLIC_BASE_URL=$BASE_URL
 
 # Build the veil app, filtering for relevant dependencies.
 RUN pnpm -r --filter "penumbra-veil..." build


### PR DESCRIPTION
## Description of Changes

Here we introduce a container build-arg that permits overriding the `NEXT_PUBLIC_BASE_URL` env var for the nextjs prod build. This is not a comprehensive solution: there's a slew of `process.env` calls scattered around the Veil codebase. Cleaning up the interface for obtaining runtime config in client-side can wait, however; right now, I'm shoving things around to keep the deploys flowing in their current forms, so that hotfixes to Veil land immediately.

## Related Issue

Refs #2436.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
