### PR TITLE
wasm: encrypted position metadata support

### DIFF
--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -826,8 +826,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -840,8 +840,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -2353,8 +2353,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2393,8 +2393,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2438,8 +2438,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2468,8 +2468,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2499,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2514,6 +2514,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
+ "chacha20poly1305",
  "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
@@ -2552,8 +2553,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2568,8 +2569,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2592,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -2623,8 +2624,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2672,8 +2673,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2707,8 +2708,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "aes",
  "anyhow",
@@ -2751,8 +2752,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2787,8 +2788,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2812,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2839,8 +2840,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2873,8 +2874,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2924,8 +2925,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2965,8 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2994,8 +2995,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3046,8 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.11"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.0-alpha.11#3884141d4c167af2166bce7c090b84bed4d8a4e1"
+version = "2.0.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.lock
+++ b/packages/wasm/crate/Cargo.lock
@@ -826,8 +826,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -840,8 +840,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -2353,8 +2353,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2393,8 +2393,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2438,8 +2438,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2468,8 +2468,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2499,8 +2499,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2553,8 +2553,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2569,8 +2569,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2593,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -2624,8 +2624,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2673,8 +2673,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2708,8 +2708,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "aes",
  "anyhow",
@@ -2752,8 +2752,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2788,8 +2788,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2813,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2840,8 +2840,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2874,8 +2874,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2925,8 +2925,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2966,8 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -2995,8 +2995,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3047,8 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.1#edb3d5f2cb1335880ae6ecdc10192f48d62edd16"
+version = "2.0.4"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v2.0.4#6cefeb7f4e895970e6555b37b1c14e0962b55de9"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -14,22 +14,22 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-transaction", default-features = false }
-penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-funding", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-transaction", default-features = false }
+penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.4", package = "penumbra-sdk-funding", default-features = false }
 
 anyhow = "1.0.89"
 ark-ff = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/crate/Cargo.toml
+++ b/packages/wasm/crate/Cargo.toml
@@ -14,22 +14,22 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-auction", default-features = false }
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-asset" }
-penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-compact-block", default-features = false }
-penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-dex", default-features = false }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-fee", default-features = false }
-penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-governance", default-features = false }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-keys" }
-penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-num" }
-penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-proof-params", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-proto", default-features = false }
-penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-sct", default-features = false }
-penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-shielded-pool", default-features = false }
-penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-stake", default-features = false }
-penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-tct" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-transaction", default-features = false }
-penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.0-alpha.11", package = "penumbra-sdk-funding", default-features = false }
+penumbra-auction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-auction", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-asset" }
+penumbra-compact-block = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-compact-block", default-features = false }
+penumbra-dex = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-dex", default-features = false }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-fee", default-features = false }
+penumbra-governance = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-governance", default-features = false }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-keys" }
+penumbra-num = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-num" }
+penumbra-proof-params = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-proof-params", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-proto", default-features = false }
+penumbra-sct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-sct", default-features = false }
+penumbra-shielded-pool = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-shielded-pool", default-features = false }
+penumbra-stake = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-stake", default-features = false }
+penumbra-tct = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-tct" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-transaction", default-features = false }
+penumbra-funding = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v2.0.1", package = "penumbra-sdk-funding", default-features = false }
 
 anyhow = "1.0.89"
 ark-ff = { version = "0.4.2", features = ["std"] }

--- a/packages/wasm/src/dex.ts
+++ b/packages/wasm/src/dex.ts
@@ -1,10 +1,12 @@
-import { compute_position_id, get_lpnft_asset } from '../wasm/index.js';
+import { compute_position_id, decrypt_position_metadata, get_lpnft_asset } from '../wasm/index.js';
 import {
   Position,
   PositionId,
+  PositionMetadata,
   PositionState,
 } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { FullViewingKey } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 
 export const computePositionId = (position: Position): PositionId => {
   const bytes = compute_position_id(position.toBinary());
@@ -17,4 +19,12 @@ export const getLpNftMetadata = (
 ): Metadata => {
   const result = get_lpnft_asset(positionId.toBinary(), positionState.toBinary());
   return Metadata.fromBinary(result);
+};
+
+export const decryptPositionMetadata = (
+  fullViewingKey: FullViewingKey,
+  position_metadata: Uint8Array,
+): PositionMetadata => {
+  const bytes = decrypt_position_metadata(fullViewingKey.toBinary(), position_metadata);
+  return PositionMetadata.fromBinary(bytes);
 };


### PR DESCRIPTION
## Description of Changes

CI is currently failing due to outdated proto definitions. Once https://github.com/penumbra-zone/web/pull/2508 lands, everything should compile correctly.

- bumps wasm deps to v2.0.1 tag,
- the `PositionOpen` transaction planner request in the planner is amended to generate a bundle identifier and include it in the position metadata object, as part of the `ActionPlan` payload.

## Related Issue

https://github.com/penumbra-zone/web/issues/2500

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
