### PR TITLE
fix(veil): #2610: update gauge voting designs

### DIFF
--- a/apps/veil/src/pages/tournament/ui/landing-card/explainer.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/explainer.tsx
@@ -11,7 +11,7 @@ export const Explainer = () => {
       <Text variant='h1' color='text.primary'>
         Liquidity Tournament
       </Text>
-      <div className='flex flex-col gap-10'>
+      <div className='flex h-full flex-col gap-10'>
         <div className='flex items-start gap-2'>
           <Image
             src='/assets/lqt-delegators.svg'
@@ -68,7 +68,7 @@ export const Explainer = () => {
         </div>
 
         {/* eslint-disable-next-line react/jsx-no-target-blank -- we want analytics to see referrers */}
-        <a href={LQT_MARKETING_URL} target='_blank'>
+        <a href={LQT_MARKETING_URL} target='_blank' className='mt-auto'>
           <Button icon={ExternalLink} priority='primary'>
             Learn More
           </Button>

--- a/apps/veil/src/pages/tournament/ui/landing-card/results.tsx
+++ b/apps/veil/src/pages/tournament/ui/landing-card/results.tsx
@@ -1,7 +1,14 @@
+import { useMemo } from 'react';
+import { InfoIcon } from 'lucide-react';
 import { Text } from '@penumbra-zone/ui/Text';
+import { Tooltip } from '@penumbra-zone/ui/Tooltip';
 import { Skeleton } from '@penumbra-zone/ui/Skeleton';
 import type { MappedGauge } from '../../server/previous-epochs';
-import { VoteAssetIcon, VoteAssetContent } from '../vote-dialog/vote-dialog-asset';
+import {
+  VoteAssetIcon,
+  VoteAssetContent,
+  VOTING_THRESHOLD,
+} from '../vote-dialog/vote-dialog-asset';
 import { ProvideLiquidityButton } from '../shared/provide-liquidity-button';
 
 export interface TournamentResultsProps {
@@ -14,12 +21,34 @@ const TournamentResultsAsset = ({ asset }: { asset: MappedGauge }) => {
     <div key={asset.asset.symbol} className='flex items-center gap-3'>
       <VoteAssetIcon asset={asset} />
       <VoteAssetContent asset={asset} />
-      <ProvideLiquidityButton symbol={asset.asset.symbol} />
+      <ProvideLiquidityButton
+        symbol={asset.asset.symbol}
+        primary={asset.portion >= VOTING_THRESHOLD}
+      />
     </div>
   );
 };
 
 export const TournamentResults = ({ loading, results }: TournamentResultsProps) => {
+  const { below, above } = useMemo(() => {
+    if (!results.length || loading) {
+      return {
+        below: [],
+        above: [],
+      };
+    }
+
+    const belowIndex = results.findIndex(asset => asset.portion < VOTING_THRESHOLD);
+    const above = results.slice(0, belowIndex === -1 ? results.length : belowIndex);
+    let below = results.slice(belowIndex === -1 ? results.length : belowIndex);
+    below = above.length > 5 ? [] : below.slice(0, 5 - above.length);
+
+    return {
+      below,
+      above,
+    };
+  }, [results, loading]);
+
   if (!loading && !results.length) {
     return <div className='grow' />;
   }
@@ -36,13 +65,34 @@ export const TournamentResults = ({ loading, results }: TournamentResultsProps) 
         </Text>
       )}
 
-      {loading
-        ? new Array(5).fill({}).map((_, index) => (
-            <div key={index} className='h-8 w-full rounded'>
-              <Skeleton />
-            </div>
-          ))
-        : results.map(asset => <TournamentResultsAsset asset={asset} key={asset.asset.base} />)}
+      {loading ? (
+        new Array(5).fill({}).map((_, index) => (
+          <div key={index} className='h-8 w-full rounded'>
+            <Skeleton />
+          </div>
+        ))
+      ) : (
+        <>
+          {above.slice(0, 5).map(asset => (
+            <TournamentResultsAsset asset={asset} key={asset.asset.base} />
+          ))}
+        </>
+      )}
+
+      {!!below.length && (
+        <div className='flex items-center gap-2'>
+          <Text small color='text.secondary'>
+            Below threshold ({'<'}5%)
+          </Text>
+          <Tooltip message='LPs for assets below the 5% threshold are not eligible for rewards'>
+            <InfoIcon className='size-3 text-neutral-light' />
+          </Tooltip>
+        </div>
+      )}
+
+      {below.map(asset => (
+        <TournamentResultsAsset asset={asset} key={asset.asset.base} />
+      ))}
     </div>
   );
 };

