### PR TITLE
ci(fly): build protobuf packages first

### DIFF
--- a/ci/containerfiles/Containerfile-veil-fly
+++ b/ci/containerfiles/Containerfile-veil-fly
@@ -35,7 +35,7 @@ RUN pnpm run postinstall || echo "Syncpack completed with warnings"
 RUN pnpm rebuild canvas
 RUN pnpm rebuild || echo "Some rebuilds failed but continuing..."
 
-ENV NODE_OPTIONS=--max-old-space-size=4096
+ENV NODE_OPTIONS=--max-old-space-size=8192
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN echo "=== Building veil ===" && \
     pnpm --filter "penumbra-veil..." run build 2>&1


### PR DESCRIPTION
## Description of Changes

I can run CI locally, so I suspect this is a race condition in the parallel build step. This is an attempt at fixing the problem by first running the protobuf packages install. It might uncover another issue next.

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
