### PR TITLE
fix: veil: name active pairs correctly in explore page

### DIFF
--- a/apps/veil/src/pages/explore/ui/stats.tsx
+++ b/apps/veil/src/pages/explore/ui/stats.tsx
@@ -105,7 +105,7 @@ const TotalLiquidity = ({ registry, stats }: CardProps) => {
 
 const NumberOfActivePairs = ({ stats }: CardProps) => {
   return (
-    <InfoCard title='Number of Trades (24h)'>
+    <InfoCard title='Number of Active Pairs (24h)'>
       <Text large color='text.primary'>
         {pluralizeAndShortify(stats.activePairs, 'pair', 'pairs')}
       </Text>


### PR DESCRIPTION
There was a regression (my B) in the name of this part of the explore page, where the active pairs repeated the same name as another segment.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
