### PR TITLE
fix: render earnings in social card correctly

### DIFF
--- a/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
+++ b/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
@@ -174,7 +174,7 @@ export const SocialCardDialog = observer(
       setInitialParams({
         epoch: String(epoch),
         rewarded: latestReward.reward > 0,
-        earnings: `${latestReward.reward}:UM`,
+        earnings: `${Math.floor(latestReward.reward) / 10 ** exponent}:UM`,
         votingStreak: `${delegatorSummary.data.streak}:`,
         incentivePool: `${Math.floor(Number(summaryData.lp_rewards) + Number(summaryData.delegator_rewards)) / 10 ** exponent}:UM`,
         lpPool: `${Math.floor(summaryData.lp_rewards) / 10 ** exponent}:UM`,


### PR DESCRIPTION
We missed correcting the exponent here.

The social card renderer expects display units for everything.


## Related Issue

Closes #2535.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
