### PR TITLE
fix(veil): #2541: share button

### DIFF
--- a/apps/veil/src/features/tournament-earnings-canvas/utils.ts
+++ b/apps/veil/src/features/tournament-earnings-canvas/utils.ts
@@ -12,11 +12,14 @@ export const queryParamMap = {
 };
 
 export function encodeParams(params: TournamentParams): string {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- discard the rewarded param
+  const { rewarded, ...shortParams } = params;
+
   const keyMap = Object.fromEntries(
     Object.entries(queryParamMap).map(([key, value]) => [value, key]),
   ) as Record<string, string>;
 
-  return Object.entries(params)
+  return Object.entries(shortParams)
     .map(([key, value]) => `${keyMap[key]}=${value}`)
     .join('&');
 }

--- a/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
+++ b/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
@@ -162,12 +162,13 @@ export const SocialCardDialog = observer(
 
     const summaryData = summary?.[0];
     const latestReward = rewards.values().next().value as LqtDelegatorHistoryData | undefined;
+    const earnings = latestReward?.reward && Math.floor(latestReward.reward) / 10 ** exponent;
 
     const loading =
       loadingSummary || loadingRewards || loadingDelegatorSummary || stakingTokenLoading;
 
     useEffect(() => {
-      if (loading || (initialParams ?? !summaryData) || !latestReward || !delegatorSummary?.data) {
+      if (loading || (initialParams ?? !summaryData) || !latestReward) {
         return;
       }
 
@@ -175,7 +176,7 @@ export const SocialCardDialog = observer(
         epoch: String(epoch),
         rewarded: latestReward.reward > 0,
         earnings: `${Math.floor(latestReward.reward) / 10 ** exponent}:UM`,
-        votingStreak: `${delegatorSummary.data.streak}:`,
+        votingStreak: `${delegatorSummary?.data?.streak ?? 1}:`,
         incentivePool: `${Math.floor(Number(summaryData.lp_rewards) + Number(summaryData.delegator_rewards)) / 10 ** exponent}:UM`,
         lpPool: `${Math.floor(summaryData.lp_rewards) / 10 ** exponent}:UM`,
         delegatorPool: `${Math.floor(summaryData.delegator_rewards) / 10 ** exponent}:UM`,
@@ -193,7 +194,7 @@ export const SocialCardDialog = observer(
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [dontShowAgain, setDontShowAgain] = useState(false);
 
-    const text = `Just won ${latestReward?.reward} UM from the @penumbrazone Liquidity Tournament
+    const text = `Just won ${earnings} UM from the @penumbrazone Liquidity Tournament
 Delegated UM. Voted. Earned. All without giving up privacy.
 ${currentEpochSummary?.[0]?.ends_in_s ? `Next round starts in ${formatTimeRemaining(currentEpochSummary[0].ends_in_s)}` : ''}`;
 


### PR DESCRIPTION
Closes #2541 

Fixed UM exponent display in the share button, and also fixed social card not showing if the address is not reveled because it couldn't calculate the streak. I assigned the default streak to "1" if address is not revealed.