### PR TITLE
fix(veil): hardcode veil fqdn in social card

### DIFF
--- a/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
+++ b/apps/veil/src/pages/tournament/ui/social-card-dialog.tsx
@@ -23,7 +23,10 @@ import { LqtDelegatorHistoryData } from '../server/delegator-history';
 import { formatTimeRemaining } from '@/shared/utils/format-time';
 
 export const dismissedKey = 'veil-tournament-social-card-dismissed';
-const baseUrl = process.env['NEXT_PUBLIC_BASE_URL'] ?? 'http://localhost:3000';
+
+// We hardcode the URL to Veil to be the prod instance, rather than testing instances.
+// This value is used for generated a URL to the LQT, for sharing on social media sites.
+const baseUrl = 'https://dex.penumbra.zone';
 
 // Custom hook that consolidates all location storage operations.
 export function useTournamentSocialCard(epoch: number | undefined) {


### PR DESCRIPTION

## Description of Changes
The social card dialog logic was using `process.env` to try to look up the site's base URL. That can't work. While we want to standardize on a pattern for app config that works in all cases, e.g. [0], we also want an immediate fix for near-term to resolve bugs [1], which is why I'm submitting this stopgap.

[0] https://github.com/penumbra-zone/web/pull/2593
[1] https://github.com/penumbra-zone/web/issues/2575