### PR TITLE
veil: only display version footer on `/inspect`

### DIFF
--- a/apps/veil/src/widgets/footer/ui/footer.tsx
+++ b/apps/veil/src/widgets/footer/ui/footer.tsx
@@ -1,10 +1,17 @@
+'use client';
+
 import { VeilVersion } from './veil-version';
+import { useBasePath } from '@/shared/const/pages';
+import { PagePath } from '@/shared/const/pages';
 
 export const Footer = () => {
+  const currentPath = useBasePath();
+  const isInspectPage = currentPath === PagePath.Inspect;
+
   return (
     <footer className='mt-auto border-t border-t-other-solid-stroke px-6 py-4'>
       <div className='flex justify-center'>
-        <VeilVersion />
+        {isInspectPage && <VeilVersion />}
       </div>
     </footer>
   );

--- a/apps/veil/src/widgets/footer/ui/veil-version.tsx
+++ b/apps/veil/src/widgets/footer/ui/veil-version.tsx
@@ -16,12 +16,11 @@ export const VeilVersion = () => {
   const commitUrl = gitOriginUrl !== 'unknown' ? `${gitOriginUrl}/commit/${commitHash}` : '#';
 
   return (
-    <div className='text-sm'>
-      Version&nbsp;
-      <a href={commitUrl} target='_blank' rel='noopener noreferrer' className='underline'>
+    <div className='text-xs text-other-tonalStroke opacity-50'>
+      <a href={commitUrl} target='_blank' rel='noopener noreferrer' className='hover:underline'>
         {shortHash}
       </a>
-      {' - '}
+      {' • '}
       {formattedDate}
     </div>
   );


### PR DESCRIPTION
## Description of Changes

I am not a fan of having a git commit linking to a repository at all, but let's keep it for now. This PR improves the styling to make it more discreet and moves it to the nerds page.

## Related Issue

NA

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
