### PR TITLE
veil(portfolio): support cosmos wallet connections on testnet

### DIFF
--- a/apps/veil/src/features/cosmos/chain-provider.tsx
+++ b/apps/veil/src/features/cosmos/chain-provider.tsx
@@ -1,5 +1,5 @@
 import { ChainProvider } from '@cosmos-kit/react';
-import { assets, chains } from 'chain-registry/mainnet';
+import { assets, chains } from 'chain-registry';
 import { wallets } from 'cosmos-kit';
 import { ReactNode, useMemo } from 'react';
 import { Chain, Registry as PenumbraRegistry } from '@penumbra-labs/registry';

--- a/apps/veil/src/features/cosmos/use-augmented-balances.ts
+++ b/apps/veil/src/features/cosmos/use-augmented-balances.ts
@@ -3,7 +3,7 @@ import { useQueries } from '@tanstack/react-query';
 import { ChainWalletBase, WalletStatus } from '@cosmos-kit/core';
 
 import { Asset } from '@chain-registry/types';
-import cosmosAssetList from 'chain-registry/mainnet/assets';
+import cosmosAssetList from 'chain-registry/assets';
 import { Coin, StargateClient } from '@cosmjs/stargate';
 
 // Map of reliable RPC endpoints for different Cosmos chains


### PR DESCRIPTION
## Description of Changes

a regression may have been introduced where localhost and testnet environments (https://dex-explorer.testnet.plinfra.net/portfolio) using `penumbra-testnet-phobos-3` failed to trigger Cosmos wallet connections.

specifically calling:

```ts
const wallet = useWallet();
```

would return `undefined`. 

To debug, I traced the "Connect Cosmos Wallet" callsites, which pointed to [cosmos-connect-button.tsx](https://github.com/penumbra-zone/web/blob/main/apps/veil/src/features/cosmos/cosmos-connect-button.tsx) and its corresponding chain provider in [chain-provider.tsx](https://github.com/penumbra-zone/web/blob/main/apps/veil/src/features/cosmos/chain-provider.tsx). 

After logging this code snippet:
```ts
    const { data: registry } = useRegistry();
    const penumbraIbcChains = chainsInPenumbraRegistry(registry.ibcConnections).map(
      c => c.chain_name,
    );
    const chains = useChains(penumbraIbcChains);
```

<img width="529" alt="Screenshot 2025-06-15 at 10 33 45 AM-1" src="https://github.com/user-attachments/assets/805e7db3-5569-4e7b-842b-46ff19de07ce" />

it revealed that `penumbraIbcChains` and `chains` params were empty. The root cause was that inside the `ChainProvider` component, we were importing: `{ assets, chains } from 'chain-registry/mainnet'` instead of `{ assets, chains } from 'chain-registry'`. This meant testnet chains weren't being considered. Therefore, this updates the provider to include _both_ mainnet and testnet chains by default, ensuring testnet compatibility in local and dev environments. 

@vacekj Any downside to doing it this way given that we already use the same generic chain-registry import in other parts of the codebase? 

-------------

https://github.com/user-attachments/assets/c5acdd3c-693a-4949-8240-cc05018139bc

## Related Issue

serves as prerequisite for testing https://github.com/penumbra-zone/web/pull/2483 on my end. @vacekj how were you testing in local env around this issue?

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
