### PR TITLE
action views: encrypted position metadata support

### DIFF
--- a/.changeset/sixty-boats-fry.md
+++ b/.changeset/sixty-boats-fry.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/perspective': minor
+---
+
+add action view for encrypted LP metadata

--- a/apps/veil/src/shared/utils/transaction-classify.ts
+++ b/apps/veil/src/shared/utils/transaction-classify.ts
@@ -33,6 +33,7 @@ export type TransactionClassification =
   | 'proposalWithdraw'
   | 'proposalDepositClaim'
   | 'positionOpen'
+  | 'positionOpenView'
   | 'positionClose'
   | 'positionWithdraw'
   | 'positionRewardClaim'
@@ -169,6 +170,12 @@ export const classifyTransaction = (txv?: TransactionView): ClassificationReturn
     return {
       type: 'positionOpen',
       action: allActionCases.get('positionOpen'),
+    };
+  }
+  if (allActionCases.has('positionOpenView')) {
+    return {
+      type: 'positionOpenView',
+      action: allActionCases.get('positionOpenView'),
     };
   }
   if (allActionCases.has('positionClose')) {
@@ -317,6 +324,7 @@ export const TRANSACTION_LABEL_BY_CLASSIFICATION: Record<TransactionClassificati
   ibcRelayAction: 'IBC Relay Action',
   positionClose: 'Position Close',
   positionOpen: 'Position Open',
+  positionOpenView: 'Position Open',
   positionRewardClaim: 'Position Reward Claim',
   positionWithdraw: 'Position Withdraw',
   proposalDepositClaim: 'Proposal Deposit Claim',

--- a/packages/perspective/src/transaction/classification.ts
+++ b/packages/perspective/src/transaction/classification.ts
@@ -27,6 +27,7 @@ export type TransactionClassification =
   | 'proposalWithdraw'
   | 'proposalDepositClaim'
   | 'positionOpen'
+  | 'positionOpenView'
   | 'positionClose'
   | 'positionWithdraw'
   | 'positionRewardClaim'

--- a/packages/perspective/src/transaction/classify.ts
+++ b/packages/perspective/src/transaction/classify.ts
@@ -135,6 +135,12 @@ export const classifyTransaction = (txv?: TransactionView): ClassificationReturn
       action: allActionCases.get('positionOpen'),
     };
   }
