### PR TITLE
fix(veil): #2468: persist subaccount

### DIFF
--- a/apps/veil/src/shared/model/connection/index.ts
+++ b/apps/veil/src/shared/model/connection/index.ts
@@ -95,6 +95,7 @@ class ConnectionStateStore {
 
     try {
       await penumbra.disconnect();
+      localStorage.removeItem(SUBACCOUNT_LS_KEY);
     } catch (error) {
       console.error(error);
     } finally {


### PR DESCRIPTION
Closes #2468 

Saves the selected subaccount index in LocalStorage and retrieves it on connect and reconnect to Prax. Stops persisting when user chooses to disconnect their wallet.