### PR TITLE
LP leaderboard: fix asset selector

### DIFF
--- a/apps/veil/src/entities/leaderboard/ui/table.tsx
+++ b/apps/veil/src/entities/leaderboard/ui/table.tsx
@@ -172,107 +172,105 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
                   </div>
                 ))
               ) : (
-                <>
-                  <div ref={parent} className='contents col-span-6'>
-                    {positions?.length ? (
-                      positions.map(position => {
-                        return (
-                          <Link
-                            key={position.positionIdString}
-                            href={`/inspect/lp/${position.positionIdString}`}
-                            className={cn(
-                              'relative grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] col-span-6',
-                              'bg-transparent hover:bg-action-hoverOverlay transition-colors',
-                              '[&>*]:h-auto',
-                            )}
-                          >
-                            <TableCell cell>
-                              <div className='flex max-w-[104px]'>
-                                <Text smallTechnical color='text.primary' truncate>
-                                  {position.positionIdString}
-                                </Text>
-                                <span>
-                                  <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
-                                </span>
-                              </div>
-                            </TableCell>
-                            <TableCell cell>
-                              <Text smallTechnical>{position.executions}</Text>
-                            </TableCell>
-                            <TableCell cell loading={isLoading}>
-                              <Text smallTechnical>
-                                {round({ value: position.pointsShare * 100, decimals: 2 })}%
-                              </Text>
-                            </TableCell>
-                            {/* @TODO add age & pnlPercentage */}
-                            {/* <TableCell cell numeric loading={isLoading}>
-                        <Text
-                          smallTechnical
-                          color={
-                            position.pnlPercentage >= 0 ? 'success.light' : 'destructive.light'
-                          }
+                <div ref={parent} className='contents col-span-6'>
+                  {positions?.length ? (
+                    positions.map(position => {
+                      return (
+                        <Link
+                          key={position.positionIdString}
+                          href={`/inspect/lp/${position.positionIdString}`}
+                          className={cn(
+                            'relative grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] col-span-6',
+                            'bg-transparent hover:bg-action-hoverOverlay transition-colors',
+                            '[&>*]:h-auto',
+                          )}
                         >
-                          {position.pnlPercentage}%
-                        </Text>
-                      </TableCell> */}
-                            {/* <TableCell cell numeric>
-                        {formatAge(position.openingTime)}
-                      </TableCell> */}
-                            <TableCell cell>
-                              <div className='flex gap-1 flex-col'>
-                                <ValueViewComponent
-                                  valueView={pnum(position.umVolume).toValueView(umMetadata)}
-                                  abbreviate={true}
-                                  density='slim'
-                                />
-                                <ValueViewComponent
-                                  valueView={pnum(position.assetVolume).toValueView(
-                                    getAssetMetadata(position.assetId),
-                                  )}
-                                  abbreviate={true}
-                                  density='slim'
-                                />
-                              </div>
-                            </TableCell>
-                            <TableCell cell>
-                              <div className='flex gap-1 flex-col'>
-                                <ValueViewComponent
-                                  valueView={pnum(position.umFees).toValueView(umMetadata)}
-                                  abbreviate={true}
-                                  density='slim'
-                                />
-                                <ValueViewComponent
-                                  valueView={pnum(position.assetFees).toValueView(
-                                    getAssetMetadata(position.assetId),
-                                  )}
-                                  abbreviate={true}
-                                  density='slim'
-                                />
-                              </div>
-                            </TableCell>
-                            <TableCell cell>
-                              <Text smallTechnical>
-                                {stateToString(position.position.state?.state)}
-                              </Text>
-                            </TableCell>
-                          </Link>
-                        );
-                      })
-                    ) : (
-                      <div className='col-span-6'>
-                        <div className='grid grid-cols-subgrid col-span-4'>
                           <TableCell cell>
-                            <span className='!text-sm'>
-                              {tab === Tabs.AllLPs
-                                ? 'There are no liquidity positions in this epoch.'
-                                : 'Your LPs have not received any rewards during this epoch.'}
-                            </span>
+                            <div className='flex max-w-[104px]'>
+                              <Text smallTechnical color='text.primary' truncate>
+                                {position.positionIdString}
+                              </Text>
+                              <span>
+                                <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
+                              </span>
+                            </div>
                           </TableCell>
-                        </div>
+                          <TableCell cell>
+                            <Text smallTechnical>{position.executions}</Text>
+                          </TableCell>
+                          <TableCell cell loading={isLoading}>
+                            <Text smallTechnical>
+                              {round({ value: position.pointsShare * 100, decimals: 2 })}%
+                            </Text>
+                          </TableCell>
+                          {/* @TODO add age & pnlPercentage */}
+                          {/* <TableCell cell numeric loading={isLoading}>
+                      <Text
+                        smallTechnical
+                        color={
+                          position.pnlPercentage >= 0 ? 'success.light' : 'destructive.light'
+                        }
+                      >
+                        {position.pnlPercentage}%
+                      </Text>
+                    </TableCell> */}
+                          {/* <TableCell cell numeric>
+                      {formatAge(position.openingTime)}
+                    </TableCell> */}
+                          <TableCell cell>
+                            <div className='flex gap-1 flex-col'>
+                              <ValueViewComponent
+                                valueView={pnum(position.umVolume).toValueView(umMetadata)}
+                                abbreviate={true}
+                                density='slim'
+                              />
+                              <ValueViewComponent
+                                valueView={pnum(position.assetVolume).toValueView(
+                                  getAssetMetadata(position.assetId),
+                                )}
+                                abbreviate={true}
+                                density='slim'
+                              />
+                            </div>
+                          </TableCell>
+                          <TableCell cell>
+                            <div className='flex gap-1 flex-col'>
+                              <ValueViewComponent
+                                valueView={pnum(position.umFees).toValueView(umMetadata)}
+                                abbreviate={true}
+                                density='slim'
+                              />
+                              <ValueViewComponent
+                                valueView={pnum(position.assetFees).toValueView(
+                                  getAssetMetadata(position.assetId),
+                                )}
+                                abbreviate={true}
+                                density='slim'
+                              />
+                            </div>
+                          </TableCell>
+                          <TableCell cell>
+                            <Text smallTechnical>
+                              {stateToString(position.position.state?.state)}
+                            </Text>
+                          </TableCell>
+                        </Link>
+                      );
+                    })
+                  ) : (
+                    <div className='col-span-6'>
+                      <div className='grid grid-cols-subgrid col-span-4'>
+                        <TableCell cell>
+                          <span className='!text-sm'>
+                            {tab === Tabs.AllLPs
+                              ? 'There are no liquidity positions in this epoch.'
+                              : 'Your LPs have not received any rewards during this epoch.'}
+                          </span>
+                        </TableCell>
                       </div>
-                    )}
-                  </div>
-                </>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
 

