### PR TITLE
wasm: add position metadata to wasm planner

### DIFF
--- a/apps/veil/src/shared/math/position.ts
+++ b/apps/veil/src/shared/math/position.ts
@@ -164,6 +164,17 @@ export enum LiquidityDistributionShape {
   INVERTED_PYRAMID = 'INVERTED_PYRAMID',
 }
 
+/**
+ * Defines associative numeric encoding of `LiquidityDistributionShape` representing the strategy tag
+ */
+export enum LiquidityDistributionStrategy {
+  SKIP = 1,
+  ARBITRARY = 2,
+  FLAT = 3,
+  PYRAMID = 4,
+  INVERTED_PYRAMID = 5,
+}
+
 interface SimpleLiquidityPlan {
   baseAsset: Asset;
   quoteAsset: Asset;

--- a/packages/perspective/src/plan/view-action-plan.ts
+++ b/packages/perspective/src/plan/view-action-plan.ts
@@ -411,6 +411,15 @@ export const viewActionPlan =
           actionView: actionPlan.action,
         });
 
+      case 'positionOpenPlan': {
+        return new ActionView({
+          actionView: {
+            case: 'positionOpen',
+            value: actionPlan.action.value,
+          },
+        });
+      }
+
       case 'positionClose':
         return new ActionView({
           actionView: actionPlan.action,

--- a/packages/ui-deprecated/components/ui/tx/action-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/action-view.tsx
@@ -31,6 +31,7 @@ const CASE_TO_LABEL: Record<Case, string> = {
   ics20Withdrawal: 'ICS20 Withdrawal',
   positionClose: 'Position Close',
   positionOpen: 'Position Open',
+  positionOpenView: 'Position Open View',
   positionRewardClaim: 'Position Reward Claim',
   positionWithdraw: 'Position Withdraw',
   proposalDepositClaim: 'Proposal Deposit Claim',
@@ -128,6 +129,9 @@ export const ActionViewComponent = ({
 
     case 'positionOpen':
       return <PositionOpenComponent value={actionView.value} />;
+
+    case 'positionOpenView':
+      return <UnimplementedView label='Position Open View' />;
 
     case 'positionClose':
       return <PositionCloseComponent value={actionView.value} />;

--- a/packages/ui/src/ActionView/action-view.tsx
+++ b/packages/ui/src/ActionView/action-view.tsx
@@ -66,6 +66,8 @@ const componentMap = {
   communityPoolDeposit: CommunityPoolDepositAction,
   communityPoolOutput: CommunityPoolOutputAction,
   communityPoolSpend: CommunityPoolSpendAction,
+  // Temporarily Map `positionOpenView` to `PositionOpenAction` for compilation purposes.
+  positionOpenView: PositionOpenAction,
   unknown: UnknownAction,
 } as const satisfies Record<ActionViewType | 'unknown', unknown>;
 

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -826,8 +826,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -840,8 +840,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -2353,8 +2353,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2393,8 +2393,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2438,8 +2438,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2468,8 +2468,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2499,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2514,6 +2514,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
+ "chacha20poly1305",
  "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
@@ -2552,8 +2553,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2568,8 +2569,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2592,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -2623,8 +2624,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2672,8 +2673,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2707,8 +2708,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "aes",
  "anyhow",
@@ -2751,8 +2752,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2787,8 +2788,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2812,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2839,8 +2840,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2873,8 +2874,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2924,8 +2925,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2965,8 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2994,8 +2995,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3046,8 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -14,22 +14,22 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-transaction", default-features = false }
-penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-funding", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-transaction", default-features = false }
+penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-funding", default-features = false }
 
 anyhow = "1.0.89"
 ark-ff = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -413,9 +413,9 @@ pub async fn plan_transaction_inner<Db: Database>(
         actions_list.push(ActionPlan::Ics20Withdrawal(ics20_withdrawal.try_into()?));
     }
 
-    // Note: during action creation, a convinience method exists that generates the `PositionMetadatakey`
+    // Note: during action creation, a convenience method is invoked that generates the `PositionMetadatakey`
     // derived from the outgoing viewing key (OVK), and encrypt the plaintext `PositionMetadata`
-    // with the PositionMetadatakey.
+    // with the `PositionMetadatakey`.
     for tpr::PositionOpen {
         position,
         position_meta,

--- a/packages/wasm/crate/src/planner.rs
+++ b/packages/wasm/crate/src/planner.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::mem;
+use std::num::NonZeroU32;
 
 use anyhow::anyhow;
 use decaf377::{Fq, Fr};
@@ -10,11 +11,12 @@ use penumbra_auction::auction::dutch::{
     ActionDutchAuctionEnd, ActionDutchAuctionSchedule, DutchAuctionDescription,
 };
 use penumbra_auction::auction::{AuctionId, AuctionNft};
-use penumbra_dex::lp::plan::PositionWithdrawPlan;
+use penumbra_dex::lp::plan::{PositionOpenPlan, PositionWithdrawPlan};
+use penumbra_dex::lp::PositionMetadata;
 use penumbra_dex::swap_claim::SwapClaimPlan;
 use penumbra_dex::{
     swap::{SwapPlaintext, SwapPlan},
-    PositionClose, PositionOpen, TradingPair,
+    PositionClose, TradingPair,
 };
 use penumbra_fee::FeeTier;
 use penumbra_funding::liquidity_tournament::ActionLiquidityTournamentVotePlan;
@@ -411,11 +413,31 @@ pub async fn plan_transaction_inner<Db: Database>(
         actions_list.push(ActionPlan::Ics20Withdrawal(ics20_withdrawal.try_into()?));
     }
 
-    for tpr::PositionOpen { position } in request.position_opens {
-        actions_list.push(ActionPlan::PositionOpen(PositionOpen {
+    // Note: during action creation, a convinience method exists that generates the `PositionMetadatakey`
+    // derived from the outgoing viewing key (OVK), and encrypt the plaintext `PositionMetadata`
+    // with the PositionMetadatakey.
+    for tpr::PositionOpen {
+        position,
+        position_meta,
+    } in request.position_opens
+    {
+        // Relationship here is that all positions with the same `bundle_id` must share the same `strategy_tag`.
+        let bundle_identifier = NonZeroU32::new(OsRng.next_u32());
+        let mut position_metadata: Option<PositionMetadata> = position_meta
+            .map(TryInto::try_into)
+            .transpose()
+            .expect("invalid or malformed position metadata");
+
+        if let Some(ref mut metadata) = position_metadata {
+            metadata.identifier =
+                bundle_identifier.expect("invalid or malformed position metadata identifier");
+        }
+
+        actions_list.push(ActionPlan::PositionOpen(PositionOpenPlan {
             position: position
-                .ok_or_else(|| anyhow!("missing position in PositionOpen"))?
+                .ok_or_else(|| anyhow!("missing position in PositionOpenPlan"))?
                 .try_into()?,
+            metadata: position_metadata,
         }));
     }
 

--- a/packages/wasm/src/build.ts
+++ b/packages/wasm/src/build.ts
@@ -52,8 +52,13 @@ export const buildActionParallel = async (
   if (!actionPlan?.action.case) {
     throw new Error('No action key provided');
   }
+
+  // Remapping only for the proving-key loader
+  const actionCase =
+    actionPlan.action.case === 'positionOpenPlan' ? 'positionOpen' : actionPlan.action.case;
+
   if (keyPath) {
-    await loadProvingKey(actionPlan.action.case, keyPath);
+    await loadProvingKey(actionCase, keyPath);
   }
 
   const result = build_action(

--- a/packages/wasm/src/dex.ts
+++ b/packages/wasm/src/dex.ts
@@ -23,8 +23,8 @@ export const getLpNftMetadata = (
 
 export const decryptPositionMetadata = (
   fullViewingKey: FullViewingKey,
-  position_metadata: PositionMetadata,
+  position_metadata: Uint8Array,
 ): PositionMetadata => {
-  const bytes = decrypt_position_metadata(fullViewingKey.toBinary(), position_metadata.toBinary());
+  const bytes = decrypt_position_metadata(fullViewingKey.toBinary(), position_metadata);
   return PositionMetadata.fromBinary(bytes);
 };

--- a/packages/wasm/src/dex.ts
+++ b/packages/wasm/src/dex.ts
@@ -1,10 +1,12 @@
-import { compute_position_id, get_lpnft_asset } from '../wasm/index.js';
+import { compute_position_id, decrypt_position_metadata, get_lpnft_asset } from '../wasm/index.js';
 import {
   Position,
   PositionId,
+  PositionMetadata,
   PositionState,
 } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { FullViewingKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 
 export const computePositionId = (position: Position): PositionId => {
   const bytes = compute_position_id(position.toBinary());
@@ -17,4 +19,12 @@ export const getLpNftMetadata = (
 ): Metadata => {
   const result = get_lpnft_asset(positionId.toBinary(), positionState.toBinary());
   return Metadata.fromBinary(result);
+};
+
+export const decryptPositionMetadata = (
+  fullViewingKey: FullViewingKey,
+  position_metadata: PositionMetadata,
+): PositionMetadata => {
+  const bytes = decrypt_position_metadata(fullViewingKey.toBinary(), position_metadata.toBinary());
+  return PositionMetadata.fromBinary(bytes);
 };


### PR DESCRIPTION
## Description of Changes

- bumps wasm deps to `v2.0.1` tag,
- the `PositionOpen` transaction planner request in the planner is amended to generate a bundle identifier and include it in the position metadata object, as part of the `ActionPlan` payload.

## Related Issue

references https://github.com/penumbra-zone/web/issues/2500, and extends https://github.com/penumbra-zone/web/pull/2508

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
