### PR TITLE
landing card: add epoch time remaining

### DIFF
--- a/apps/veil/src/pages/tournament/ui/round/round-card.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/round-card.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Hourglass } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { addSeconds, format } from 'date-fns';
 import { Skeleton } from '@penumbra-zone/ui/Skeleton';
@@ -78,9 +78,12 @@ export const RoundCard = observer(({ epoch }: RoundCardProps) => {
 
               {!ended && summary?.[0]?.ends_in_s && (
                 <Tooltip message={endingTime}>
-                  <Text technical color='text.primary'>
-                    Ends in {formatTimeRemaining(summary[0].ends_in_s)}
-                  </Text>
+                  <div className='flex items-center gap-2'>
+                    <Hourglass className='h-5 w-5 text-white/80' />
+                    <Text technical color='text.primary'>
+                      Ends in {formatTimeRemaining(summary[0].ends_in_s)}
+                    </Text>
+                  </div>
                 </Tooltip>
               )}
             </div>


### PR DESCRIPTION
## Description of Changes

- add an hourglass icon to both the landing and round cards (details page), 
- show the epoch’s remaining time on the landing card with a tooltip,
- apply the same gradient used on the epoch number to the “Current Epoch” text.

## Related Issue

https://github.com/penumbra-zone/web/issues/2608

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