+  if (allActionCases.has('positionOpenView')) {
+    return {
+      type: 'positionOpenView',
+      action: allActionCases.get('positionOpenView'),
+    };
+  }
   if (allActionCases.has('positionClose')) {
     return {
       type: 'positionClose',
@@ -281,6 +287,7 @@ export const TRANSACTION_LABEL_BY_CLASSIFICATION: Record<TransactionClassificati
   ibcRelayAction: 'IBC Relay Action',
   positionClose: 'Position Close',
   positionOpen: 'Position Open',
+  positionOpenView: 'Position Open',
   positionRewardClaim: 'Position Reward Claim',
   positionWithdraw: 'Position Withdraw',
   proposalDepositClaim: 'Proposal Deposit Claim',

--- a/packages/ui-deprecated/components/ui/tx/action-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/action-view.tsx
@@ -19,6 +19,7 @@ import { PositionCloseComponent } from './actions-views/position-close.tsx';
 import { PositionWithdrawComponent } from './actions-views/position-withdraw.tsx';
 import { IbcRelayComponent } from './actions-views/ibc-relay.tsx';
 import { LiquidityTournamentVoteComponent } from './actions-views/liquidity-tournament-vote.tsx';
+import { PositionOpenViewComponent } from './actions-views/position-open-view.tsx';
 
 type Case = Exclude<ActionView['actionView']['case'], undefined>;
 
@@ -31,7 +32,7 @@ const CASE_TO_LABEL: Record<Case, string> = {
   ics20Withdrawal: 'ICS20 Withdrawal',
   positionClose: 'Position Close',
   positionOpen: 'Position Open',
-  positionOpenView: 'Position Open View',
+  positionOpenView: 'Position Open',
   positionRewardClaim: 'Position Reward Claim',
   positionWithdraw: 'Position Withdraw',
   proposalDepositClaim: 'Proposal Deposit Claim',
@@ -131,7 +132,7 @@ export const ActionViewComponent = ({
       return <PositionOpenComponent value={actionView.value} />;
 
     case 'positionOpenView':
-      return <UnimplementedView label='Position Open View' />;
+      return <PositionOpenViewComponent value={actionView.value} />;
 
     case 'positionClose':
       return <PositionCloseComponent value={actionView.value} />;

--- a/packages/ui-deprecated/components/ui/tx/actions-views/position-open-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/actions-views/position-open-view.tsx
@@ -11,53 +11,50 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../
 import { InfoIcon } from 'lucide-react';
 
 export const PositionOpenViewComponent = ({ value }: { value: PositionOpenView }) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- positionOpenView is present for action rendering.
+  const position = value.positionOpenView.value!.action!.position!;
+
   return (
     <ViewBox
       label='Position Open'
       visibleContent={
         <ActionDetails>
           <ActionDetails.Row label='State'>
-            {stateToString(value.positionOpenView.value?.action?.position?.state?.state)}
+            {stateToString(position.state?.state)}
           </ActionDetails.Row>
 
           <ActionDetails.Row label='Sequence'>
-            {value.positionOpenView.value?.action?.position?.state?.sequence
-              ? value.positionOpenView.value?.action?.position.state.sequence.toString()
-              : '0'}
+            {position.state?.sequence ? position.state.sequence.toString() : '0'}
           </ActionDetails.Row>
 
-          {!!value.positionOpenView.value?.action?.position?.phi?.pair?.asset1 && (
+          {!!position.phi?.pair?.asset1 && (
             <ActionDetails.Row label='Asset 1'>
               <ActionDetails.TruncatedText>
-                {bech32mAssetId(value.positionOpenView.value?.action?.position.phi.pair.asset1)}
+                {bech32mAssetId(position.phi.pair.asset1)}
               </ActionDetails.TruncatedText>
             </ActionDetails.Row>
           )}
 
-          {!!value.positionOpenView.value?.action?.position?.phi?.pair?.asset2 && (
+          {!!position.phi?.pair?.asset2 && (
             <ActionDetails.Row label='Asset 2'>
               <ActionDetails.TruncatedText>
-                {bech32mAssetId(value.positionOpenView.value?.action?.position.phi.pair.asset2)}
+                {bech32mAssetId(position.phi.pair.asset2)}
               </ActionDetails.TruncatedText>
             </ActionDetails.Row>
           )}
 
-          {!!value.positionOpenView.value?.action?.position?.phi?.component?.fee && (
-            <ActionDetails.Row label='fee'>
-              {value.positionOpenView.value?.action?.position.phi.component.fee}
-            </ActionDetails.Row>
+          {!!position.phi?.component?.fee && (
+            <ActionDetails.Row label='fee'>{position.phi.component.fee}</ActionDetails.Row>
           )}
 
-          {value.positionOpenView.value?.action?.position?.nonce && (
-            <ActionDetails.Row label='Nonce'>
-              <ActionDetails.TruncatedText>
-                {uint8ArrayToBase64(value.positionOpenView.value?.action?.position.nonce)}
-              </ActionDetails.TruncatedText>
-            </ActionDetails.Row>
-          )}
+          <ActionDetails.Row label='Nonce'>
+            <ActionDetails.TruncatedText>
+              {uint8ArrayToBase64(position.nonce)}
+            </ActionDetails.TruncatedText>
+          </ActionDetails.Row>
 
           <ActionDetails.Row label='Close on fill'>
-            {value.positionOpenView.value?.action?.position?.closeOnFill ? 'true' : 'false'}
+            {position.closeOnFill ? 'true' : 'false'}
           </ActionDetails.Row>
 
           <div className='flex gap-2'>
@@ -77,35 +74,27 @@ export const PositionOpenViewComponent = ({ value }: { value: PositionOpenView }
             </TooltipProvider>
           </div>
 
-          {value.positionOpenView.value?.action?.position?.phi?.component?.p && (
+          {position.phi?.component?.p && (
             <ActionDetails.Row label='p'>
-              {joinLoHiAmount(
-                value.positionOpenView.value?.action?.position.phi.component.p,
-              ).toString()}
+              {joinLoHiAmount(position.phi.component.p).toString()}
             </ActionDetails.Row>
           )}
 
-          {value.positionOpenView.value?.action?.position?.phi?.component?.q && (
+          {position.phi?.component?.q && (
             <ActionDetails.Row label='q'>
-              {joinLoHiAmount(
-                value.positionOpenView.value?.action?.position.phi.component.q,
-              ).toString()}
+              {joinLoHiAmount(position.phi.component.q).toString()}
             </ActionDetails.Row>
           )}
 
-          {value.positionOpenView.value?.action?.position?.reserves?.r1 && (
+          {position.reserves?.r1 && (
             <ActionDetails.Row label='r1'>
-              {joinLoHiAmount(
-                value.positionOpenView.value?.action?.position.reserves.r1,
-              ).toString()}
+              {joinLoHiAmount(position.reserves.r1).toString()}
             </ActionDetails.Row>
           )}
 
-          {value.positionOpenView.value?.action?.position?.reserves?.r2 && (
+          {position.reserves?.r2 && (
             <ActionDetails.Row label='r2'>
-              {joinLoHiAmount(
-                value.positionOpenView.value?.action?.position.reserves.r2,
-              ).toString()}
+              {joinLoHiAmount(position.reserves.r2).toString()}
             </ActionDetails.Row>
           )}
         </ActionDetails>

--- a/packages/ui-deprecated/components/ui/tx/actions-views/position-open-view.tsx
+++ b/packages/ui-deprecated/components/ui/tx/actions-views/position-open-view.tsx
@@ -1,0 +1,138 @@
+import { ViewBox } from '../viewbox';
+import { ActionDetails } from './action-details';
+import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
+import {
+  PositionOpenView,
+  PositionState_PositionStateEnum,
+} from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { joinLoHiAmount } from '@penumbra-zone/types/amount';
+import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../tooltip';
+import { InfoIcon } from 'lucide-react';
+
+export const PositionOpenViewComponent = ({ value }: { value: PositionOpenView }) => {
+  return (
+    <ViewBox
+      label='Position Open'
+      visibleContent={
+        <ActionDetails>
+          <ActionDetails.Row label='State'>
+            {stateToString(value.positionOpenView.value?.action?.position?.state?.state)}
+          </ActionDetails.Row>
+
+          <ActionDetails.Row label='Sequence'>
+            {value.positionOpenView.value?.action?.position?.state?.sequence
+              ? value.positionOpenView.value?.action?.position.state.sequence.toString()
+              : '0'}
+          </ActionDetails.Row>
+
+          {!!value.positionOpenView.value?.action?.position?.phi?.pair?.asset1 && (
+            <ActionDetails.Row label='Asset 1'>
+              <ActionDetails.TruncatedText>
+                {bech32mAssetId(value.positionOpenView.value?.action?.position.phi.pair.asset1)}
+              </ActionDetails.TruncatedText>
+            </ActionDetails.Row>
+          )}
+
+          {!!value.positionOpenView.value?.action?.position?.phi?.pair?.asset2 && (
+            <ActionDetails.Row label='Asset 2'>
+              <ActionDetails.TruncatedText>
+                {bech32mAssetId(value.positionOpenView.value?.action?.position.phi.pair.asset2)}
+              </ActionDetails.TruncatedText>
+            </ActionDetails.Row>
+          )}
+
+          {!!value.positionOpenView.value?.action?.position?.phi?.component?.fee && (
+            <ActionDetails.Row label='fee'>
+              {value.positionOpenView.value?.action?.position.phi.component.fee}
+            </ActionDetails.Row>
+          )}
+
+          {value.positionOpenView.value?.action?.position?.nonce && (
+            <ActionDetails.Row label='Nonce'>
+              <ActionDetails.TruncatedText>
+                {uint8ArrayToBase64(value.positionOpenView.value?.action?.position.nonce)}
+              </ActionDetails.TruncatedText>
+            </ActionDetails.Row>
+          )}
+
+          <ActionDetails.Row label='Close on fill'>
+            {value.positionOpenView.value?.action?.position?.closeOnFill ? 'true' : 'false'}
+          </ActionDetails.Row>
+
+          <div className='flex gap-2'>
+            <p className='font-bold'>Trading Parameters</p>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <InfoIcon className='size-4 cursor-pointer text-muted-foreground hover:text-[#8D5728]' />
+                </TooltipTrigger>
+                <TooltipContent className='w-[250px]'>
+                  <p>
+                    p and q are the price coefficients of the trading function: phi(r1, r2) = p * r1
+                    + q * r2, where r1 and r2 represent the old and new reserves.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+
+          {value.positionOpenView.value?.action?.position?.phi?.component?.p && (
+            <ActionDetails.Row label='p'>
+              {joinLoHiAmount(
+                value.positionOpenView.value?.action?.position.phi.component.p,
+              ).toString()}
+            </ActionDetails.Row>
+          )}
+
+          {value.positionOpenView.value?.action?.position?.phi?.component?.q && (
+            <ActionDetails.Row label='q'>
+              {joinLoHiAmount(
+                value.positionOpenView.value?.action?.position.phi.component.q,
+              ).toString()}
+            </ActionDetails.Row>
+          )}
+
+          {value.positionOpenView.value?.action?.position?.reserves?.r1 && (
+            <ActionDetails.Row label='r1'>
+              {joinLoHiAmount(
+                value.positionOpenView.value?.action?.position.reserves.r1,
+              ).toString()}
+            </ActionDetails.Row>
+          )}
+
+          {value.positionOpenView.value?.action?.position?.reserves?.r2 && (
+            <ActionDetails.Row label='r2'>
+              {joinLoHiAmount(
+                value.positionOpenView.value?.action?.position.reserves.r2,
+              ).toString()}
+            </ActionDetails.Row>
+          )}
+        </ActionDetails>
+      }
+    />
+  );
+};
+
+export const stateToString = (state?: PositionState_PositionStateEnum): string => {
+  switch (state) {
+    case PositionState_PositionStateEnum.UNSPECIFIED: {
+      return 'UNSPECIFIED';
+    }
+    case PositionState_PositionStateEnum.OPENED: {
+      return 'OPENED';
+    }
+    case PositionState_PositionStateEnum.CLOSED: {
+      return 'CLOSED';
+    }
+    case PositionState_PositionStateEnum.WITHDRAWN: {
+      return 'WITHDRAWN';
+    }
+    case PositionState_PositionStateEnum.CLAIMED: {
+      return 'CLAIMED';
+    }
+    case undefined: {
+      return 'UNSPECIFIED';
+    }
+  }
+};

--- a/packages/ui/src/ActionView/action-view.tsx
+++ b/packages/ui/src/ActionView/action-view.tsx
@@ -66,7 +66,6 @@ const componentMap = {
   communityPoolDeposit: CommunityPoolDepositAction,
   communityPoolOutput: CommunityPoolOutputAction,
   communityPoolSpend: CommunityPoolSpendAction,
-  // Temporarily Map `positionOpenView` to `PositionOpenAction` for compilation purposes.
   positionOpenView: PositionOpenAction,
   unknown: UnknownAction,
 } as const satisfies Record<ActionViewType | 'unknown', unknown>;

--- a/packages/ui/src/TransactionSummary/use-classification.ts
+++ b/packages/ui/src/TransactionSummary/use-classification.ts
@@ -59,6 +59,7 @@ const CLASSIFICATION_LABEL_MAP: Record<TransactionClassification, string> = {
   communityPoolSpend: 'Community Pool Spend',
   positionClose: 'Close Position',
   positionOpen: 'Open Position',
+  positionOpenView: 'Open Position View',
   positionWithdraw: 'Withdraw Position',
   positionRewardClaim: 'Claim Position Reward',
   proposalDepositClaim: 'Proposal Deposit Claim',


### PR DESCRIPTION
## Description of Changes

Temporary fix to restore the action view for position opens for opaque / visible action views on current main, allowing history to continue populating. It still _doesn't_ distinguish between visible and opaque views—where the visible view includes all the information of the opaque view, plus the decrypted position metadata. 

<img width="717" height="370" alt="Screenshot 2025-07-16 at 4 46 33 PM" src="https://github.com/user-attachments/assets/ca956aad-88df-491f-9a1d-58160921f53a" />

## Related Issue

https://github.com/penumbra-zone/web/issues/2503 and pairs with https://github.com/prax-wallet/prax/pull/395

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
