### PR TITLE
Add help popover item to show ticker

### DIFF
--- a/apps/veil/src/shared/const/pages.ts
+++ b/apps/veil/src/shared/const/pages.ts
@@ -20,6 +20,11 @@ const basePath: Partial<Record<PagePath, PagePath>> = {
   '/tournament/:epoch': PagePath.Tournament,
 };
 
+// predefined query params for pages
+export enum QueryParams {
+  PortfolioShowShieldingTicker = 'showShieldingTicker',
+}
+
 // Used for dynamic routing when wanting to exclude the dynamic elements
 export const useBasePath = (): PagePath => {
   const path = usePagePath();
@@ -38,5 +43,20 @@ export const getTradePairPath = (
 ): string => {
   const route = PagePath.TradePair.replace(':primary', primary).replace(':numeraire', numeraire);
   const query = options.highlight ? `?highlight=${options.highlight}` : '';
+  return `${route}${query}`;
+};
+
+export const getPortfolioPath = (options: { showShieldingTicker?: boolean } = {}): string => {
+  const route = PagePath.Portfolio;
+  let query = '';
+
+  if (options.showShieldingTicker === true) {
+    query = `?${QueryParams.PortfolioShowShieldingTicker}=true`;
+  }
+
+  if (options.showShieldingTicker === false) {
+    query = `?${QueryParams.PortfolioShowShieldingTicker}=false`;
+  }
+
   return `${route}${query}`;
 };

--- a/apps/veil/src/widgets/header/ui/help-popover.tsx
+++ b/apps/veil/src/widgets/header/ui/help-popover.tsx
@@ -13,6 +13,7 @@ import { Text } from '@penumbra-zone/ui/Text';
 import { Icon } from '@penumbra-zone/ui/Icon';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
+import { getPortfolioPath } from '@/shared/const/pages';
 
 const HelpPopoverItem = ({
   href,
@@ -61,7 +62,10 @@ export const HelpPopover = observer(() => {
         <HelpPopoverItem href='https://penumbra.zone/' IconComponent={Info}>
           About Penumbra
         </HelpPopoverItem>
-        <HelpPopoverItem href='/portfolio?showShieldingTicker=true' IconComponent={Shield}>
+        <HelpPopoverItem
+          href={getPortfolioPath({ showShieldingTicker: true })}
+          IconComponent={Shield}
+        >
           Show Shielding Activity
         </HelpPopoverItem>
       </Popover.Content>

--- a/apps/veil/src/widgets/shielding-ticker/index.tsx
+++ b/apps/veil/src/widgets/shielding-ticker/index.tsx
@@ -15,6 +15,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 import Image from 'next/image';
 import type { ShieldingDepositWithMeta } from '@/shared/api/server/shielding-deposits';
+import { getPortfolioPath, QueryParams } from '@/shared/const/pages';
 
 interface DepositItemProps {
   deposit: ShieldingDepositWithMeta;
@@ -133,7 +134,7 @@ export const ShieldingTicker = () => {
   const [isVisible, setIsVisible] = useState(true);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const showShieldingTicker = searchParams?.get('showShieldingTicker');
+  const showShieldingTicker = searchParams?.get(QueryParams.PortfolioShowShieldingTicker);
 
   const { data: deposits, isLoading } = useShieldingDeposits(50);
 
@@ -167,7 +168,7 @@ export const ShieldingTicker = () => {
             iconOnly
             icon={X}
             onClick={() => {
-              router.push('/portfolio?showShieldingTicker=false');
+              router.push(getPortfolioPath({ showShieldingTicker: false }));
             }}
           >
             Dismiss
@@ -192,7 +193,7 @@ export const ShieldingTicker = () => {
           iconOnly
           icon={X}
           onClick={() => {
-            router.push('/portfolio?showShieldingTicker=false');
+            router.push(getPortfolioPath({ showShieldingTicker: false }));
           }}
         >
           Dismiss


### PR DESCRIPTION
## Description of Changes

Closes https://github.com/penumbra-zone/web/issues/2607

- Removes Show getting started guide menu item
- Adds Show Shielding Activity menu item
- Changes show ticker behavior to controlleable by url search param

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
