### PR TITLE
fix(ui): proper font loading for prod builds

### DIFF
--- a/.changeset/fine-wings-sin.md
+++ b/.changeset/fine-wings-sin.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Fix style export

--- a/apps/minifront-v2/src/app/global.css
+++ b/apps/minifront-v2/src/app/global.css
@@ -1,5 +1,3 @@
-@import '@ui/theme/fonts.css';
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,9 +8,10 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "vite build && pnpm run build:css",
+    "build": "vite build && pnpm run build:css && pnpm run copy:fonts",
     "build-storybook": "storybook build",
     "build:css": "pnpm exec tailwindcss -c ./tailwind.config.ts -i ./src/styles/main.css -o ./dist/style.css --minify",
+    "copy:fonts": "mkdir -p dist/fonts && cp src/theme/fonts/*.woff2 dist/fonts/",
     "dev:pack": "vite build --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,10 +8,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "vite build && pnpm run build:css && pnpm run copy:fonts",
+    "build": "vite build ",
     "build-storybook": "storybook build",
-    "build:css": "pnpm exec tailwindcss -c ./tailwind.config.ts -i ./src/styles/main.css -o ./dist/style.css --minify",
-    "copy:fonts": "mkdir -p dist/fonts && cp src/theme/fonts/*.woff2 dist/fonts/",
     "dev:pack": "vite build --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/ui/src/styles/main.css
+++ b/packages/ui/src/styles/main.css
@@ -1,3 +1,8 @@
+/* Explicitly load fonts so that generated CSS contains the necessary font-face declarations.
+ * The explicit import must precede the tailwind declarations.
+ * */
+@import '../theme/fonts.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/ui/src/styles/main.css
+++ b/packages/ui/src/styles/main.css
@@ -1,8 +1,0 @@
-/* Explicitly load fonts so that generated CSS contains the necessary font-face declarations.
- * The explicit import must precede the tailwind declarations.
- * */
-@import '../theme/fonts.css';
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;


### PR DESCRIPTION

## Description of Changes
We noticed a regression in fallback fonts when using the prod builds. The same issue wasn't present in the dev env (i.e. `pnpm dev`), because the dev env loads assets directly from disk. For prod builds, we must explicitly prepare outputs, such as static assets, so here we make two changes:

  1. ensure that the UI package explicitly imports the fonts css, so it's included in the generated tailwind outputs
  2. ensure that the font file WOFFs are copied to the dist/ output directory of the ui package.

After rerunning a prod build locally with these changes, the font loading problem was resolved on my machine.

## Related Issue

Closes #2479.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.

I did not test anything related to minifront, only veil. 

## Testing and review

The way I tested this locally was to build and run a local container on main and this branch, and observe the font fix. The process I used was:

```
cd apps/veil
just run-container
```

which calls out to local `podman` on my machine. If someone is so inclined to do that locally, please do. Maybe I should wire up a `just standalone` target that doesn't use a container, but still wires up the prod build logic for easy local testing. I think it's fine to provide visual review, merging if nothing appears obviously wrong in the diff, and then verify the behavior against a live URL post-merge-and-deploy.
