### PR TITLE
fix(veil): #2579: correct LQT eligibility

### DIFF
--- a/apps/veil/src/pages/tournament/ui/landing-card/explainer.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/explainer.tsx
@@ -39,8 +39,8 @@ export const Explainer = () => {
               Provide Liquidity
             </Text>
             <Text variant='small' color='text.secondary'>
-              Provide the best liquidity in response to delegator votes in order to deepen what is
-              available for trading. LPs earn rewards based on how much their positions are used.
+              Provide quality liquidity on the UM pair for incentivized assets, as voted for by
+              delegators. LPs earn rewards based on how much their positions are used.
             </Text>
           </div>
         </div>

--- a/apps/veil/src/pages/trade/ui/order-form/order-form-simple-liquidity.tsx
+++ b/apps/veil/src/pages/trade/ui/order-form/order-form-simple-liquidity.tsx
@@ -15,7 +15,7 @@ import { PriceSlider } from './price-slider';
 import { useEffect, useState } from 'react';
 import { Icon } from '@penumbra-zone/ui/Icon';
 import { Density } from '@penumbra-zone/ui/Density';
-import { isLqtEligible } from '@/shared/utils/is-lqt-eligible';
+import { useIsLqtEligible } from '@/shared/utils/is-lqt-eligible';
 import { LiquidityDistributionShape } from '@/shared/math/position';
 import { LiquidityShape } from './liquidity-shape';
 
@@ -23,7 +23,7 @@ export const SimpleLiquidityOrderForm = observer(
   ({ parentStore }: { parentStore: OrderFormStore }) => {
     const { connected } = connectionStore;
     const { simpleLPForm: store } = parentStore;
-    const isLQTEligible = isLqtEligible(store.baseAsset?.metadata, store.quoteAsset?.metadata);
+    const isLQTEligible = useIsLqtEligible(store.baseAsset?.metadata, store.quoteAsset?.metadata);
 
     const priceSpread = DEFAULT_PRICE_SPREAD;
     const priceRange = DEFAULT_PRICE_RANGE;

--- a/apps/veil/src/pages/trade/ui/pair-selector/default-results.tsx
+++ b/apps/veil/src/pages/trade/ui/pair-selector/default-results.tsx
@@ -9,7 +9,7 @@ import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
 import { usePairs } from '@/pages/trade/api/use-pairs';
 import { shortify } from '@penumbra-zone/types/shortify';
 import { Skeleton } from '@/shared/ui/skeleton';
-import { isLqtEligible } from '@/shared/utils/is-lqt-eligible';
+import { useIsLqtEligible } from '@/shared/utils/is-lqt-eligible';
 import { Pair, StarButton, starStore } from '@/features/star-pair';
 import { LoadingAsset } from './loading-asset';
 
@@ -33,7 +33,7 @@ const StartAdornment = ({ base, quote }: { base: Metadata; quote: Metadata }) =>
 };
 
 const EndAdornment = ({ base, quote }: { base: Metadata; quote: Metadata }) => {
-  const isLQTEligible = isLqtEligible(base, quote);
+  const isLQTEligible = useIsLqtEligible(base, quote);
 
   return (
     <div className='flex items-center gap-2'>

--- a/apps/veil/src/shared/utils/is-lqt-eligible.ts
+++ b/apps/veil/src/shared/utils/is-lqt-eligible.ts
@@ -1,12 +1,25 @@
 import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { assetPatterns } from '@penumbra-zone/types/assets';
+import { useStakingTokenMetadata } from '@/shared/api/registry';
 
 /**
  * Checks if any of the provided assets is eligible for rewards in liquidity tournament.
  * Only IBC assets are eligible.
  */
-export const isLqtEligible = (...assets: (Metadata | undefined)[]): boolean => {
-  return assets.some(asset => {
-    return !!asset && assetPatterns.ibc.matches(asset.base);
-  });
+export const useIsLqtEligible = (
+  asset1: Metadata | undefined,
+  asset2: Metadata | undefined,
+): boolean => {
+  const { data: umMetadata } = useStakingTokenMetadata();
+
+  if (!asset1 || !asset2) {
+    return false;
+  }
+
+  const isOneIBC = assetPatterns.ibc.matches(asset1.base) || assetPatterns.ibc.matches(asset2.base);
+  const isOneUm =
+    !!asset1.penumbraAssetId?.equals(umMetadata.penumbraAssetId) ||
+    !!asset2.penumbraAssetId?.equals(umMetadata.penumbraAssetId);
+
+  return isOneIBC && isOneUm;
 };


### PR DESCRIPTION
Closes #2579 

Closes #2577 

Adds a check that one asset in a pair must be UM, while other is an IBC asset. Allows UM/USDC, SHITMOS/UM, but disallows TIA/USDC.