### PR TITLE
feat: add git version to veil footer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,9 @@
 !.npmrc
 !.syncpackrc
 
+# permit git dir, for version info
+!.git/
+
 # allow ca
 !ci/cert/ca-certificate.crt
 

--- a/apps/veil/app/app.tsx
+++ b/apps/veil/app/app.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ToastProvider } from '@penumbra-zone/ui/Toast';
 import { TooltipProvider } from '@penumbra-zone/ui/Tooltip';
 import { Header, SyncBar } from '@/widgets/header';
+import { Footer } from '@/widgets/footer';
 import { queryClient } from '@/shared/const/queryClient';
 import { connectionStore } from '@/shared/model/connection';
 import { recentPairsStore } from '@/pages/trade/ui/pair-selector/store';
@@ -37,11 +38,14 @@ export const App = observer(
         <RegistryProvider value={jsonRegistryWithGlobals}>
           <QueryClientProvider client={queryClient}>
             <TooltipProvider delayDuration={0}>
-              <main className='relative z-0'>
-                <SyncBar />
-                <Header />
-                {children}
-              </main>
+              <div className='min-h-screen flex flex-col'>
+                <main className='relative z-0 flex-1'>
+                  <SyncBar />
+                  <Header />
+                  {children}
+                </main>
+                <Footer />
+              </div>
               <div className='relative z-10'>
                 <ToastProvider />
               </div>

--- a/apps/veil/next.config.mjs
+++ b/apps/veil/next.config.mjs
@@ -25,12 +25,21 @@ const getCommitInfo = () => {
       GIT_ORIGIN_URL: gitOriginUrl,
     };
   } catch (error) {
-    console.warn('Failed to get commit info:', error);
-    return {
-      COMMIT_HASH: 'unknown',
-      COMMIT_DATE: 'unknown',
-      GIT_ORIGIN_URL: 'unknown',
-    };
+    const errorMessage = `Failed to get git commit info for version footer. This is likely because:
+1. Git is not installed in the container
+2. The .git directory is not available (missing from Docker context)
+3. The git repository is not properly initialized
+4. Permission issues accessing git commands
+
+Original error: ${error.message}
+
+To fix this in production containers, ensure:
+- Git is installed in the container
+- The .git directory is included in the Docker build context
+- The container has proper permissions to run git commands`;
+
+    console.error(errorMessage);
+    throw new Error(errorMessage);
   }
 };
 

--- a/apps/veil/src/widgets/footer/index.ts
+++ b/apps/veil/src/widgets/footer/index.ts
@@ -1,0 +1,1 @@
+export { Footer } from './ui/footer';

--- a/apps/veil/src/widgets/footer/ui/footer.tsx
+++ b/apps/veil/src/widgets/footer/ui/footer.tsx
@@ -1,0 +1,11 @@
+import { VeilVersion } from './veil-version';
+
+export const Footer = () => {
+  return (
+    <footer className='mt-auto border-t border-t-other-solid-stroke px-6 py-4'>
+      <div className='flex justify-center'>
+        <VeilVersion />
+      </div>
+    </footer>
+  );
+};

--- a/apps/veil/src/widgets/footer/ui/veil-version.tsx
+++ b/apps/veil/src/widgets/footer/ui/veil-version.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { format } from 'date-fns';
+
+export const VeilVersion = () => {
+  const commitHash = process.env.COMMIT_HASH || 'unknown';
+  const commitDate = process.env.COMMIT_DATE || 'unknown';
+  const gitOriginUrl = process.env.GIT_ORIGIN_URL || 'unknown';
+
+  const shortHash = commitHash.substring(0, 7);
+  const formattedDate =
+    commitDate !== 'unknown'
+      ? format(new Date(commitDate), "MMM dd yyyy HH:mm:ss 'GMT'x")
+      : 'unknown';
+
+  const commitUrl = gitOriginUrl !== 'unknown' ? `${gitOriginUrl}/commit/${commitHash}` : '#';
+
+  return (
+    <div className='text-sm'>
+      Version&nbsp;
+      <a href={commitUrl} target='_blank' rel='noopener noreferrer' className='underline'>
+        {shortHash}
+      </a>
+      {' - '}
+      {formattedDate}
+    </div>
+  );
+};

--- a/apps/veil/tsconfig.json
+++ b/apps/veil/tsconfig.json
@@ -30,6 +30,7 @@
     "src/**/*.ts",
     "src/**/*.tsx",
     "styles/styles.d.ts",
+    "types/**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]

--- a/apps/veil/types/env.d.ts
+++ b/apps/veil/types/env.d.ts
@@ -1,0 +1,7 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    COMMIT_HASH: string;
+    COMMIT_DATE: string;
+    GIT_ORIGIN_URL: string;
+  }
+}

--- a/ci/containerfiles/Containerfile-veil-fly
+++ b/ci/containerfiles/Containerfile-veil-fly
@@ -2,8 +2,8 @@ FROM node:22-bookworm AS builder
 WORKDIR /app
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    apt-get update --allow-insecure-repositories && \
-    apt-get install -y --allow-unauthenticated \
+    apt-get update && \
+    apt-get install -y \
     build-essential libcairo2-dev libpango1.0-dev \
     libjpeg-dev libgif-dev librsvg2-dev git-lfs curl \
     && rm -rf /var/lib/apt/lists/*

--- a/ci/containerfiles/Containerfile-veil-fly
+++ b/ci/containerfiles/Containerfile-veil-fly
@@ -21,6 +21,9 @@ COPY packages/*/package.json packages/
 # install dependencies, skip postinstall.
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
+# Copy in git dir, for displaying Veil version info
+COPY .git .git
+# Copy in Veil app code
 COPY apps/veil apps/veil/
 
 COPY packages packages/

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ lint-rust:
   pnpm turbo lint:rust
 
 # Build top-level debug container
-container: clean
+container:
   @just veil-container
   podman image ls | rg veil
 


### PR DESCRIPTION
## Description of Changes

Adds a git hash in the footer for Veil, so that it's obvious which commit is running on a given instance. There are multiple frontends managed by multiple orgs, all on their own deploy schedule, so this change is intended to make it clear whether a given fix has in fact been deployed to a given environment.

Closes https://github.com/penumbra-zone/web/issues/2154

## Images

It looks like this:

![veil-footer-2](https://github.com/user-attachments/assets/35a759ae-fc09-4d39-9068-76ea065845f7)


## Testing and review

Functionality-wise, this looks "good enough" to me, but I'm mostly concerned about the shape of the implementation. What you see is mostly what the LLM thought was a good idea. In particular, please scrutinize the overriding the node env and the resulting process.env calls; should we instead use an api env route as described in https://github.com/penumbra-zone/web/pull/2593?