### PR TITLE
fix(veil): #2544: allow zeros in order input

### DIFF
--- a/apps/veil/src/pages/trade/ui/order-form/order-form-limit.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-limit.tsx
@@ -1,7 +1,6 @@
 import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
-import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
@@ -25,11 +24,10 @@ export const LimitOrderForm = observer(({ parentStore }: { parentStore: OrderFor
       <div className='mb-4'>
         <div className='mb-2'>
           <OrderInput
+            round
             label={`When ${store.baseAsset?.symbol} is`}
-            value={round({
-              value: store.priceInput,
-              decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-            })}
+            value={store.priceInput}
+            decimals={store.quoteAsset?.exponent ?? defaultDecimals}
             onChange={price => store.setPriceInput(price)}
             denominator={store.quoteAsset?.symbol}
           />
@@ -44,22 +42,20 @@ export const LimitOrderForm = observer(({ parentStore }: { parentStore: OrderFor
       </div>
       <div className='mb-4'>
         <OrderInput
+          round
           label={isBuy ? 'Buy' : 'Sell'}
-          value={round({
-            value: store.baseInput,
-            decimals: store.baseAsset?.exponent ?? defaultDecimals,
-          })}
+          value={store.baseInput}
+          decimals={store.baseAsset?.exponent ?? defaultDecimals}
           onChange={store.setBaseInput}
           denominator={store.baseAsset?.symbol}
         />
       </div>
       <div className='mb-4'>
         <OrderInput
+          round
           label={isBuy ? 'Pay with' : 'Receive'}
-          value={round({
-            value: store.quoteInput,
-            decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-          })}
+          value={store.quoteInput}
+          decimals={store.quoteAsset?.exponent ?? defaultDecimals}
           onChange={store.setQuoteInput}
           denominator={store.quoteAsset?.symbol}
         />

--- a/apps/veil/src/pages/trade/ui/order-form/order-form-market.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-market.tsx
@@ -2,7 +2,6 @@ import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
-import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
@@ -65,11 +64,10 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
       <SegmentedControl direction={store.direction} setDirection={store.setDirection} />
       <div className='mb-4'>
         <OrderInput
+          round
+          value={store.baseInput}
+          decimals={store.baseAsset?.exponent ?? defaultDecimals}
           label={isBuy ? 'Buy' : 'Sell'}
-          value={round({
-            value: store.baseInput,
-            decimals: store.baseAsset?.exponent ?? defaultDecimals,
-          })}
           onChange={store.setBaseInput}
           isEstimating={store.baseEstimating}
           isApproximately={isBuy && store.baseInputAmount !== 0}
@@ -78,11 +76,10 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
       </div>
       <div className='mb-4'>
         <OrderInput
+          round
           label={isBuy ? 'Pay with' : 'Receive'}
-          value={round({
-            value: store.quoteInput,
-            decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-          })}
+          value={store.quoteInput}
+          decimals={store.quoteAsset?.exponent ?? defaultDecimals}
           onChange={store.setQuoteInput}
           isEstimating={store.quoteEstimating}
           isApproximately={!isBuy && store.quoteInputAmount !== 0}

--- a/apps/veil/src/pages/trade/ui/order-form/order-form-range-liquidity.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-range-liquidity.tsx
@@ -2,7 +2,6 @@ import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
-import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
@@ -28,11 +27,10 @@ export const RangeLiquidityOrderForm = observer(
         <div className='mb-4'>
           <div className='mb-1'>
             <OrderInput
+              round
               label='Liquidity Target'
-              value={round({
-                value: store.liquidityTargetInput,
-                decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-              })}
+              value={store.liquidityTargetInput}
+              decimals={store.quoteAsset?.exponent ?? defaultDecimals}
               onChange={store.setLiquidityTargetInput}
               denominator={store.quoteAsset?.symbol}
             />
@@ -68,11 +66,10 @@ export const RangeLiquidityOrderForm = observer(
         <div className='mb-4'>
           <div className='mb-2'>
             <OrderInput
+              round
               label='Upper Price Bound'
-              value={round({
-                value: store.upperPriceInput,
-                decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-              })}
+              value={store.upperPriceInput}
+              decimals={store.quoteAsset?.exponent ?? defaultDecimals}
               onChange={price => store.setUpperPriceInput(price)}
               denominator={store.quoteAsset?.symbol}
             />
@@ -86,11 +83,10 @@ export const RangeLiquidityOrderForm = observer(
         <div className='mb-4'>
           <div className='mb-2'>
             <OrderInput
+              round
               label='Lower Price Bound'
-              value={round({
-                value: store.lowerPriceInput,
-                decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-              })}
+              value={store.lowerPriceInput}
+              decimals={store.quoteAsset?.exponent ?? defaultDecimals}
               onChange={price => store.setLowerPriceInput(price)}
               denominator={store.quoteAsset?.symbol}
             />

--- a/apps/veil/src/pages/trade/ui/order-form/order-form-simple-liquidity.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-simple-liquidity.tsx
@@ -4,7 +4,6 @@ import { WalletMinimal, InfoIcon } from 'lucide-react';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { TextInput } from '@penumbra-zone/ui/TextInput';
-import { round } from '@penumbra-zone/types/round';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { Tooltip } from '@penumbra-zone/ui/Tooltip';
@@ -68,10 +67,8 @@ export const SimpleLiquidityOrderForm = observer(
                 type='number'
                 typography='large'
                 blurOnWheel
-                value={round({
-                  value: store.baseInput,
-                  decimals: store.baseAsset?.exponent ?? defaultDecimals,
-                })}
+                value={store.baseInput}
+                maxDecimals={store.quoteAsset?.exponent ?? defaultDecimals}
                 onChange={store.setBaseInput}
                 endAdornment={
                   store.baseAsset?.symbol && (
@@ -116,10 +113,8 @@ export const SimpleLiquidityOrderForm = observer(
                 type='number'
                 typography='large'
                 blurOnWheel
-                value={round({
-                  value: store.quoteInput,
-                  decimals: store.quoteAsset?.exponent ?? defaultDecimals,
-                })}
+                value={store.quoteInput}
+                maxDecimals={store.quoteAsset?.exponent ?? defaultDecimals}
                 onChange={store.setQuoteInput}
                 endAdornment={
                   store.quoteAsset?.symbol && (

--- a/packages/ui/src/TextInput/index.tsx
+++ b/packages/ui/src/TextInput/index.tsx
@@ -1,8 +1,8 @@
-import { HTMLAttributes, ReactNode, Ref } from 'react';
+import cn from 'clsx';
+import { HTMLAttributes, ReactNode, Ref, KeyboardEvent } from 'react';
 import { small, body, large } from '../utils/typography';
 import { ActionType, getFocusWithinOutlineColorByActionType } from '../utils/action-type';
 import { useDisabled } from '../utils/disabled-context';
-import cn from 'clsx';
 import { Text } from '../Text';
 import { ThemeColor } from '../utils/color';
 import { useDensity } from '../utils/density';
@@ -45,6 +45,11 @@ export interface TextInputProps
    * value. This prop will prevent that if set to true.
    */
   blurOnWheel?: boolean;
+  /**
+   * Prevent the input from entering more decimals than a given number.
+   * Useful for entering amounts or prices of tokens.
+   */
+  maxDecimals?: number;
 }
 
 /**
@@ -68,6 +73,7 @@ export const TextInput = ({
   blurOnWheel = false,
   ref,
   typography = 'small',
+  maxDecimals,
   ...rest
 }: TextInputProps) => {
   const density = useDensity();
@@ -78,6 +84,15 @@ export const TextInput = ({
   } else if (typography === 'body') {
     typographyCn = body;
   }
+
+  // prevent input from exceeding the specified number of decimals
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    const key = parseInt(event.key);
+    const decimalPart = value?.split('.')[1] ?? '';
+    if (!isNaN(key) && typeof maxDecimals !== 'undefined' && decimalPart.length >= maxDecimals) {
+      event.preventDefault();
+    }
+  };
 
   return (
     <label
@@ -110,6 +125,7 @@ export const TextInput = ({
       <input
         {...rest}
         value={value}
+        onKeyDown={onKeyDown}
         onChange={e => onChange?.(e.target.value)}
         onWheel={
           blurOnWheel


### PR DESCRIPTION
Closes #2544 

Trailing zeros were adding an overhead for value rendering in order inputs. Now, it uses `round` function only if the input is not focuses. Previously, `round` was used to prevent entering more decimal numbers than the asset exponent, now `onKeyDown` controls it.