### PR TITLE
fix(veil): #2482: add LPs leaderboard to landing tournament page

### DIFF
--- a/apps/veil/src/entities/leaderboard/ui/page.tsx
+++ b/apps/veil/src/entities/leaderboard/ui/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LeaderboardTable } from './table';
+import { LPLeaderboard } from './table';
 import { PenumbraWaves } from '@/pages/explore/ui/waves';
 import { useCurrentEpoch } from '@/pages/tournament/api/use-current-epoch';
 
@@ -10,7 +10,7 @@ export const LeaderboardPage = () => {
   return (
     <section className='flex flex-col gap-6 p-4 max-w-[1062px] mx-auto'>
       <PenumbraWaves />
-      <LeaderboardTable epoch={currentEpoch} />
+      <LPLeaderboard epoch={currentEpoch} />
     </section>
   );
 };

--- a/apps/veil/src/entities/leaderboard/ui/table.tsx
+++ b/apps/veil/src/entities/leaderboard/ui/table.tsx
@@ -26,6 +26,7 @@ import { useGetMetadata } from '@/shared/api/assets';
 import { AssetSelector, AssetSelectorValue } from '@penumbra-zone/ui/AssetSelector';
 import { getAssetId } from './utils';
 import { useEpochResults } from '@/pages/tournament/api/use-epoch-results';
