### PR TITLE
feat(ui): #2152: new scrollbar styles

### DIFF
--- a/apps/minifront-v2/index.html
+++ b/apps/minifront-v2/index.html
@@ -3,7 +3,7 @@
   <head>
     <link href="/favicon.png" rel="icon" sizes="80x80" type="image/png" />
   </head>
-  <body>
+  <body class="scroll-area-page">
     <div id="root"></div>
     <script src="./src/app/index.tsx" type="module"></script>
   </body>

--- a/apps/veil/app/layout.tsx
+++ b/apps/veil/app/layout.tsx
@@ -18,7 +18,7 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
   const jsonRegistryWithGlobals = await fetchJsonRegistryWithGlobals(PENUMBRA_CHAIN_ID);
   return (
     <html lang='en'>
-      <body>
+      <body className='scroll-area-page'>
         <App jsonRegistryWithGlobals={jsonRegistryWithGlobals}>{children}</App>
       </body>
     </html>

--- a/packages/ui/src/Dialog/Content.tsx
+++ b/packages/ui/src/Dialog/Content.tsx
@@ -47,7 +47,9 @@ export const Content = ({
                   {headerChildren}
                 </header>
 
-                <div className='flex flex-col gap-6 overflow-y-auto px-6 pb-8'>{children}</div>
+                <div className='scroll-area-component flex flex-col gap-6 overflow-y-auto px-6 pb-8'>
+                  {children}
+                </div>
 
                 {buttons && <div className='flex flex-col gap-2'>{buttons}</div>}
 

--- a/packages/ui/src/theme/globals.css
+++ b/packages/ui/src/theme/globals.css
@@ -1,18 +1,55 @@
-::-webkit-scrollbar {
-  width: 4px;
+/**
+  Utility classes for scroll management.
+  - Use `.scroll-area-page` for page-level scroll areas, usually on `body` element.
+  - Use `.scroll-area-component` for component-level scroll areas. It is applied, for example, in Dialog component.
+
+  Note that the styles can work only in webkit browsers (like Chrome, Safari, Edge).
+  Even though these styles have a `transition` property, it isn't supported in any of the browsers.
+ */
+.scroll-area-page::-webkit-scrollbar {
+  width: 10px;
 }
 
-/* Track */
-::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.25);
+.scroll-area-page::-webkit-scrollbar-track {
+  background: transparent;
+  backdrop-filter: blur(16px);
 }
 
-/* Handle */
-::-webkit-scrollbar-thumb {
-  background: #888;
+.scroll-area-page::-webkit-scrollbar-thumb {
+  background-color: #fafafa1a;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+  background-clip: content-box;
+  border-radius: 7px;
+  transition: all 0.3s ease;
 }
 
-/* Handle on hover */
-::-webkit-scrollbar-thumb:hover {
-  background: #555;
+.scroll-area-page::-webkit-scrollbar-thumb:hover {
+  background-color: #a3a3a3;
+  border-left: none;
+  border-right: none;
+}
+
+.scroll-area-component::-webkit-scrollbar {
+  width: 10px;
+}
+
+.scroll-area-component::-webkit-scrollbar-track {
+  background: transparent;
+  backdrop-filter: blur(16px);
+}
+
+.scroll-area-component::-webkit-scrollbar-thumb {
+  background-color: #fafafa1a;
+  border-left: 2px solid transparent;
+  border-right: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 5px;
+  transition: all 0.3s ease;
+}
+
+.scroll-area-component::-webkit-scrollbar-thumb:hover {
+  background-color: #a3a3a3;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
 }


### PR DESCRIPTION
Closes #2152

Creates 2 global classes: 
1. `.scroll-area-page` – page-level scrollbars with 8px default width and 10px when hovered.
2. `.scroll-area-component` – component-level scrollbars with 6px default width and 8px when hovered.

Demo video:

https://github.com/user-attachments/assets/018cac92-5d04-4e6f-b3d0-fde0bfabe515

