### PR TITLE
feat: redirect to tx in explorer if present

### DIFF
--- a/apps/veil/src/shared/api/server/shielding-deposits.ts
+++ b/apps/veil/src/shared/api/server/shielding-deposits.ts
@@ -4,6 +4,7 @@ import { pindexerDb } from '@/shared/database/client';
 import { serialize, Serialized } from '@/shared/utils/serializer';
 import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { ChainRegistryClient } from '@penumbra-labs/registry';
+import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 
 export interface ShieldingDeposit {
   id: number;
@@ -13,6 +14,7 @@ export interface ShieldingDeposit {
   foreignAddr: string;
   kind: string;
   timestamp: number;
+  txHash: string | null;
 }
 
 export interface ShieldingDepositWithMeta extends ShieldingDeposit {
@@ -35,22 +37,59 @@ export async function fetchShieldingDeposits(
   const registry = await registryClient.remote.get(chainId);
 
   // Query the pindexer database for recent inbound IBC transfers with timestamps
-  const rows = await pindexerDb
+  // Try to include tx_hash, gracefully handle if column doesn't exist
+  const baseQuery = pindexerDb
     .selectFrom('ibc_transfer')
     .innerJoin('block_details', 'ibc_transfer.height', 'block_details.height')
-    .select([
-      'ibc_transfer.id',
-      'ibc_transfer.height',
-      'ibc_transfer.amount',
-      'ibc_transfer.asset',
-      'ibc_transfer.foreign_addr',
-      'ibc_transfer.kind',
-      'block_details.timestamp',
-    ])
     .where('ibc_transfer.kind', '=', 'inbound')
     .orderBy('ibc_transfer.height', 'desc')
-    .limit(Math.min(limit, 100))
-    .execute();
+    .limit(Math.min(limit, 100));
+
+  interface DatabaseRow {
+    id: number;
+    height: string;
+    amount: string;
+    asset: Buffer;
+    foreign_addr: string;
+    kind: string;
+    timestamp: Date;
+    tx_hash?: Buffer | null;
+  }
+
+  let rows: DatabaseRow[];
+
+  try {
+    // Try with tx_hash first
+    rows = await baseQuery
+      .select([
+        'ibc_transfer.id',
+        'ibc_transfer.height',
+        'ibc_transfer.amount',
+        'ibc_transfer.asset',
+        'ibc_transfer.foreign_addr',
+        'ibc_transfer.kind',
+        'ibc_transfer.tx_hash',
+        'block_details.timestamp',
+      ])
+      .execute();
+  } catch (error) {
+    // If tx_hash column doesn't exist, fall back to query without it
+    if (error && typeof error === 'object' && 'code' in error && error.code === '42703') {
+      rows = await baseQuery
+        .select([
+          'ibc_transfer.id',
+          'ibc_transfer.height',
+          'ibc_transfer.amount',
+          'ibc_transfer.asset',
+          'ibc_transfer.foreign_addr',
+          'ibc_transfer.kind',
+          'block_details.timestamp',
+        ])
+        .execute();
+    } else {
+      throw error;
+    }
+  }
 
   // Process rows and enrich with metadata
   const deposits: ShieldingDepositWithMeta[] = rows.map(row => {
@@ -68,6 +107,7 @@ export async function fetchShieldingDeposits(
       foreignAddr: row.foreign_addr,
       kind: row.kind,
       timestamp: row.timestamp.getTime(),
+      txHash: row.tx_hash ? uint8ArrayToHex(Uint8Array.from(row.tx_hash)) : null,
       metadata,
     };
   });

--- a/apps/veil/src/shared/database/schema.ts
+++ b/apps/veil/src/shared/database/schema.ts
@@ -267,6 +267,7 @@ export interface IbcTransfer {
   id: Generated<number>;
   kind: string;
   penumbra_addr: Buffer;
+  tx_hash: Buffer | null;
 }
 
 export interface IndexWatermarks {

--- a/apps/veil/src/widgets/shielding-ticker/index.tsx
+++ b/apps/veil/src/widgets/shielding-ticker/index.tsx
@@ -64,8 +64,10 @@ const DepositItem = ({ deposit }: DepositItemProps) => {
   const sourceChain = getSourceChainFromDeposit(deposit, registry);
   const chainIconUrl = sourceChain?.images[0]?.png ?? sourceChain?.images[0]?.svg;
 
-  // Construct the Noctis block URL
-  const noctisUrl = `https://explorer.penumbra.zone/block/${deposit.height}`;
+  // Construct the Noctis URL - use transaction hash if available, otherwise fallback to block
+  const noctisUrl = deposit.txHash
+    ? `https://explorer.penumbra.zone/tx/${deposit.txHash}`
+    : `https://explorer.penumbra.zone/block/${deposit.height}`;
 
   return (
     <a


### PR DESCRIPTION
fixes #2605 

This makes the individual deposit links go to the tx of the deposit instead of the block.
Currently, the new pindexer changes that add the tx_hash are not live yet, so it falls back to block. Once they are live, it will default to the tx page.