### PR TITLE
fix: enforce displaying unique gauge assets in asset selector

### DIFF
--- a/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
@@ -52,8 +52,6 @@ export const LandingCard = observer(() => {
   // We want to pass the most recent epoch with rewards to trigger the social card dialogue.
   const { isOpen: showSocial, close: hideSocial } = useTournamentSocialCard(latestReward?.epoch);
 
-  const nonZeroGauges = assetGauges.filter(g => g.votes > 0);
-
   return (
     <>
       <GradientCard>
@@ -81,12 +79,10 @@ export const LandingCard = observer(() => {
             </div>
 
             <IncentivePool summary={summary?.[0]} loading={summaryLoading} />
-            {nonZeroGauges.length > 0 && (
-              <TournamentResults
-                results={nonZeroGauges.slice(0, 5)}
-                loading={isPending || epochGaugeLoading}
-              />
-            )}
+            <TournamentResults
+              results={assetGauges.slice(0, 5)}
+              loading={isPending || epochGaugeLoading}
+            />
             <VotingInfo />
           </div>
         </div>

--- a/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
@@ -52,6 +52,8 @@ export const LandingCard = observer(() => {
   // We want to pass the most recent epoch with rewards to trigger the social card dialogue.
   const { isOpen: showSocial, close: hideSocial } = useTournamentSocialCard(latestReward?.epoch);
 
+  const nonZeroGauges = assetGauges.filter(g => g.votes > 0);
+
   return (
     <>
       <GradientCard>
@@ -79,10 +81,12 @@ export const LandingCard = observer(() => {
             </div>
 
             <IncentivePool summary={summary?.[0]} loading={summaryLoading} />
-            <TournamentResults
-              results={assetGauges.slice(0, 5)}
-              loading={isPending || epochGaugeLoading}
-            />
+            {nonZeroGauges.length > 0 && (
+              <TournamentResults
+                results={nonZeroGauges.slice(0, 5)}
+                loading={isPending || epochGaugeLoading}
+              />
+            )}
             <VotingInfo />
           </div>
         </div>

--- a/apps/veil/src/pages/tournament/ui/round/current-voting-results/table-row.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/current-voting-results/table-row.tsx
@@ -2,11 +2,11 @@ import cn from 'clsx';
 import { TableCell } from '@penumbra-zone/ui/TableCell';
 import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
 import { Text } from '@penumbra-zone/ui/Text';
-import { round } from '@penumbra-zone/types/round';
 import { pnum } from '@penumbra-zone/types/pnum';
 import type { MappedGauge } from '../../../server/previous-epochs';
 import { ProvideLiquidityButton } from '../../shared/provide-liquidity-button';
 import { VoteButton } from './vote-button';
+import { formatPercentage, VOTING_THRESHOLD } from '../../vote-dialog/vote-dialog-asset';
 
 export const TableRow = ({
   item,
@@ -41,8 +41,11 @@ export const TableRow = ({
                 style={{ width: `${item.portion * 100}%` }}
               />
             </div>
-            <Text technical color='text.secondary'>
-              {round({ value: item.portion * 100, decimals: 0 })}%
+            <Text
+              technical
+              color={item.portion < VOTING_THRESHOLD ? 'text.secondary' : 'text.primary'}
+            >
+              {formatPercentage(item.portion)}%
             </Text>
           </div>
         )}

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/asset-selector.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/asset-selector.tsx
@@ -19,13 +19,23 @@ export const VotingAssetSelector = ({
   gauge,
   onSelect,
 }: VotingAssetSelectorProps) => {
+  const uniqueGauge = useMemo(() => {
+    const seen = new Set<string>();
+    return gauge.filter(g => {
+      if (seen.has(g.asset.base)) {
+        return false;
+      }
+      seen.add(g.asset.base);
+      return true;
+    });
+  }, [gauge]);
+
   const gaugeWithValue = useMemo(() => {
     if (!selectedAsset) {
-      return gauge;
+      return uniqueGauge;
     }
-
-    return [selectedAsset, ...gauge.filter(asset => asset.asset.base !== selectedAsset.asset.base)];
-  }, [selectedAsset, gauge]);
+    return [selectedAsset, ...uniqueGauge.filter(a => a.asset.base !== selectedAsset.asset.base)];
+  }, [selectedAsset, uniqueGauge]);
 
   return (
     <div className='flex flex-col gap-2'>
@@ -40,9 +50,9 @@ export const VotingAssetSelector = ({
           {loading && new Array(5).fill({}).map((_, index) => <LoadingVoteAsset key={index} />)}
 
           {!loading &&
-            gaugeWithValue.map(asset => (
+            gaugeWithValue.map((asset, idx) => (
               <VoteDialogAsset
-                key={asset.asset.base}
+                key={`${asset.asset.base}-${idx}`}
                 asset={asset}
                 onSelect={() => onSelect(asset)}
               />

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
@@ -22,18 +22,21 @@ export const VoteAssetIcon = ({ asset }: { asset: MappedGauge }) => {
   );
 };
 
+export const formatPercentage = (portion: number): string => {
+  if (portion < 0.01) {
+    return '<1';
+  }
+  if (portion === 0) {
+    return '0';
+  }
+
+  return round({ value: portion * 100, decimals: 0 });
+};
+
 export const VoteAssetContent = ({ asset }: { asset: MappedGauge }) => {
   const isSecondary = asset.portion < VOTING_THRESHOLD;
 
-  const percentage = useMemo(() => {
-    if (asset.portion < 0.01) {
-      return '<1';
-    }
-    if (asset.portion === 0) {
-      return '0';
-    }
-    return round({ value: asset.portion * 100, decimals: 0 });
-  }, [asset]);
+  const percentage = useMemo(() => formatPercentage(asset.portion), [asset.portion]);
 
   return (
     <div className='ml-1 flex grow flex-col gap-1'>


### PR DESCRIPTION
## Description of Changes

fixes bug where every time you click a different asset in the vote dialog an existing asset is added to the modal. 

https://github.com/penumbra-zone/web/issues/2540 as follow-up work.

https://github.com/user-attachments/assets/69c0cc41-37f8-4f0d-a03c-061b2c64c843

## Related Issue

https://github.com/penumbra-zone/web/issues/2539

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
