### PR TITLE
Import `BigNumber` correctly

### DIFF
--- a/.changeset/stupid-camels-lay.md
+++ b/.changeset/stupid-camels-lay.md
@@ -1,0 +1,9 @@
+---
+'@penumbra-zone/types': major
+'@penumbra-zone/ui-deprecated': patch
+'minifront-v2': patch
+'minifront': patch
+'penumbra-veil': patch
+---
+
+import `BigNumber` correctly

--- a/apps/minifront-v2/src/shared/stores/transfer-store.ts
+++ b/apps/minifront-v2/src/shared/stores/transfer-store.ts
@@ -17,7 +17,7 @@ import { getAddress, getAddressIndex } from '@penumbra-zone/getters/address-view
 import { toBaseUnit } from '@penumbra-zone/types/lo-hi';
 import { isAddress, bech32mAddress } from '@penumbra-zone/bech32m/penumbra';
 import { uint8ArrayToBase64 } from '@penumbra-zone/types/base64';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { ViewService } from '@penumbra-zone/protobuf';
 import { penumbra } from '../lib/penumbra';
 

--- a/apps/minifront/src/components/ibc/deposit-manual/asset-utils.test.ts
+++ b/apps/minifront/src/components/ibc/deposit-manual/asset-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { fromDisplayAmount, toDisplayAmount } from './asset-utils';
 import { bigNumConfig } from '@penumbra-zone/types/lo-hi';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { Asset } from '@chain-registry/types';
 
 BigNumber.config(bigNumConfig);

--- a/apps/minifront/src/components/ibc/deposit-manual/asset-utils.tsx
+++ b/apps/minifront/src/components/ibc/deposit-manual/asset-utils.tsx
@@ -1,6 +1,6 @@
 import { assets as cosmosAssetList } from 'chain-registry';
 import { Asset, DenomUnit } from '@chain-registry/types';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { CosmosAssetBalance } from './hooks.ts';
 import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { bigNumConfig } from '@penumbra-zone/types/lo-hi';

