### PR TITLE
fix details button 

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-voting-info.ts
+++ b/apps/veil/src/pages/tournament/api/use-voting-info.ts
@@ -27,14 +27,14 @@ export interface VotingAbility {
 }
 
 export type VotingInfo =
-  | { case: 'loading'; epoch: number | undefined }
-  | { case: 'not-connected'; epoch: number | undefined }
+  | { case: 'loading'; epoch: number }
+  | { case: 'not-connected'; epoch: number }
   | { case: 'already-voted'; epoch: number; votedFor: ValueView }
   | { case: 'needs-to-delegate'; epoch: number }
   | { case: 'can-vote'; epoch: number; ability: VotingAbility; power: ValueView }
   | { case: 'ended'; epoch: number; currentEpoch: number; votedFor?: ValueView }
   | { case: 'delegated-after-start'; epoch: number }
-  | { case: 'error'; epoch: number | undefined; error: Error };
+  | { case: 'error'; epoch: number; error: Error };
 
 async function votedFor(
   getMetadata: GetMetadata,
@@ -122,7 +122,7 @@ async function query(
   return { case: 'needs-to-delegate', epoch };
 }
 
-export function useVotingInfo(epoch?: number): VotingInfo {
+export function useVotingInfo(epoch: number): VotingInfo {
   const getMetadata = useGetMetadata();
   const { data: stakingTokenMetadata } = useStakingTokenMetadata();
   const { connectedLoading, connected, subaccount: account } = connectionStore;

--- a/apps/veil/src/pages/tournament/api/use-voting-info.ts
+++ b/apps/veil/src/pages/tournament/api/use-voting-info.ts
@@ -27,14 +27,14 @@ export interface VotingAbility {
 }
 
 export type VotingInfo =
-  | { case: 'loading' }
-  | { case: 'not-connected' }
-  | { case: 'already-voted'; votedFor: ValueView }
-  | { case: 'needs-to-delegate' }
-  | { case: 'can-vote'; ability: VotingAbility; power: ValueView }
-  | { case: 'ended'; currentEpoch: number; votedFor?: ValueView }
-  | { case: 'delegated-after-start' }
-  | { case: 'error'; error: Error };
+  | { case: 'loading'; epoch: number | undefined }
+  | { case: 'not-connected'; epoch: number | undefined }
+  | { case: 'already-voted'; epoch: number; votedFor: ValueView }
+  | { case: 'needs-to-delegate'; epoch: number }
+  | { case: 'can-vote'; epoch: number; ability: VotingAbility; power: ValueView }
+  | { case: 'ended'; epoch: number; currentEpoch: number; votedFor?: ValueView }
+  | { case: 'delegated-after-start'; epoch: number }
+  | { case: 'error'; epoch: number | undefined; error: Error };
 
 async function votedFor(
   getMetadata: GetMetadata,
@@ -103,7 +103,7 @@ async function query(
     hasDelegatedP,
   ]);
   if (votedForR) {
-    return { case: 'already-voted', votedFor: votedForR };
+    return { case: 'already-voted', epoch, votedFor: votedForR };
   }
   if (votingNotesR.length > 0) {
     const amount = votingNotesR.reduce(
@@ -113,13 +113,13 @@ async function query(
     const clonedMeta = stakingTokenMetadata.clone();
     clonedMeta.symbol = 'delUM';
     const power = toValueView({ amount, metadata: clonedMeta });
-    return { case: 'can-vote', ability: { notes: votingNotesR, epoch, account }, power };
+    return { case: 'can-vote', epoch, ability: { notes: votingNotesR, epoch, account }, power };
   }
   if (hasDelegatedR) {
-    return { case: 'delegated-after-start' };
+    return { case: 'delegated-after-start', epoch };
   }
 
-  return { case: 'needs-to-delegate' };
+  return { case: 'needs-to-delegate', epoch };
 }
 
 export function useVotingInfo(epoch?: number): VotingInfo {
@@ -141,7 +141,7 @@ export function useVotingInfo(epoch?: number): VotingInfo {
   });
   useRefetchOnNewBlock(['voting-info', theEpoch, account], votingQuery, !connected || !theEpoch);
   if (!connectedLoading && !connected) {
-    return { case: 'not-connected' };
+    return { case: 'not-connected', epoch: theEpoch };
   }
   if (
     connectedLoading ||
@@ -150,14 +150,15 @@ export function useVotingInfo(epoch?: number): VotingInfo {
     epochLoading ||
     votingQuery.isPending
   ) {
-    return { case: 'loading' };
+    return { case: 'loading', epoch: theEpoch };
   }
   if (votingQuery.error) {
-    return { case: 'error', error: votingQuery.error };
+    return { case: 'error', epoch: theEpoch, error: votingQuery.error };
   }
   if (currentEpoch > theEpoch) {
     return {
       case: 'ended',
+      epoch: theEpoch,
       currentEpoch,
       votedFor: votingQuery.data.case === 'already-voted' ? votingQuery.data.votedFor : undefined,
     };

--- a/apps/veil/src/pages/tournament/api/use-voting-info.ts
+++ b/apps/veil/src/pages/tournament/api/use-voting-info.ts
@@ -163,5 +163,5 @@ export function useVotingInfo(epoch?: number): VotingInfo {
       votedFor: votingQuery.data.case === 'already-voted' ? votingQuery.data.votedFor : undefined,
     };
   }
-  return votingQuery.data;
+  return { ...votingQuery.data, epoch: theEpoch };
 }

--- a/apps/veil/src/pages/tournament/api/use-voting-info.ts
+++ b/apps/veil/src/pages/tournament/api/use-voting-info.ts
@@ -162,5 +162,5 @@ export function useVotingInfo(epoch?: number): VotingInfo {
       votedFor: votingQuery.data.case === 'already-voted' ? votingQuery.data.votedFor : undefined,
     };
   }
-  return { ...votingQuery.data };
+  return votingQuery.data;
 }

--- a/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/index.tsx
@@ -83,7 +83,7 @@ export const LandingCard = observer(() => {
               results={assetGauges.slice(0, 5)}
               loading={isPending || epochGaugeLoading}
             />
-            <VotingInfo />
+            <VotingInfo epoch={epoch} identifier='landing-card' />
           </div>
         </div>
       </GradientCard>

--- a/apps/veil/src/pages/tournament/ui/round/round-card.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/round-card.tsx
@@ -125,7 +125,7 @@ export const RoundCard = observer(({ epoch }: RoundCardProps) => {
             <Text variant='h4' color='text.primary'>
               {ended ? 'This Epoch has Ended' : 'Cast Your Vote'}
             </Text>
-            <VotingInfo epoch={epoch} />
+            <VotingInfo epoch={epoch} identifier='round-card' />
           </div>
         </div>
       </GradientCard>

--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -16,7 +16,7 @@ import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_
 const STAKING_LINK = 'https://app.penumbra.zone/#/staking';
 
 export interface VotingInfoProps {
-  epoch: number;
+  epoch?: number;
   identifier: string;
 }
 

--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -37,7 +37,9 @@ export const VotingInfo = observer(({ epoch }: VotingInfoProps) => {
   const votingInfo = useVotingInfo(epoch);
 
   const isRoundPage = !!epoch;
-  const epochLink = epoch ? PagePath.TournamentRound.replace(':epoch', epoch.toString()) : '';
+  const epochLink = votingInfo.epoch
+    ? PagePath.TournamentRound.replace(':epoch', votingInfo.epoch.toString())
+    : '';
 
   const [isVoteDialogueOpen, setIsVoteDialogOpen] = useState(false);
 

--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -17,6 +17,7 @@ const STAKING_LINK = 'https://app.penumbra.zone/#/staking';
 
 export interface VotingInfoProps {
   epoch?: number;
+  identifier: string;
 }
 
 export const VotedFor = ({ votedFor }: { votedFor: ValueView }) => {
@@ -33,13 +34,11 @@ export const VotedFor = ({ votedFor }: { votedFor: ValueView }) => {
   );
 };
 
-export const VotingInfo = observer(({ epoch }: VotingInfoProps) => {
+export const VotingInfo = observer(({ epoch, identifier }: VotingInfoProps) => {
   const votingInfo = useVotingInfo(epoch);
 
-  const isRoundPage = !!epoch;
-  const epochLink = votingInfo.epoch
-    ? PagePath.TournamentRound.replace(':epoch', votingInfo.epoch.toString())
-    : '';
+  const isRoundPage = identifier == 'round-card';
+  const epochLink = epoch ? PagePath.TournamentRound.replace(':epoch', epoch.toString()) : '';
 
   const [isVoteDialogueOpen, setIsVoteDialogOpen] = useState(false);
 

--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -16,7 +16,7 @@ import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_
 const STAKING_LINK = 'https://app.penumbra.zone/#/staking';
 
 export interface VotingInfoProps {
-  epoch?: number;
+  epoch: number;
   identifier: string;
 }
 

--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -37,7 +37,7 @@ export const VotedFor = ({ votedFor }: { votedFor: ValueView }) => {
 export const VotingInfo = observer(({ epoch, identifier }: VotingInfoProps) => {
   const votingInfo = useVotingInfo(epoch);
 
-  const isRoundPage = identifier == 'round-card';
+  const isRoundPage = identifier === 'round-card';
   const epochLink = epoch ? PagePath.TournamentRound.replace(':epoch', epoch.toString()) : '';
 
   const [isVoteDialogueOpen, setIsVoteDialogOpen] = useState(false);


### PR DESCRIPTION
## Description of Changes

fixes regression from https://github.com/penumbra-zone/web/pull/2557

the `VotingInfo` component has two call sites: the [landing card](https://github.com/penumbra-zone/web/blob/main/apps/veil/src/pages/tournament/ui/landing-card/index.tsx#L86) and [round card](https://github.com/penumbra-zone/web/blob/main/apps/veil/src/pages/tournament/ui/round/round-card.tsx#L128). Notably, the landing card renders `<VotingInfo />`, while the latter passes an epoch prop via `<VotingInfo epoch={epoch} />`. This distinction allows `VotingInfo` to infer which page it's on and conditionally render the details button in the UI only when used on the landing page.

the regression here is that if you inspect the previous code,

<img width="667" alt="Screenshot 2025-07-08 at 10 27 45 PM" src="https://github.com/user-attachments/assets/87aa11ee-e1a3-4b33-86c2-9594c23e7573" />

notice the details button used the epoch field from  `useVotingInfo` to construct its link. In the updated code, however, it relies directly on the epoch prop passed to `VotingInfo`, which again may be _undefined_ if the caller is the landing page (which is fine). 

<img width="711" alt="Screenshot 2025-07-08 at 10 39 21 PM" src="https://github.com/user-attachments/assets/95fb8fc4-ed01-472a-b86a-fc0b0febfc6c" />

the fix here is amending the `VotingInfo` union type so that every variant includes an `epoch` field, and then inside the `VotingInfo` component, using the epoch value returned from `useVotingInfo` instead to match the previous behavior. 

<img width="866" alt="Screenshot 2025-07-08 at 10 41 16 PM" src="https://github.com/user-attachments/assets/bbff236f-8917-4f7a-abdb-c04e6baab067" />

-------------------

https://github.com/user-attachments/assets/682e017f-1b16-46b5-895b-b11dc686c4ef

## Related Issue

https://github.com/penumbra-zone/web/issues/2589

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
