### PR TITLE
fix(minifront): reduce time to load the connect page

### DIFF
--- a/apps/minifront/src/abort-loader.ts
+++ b/apps/minifront/src/abort-loader.ts
@@ -47,8 +47,7 @@ const throwIfProviderNotInstalled = () => {
  */
 export const abortLoader = async (): Promise<null> => {
   throwIfProviderNotInstalled();
-  // Increased timeout from 500ms to 3000ms to allow reconnection to complete
-  await retry(() => Boolean(penumbra.connected), 3000);
+  await retry(() => Boolean(penumbra.connected), 500);
   throwIfProviderNotConnected();
 
   // Loaders are required to return a value, even if it's null. By returning


### PR DESCRIPTION
## Description of Changes

A previous PR https://github.com/penumbra-zone/web/pull/2451 unintentionally increased the timeout of the initial load in Minifront in favor of fixing an edge case (connect issue). This PR uses a reduced timeout to restore the UX for first, unconnected visits of Minifront. 

## Related Issue
https://github.com/penumbra-zone/web/issues/2460