--- a/apps/minifront/src/components/swap/swap-form/simulate-swap-result/traces/trace/price.tsx
+++ b/apps/minifront/src/components/swap/swap-form/simulate-swap-result/traces/trace/price.tsx
@@ -3,7 +3,7 @@ import { SwapExecution_Trace } from '@penumbra-zone/protobuf/penumbra/core/compo
 import { bech32mAssetId } from '@penumbra-zone/bech32m/passet';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 import { formatAmount } from '@penumbra-zone/types/amount';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { removeTrailingZeros } from '@penumbra-zone/types/shortify';
 
 export const Price = ({

--- a/apps/minifront/src/state/helpers.ts
+++ b/apps/minifront/src/state/helpers.ts
@@ -20,7 +20,7 @@ import { TransactionToast } from '@penumbra-zone/ui-deprecated/lib/toast/transac
 import { TransactionClassification } from '@penumbra-zone/perspective/transaction/classification';
 import { uint8ArrayToHex } from '@penumbra-zone/types/hex';
 import { fromValueView } from '@penumbra-zone/types/amount';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {
   getMetadataFromBalancesResponse,
   getValueViewCaseFromBalancesResponse,

--- a/apps/minifront/src/state/ibc-out.ts
+++ b/apps/minifront/src/state/ibc-out.ts
@@ -3,7 +3,7 @@ import {
   BalancesResponse,
   TransactionPlannerRequest,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { ClientState } from '@penumbra-zone/protobuf/ibc/lightclients/tendermint/v1/tendermint_pb';
 import { Height } from '@penumbra-zone/protobuf/ibc/core/client/v1/client_pb';
 import {

--- a/apps/minifront/src/state/send/index.ts
+++ b/apps/minifront/src/state/send/index.ts
@@ -4,7 +4,7 @@ import {
   BalancesResponse,
   TransactionPlannerRequest,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { MemoPlaintext } from '@penumbra-zone/protobuf/penumbra/core/transaction/v1/transaction_pb';
 import { amountMoreThanBalance, isIncorrectDecimal, plan, planBuildBroadcast } from '../helpers';
 

--- a/apps/minifront/src/state/staking/index.ts
+++ b/apps/minifront/src/state/staking/index.ts
@@ -9,7 +9,7 @@ import {
   TransactionPlannerRequest,
   UnbondingTokensByAddressIndexResponse,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { assembleUndelegateClaimRequest } from './assemble-undelegate-claim-request';
 import throttle from 'lodash/throttle';
 import {

--- a/apps/minifront/src/state/swap/dutch-auction/get-sub-auctions.ts
+++ b/apps/minifront/src/state/swap/dutch-auction/get-sub-auctions.ts
@@ -12,7 +12,7 @@ import { BLOCKS_PER_MINUTE } from '../../constants';
 import { timeUntilNextEvent } from './time-until-next-event';
 import { splitLoHi } from '@penumbra-zone/types/lo-hi';
 import { Amount } from '@penumbra-zone/protobuf/penumbra/core/num/v1/num_pb';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { SwapSlice } from '..';
 import { penumbra } from '../../../penumbra';
 

--- a/apps/minifront/src/state/swap/helpers.ts
+++ b/apps/minifront/src/state/swap/helpers.ts
@@ -12,7 +12,7 @@ import {
   getMetadata,
 } from '@penumbra-zone/getters/value-view';
 import { toBaseUnit } from '@penumbra-zone/types/lo-hi';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { SwapSlice } from '.';
 import { assetPatterns } from '@penumbra-zone/types/assets';
 import { BalancesResponse } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';

--- a/apps/minifront/src/state/swap/instant-swap.ts
+++ b/apps/minifront/src/state/swap/instant-swap.ts
@@ -7,7 +7,7 @@ import {
   Value,
   ValueView,
 } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { getAddressByIndex } from '../../fetchers/address';
 import { StateCommitment } from '@penumbra-zone/protobuf/penumbra/crypto/tct/v1/tct_pb';
 import { errorToast } from '@penumbra-zone/ui-deprecated/lib/toast/presets';

--- a/apps/veil/src/entities/position/model/position-adapters.test.ts
+++ b/apps/veil/src/entities/position/model/position-adapters.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { describe, expect, it } from 'vitest';
 import {
   Position,

--- a/apps/veil/src/entities/transaction/model/validations.ts
+++ b/apps/veil/src/entities/transaction/model/validations.ts
@@ -1,6 +1,6 @@
 import { BalancesResponse } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { fromValueView } from '@penumbra-zone/types/amount';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {
   getMetadataFromBalancesResponse,
   getValueViewCaseFromBalancesResponse,

--- a/apps/veil/src/pages/portfolio/ui/unshield-dialog.tsx
+++ b/apps/veil/src/pages/portfolio/ui/unshield-dialog.tsx
@@ -12,7 +12,7 @@ import {
   TransactionPlannerRequest,
 } from '@penumbra-zone/protobuf/penumbra/view/v1/view_pb';
 import { toBaseUnit } from '@penumbra-zone/types/lo-hi';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { ViewService } from '@penumbra-zone/protobuf/penumbra/view/v1/view_connect';
 import { penumbra } from '@/shared/const/penumbra';
 import { getAddressIndex } from '@penumbra-zone/getters/balances-response';

--- a/packages/types/src/amount.ts
+++ b/packages/types/src/amount.ts
@@ -1,6 +1,6 @@
 import { Amount } from '@penumbra-zone/protobuf/penumbra/core/num/v1/num_pb';
 import { fromBaseUnit, joinLoHi, splitLoHi, toBaseUnit } from './lo-hi.js';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { getAmount, getDisplayDenomExponentFromValueView } from '@penumbra-zone/getters/value-view';
 import { removeTrailingZeros } from './shortify.js';

--- a/packages/types/src/lo-hi.test.ts
+++ b/packages/types/src/lo-hi.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise -- expected bitwise operations */
 import { describe, expect, it } from 'vitest';
 import { addLoHi, fromBaseUnit, joinLoHi, splitLoHi, toBaseUnit } from './lo-hi.js';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
 describe('lo-hi', () => {
   describe('splitLoHi', () => {

--- a/packages/types/src/lo-hi.ts
+++ b/packages/types/src/lo-hi.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise -- expected bitwise operations */
 
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
 export const bigNumConfig: BigNumber.Config = {
   EXPONENTIAL_AT: [-20, 20],

--- a/packages/types/src/pnum.test.ts
+++ b/packages/types/src/pnum.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { pnum } from './pnum.js';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { Amount } from '@penumbra-zone/protobuf/penumbra/core/num/v1/num_pb';
 import {
   DenomUnit,

--- a/packages/types/src/pnum.ts
+++ b/packages/types/src/pnum.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { round } from '@penumbra-zone/types/round';
 import { LoHi, joinLoHi, splitLoHi } from '@penumbra-zone/types/lo-hi';
 import { Amount } from '@penumbra-zone/protobuf/penumbra/core/num/v1/num_pb';

--- a/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
+++ b/packages/ui-deprecated/components/ui/block-sync-status/block-sync-status.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon } from '@radix-ui/react-icons';
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { motion } from 'framer-motion';
 import { LineWave } from 'react-loader-spinner';
 import { cn } from '../../../lib/utils';


### PR DESCRIPTION
## Description of Changes

Use default import for `bignumber.js` instead of destructuring import.

## Related Issue

https://github.com/penumbra-zone/web/issues/2632

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