+import { useCurrentEpoch } from '@/pages/tournament/api/use-current-epoch';
 
 const Tabs = {
   AllLPs: 'All LPs',
@@ -34,179 +35,198 @@ const Tabs = {
 
 type Tab = (typeof Tabs)[keyof typeof Tabs];
 
-export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined }) => {
-  const { connected, subaccount } = connectionStore;
-  const totalRef = useRef<number>(0);
-  const searchParams = useSearchParams();
-  const page = Number(searchParams?.get('page') ?? 1);
-  const [currentPage, setCurrentPage] = useState(page);
-  const [parent] = useAutoAnimate();
-  const [tab, setTab] = useState<Tab>(Tabs.AllLPs);
-  const [limit, setLimit] = useState(10);
-  const { getTableHeader, sortBy } = useSortableTableHeaders<LpLeaderboardSortKey>('points');
-  const getAssetMetadata = useGetMetadata();
-  const { data: umMetadata } = useStakingTokenMetadata();
-  const [selectedAsset, setSelectedAsset] = useState<AssetSelectorValue>();
+export const LeaderboardTable = observer(
+  ({ epoch: propEpoch, showEpoch }: { epoch?: number; showEpoch?: boolean }) => {
+    const { connected, subaccount } = connectionStore;
+    const totalRef = useRef<number>(0);
+    const searchParams = useSearchParams();
+    const page = Number(searchParams?.get('page') ?? 1);
+    const [currentPage, setCurrentPage] = useState(page);
+    const [parent] = useAutoAnimate();
+    const [tab, setTab] = useState<Tab>(Tabs.AllLPs);
+    const [limit, setLimit] = useState(10);
+    const { getTableHeader, sortBy } = useSortableTableHeaders<LpLeaderboardSortKey>('points');
+    const [selectedAsset, setSelectedAsset] = useState<AssetSelectorValue>();
 
-  const handleAssetChange = (next?: AssetSelectorValue) => {
-    setSelectedAsset(prev => (getAssetId(prev) === getAssetId(next) ? undefined : next));
-  };
+    const getAssetMetadata = useGetMetadata();
+    const { data: umMetadata } = useStakingTokenMetadata();
+    const { epoch: currentEpoch } = useCurrentEpoch();
+    const epoch = propEpoch ?? currentEpoch;
 
-  const {
-    data: leaderboard,
-    error: leaderboardError,
-    isPending: leaderboardLoading,
-  } = useLpLeaderboard({
-    epoch,
-    page: currentPage,
-    limit,
-    sortKey: sortBy.key,
-    sortDirection: sortBy.direction,
-    assetId: getAssetId(selectedAsset),
-    isActive: tab === Tabs.AllLPs,
-  });
+    const handleAssetChange = (next?: AssetSelectorValue) => {
+      setSelectedAsset(prev => (getAssetId(prev) === getAssetId(next) ? undefined : next));
+    };
 
-  const isMyTab = tab === Tabs.MyLPs;
-  const {
-    data: myLeaderboard,
-    error: myLeaderboardError,
-    isPending: myLeaderboardLoading,
-  } = useMyLpLeaderboard({
-    subaccount,
-    epoch,
-    page: currentPage,
-    limit,
-    sortKey: sortBy.key,
-    sortDirection: sortBy.direction,
-    assetId: getAssetId(selectedAsset),
-    isActive: isMyTab,
-  });
+    const {
+      data: leaderboard,
+      error: leaderboardError,
+      isPending: leaderboardLoading,
+    } = useLpLeaderboard({
+      epoch,
+      page: currentPage,
+      limit,
+      sortKey: sortBy.key,
+      sortDirection: sortBy.direction,
+      assetId: getAssetId(selectedAsset),
+      isActive: tab === Tabs.AllLPs,
+    });
 
-  const { data: assetsData, assetGauges } = useEpochResults('epoch-results-vote-dialog', {
-    epoch,
-    limit: 30,
-    page: 1,
-  });
+    const isMyTab = tab === Tabs.MyLPs;
+    const {
+      data: myLeaderboard,
+      error: myLeaderboardError,
+      isPending: myLeaderboardLoading,
+    } = useMyLpLeaderboard({
+      subaccount,
+      epoch,
+      page: currentPage,
+      limit,
+      sortKey: sortBy.key,
+      sortDirection: sortBy.direction,
+      assetId: getAssetId(selectedAsset),
+      isActive: isMyTab,
+    });
 
-  // Collect an array of minium 5 items. If there are more than 5 voted assets, return all of them.
-  // If less than 5, firstly return all voted assets, and then fill the rest with non-voted assets.
-  const metadataAssets = useMemo(() => {
-    const base = assetsData?.data ?? [];
-    const extra =
-      base.length < 5 ? assetGauges.slice(base.length, base.length + 5 - base.length) : [];
+    const { data: assetsData, assetGauges } = useEpochResults('epoch-results-vote-dialog', {
+      epoch,
+      limit: 30,
+      page: 1,
+    });
 
-    return [...base, ...extra].map(g => g.asset);
-  }, [assetsData?.data, assetGauges]);
+    // Collect an array of minium 5 items. If there are more than 5 voted assets, return all of them.
+    // If less than 5, firstly return all voted assets, and then fill the rest with non-voted assets.
+    const metadataAssets = useMemo(() => {
+      const base = assetsData?.data ?? [];
+      const extra =
+        base.length < 5 ? assetGauges.slice(base.length, base.length + 5 - base.length) : [];
 
-  const [positions, total, error, isLoading] = isMyTab
-    ? [myLeaderboard?.data, myLeaderboard?.total, myLeaderboardError, myLeaderboardLoading]
-    : [leaderboard?.data, leaderboard?.total, leaderboardError, leaderboardLoading];
-  totalRef.current = total ?? totalRef.current;
+      return [...base, ...extra].map(g => g.asset);
+    }, [assetsData?.data, assetGauges]);
 
-  return (
-    <Card>
-      <div className='px-2'>
-        <div className='flex justify-between items-center mb-4'>
-          <Text xxl color='text.primary'>
-            LPs Leaderboard
-          </Text>
+    const [positions, total, error, isLoading] = isMyTab
+      ? [myLeaderboard?.data, myLeaderboard?.total, myLeaderboardError, myLeaderboardLoading]
+      : [leaderboard?.data, leaderboard?.total, leaderboardError, leaderboardLoading];
+    totalRef.current = total ?? totalRef.current;
 
-          <div className='rounded-full overflow-hidden'>
-            <AssetSelector
-              assets={metadataAssets}
-              balances={undefined}
-              value={selectedAsset}
-              onChange={handleAssetChange}
-            />
-          </div>
-        </div>
-
-        {error ? (
-          <Text large color='destructive.light'>
-            {error.message}
-          </Text>
-        ) : (
-          <>
-            {connected && (
-              <div className='[&>*>*]:w-1/2 mb-4'>
-                <SegmentedControl value={tab} onChange={opt => setTab(opt as 'All LPs' | 'My LPs')}>
-                  <SegmentedControl.Item
-                    value='All LPs'
-                    style={tab === 'All LPs' ? 'filled' : 'unfilled'}
-                  >
-                    All LPs
-                  </SegmentedControl.Item>
-                  <SegmentedControl.Item
-                    value='My LPs'
-                    style={tab === 'My LPs' ? 'filled' : 'unfilled'}
-                  >
-                    My LPs
-                  </SegmentedControl.Item>
-                </SegmentedControl>
-              </div>
-            )}
-
-            <div className='grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] h-auto overflow-auto'>
-              <div className='grid grid-cols-subgrid col-span-6'>
-                <TableCell heading>Position ID</TableCell>
-                {getTableHeader('executions', 'Execs')}
-                {getTableHeader('points', 'Points')}
-                {/* @TODO add age & pnlPercentage */}
-                {/* {getTableHeader('pnlPercentage', 'PnL')} */}
-                {/* {getTableHeader('age', 'Age')} */}
-                <TableCell heading>Volume</TableCell>
-                <TableCell heading>Fees</TableCell>
-                <TableCell heading>State</TableCell>
-              </div>
-
-              {isLoading ? (
-                Array.from({ length: limit }).map((_, index) => (
-                  <div className='grid grid-cols-subgrid col-span-6' key={index}>
-                    <TableCell loading>&nbsp;</TableCell>
-                    <TableCell loading>&nbsp;</TableCell>
-                    <TableCell loading>&nbsp;</TableCell>
-                    {/* @TODO add age & pnlPercentage */}
-                    {/* <TableCell loading>&nbsp;</TableCell> */}
-                    {/* <TableCell loading>&nbsp;</TableCell> */}
-                    <TableCell loading>&nbsp;</TableCell>
-                    <TableCell loading>&nbsp;</TableCell>
-                    <TableCell loading>&nbsp;</TableCell>
+    return (
+      <Card>
+        <div className='px-2'>
+          <div className='flex gap-3 items-center mb-4'>
+            <div className='flex flex-col gap-1'>
+              <Text xxl color='text.primary'>
+                LPs Leaderboard
+                {showEpoch && !!epoch && (
+                  <div className='desktop:ml-3 inline-flex items-center rounded-sm bg-base-blackAlt px-2'>
+                    <div className='text-transparent bg-clip-text [background-image:linear-gradient(90deg,rgb(244,156,67),rgb(83,174,168))]'>
+                      <Text xxl>Epoch #{epoch}</Text>
+                    </div>
                   </div>
-                ))
-              ) : (
-                <div ref={parent} className='contents col-span-6'>
-                  {positions?.length ? (
-                    positions.map(position => {
-                      return (
-                        <Link
-                          key={position.positionIdString}
-                          href={`/inspect/lp/${position.positionIdString}`}
-                          className={cn(
-                            'relative grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] col-span-6',
-                            'bg-transparent hover:bg-action-hoverOverlay transition-colors',
-                            '[&>*]:h-auto',
-                          )}
-                        >
-                          <TableCell cell>
-                            <div className='flex max-w-[104px]'>
-                              <Text smallTechnical color='text.primary' truncate>
-                                {position.positionIdString}
+                )}
+              </Text>
+              <Text small color='text.secondary'>
+                Liquidity positions from the current epoch that have executed trades.
+              </Text>
+            </div>
+
+            <div className='min-w-[80px] ml-auto rounded-full overflow-hidden'>
+              <AssetSelector
+                assets={metadataAssets}
+                balances={undefined}
+                value={selectedAsset}
+                onChange={handleAssetChange}
+              />
+            </div>
+          </div>
+
+          {error ? (
+            <Text large color='destructive.light'>
+              {error.message}
+            </Text>
+          ) : (
+            <>
+              {connected && (
+                <div className='[&>*>*]:w-1/2 mb-4'>
+                  <SegmentedControl
+                    value={tab}
+                    onChange={opt => setTab(opt as 'All LPs' | 'My LPs')}
+                  >
+                    <SegmentedControl.Item
+                      value='All LPs'
+                      style={tab === 'All LPs' ? 'filled' : 'unfilled'}
+                    >
+                      All LPs
+                    </SegmentedControl.Item>
+                    <SegmentedControl.Item
+                      value='My LPs'
+                      style={tab === 'My LPs' ? 'filled' : 'unfilled'}
+                    >
+                      My LPs
+                    </SegmentedControl.Item>
+                  </SegmentedControl>
+                </div>
+              )}
+
+              <div className='grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] h-auto overflow-auto'>
+                <div className='grid grid-cols-subgrid col-span-6'>
+                  <TableCell heading>Position ID</TableCell>
+                  {getTableHeader('executions', 'Execs')}
+                  {getTableHeader('points', 'Points')}
+                  {/* @TODO add age & pnlPercentage */}
+                  {/* {getTableHeader('pnlPercentage', 'PnL')} */}
+                  {/* {getTableHeader('age', 'Age')} */}
+                  <TableCell heading>Volume</TableCell>
+                  <TableCell heading>Fees</TableCell>
+                  <TableCell heading>State</TableCell>
+                </div>
+
+                {isLoading ? (
+                  Array.from({ length: limit }).map((_, index) => (
+                    <div className='grid grid-cols-subgrid col-span-6' key={index}>
+                      <TableCell loading>&nbsp;</TableCell>
+                      <TableCell loading>&nbsp;</TableCell>
+                      <TableCell loading>&nbsp;</TableCell>
+                      {/* @TODO add age & pnlPercentage */}
+                      {/* <TableCell loading>&nbsp;</TableCell> */}
+                      {/* <TableCell loading>&nbsp;</TableCell> */}
+                      <TableCell loading>&nbsp;</TableCell>
+                      <TableCell loading>&nbsp;</TableCell>
+                      <TableCell loading>&nbsp;</TableCell>
+                    </div>
+                  ))
+                ) : (
+                  <div ref={parent} className='contents col-span-6'>
+                    {positions?.length ? (
+                      positions.map(position => {
+                        return (
+                          <Link
+                            key={position.positionIdString}
+                            href={`/inspect/lp/${position.positionIdString}`}
+                            className={cn(
+                              'relative grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] col-span-6',
+                              'bg-transparent hover:bg-action-hoverOverlay transition-colors',
+                              '[&>*]:h-auto',
+                            )}
+                          >
+                            <TableCell cell>
+                              <div className='flex max-w-[104px]'>
+                                <Text smallTechnical color='text.primary' truncate>
+                                  {position.positionIdString}
+                                </Text>
+                                <span>
+                                  <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
+                                </span>
+                              </div>
+                            </TableCell>
+                            <TableCell cell>
+                              <Text smallTechnical>{position.executions}</Text>
+                            </TableCell>
+                            <TableCell cell loading={isLoading}>
+                              <Text smallTechnical>
+                                {round({ value: position.pointsShare * 100, decimals: 2 })}%
                               </Text>
-                              <span>
-                                <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
-                              </span>
-                            </div>
-                          </TableCell>
-                          <TableCell cell>
-                            <Text smallTechnical>{position.executions}</Text>
-                          </TableCell>
-                          <TableCell cell loading={isLoading}>
-                            <Text smallTechnical>
-                              {round({ value: position.pointsShare * 100, decimals: 2 })}%
-                            </Text>
-                          </TableCell>
-                          {/* @TODO add age & pnlPercentage */}
-                          {/* <TableCell cell numeric loading={isLoading}>
+                            </TableCell>
+                            {/* @TODO add age & pnlPercentage */}
+                            {/* <TableCell cell numeric loading={isLoading}>
                       <Text
                         smallTechnical
                         color={
@@ -216,78 +236,79 @@ export const LeaderboardTable = observer(({ epoch }: { epoch: number | undefined
                         {position.pnlPercentage}%
                       </Text>
                     </TableCell> */}
-                          {/* <TableCell cell numeric>
+                            {/* <TableCell cell numeric>
                       {formatAge(position.openingTime)}
                     </TableCell> */}
+                            <TableCell cell>
+                              <div className='flex gap-1 flex-col'>
+                                <ValueViewComponent
+                                  valueView={pnum(position.umVolume).toValueView(umMetadata)}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                                <ValueViewComponent
+                                  valueView={pnum(position.assetVolume).toValueView(
+                                    getAssetMetadata(position.assetId),
+                                  )}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                              </div>
+                            </TableCell>
+                            <TableCell cell>
+                              <div className='flex gap-1 flex-col'>
+                                <ValueViewComponent
+                                  valueView={pnum(position.umFees).toValueView(umMetadata)}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                                <ValueViewComponent
+                                  valueView={pnum(position.assetFees).toValueView(
+                                    getAssetMetadata(position.assetId),
+                                  )}
+                                  abbreviate={true}
+                                  density='slim'
+                                />
+                              </div>
+                            </TableCell>
+                            <TableCell cell>
+                              <Text smallTechnical>
+                                {stateToString(position.position.state?.state)}
+                              </Text>
+                            </TableCell>
+                          </Link>
+                        );
+                      })
+                    ) : (
+                      <div className='col-span-6'>
+                        <div className='grid grid-cols-subgrid col-span-4'>
                           <TableCell cell>
-                            <div className='flex gap-1 flex-col'>
-                              <ValueViewComponent
-                                valueView={pnum(position.umVolume).toValueView(umMetadata)}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                              <ValueViewComponent
-                                valueView={pnum(position.assetVolume).toValueView(
-                                  getAssetMetadata(position.assetId),
-                                )}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                            </div>
+                            <span className='!text-sm'>
+                              {tab === Tabs.AllLPs
+                                ? 'There are no liquidity positions in this epoch.'
+                                : 'Your LPs have not received any rewards during this epoch.'}
+                            </span>
                           </TableCell>
-                          <TableCell cell>
-                            <div className='flex gap-1 flex-col'>
-                              <ValueViewComponent
-                                valueView={pnum(position.umFees).toValueView(umMetadata)}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                              <ValueViewComponent
-                                valueView={pnum(position.assetFees).toValueView(
-                                  getAssetMetadata(position.assetId),
-                                )}
-                                abbreviate={true}
-                                density='slim'
-                              />
-                            </div>
-                          </TableCell>
-                          <TableCell cell>
-                            <Text smallTechnical>
-                              {stateToString(position.position.state?.state)}
-                            </Text>
-                          </TableCell>
-                        </Link>
-                      );
-                    })
-                  ) : (
-                    <div className='col-span-6'>
-                      <div className='grid grid-cols-subgrid col-span-4'>
-                        <TableCell cell>
-                          <span className='!text-sm'>
-                            {tab === Tabs.AllLPs
-                              ? 'There are no liquidity positions in this epoch.'
-                              : 'Your LPs have not received any rewards during this epoch.'}
-                          </span>
-                        </TableCell>
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+                    )}
+                  </div>
+                )}
+              </div>
 
-            <div className='pt-4'>
-              <Pagination
-                value={currentPage}
-                totalItems={totalRef.current}
-                limit={limit}
-                onLimitChange={setLimit}
-                onChange={setCurrentPage}
-              />
-            </div>
-          </>
-        )}
-      </div>
-    </Card>
-  );
-});
+              <div className='pt-4'>
+                <Pagination
+                  value={currentPage}
+                  totalItems={totalRef.current}
+                  limit={limit}
+                  onLimitChange={setLimit}
+                  onChange={setCurrentPage}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </Card>
+    );
+  },
+);

--- a/apps/veil/src/entities/leaderboard/ui/table.tsx
+++ b/apps/veil/src/entities/leaderboard/ui/table.tsx
@@ -35,7 +35,7 @@ const Tabs = {
 
 type Tab = (typeof Tabs)[keyof typeof Tabs];
 
-export const LeaderboardTable = observer(
+export const LPLeaderboard = observer(
   ({ epoch: propEpoch, showEpoch }: { epoch?: number; showEpoch?: boolean }) => {
     const { connected, subaccount } = connectionStore;
     const totalRef = useRef<number>(0);

--- a/apps/veil/src/pages/tournament/ui/page.tsx
+++ b/apps/veil/src/pages/tournament/ui/page.tsx
@@ -5,7 +5,7 @@ import { DelegatorRewards } from './delegator-rewards';
 import { LandingCard } from './landing-card';
 import { DelegatorLeaderboard } from './delegator-leaderboard';
 import { PreviousEpochs } from './previous-epochs';
-import { LeaderboardTable } from '@/entities/leaderboard/ui/table';
+import { LPLeaderboard } from '@/entities/leaderboard/ui/table';
 
 export const TournamentPage = () => {
   return (
@@ -13,7 +13,7 @@ export const TournamentPage = () => {
       <PenumbraWaves />
       <LandingCard />
       <DelegatorRewards />
-      <LeaderboardTable showEpoch />
+      <LPLeaderboard showEpoch />
       <DelegatorLeaderboard />
       <PreviousEpochs />
     </section>

--- a/apps/veil/src/pages/tournament/ui/page.tsx
+++ b/apps/veil/src/pages/tournament/ui/page.tsx
@@ -5,6 +5,7 @@ import { DelegatorRewards } from './delegator-rewards';
 import { LandingCard } from './landing-card';
 import { DelegatorLeaderboard } from './delegator-leaderboard';
 import { PreviousEpochs } from './previous-epochs';
+import { LeaderboardTable } from '@/entities/leaderboard/ui/table';
 
 export const TournamentPage = () => {
   return (
@@ -12,6 +13,7 @@ export const TournamentPage = () => {
       <PenumbraWaves />
       <LandingCard />
       <DelegatorRewards />
+      <LeaderboardTable showEpoch />
       <DelegatorLeaderboard />
       <PreviousEpochs />
     </section>

--- a/apps/veil/src/pages/tournament/ui/round/page.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { PenumbraWaves } from '@/pages/explore/ui/waves';
-import { LeaderboardTable } from '@/entities/leaderboard/ui/table';
+import { LPLeaderboard } from '@/entities/leaderboard/ui/table';
 import { PagePath } from '@/shared/const/pages';
 import { CurrentVotingResults } from './current-voting-results';
 import { RoundCard } from './round-card';
@@ -22,7 +22,7 @@ export const TournamentRoundPage = () => {
       <PenumbraWaves />
       <RoundCard epoch={epoch} />
       <CurrentVotingResults epoch={epoch} />
-      <LeaderboardTable epoch={epoch} />
+      <LPLeaderboard epoch={epoch} />
     </section>
   );
 };


### PR DESCRIPTION
Closes #2482 

Reuses the existing component and adds the "Epoch #{epoch}" block and a section subtitle per new designs.

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/a1e07dcf-31ad-4aaf-88fb-65cd0e202b14" />
