### PR TITLE
Fix pnum case when input is NaN

### DIFF
--- a/.changeset/eighty-ears-start.md
+++ b/.changeset/eighty-ears-start.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/types': patch
+---
+
+Fix pnum case of NaN input

--- a/packages/types/src/pnum.ts
+++ b/packages/types/src/pnum.ts
@@ -32,7 +32,12 @@ function pnum(
     typeof optionsOrExponent === 'number' ? optionsOrExponent : (optionsOrExponent.exponent ?? 0);
 
   if (typeof input === 'string' || typeof input === 'number') {
-    value = new BigNumber(input).shiftedBy(exponent);
+    if (Number.isNaN(input)) {
+      console.error('pnum input is NaN', input);
+      value = new BigNumber(0);
+    } else {
+      value = new BigNumber(input).shiftedBy(exponent);
+    }
   } else if (typeof input === 'bigint') {
     value = new BigNumber(input.toString());
   } else if (


### PR DESCRIPTION
## Description of Changes

Addresses https://github.com/penumbra-zone/web/issues/2617

pnum currently throws when the input is not a number (NaN).

Logs that shows that one of the input is NaN:
<img width="302" height="162" alt="image" src="https://github.com/user-attachments/assets/79daa7ff-a7f4-4e9c-86cc-0b57c277fee7" />

Fix is confirmed & testing by pointing to mainnet.

## Related Issue

Link to the issue this PR addresses.

## Checklist Before Requesting Review

- [ ] I have ensured that any relevant minifront changes do not cause the existing extension to break.
