### PR TITLE
fix(ui): #2405: center dialog for XL screens

### DIFF
--- a/.changeset/plenty-worlds-study.md
+++ b/.changeset/plenty-worlds-study.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Fix dialog component placement for XL screens

--- a/packages/ui/src/Dialog/Content.tsx
+++ b/packages/ui/src/Dialog/Content.tsx
@@ -31,7 +31,6 @@ export const Content = ({
 
   return (
     <EmptyContent zIndex={zIndex}>
-      {/* TODO: this display breaks dialogs on large screens */}
       <Display>
         <Grid container>
           <Grid mobile={0} tablet={2} desktop={3} xl={4} />

--- a/packages/ui/src/Display/index.tsx
+++ b/packages/ui/src/Display/index.tsx
@@ -21,7 +21,7 @@ export interface DisplayProps {
 export const Display = ({ children }: DisplayProps) => {
   return (
     <section className='px-4 py-0 desktop:px-8'>
-      <div className='max-w-screen-xl'>{children}</div>
+      <div className='mx-auto max-w-screen-xl'>{children}</div>
     </section>
   );
 };


### PR DESCRIPTION
Closes #2405 

XL screens were hitting the maximum width of content, and without proper centering it was moving the dialog to the left