### PR TITLE
fix: allow withdrawing withdrawn positions with reserves

### DIFF
--- a/apps/veil/src/entities/position/ui/action-button.tsx
+++ b/apps/veil/src/entities/position/ui/action-button.tsx
@@ -9,6 +9,7 @@ import {
 import { withdrawPositions } from '../api/withdraw-positions';
 import { closePositions } from '../api/close-positions';
 import { Dash } from './dash';
+import { fullyWithdrawn } from '@/shared/utils/position';
 
 export const ActionButton = observer(({ id, position }: { id: PositionId; position: Position }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -33,7 +34,7 @@ export const ActionButton = observer(({ id, position }: { id: PositionId; positi
         Close
       </Button>
     );
-  } else if (state?.state === PositionState_PositionStateEnum.CLOSED) {
+  } else if (!fullyWithdrawn(position)) {
     return (
       <Button disabled={isLoading} onClick={() => void withdraw()}>
         Withdraw

--- a/apps/veil/src/entities/position/ui/table.tsx
+++ b/apps/veil/src/entities/position/ui/table.tsx
@@ -29,6 +29,7 @@ import { Dash } from './dash';
 import { useObserver } from '@/shared/utils/use-observer';
 import SpinnerIcon from '@/shared/assets/spinner-icon.svg';
 import { PositionState_PositionStateEnum } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { fullyWithdrawn } from '@/shared/utils/position';
 
 export interface PositionsTableProps {
   base?: Metadata;
@@ -239,7 +240,11 @@ export const PositionsTable = observer(({ base, quote, stateFilter }: PositionsT
                     </TableCell>
 
                     <TableCell loading={isLoading} variant={variant}>
-                      {position.isWithdrawn ? <Dash /> : <PositionsCurrentValue order={order} />}
+                      {fullyWithdrawn(position.position) ? (
+                        <Dash />
+                      ) : (
+                        <PositionsCurrentValue order={order} />
+                      )}
                     </TableCell>
 
                     <TableCell loading={isLoading} variant={variant}>

--- a/apps/veil/src/shared/utils/position.ts
+++ b/apps/veil/src/shared/utils/position.ts
@@ -1,0 +1,17 @@
+import {
+  Position,
+  PositionState_PositionStateEnum,
+} from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { pnum } from '@penumbra-zone/types/pnum';
+
+/** Check if a position is fully withdrawn.
+ *
+ * In other words, the position is withdrawn, with no reserves.
+ */
+export function fullyWithdrawn(position: Position): boolean {
+  return (
+    position.state?.state === PositionState_PositionStateEnum.WITHDRAWN &&
+    pnum(position.reserves?.r1).toNumber() <= 0 &&
+    pnum(position.reserves?.r2).toNumber() <= 0
+  );
+}


### PR DESCRIPTION
## Description of Changes

The logic was simply wrong, making the assumption that only closed positions can be withdrawn.

Instead, this adds a little helper to check if a position is "fullyWithdrawn", i.e. has no reserves, and is withdrawn.

This is the kind of thing where having an actual domain library would be helpful.

## Related Issue

Closes #2552.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
