### PR TITLE
Fix uncaught error incase of undefined price

### DIFF
--- a/apps/veil/src/pages/trade/ui/summary.tsx
+++ b/apps/veil/src/pages/trade/ui/summary.tsx
@@ -62,7 +62,7 @@ export const Summary = () => {
     <div className='flex flex-wrap items-center gap-x-4 gap-y-2 text-text-primary'>
       <SummaryCard title='Last price' loading={isLoading}>
         <Text detail color='text.primary'>
-          {data ? round({ value: data.price, decimals: 6 }) : '-'}
+          {data?.price ? round({ value: data.price, decimals: 6 }) : '-'}
         </Text>
       </SummaryCard>
       <SummaryCard title='24h Change' loading={isLoading}>


### PR DESCRIPTION
## Description of Changes

Fix uncaught error:
![image](https://github.com/user-attachments/assets/85027e44-6b1b-415b-a633-9b57b26364c1)

Trace:
<img width="289" alt="image" src="https://github.com/user-attachments/assets/8c7abc1f-f71e-406d-bb53-6a25923e4aa3" />


## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
