### PR TITLE
fix(ui): #2472: pagination input

### DIFF
--- a/.changeset/olive-worms-cross.md
+++ b/.changeset/olive-worms-cross.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/ui': patch
+---
+
+Add input component into Pagination

--- a/packages/ui/src/Pagination/index.tsx
+++ b/packages/ui/src/Pagination/index.tsx
@@ -166,6 +166,16 @@ export const Pagination = ({
     onChange(value + 1 >= pages ? pages : value + 1);
   };
 
+  const onChangeValue = (newValue: number) => {
+    if (newValue < 1) {
+      onChange(1);
+    } else if (newValue > pages) {
+      onChange(pages);
+    } else {
+      onChange(newValue);
+    }
+  };
+
   const onSelect: ChangeEventHandler<HTMLSelectElement> = event => {
     onLimitChange?.(parseInt(event.target.value));
   };
@@ -209,7 +219,7 @@ export const Pagination = ({
                 key={index}
                 value={key}
                 active={value === key}
-                onClick={() => typeof key === 'number' && onChange(key)}
+                onClick={onChangeValue}
               />
             ))}
           </div>

--- a/packages/ui/src/Pagination/pagination-button.tsx
+++ b/packages/ui/src/Pagination/pagination-button.tsx
@@ -1,33 +1,87 @@
 import cn from 'clsx';
+import { useState, KeyboardEvent } from 'react';
 import { Text } from '../Text';
 
 export const ELLIPSIS_KEY = '...';
 
 interface PaginationButtonProps {
   value: number | typeof ELLIPSIS_KEY;
-  onClick: VoidFunction;
+  onClick: (value: number) => void;
   active?: boolean;
+  disabled?: boolean;
 }
 
-export const PaginationButton = ({ value, onClick, active }: PaginationButtonProps) => {
-  const disabled = value === ELLIPSIS_KEY;
+export const PaginationButton = ({ value, onClick, active, disabled }: PaginationButtonProps) => {
+  const [isInput, setIsInput] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+
+  const isEllipsis = value === ELLIPSIS_KEY;
+
+  const handleClick = () => {
+    if (isEllipsis) {
+      setIsInput(true);
+      return;
+    }
+    onClick(value);
+  };
+
+  const clearInput = () => {
+    setInputValue('');
+    setIsInput(false);
+  };
+
+  const setNewValue = () => {
+    const newValue = parseInt(inputValue, 10);
+    if (!isNaN(newValue)) {
+      onClick(newValue);
+    }
+    clearInput();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      setNewValue();
+    } else if (event.key === 'Escape') {
+      clearInput();
+    }
+  };
 
   let color = active
     ? cn('text-text-primary bg-other-tonalFill10')
     : cn('text-text-secondary hover:text-text-primary focus:text-text-primary');
-  if (disabled) {
+  if (isEllipsis) {
     color = cn('text-text-muted');
+  }
+
+  if (isInput) {
+    return (
+      <input
+        autoFocus
+        type='number'
+        value={inputValue}
+        onBlur={setNewValue}
+        onKeyDown={onKeyDown}
+        onInput={event => setInputValue(event.currentTarget.value)}
+        className={cn(
+          'w-12 h-8 px-2 rounded-sm bg-other-tonalFill5 text-textSm font-normal',
+          'transition-[background-color,outline-color] duration-150 outline outline-2 outline-transparent',
+          'hover:bg-action-hoverOverlay focus:outline-action-neutralFocusOutline',
+          '[&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none',
+          disabled ? 'text-text-muted' : 'text-text-primary',
+        )}
+      />
+    );
   }
 
   return (
     <button
       type='button'
-      onClick={() => onClick()}
+      onClick={handleClick}
+      disabled={disabled}
       className={cn(
         'size-8 min-w-8 rounded-full border-none transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-action-neutralFocusOutline',
         color,
       )}
-      disabled={disabled}
     >
       <Text small>{value}</Text>
     </button>


### PR DESCRIPTION
Closes #2472

Implements pagination input that allows jumping to specific page. Opens on click to "..." button, triggers the change either on Enter keypress or the blur event, closes on blur or Escape keypress. Validates only numbers within the page range.


https://github.com/user-attachments/assets/be0d201d-ea0f-4d2f-8dfc-2e317cc8a011

