### PR TITLE
fix(veil): #2540: introduce threshold bounds in voting dialog

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-epoch-results.ts
+++ b/apps/veil/src/pages/tournament/api/use-epoch-results.ts
@@ -54,19 +54,21 @@ export const useEpochResults = (
 
   // adapts filtered assets to the gauges
   const assetGauges = useMemo<MappedGauge[]>(() => {
-    return filteredAssets.map(asset => {
-      const fromGauge = gaugeMapByDenom.get(asset.base);
-      if (fromGauge) {
-        return fromGauge;
-      }
+    return filteredAssets
+      .map(asset => {
+        const fromGauge = gaugeMapByDenom.get(asset.base);
+        if (fromGauge) {
+          return fromGauge;
+        }
 
-      return {
-        asset,
-        epoch: 0,
-        votes: 0,
-        portion: 0,
-      };
-    });
+        return {
+          asset,
+          epoch: 0,
+          votes: 0,
+          portion: 0,
+        };
+      })
+      .sort((a, b) => b.votes - a.votes);
   }, [filteredAssets, gaugeMapByDenom]);
 
   return {

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/index.tsx
@@ -43,11 +43,7 @@ export const VoteDialogueSelector = observer(
     const { epoch, isLoading: epochLoading } = useCurrentEpoch();
 
     const { data: notes } = useLQTNotes(subaccount, epoch);
-    const {
-      data: assetsData,
-      isLoading,
-      assetGauges,
-    } = useEpochResults(
+    const { isLoading, assetGauges } = useEpochResults(
       'epoch-results-vote-dialog',
       {
         epoch,
@@ -57,16 +53,6 @@ export const VoteDialogueSelector = observer(
       !isOpen && epochLoading,
       searchQuery,
     );
-
-    // Collect an array of minium 5 items. If there are more than 5 voted assets, return all of them.
-    // If less than 5, firstly return all voted assets, and then fill the rest with non-voted assets.
-    const assets = assetsData?.data ?? [];
-    const selectorAssets = [
-      ...assets,
-      ...((assets.length || 5) < 5
-        ? assetGauges.slice(assets.length, assets.length + 5 - assets.length)
-        : []),
-    ];
 
     const handleVoteSubmit = async () => {
       if (!selectedAsset) {
@@ -184,7 +170,7 @@ export const VoteDialogueSelector = observer(
               <VotingAssetSelector
                 selectedAsset={selectedAsset}
                 loading={isLoading}
-                gauge={selectorAssets}
+                gauge={assetGauges}
                 onSelect={onSearchSelect}
               />
             )}

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
@@ -14,9 +14,8 @@ export interface VoteDialogAssetProps {
 }
 
 export const VoteAssetIcon = ({ asset }: { asset: MappedGauge }) => {
-  const isSecondary = asset.portion < VOTING_THRESHOLD;
   return (
-    <div className={cn('min-w-8', isSecondary && 'grayscale')}>
+    <div className={cn('min-w-8')}>
       <AssetIcon size='lg' metadata={asset.asset} />
     </div>
   );


### PR DESCRIPTION
Closes #2540 

In voting dialog, splits all assets into 2 categories: above and below the threshold. If there's no assets above it, doesn't split into groups.

Also, removes grayscale from asset icons that are below the threshold.