### PR TITLE
fix (services): don't randomly select index in status stream test

### DIFF
--- a/packages/services/src/view-service/status-stream.test.ts
+++ b/packages/services/src/view-service/status-stream.test.ts
@@ -67,7 +67,8 @@ describe('Status stream request handler', () => {
 
   test('should stream status updates while catching up and and passing initial latest', async () => {
     const highest = mockHeights.at(-1)!;
-    const later = mockHeights.at(-((mockHeights.length * Math.random()) / 2))!;
+    const later = mockHeights.at(mockHeights.length * 0.666)!;
+    expect(later).toBeLessThan(highest);
     mockTendermint.latestBlockHeight?.mockResolvedValue(later);
 
     let reachedLater = false;


### PR DESCRIPTION
status stream test was flaky due to selection of a random value.

if the selected value happened to be the last item in the mock stream, the test expectations were violated. now, a constant value is selected.