### PR TITLE
fix(veil): #2591: display unknown assets

### DIFF
--- a/apps/veil/src/pages/tournament/api/use-previous-epochs.ts
+++ b/apps/veil/src/pages/tournament/api/use-previous-epochs.ts
@@ -1,14 +1,49 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/shared/utils/api-fetch';
-import type {
+import { useGetMetadata } from '@/shared/api/assets';
+import {
+  ApiGauge,
+  MappedGauge,
   PreviousEpochsApiResponse,
   PreviousEpochsRequest,
   PreviousEpochsSortDirection,
   PreviousEpochsSortKey,
 } from '../server/previous-epochs';
+import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { base64ToUint8Array } from '@penumbra-zone/types/base64';
 
 export const BASE_LIMIT = 10;
 export const BASE_PAGE = 1;
+
+export interface UsePreviousEpochsData {
+  epoch: number;
+  gauge: MappedGauge[];
+}
+
+export const useMappedGauge = () => {
+  const getMetadata = useGetMetadata();
+
+  return (gauge: ApiGauge): MappedGauge => {
+    const asset = getMetadata(
+      new AssetId({
+        inner: base64ToUint8Array(gauge.asset_id),
+      }),
+    );
+
+    return {
+      ...gauge,
+      asset:
+        asset ??
+        new Metadata({
+          base: gauge.asset_id,
+          name: '',
+          symbol: '',
+          description: '',
+          images: [],
+        }),
+    } satisfies MappedGauge;
+  };
+};
 
 export const usePreviousEpochs = (
   connected: boolean,
@@ -17,15 +52,28 @@ export const usePreviousEpochs = (
   sortKey?: PreviousEpochsSortKey,
   sortDirection?: PreviousEpochsSortDirection,
 ) => {
+  const getMappedGauge = useMappedGauge();
+
   const query = useQuery({
     queryKey: ['previous-epochs', connected, page, limit, sortKey, sortDirection],
     queryFn: async () => {
-      return apiFetch<PreviousEpochsApiResponse>('/api/tournament/previous-epochs', {
+      const res = await apiFetch<PreviousEpochsApiResponse>('/api/tournament/previous-epochs', {
         limit,
         page,
         sortKey,
         sortDirection,
       } satisfies Partial<PreviousEpochsRequest>);
+
+      return {
+        total: res.total,
+        data: res.data.map(
+          epochData =>
+            ({
+              epoch: epochData.epoch,
+              gauge: epochData.gauge.map(gauge => getMappedGauge(gauge)),
+            }) satisfies UsePreviousEpochsData,
+        ),
+      } as { total: number; data: UsePreviousEpochsData[] };
     },
   });
 

--- a/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
+++ b/apps/veil/src/pages/tournament/ui/previous-epochs.tsx
@@ -12,8 +12,12 @@ import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { connectionStore } from '@/shared/model/connection';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
-import { usePreviousEpochs, BASE_PAGE, BASE_LIMIT } from '../api/use-previous-epochs';
-import type { PreviousEpochData } from '../server/previous-epochs';
+import {
+  usePreviousEpochs,
+  UsePreviousEpochsData,
+  BASE_PAGE,
+  BASE_LIMIT,
+} from '../api/use-previous-epochs';
 import { useSortableTableHeaders } from './sortable-table-header';
 import { usePersonalRewards } from '../api/use-personal-rewards';
 import { Vote } from './vote';
@@ -31,7 +35,7 @@ const TABLE_CLASSES = {
 };
 
 interface PreviousEpochsRowProps {
-  row: PreviousEpochData;
+  row: UsePreviousEpochsData;
   isLoading: boolean;
   className: string;
   connected: boolean;
@@ -123,7 +127,7 @@ export const PreviousEpochs = observer(() => {
     total,
   } = usePreviousEpochs(connected, page, limit, sortBy.key, sortBy.direction);
 
-  const loadingArr = new Array(10).fill({ votes: [] }) as PreviousEpochData[];
+  const loadingArr = new Array(10).fill({ gauge: [] }) as UsePreviousEpochsData[];
   const epochs = data ?? loadingArr;
 
   const onLimitChange = (newLimit: number) => {

--- a/apps/veil/src/pages/tournament/ui/round/current-voting-results/table-row.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/current-voting-results/table-row.tsx
@@ -32,7 +32,7 @@ export const TableRow = ({
           <div className='flex items-center gap-1'>
             <AssetIcon metadata={item.asset} size='md' />
             <Text smallTechnical color='text.primary'>
-              {item.asset.symbol}
+              {item.asset.symbol || 'Unknown Asset'}
             </Text>
           </div>
         )}

--- a/apps/veil/src/pages/tournament/ui/shared/provide-liquidity-button.tsx
+++ b/apps/veil/src/pages/tournament/ui/shared/provide-liquidity-button.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { MouseEventHandler } from 'react';
 import { Button } from '@penumbra-zone/ui/Button';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
 import { getTradePairPath } from '@/shared/const/pages';
@@ -13,9 +14,17 @@ export const ProvideLiquidityButton = ({ symbol }: ProvideLiquidityButtonProps) 
     highlight: 'liquidity',
   });
 
+  const isDisabled = !symbol;
+  const onClick: MouseEventHandler<HTMLAnchorElement> = event => {
+    if (isDisabled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
-    <Link href={link}>
-      <Button actionType='default' density='slim'>
+    <Link href={link} onClick={onClick}>
+      <Button actionType='default' density='slim' disabled={isDisabled}>
         Provide Liquidity
       </Button>
     </Link>

--- a/apps/veil/src/pages/tournament/ui/vote.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote.tsx
@@ -17,7 +17,7 @@ export const Vote = ({ asset, percent, hideFor }: VoteProps) => {
         {round({ value: percent * 100, decimals: 3 })}% {hideFor ? '' : 'for'}
       </Text>
       <Text smallTechnical color='text.secondary'>
-        {asset.symbol}
+        {asset.symbol || 'Unknown'}
       </Text>
     </div>
   );


### PR DESCRIPTION
Closes #2591 

Displays Unknown assets.

1. In previous epochs table

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/41e27612-a78f-4907-af60-d33cf29e9c57" />

2. In current results tables

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/71da6f74-88f6-44a4-b4d2-b968ade89b72" />

But I left these assets ignored in the landing card results section and the voting dialog

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/552a812e-5456-42a2-8605-d72d18d16c7f" />
