### PR TITLE
fix(veil): #2590: connect button full space

### DIFF
--- a/apps/veil/src/pages/tournament/ui/voting-info.tsx
+++ b/apps/veil/src/pages/tournament/ui/voting-info.tsx
@@ -78,15 +78,15 @@ export const VotingInfo = observer(({ epoch, identifier }: VotingInfoProps) => {
           <div className='grow'>
             <ConnectButton actionType='accent' variant='default' />
           </div>
-          <div className='grow'>
-            {!isRoundPage && (
+          {!isRoundPage && (
+            <div className='grow'>
               <div className='flex-1'>
                 <Link href={epochLink}>
                   <Button actionType='default'>Details</Button>
                 </Link>
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
Closes #2590 

Didn't rename the button as we reuse this component in every place where connection is needed. And in this specific case, the text above the button mentions "Prax" already.

Before:

![image](https://github.com/user-attachments/assets/d769b648-d172-44a3-8ff5-91bffc35031d)


After:

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/7a60e7e9-efb4-4516-8b72-7d4debbefa42" />
