### PR TITLE
fix(veil): #2576: epochs pagination

### DIFF
--- a/apps/veil/src/pages/tournament/server/previous-epochs.ts
+++ b/apps/veil/src/pages/tournament/server/previous-epochs.ts
@@ -93,7 +93,7 @@ const previousEpochsQuery = async ({ limit, page, sortDirection }: PreviousEpoch
 
 const totalEpochsQuery = async () => {
   return pindexerDb
-    .selectFrom(pindexerDb.selectFrom('lqt.gauge').select('epoch').groupBy('epoch'))
+    .selectFrom(pindexerDb.selectFrom('lqt.gauge').select('epoch').groupBy('epoch').as('gauge'))
     .select(exp => [exp.fn.countAll().as('total')])
     .executeTakeFirst();
 };

--- a/apps/veil/src/pages/tournament/server/previous-epochs.ts
+++ b/apps/veil/src/pages/tournament/server/previous-epochs.ts
@@ -73,9 +73,7 @@ const previousEpochsQuery = async ({ limit, page, sortDirection }: PreviousEpoch
       sql<string>`encode(${exp.ref('gauge.asset_id')}, 'base64')`.as('asset_id'),
     ])
     .orderBy('epoch', sortDirection)
-    .orderBy('portion', 'desc')
-    .limit(limit)
-    .offset(limit * (page - 1));
+    .orderBy('portion', 'desc');
 
   // 2. group by 'epoch' and aggregate the results into a JSON array
   return pindexerDb
@@ -88,12 +86,14 @@ const previousEpochsQuery = async ({ limit, page, sortDirection }: PreviousEpoch
     ])
     .orderBy('epoch', sortDirection)
     .groupBy('epoch')
+    .limit(limit)
+    .offset(limit * (page - 1))
     .execute();
 };
 
 const totalEpochsQuery = async () => {
   return pindexerDb
-    .selectFrom('lqt.gauge')
+    .selectFrom(pindexerDb.selectFrom('lqt.gauge').select('epoch').groupBy('epoch'))
     .select(exp => [exp.fn.countAll().as('total')])
     .executeTakeFirst();
 };

--- a/apps/veil/src/pages/tournament/ui/landing-card/explainer.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/explainer.tsx
@@ -1,5 +1,9 @@
 import Image from 'next/image';
+import { ExternalLink } from 'lucide-react';
 import { Text } from '@penumbra-zone/ui/Text';
+import { Button } from '@penumbra-zone/ui/Button';
+
+const LQT_MARKETING_URL = 'https://penumbra.zone/tournament';
 
 export const Explainer = () => {
   return (
@@ -62,6 +66,13 @@ export const Explainer = () => {
             </Text>
           </div>
         </div>
+
+        {/* eslint-disable-next-line react/jsx-no-target-blank -- we want analytics to see referrers */}
+        <a href={LQT_MARKETING_URL} target='_blank'>
+          <Button icon={ExternalLink} priority='primary'>
+            Learn More
+          </Button>
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #2576 

Previously, incorrect pagination happened due to limit applying to the underlying query. Also, total rows count was incorrect.