--- a/apps/veil/src/entities/leaderboard/ui/table.tsx
+++ b/apps/veil/src/entities/leaderboard/ui/table.tsx
@@ -80,7 +80,7 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
 
   const {
     data: assetsData,
-    isLoading: { isLoadingGauge },
+    isLoading: isLoadingGauge,
     assetGauges,
   } = useEpochResults('epoch-results-vote-dialog', {
     epoch,
@@ -152,10 +152,7 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
               </div>
             )}
 
-            <div
-              ref={parent}
-              className='grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] h-auto overflow-auto'
-            >
+            <div className='grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] h-auto overflow-auto'>
               <div className='grid grid-cols-subgrid col-span-6'>
                 <TableCell heading>Position ID</TableCell>
                 {getTableHeader('executions', 'Execs')}
@@ -184,38 +181,39 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
                 ))
               ) : (
                 <>
-                  {positions?.length ? (
-                    positions.map(position => {
-                      return (
-                        <Link
-                          key={position.positionIdString}
-                          href={`/inspect/lp/${position.positionIdString}`}
-                          className={cn(
-                            'relative grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] col-span-6',
-                            'bg-transparent hover:bg-action-hoverOverlay transition-colors',
-                            '[&>*]:h-auto',
-                          )}
-                        >
-                          <TableCell cell>
-                            <div className='flex max-w-[104px]'>
-                              <Text smallTechnical color='text.primary' truncate>
-                                {position.positionIdString}
+                  <div ref={parent} className='contents col-span-6'>
+                    {positions?.length ? (
+                      positions.map(position => {
+                        return (
+                          <Link
+                            key={position.positionIdString}
+                            href={`/inspect/lp/${position.positionIdString}`}
+                            className={cn(
+                              'relative grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] col-span-6',
+                              'bg-transparent hover:bg-action-hoverOverlay transition-colors',
+                              '[&>*]:h-auto',
+                            )}
+                          >
+                            <TableCell cell>
+                              <div className='flex max-w-[104px]'>
+                                <Text smallTechnical color='text.primary' truncate>
+                                  {position.positionIdString}
+                                </Text>
+                                <span>
+                                  <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
+                                </span>
+                              </div>
+                            </TableCell>
+                            <TableCell cell>
+                              <Text smallTechnical>{position.executions}</Text>
+                            </TableCell>
+                            <TableCell cell loading={isLoading}>
+                              <Text smallTechnical>
+                                {round({ value: position.pointsShare * 100, decimals: 2 })}%
                               </Text>
-                              <span>
-                                <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
-                              </span>
-                            </div>
-                          </TableCell>
-                          <TableCell cell>
-                            <Text smallTechnical>{position.executions}</Text>
-                          </TableCell>
-                          <TableCell cell loading={isLoading}>
-                            <Text smallTechnical>
-                              {round({ value: position.pointsShare * 100, decimals: 2 })}%
-                            </Text>
-                          </TableCell>
-                          {/* @TODO add age & pnlPercentage */}
-                          {/* <TableCell cell numeric loading={isLoading}>
+                            </TableCell>
+                            {/* @TODO add age & pnlPercentage */}
+                            {/* <TableCell cell numeric loading={isLoading}>
                         <Text
                           smallTechnical
                           color={
@@ -225,62 +223,63 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
                           {position.pnlPercentage}%
                         </Text>
                       </TableCell> */}
-                          {/* <TableCell cell numeric>
+                            {/* <TableCell cell numeric>
                         {formatAge(position.openingTime)}
                       </TableCell> */}
+                            <TableCell cell>
+                              <div className='flex gap-1 flex-col'>
+                                <ValueViewComponent
+                                  valueView={pnum(position.umVolume).toValueView(umMetadata)}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                                <ValueViewComponent
+                                  valueView={pnum(position.assetVolume).toValueView(
+                                    getAssetMetadata(position.assetId),
+                                  )}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                              </div>
+                            </TableCell>
+                            <TableCell cell>
+                              <div className='flex gap-1 flex-col'>
+                                <ValueViewComponent
+                                  valueView={pnum(position.umFees).toValueView(umMetadata)}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                                <ValueViewComponent
+                                  valueView={pnum(position.assetFees).toValueView(
+                                    getAssetMetadata(position.assetId),
+                                  )}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                              </div>
+                            </TableCell>
+                            <TableCell cell>
+                              <Text smallTechnical>
+                                {stateToString(position.position.state?.state)}
+                              </Text>
+                            </TableCell>
+                          </Link>
+                        );
+                      })
+                    ) : (
+                      <div className='col-span-6'>
+                        <div className='grid grid-cols-subgrid col-span-4'>
                           <TableCell cell>
-                            <div className='flex gap-1 flex-col'>
-                              <ValueViewComponent
-                                valueView={pnum(position.umVolume).toValueView(umMetadata)}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                              <ValueViewComponent
-                                valueView={pnum(position.assetVolume).toValueView(
-                                  getAssetMetadata(position.assetId),
-                                )}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                            </div>
+                            <span className='!text-sm'>
+                              {tab === Tabs.AllLPs
+                                ? 'There are no liquidity positions in this epoch.'
+                                : 'Your LPs have not received any rewards during this epoch.'}
+                            </span>
                           </TableCell>
-                          <TableCell cell>
-                            <div className='flex gap-1 flex-col'>
-                              <ValueViewComponent
-                                valueView={pnum(position.umFees).toValueView(umMetadata)}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                              <ValueViewComponent
-                                valueView={pnum(position.assetFees).toValueView(
-                                  getAssetMetadata(position.assetId),
-                                )}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                            </div>
-                          </TableCell>
-                          <TableCell cell>
-                            <Text smallTechnical>
-                              {stateToString(position.position.state?.state)}
-                            </Text>
-                          </TableCell>
-                        </Link>
-                      );
-                    })
-                  ) : (
-                    <div className='col-span-6'>
-                      <div className='grid grid-cols-subgrid col-span-4'>
-                        <TableCell cell>
-                          <span className='!text-sm'>
-                            {tab === Tabs.AllLPs
-                              ? 'There are no liquidity positions in this epoch.'
-                              : 'Your LPs have not received any rewards during this epoch.'}
-                          </span>
-                        </TableCell>
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </>
               )}
             </div>

--- a/apps/veil/src/entities/leaderboard/ui/table.tsx
+++ b/apps/veil/src/entities/leaderboard/ui/table.tsx
@@ -78,11 +78,7 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
     isActive: isMyTab,
   });
 
-  const {
-    data: assetsData,
-    isLoading: isLoadingGauge,
-    assetGauges,
-  } = useEpochResults('epoch-results-vote-dialog', {
+  const { data: assetsData, assetGauges } = useEpochResults('epoch-results-vote-dialog', {
     epoch,
     limit: 30,
     page: 1,
@@ -114,16 +110,12 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
           </Text>
 
           <div className='rounded-full overflow-hidden'>
-            {isLoadingGauge ? (
-              <div className='h-10 w-48 animate-pulse rounded-full bg-neutral-light' />
-            ) : (
-              <AssetSelector
-                assets={metadataAssets}
-                balances={undefined}
-                value={selectedAsset}
-                onChange={setSelectedAsset}
-              />
-            )}
+            <AssetSelector
+              assets={metadataAssets}
+              balances={undefined}
+              value={selectedAsset}
+              onChange={setSelectedAsset}
+            />
           </div>
         </div>
 

--- a/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
+++ b/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
@@ -134,7 +134,7 @@ export const PreviousEpochs = observer(() => {
   return (
     <div className='flex flex-col gap-6 p-6 w-full rounded-lg bg-other-tonalFill5 backdrop-blur-lg'>
       <Text xxl color='text.primary'>
-        Previous epochs
+        Previous Epochs
       </Text>
       <Density compact>
         <div className={cn('grid max-w-full overflow-x-auto', TABLE_CLASSES.table[tableKey])}>

--- a/apps/veil/src/pages/tournament/ui/round/round-card.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/round-card.tsx
@@ -121,7 +121,7 @@ export const RoundCard = observer(({ epoch }: RoundCardProps) => {
           <div className='w-full h-[1px] md:w-[1px] md:h-auto bg-other-tonalStroke flex-shrink-0' />
           <div className='flex flex-col w-full md:w-1/2 md:justify-between gap-6 md:gap-0'>
             <Text variant='h4' color='text.primary'>
-              {ended ? 'This Epoch is Ended' : 'Cast Your Vote'}
+              {ended ? 'This Epoch has Ended' : 'Cast Your Vote'}
             </Text>
             <VotingInfo epoch={epoch} />
           </div>


### PR DESCRIPTION
## Description of Changes

1. Originally, the asset selector in LP leaderboard (round page) displayed the user's balance next to the complete list of assets. On the page where it was implemented, I initially tried replacing it with the VotingAssetSelector to match a similar structure, but that didn’t quite work out. Instead, I decided to combine elements from both approaches and ultimately kept the `AssetSelector` from the UI package, with some modifications:

```ts 
   <AssetSelector
      assets={metadataAssets}
      balances={undefined}
      value={selectedAsset}
      onChange={setSelectedAsset}
   />
```

Set the balances entry to undefined (since we're only interested in the assets), and filter for the gauge assets by calling `useEpochResults` API, then pass those directly into the `AssetSelector`.

2. Introduces smoother animations and transitions, addressing https://github.com/penumbra-zone/web/pull/2401#pullrequestreview-2858362541 when refreshing the page (which collapses the table), switching between assets in the asset selector, and toggling between "All LPs" and "My LPs" tabs. 

3. Updates the message from "You have no liquidity positions in this epoch" to "Your LPs have not received any rewards during this epoch" to avoid misleading language. 

_However_, this doesn't address the feedback: "there should also not be an 'all assets' view for the LP leaderboard..." — what should we be showing instead? A default asset in the asset selector on page load? Is it fine to keep this unidirectionality? cc @garwalsh @@smmhrdmn

---------------

https://github.com/user-attachments/assets/9d5d1656-8b40-4877-a7d9-f779ec222bf1

## Related Issue

references https://github.com/penumbra-zone/web/issues/2471

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