--- a/apps/veil/src/pages/tournament/ui/round/current-voting-results/index.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/current-voting-results/index.tsx
@@ -21,8 +21,8 @@ const BASE_LIMIT = 10;
 
 const TABLE_CLASSES = {
   table: {
-    default: cn('grid-cols-[1fr_1fr_1fr_1fr_136px]'),
-    canVote: cn('grid-cols-[1fr_1fr_1fr_1fr_72px_136px]'),
+    default: cn('grid-cols-[1fr_1fr_1fr_1fr_144px]'),
+    canVote: cn('grid-cols-[1fr_1fr_1fr_1fr_72px_144px]'),
   },
   row: {
     default: cn('col-span-5'),

--- a/apps/veil/src/pages/tournament/ui/round/current-voting-results/table-row.tsx
+++ b/apps/veil/src/pages/tournament/ui/round/current-voting-results/table-row.tsx
@@ -20,6 +20,8 @@ export const TableRow = ({
   loading: boolean;
   exponent: number;
 }) => {
+  const isSecondary = item.portion < VOTING_THRESHOLD;
+
   return (
     <div
       className={cn(
@@ -31,7 +33,7 @@ export const TableRow = ({
         {!loading && (
           <div className='flex items-center gap-1'>
             <AssetIcon metadata={item.asset} size='md' />
-            <Text smallTechnical color='text.primary'>
+            <Text smallTechnical color={isSecondary ? 'text.secondary' : 'text.primary'}>
               {item.asset.symbol}
             </Text>
           </div>
@@ -43,14 +45,14 @@ export const TableRow = ({
           <div className='flex items-center gap-2'>
             <div className='flex h-[6px] w-[64px] rounded-full bg-other-tonal-fill5 md:w-[106px]'>
               <div
-                className='h-[6px] rounded-full bg-secondary-light'
+                className={cn(
+                  'h-[6px] rounded-full',
+                  isSecondary ? 'bg-neutral-light' : 'bg-secondary-light',
+                )}
                 style={{ width: `${item.portion * 100}%` }}
               />
             </div>
-            <Text
-              technical
-              color={item.portion < VOTING_THRESHOLD ? 'text.secondary' : 'text.primary'}
-            >
+            <Text technical color={isSecondary ? 'text.secondary' : 'text.primary'}>
               {formatPercentage(item.portion)}%
             </Text>
           </div>
@@ -58,7 +60,9 @@ export const TableRow = ({
       </TableCell>
 
       <TableCell loading={loading}>
-        {pnum(item.votes / 10 ** exponent).toFormattedString()}
+        <Text smallTechnical color={isSecondary ? 'text.secondary' : 'text.primary'}>
+          {pnum(item.votes / 10 ** exponent).toFormattedString()}
+        </Text>
       </TableCell>
 
       {/* TODO: implement "estimated incentive" */}
@@ -71,7 +75,7 @@ export const TableRow = ({
       )}
 
       <TableCell loading={loading}>
-        <ProvideLiquidityButton symbol={item.asset.symbol} />
+        <ProvideLiquidityButton symbol={item.asset.symbol} primary={!isSecondary} />
       </TableCell>
     </div>
   );

--- a/apps/veil/src/pages/tournament/ui/shared/provide-liquidity-button.tsx
+++ b/apps/veil/src/pages/tournament/ui/shared/provide-liquidity-button.tsx
@@ -1,21 +1,65 @@
+import { useState } from 'react';
 import Link from 'next/link';
+import { Text } from '@penumbra-zone/ui/Text';
 import { Button } from '@penumbra-zone/ui/Button';
+import { Dialog } from '@penumbra-zone/ui/Dialog';
+import { Density } from '@penumbra-zone/ui/Density';
 import { useStakingTokenMetadata } from '@/shared/api/registry';
 import { getTradePairPath } from '@/shared/const/pages';
 
 export interface ProvideLiquidityButtonProps {
   symbol: string;
+  primary: boolean;
 }
 
-export const ProvideLiquidityButton = ({ symbol }: ProvideLiquidityButtonProps) => {
+export const ProvideLiquidityButton = ({ symbol, primary }: ProvideLiquidityButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
   const umMetadata = useStakingTokenMetadata();
   const link = getTradePairPath(umMetadata.data.symbol, symbol, {
     highlight: 'liquidity',
   });
 
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  if (!primary) {
+    return (
+      <>
+        <Button actionType='default' density='slim' onClick={() => setIsOpen(true)}>
+          Provide Liquidity
+        </Button>
+
+        <Dialog isOpen={isOpen} onClose={handleClose}>
+          <Dialog.Content
+            title='LP Rewards Not Guaranteed'
+            buttons={
+              <div className='flex items-center gap-2 px-6 pb-8 [&>*]:w-1/2'>
+                <Density sparse>
+                  <Button actionType='default' onClick={handleClose}>
+                    Cancel
+                  </Button>
+                  <Link href={link}>
+                    <Button actionType='accent'>Continue</Button>
+                  </Link>
+                </Density>
+              </div>
+            }
+          >
+            <Text>
+              This asset is currently below the 5% incentive threshold, and providing liquidity may
+              not result in earning rewards this epoch.
+            </Text>
+          </Dialog.Content>
+        </Dialog>
+      </>
+    );
+  }
+
   return (
     <Link href={link}>
-      <Button actionType='default' density='slim'>
+      <Button actionType='accent' density='slim'>
         Provide Liquidity
       </Button>
     </Link>

--- a/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
+++ b/apps/veil/src/pages/tournament/ui/vote-dialog/vote-dialog-asset.tsx
@@ -40,7 +40,7 @@ export const VoteAssetContent = ({ asset }: { asset: MappedGauge }) => {
   return (
     <div className='ml-1 flex grow flex-col gap-1'>
       <div className='flex w-full justify-between gap-1'>
-        <Text technical color='text.primary'>
+        <Text technical color={isSecondary ? 'text.secondary' : 'text.primary'}>
           {asset.asset.symbol}
         </Text>
         <Text technical color={isSecondary ? 'neutral.light' : 'text.primary'}>


### PR DESCRIPTION
Closes #2610 

New looks according to the PRD "Make the gauge voting threshold more apparent on the LQT landing page  - Mini PRD"

Landing card

<img width="1166" height="718" alt="image" src="https://github.com/user-attachments/assets/260e44fe-b830-4817-8065-75866e0426b9" />

A tooltip

<img width="547" height="656" alt="image" src="https://github.com/user-attachments/assets/a41fa96e-6fa9-4998-9650-1958b0481a0d" />

A modal that opens for <5% items

<img width="1183" height="726" alt="image" src="https://github.com/user-attachments/assets/449e49d2-d7c8-4f3e-8b9a-cbddbd502f56" />


Round page

<img width="1158" height="459" alt="image" src="https://github.com/user-attachments/assets/d0af906f-5859-4f78-afbe-f8ec7cb5c9cb" />
