### PR TITLE
positions: display proper position states in the tables

### DIFF
--- a/apps/veil/src/entities/position/api/use-positions.ts
+++ b/apps/veil/src/entities/position/api/use-positions.ts
@@ -22,13 +22,9 @@ const BASE_PAGE = 0;
 const fetchQuery = async (
   subaccount = 0,
   page = BASE_PAGE,
-  activeStatus = true,
+  stateFilter?: PositionState_PositionStateEnum[],
 ): Promise<Map<string, Position>> => {
-  const states = activeStatus
-    ? [PositionState_PositionStateEnum.OPENED, PositionState_PositionStateEnum.CLOSED].map(
-        state => new PositionState({ state }),
-      )
-    : [undefined];
+  const states = stateFilter?.map(state => new PositionState({ state })) ?? [undefined];
 
   const res = await Promise.all(
     states.map(state =>
@@ -75,14 +71,14 @@ const fetchQuery = async (
 /**
  * Must be used within the `observer` mobX HOC
  */
-export const usePositions = (subaccount = 0, activeStatus = true) => {
+export const usePositions = (subaccount = 0, stateFilter?: PositionState_PositionStateEnum[]) => {
   return useInfiniteQuery<Map<string, Position>>({
-    queryKey: ['positions', subaccount, activeStatus],
+    queryKey: ['positions', subaccount, stateFilter],
     initialPageParam: BASE_PAGE,
     getNextPageParam: (lastPage, _, lastPageParam) => {
       return lastPage.size ? (lastPageParam as number) + 1 : undefined;
     },
-    queryFn: ({ pageParam }) => fetchQuery(subaccount, pageParam as number, activeStatus),
+    queryFn: ({ pageParam }) => fetchQuery(subaccount, pageParam as number, stateFilter),
     enabled: connectionStore.connected,
   });
 };

--- a/apps/veil/src/entities/position/ui/table.tsx
+++ b/apps/veil/src/entities/position/ui/table.tsx
@@ -28,20 +28,21 @@ import { ActionButton } from './action-button';
 import { Dash } from './dash';
 import { useObserver } from '@/shared/utils/use-observer';
 import SpinnerIcon from '@/shared/assets/spinner-icon.svg';
+import { PositionState_PositionStateEnum } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 
 export interface PositionsTableProps {
   base?: Metadata;
   quote?: Metadata;
-  showInactive: boolean;
+  stateFilter?: PositionState_PositionStateEnum[];
 }
 
-export const PositionsTable = observer(({ base, quote, showInactive }: PositionsTableProps) => {
+export const PositionsTable = observer(({ base, quote, stateFilter }: PositionsTableProps) => {
   const { connected, subaccount } = connectionStore;
   const getMetadata = useGetMetadata();
 
   const { data, isLoading, isRefetching, isFetchingNextPage, fetchNextPage, error } = usePositions(
     subaccount,
-    !showInactive,
+    stateFilter,
   );
   const displayPositions = getDisplayPositions({
     positions: data?.pages,

--- a/apps/veil/src/pages/portfolio/ui/position-tabs.tsx
+++ b/apps/veil/src/pages/portfolio/ui/position-tabs.tsx
@@ -4,6 +4,7 @@ import { Density } from '@penumbra-zone/ui/Density';
 import { PortfolioTransactions } from './transactions';
 import { PortfolioCard } from '@/pages/portfolio/ui/portfolio-card.tsx';
 import { PositionsTable } from '@/entities/position';
+import { PositionState_PositionStateEnum } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 
 enum PortfolioTab {
   OpenPositions = 'Open Positions',
@@ -31,9 +32,18 @@ export const PortfolioPositionTabs = () => {
         </Density>
       </div>
 
-      {tab === PortfolioTab.OpenPositions && <PositionsTable showInactive={false} />}
+      {tab === PortfolioTab.OpenPositions && (
+        <PositionsTable stateFilter={[PositionState_PositionStateEnum.OPENED]} />
+      )}
 
-      {tab === PortfolioTab.ClosedPositions && <PositionsTable showInactive={true} />}
+      {tab === PortfolioTab.ClosedPositions && (
+        <PositionsTable
+          stateFilter={[
+            PositionState_PositionStateEnum.CLOSED,
+            PositionState_PositionStateEnum.WITHDRAWN,
+          ]}
+        />
+      )}
 
       {tab === PortfolioTab.History && <PortfolioTransactions />}
     </PortfolioCard>

--- a/apps/veil/src/pages/trade/ui/history-tabs.tsx
+++ b/apps/veil/src/pages/trade/ui/history-tabs.tsx
@@ -6,6 +6,7 @@ import { Toggle } from '@penumbra-zone/ui/Toggle';
 import { Text } from '@penumbra-zone/ui/Text';
 import { PositionsTable } from '@/entities/position';
 import { usePathToMetadata } from '../model/use-path';
+import { PositionState_PositionStateEnum as State } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 
 enum PositionsTabsType {
   MY_POSITIONS = 'MY_POSITIONS',
@@ -36,7 +37,15 @@ export const HistoryTabs = () => {
       </div>
 
       <div className='p-4'>
-        <PositionsTable base={baseAsset} quote={quoteAsset} showInactive={showInactive} />
+        <PositionsTable
+          base={baseAsset}
+          quote={quoteAsset}
+          stateFilter={
+            showInactive
+              ? [State.OPENED, State.CLOSED, State.WITHDRAWN]
+              : [State.OPENED, State.CLOSED]
+          }
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description of Changes

follow-up to https://github.com/penumbra-zone/web/pull/2492

currently, `PositionsTable` performs state filtering internally. Instead of filtering based on the `showInactive` boolean, we move the state logic up to the calling component, and update `PositionsTable` to accept  an explicit array of `PositionState_PositionStateEnum` proto type values. This fixes a regression that caused open positions to appear in the closed positions table on the portfolio page.

---------

https://github.com/user-attachments/assets/d9620d53-f939-4736-8469-5406b93fc40d


## Related Issue

N/A

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
