### PR TITLE
fix(veil): #2598: eliminate layout shifts in portfolio page

### DIFF
--- a/apps/veil/src/pages/portfolio/api/use-unified-assets.ts
+++ b/apps/veil/src/pages/portfolio/api/use-unified-assets.ts
@@ -280,6 +280,8 @@ export const useUnifiedAssets = () => {
   // -------------------------------------------------------------
   const isLoading =
     unifiedAssets.length === 0 && (penumbraLoading || cosmosLoading || pricesLoading);
+  const isConnectionLoading =
+    connectionStore.connectedLoading || cosmosWalletStatus === WalletStatus.Connecting;
 
   return {
     unifiedAssets,
@@ -287,6 +289,7 @@ export const useUnifiedAssets = () => {
     totalPublicValue,
     totalValue,
     isLoading,
+    isConnectionLoading,
     isPenumbraConnected,
     isCosmosConnected,
   };

--- a/apps/veil/src/pages/portfolio/index.tsx
+++ b/apps/veil/src/pages/portfolio/index.tsx
@@ -6,15 +6,17 @@ import { XCircle } from 'lucide-react';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Density } from '@penumbra-zone/ui/Density';
-import { AssetsTable } from './ui/assets-table';
+import { AssetsTable, AssetsTableLayout } from './ui/assets-table';
 import { WalletConnect } from './ui/wallet-connect';
 import { useRegistry } from '@/shared/api/registry.tsx';
 import { IbcChainProvider } from '@/features/cosmos/chain-provider.tsx';
 import { PortfolioPositionTabs } from './ui/position-tabs';
 import { AssetBars } from './ui/asset-bars';
-import { useUnifiedAssets } from '@/pages/portfolio/api/use-unified-assets';
+import { useUnifiedAssets } from './api/use-unified-assets';
 import { PenumbraWaves } from '@/pages/explore/ui/waves.tsx';
 import { ShieldingTicker } from '@/widgets/shielding-ticker';
+import { useAutoAnimate } from '@formkit/auto-animate/react';
+import { PortfolioCard } from './ui/portfolio-card';
 
 interface PortfolioPageProps {
   isMobile: boolean;
@@ -71,21 +73,33 @@ function MobilePortfolioPage() {
 }
 
 const DesktopPortfolioPage = observer(() => {
-  const { isPenumbraConnected, isCosmosConnected } = useUnifiedAssets();
+  const [parent] = useAutoAnimate();
+  const { isPenumbraConnected, isCosmosConnected, isConnectionLoading } = useUnifiedAssets();
+
   return (
     <>
+      <PenumbraWaves />
+
       <ShieldingTicker />
-      <div className='container mx-auto flex max-w-[1136px] flex-col gap-4 py-8'>
-        <PenumbraWaves />
 
-        <WalletConnect />
+      {!isConnectionLoading && (
+        <div ref={parent} className='container mx-auto flex max-w-[1136px] flex-col gap-4 py-8'>
+          <WalletConnect />
 
-        {/* Asset Allocation Bars */}
-        {(isPenumbraConnected || isCosmosConnected) && <AssetBars />}
+          {/* Asset Allocation Bars */}
+          {(isPenumbraConnected || isCosmosConnected) && (
+            <PortfolioCard title={'Allocation'}>
+              <AssetBars />
+            </PortfolioCard>
+          )}
 
-        <AssetsTable />
-        <PortfolioPositionTabs />
-      </div>
+          <AssetsTableLayout>
+            <AssetsTable />
+          </AssetsTableLayout>
+
+          <PortfolioPositionTabs />
+        </div>
+      )}
     </>
   );
 });

--- a/apps/veil/src/pages/portfolio/ui/asset-bars.tsx
+++ b/apps/veil/src/pages/portfolio/ui/asset-bars.tsx
@@ -17,7 +17,6 @@ import { Asset } from '@chain-registry/types';
 import { AssetPrice, useAssetPrices } from '@/pages/portfolio/api/use-asset-prices.ts';
 import { pnum } from '@penumbra-zone/types/pnum';
 import { shouldFilterAsset } from '@/pages/portfolio/api/use-unified-assets.ts';
-import { PortfolioCard } from '@/pages/portfolio/ui/portfolio-card.tsx';
 import { observer } from 'mobx-react-lite';
 import { connectionStore } from '@/shared/model/connection';
 import { useWallet } from '@cosmos-kit/react';
@@ -152,96 +151,94 @@ export const AssetBars: React.FC = () => {
   }
 
   return (
-    <PortfolioCard title={'Allocation'}>
-      <div className='flex flex-col gap-4'>
-        {/* Shielded Assets Bar */}
-        <div className='flex items-center gap-2'>
-          <div className='w-16 text-xs font-normal text-neutral-400'>Shielded</div>
-          <div
-            className={`relative h-1.5 grow overflow-hidden rounded ${
-              shieldedAllocations.length === 0 ? 'bg-neutral-800' : ''
-            }`}
-          >
-            <div className='absolute top-0 left-0 h-full' style={{ width: `${shieldedBarWidth}%` }}>
-              {shieldedAllocations.length > 0 &&
-                shieldedAllocations.map((allocation, index) => {
-                  const prevWidth = shieldedAllocations
-                    .slice(0, index)
-                    .reduce((acc, item) => acc + (item.percentage / 100) * 100, 0);
+    <div className='flex flex-col gap-4'>
+      {/* Shielded Assets Bar */}
+      <div className='flex items-center gap-2'>
+        <div className='w-16 text-xs font-normal text-neutral-400'>Shielded</div>
+        <div
+          className={`relative h-1.5 grow overflow-hidden rounded ${
+            shieldedAllocations.length === 0 ? 'bg-neutral-800' : ''
+          }`}
+        >
+          <div className='absolute top-0 left-0 h-full' style={{ width: `${shieldedBarWidth}%` }}>
+            {shieldedAllocations.length > 0 &&
+              shieldedAllocations.map((allocation, index) => {
+                const prevWidth = shieldedAllocations
+                  .slice(0, index)
+                  .reduce((acc, item) => acc + (item.percentage / 100) * 100, 0);
 
-                  // Find the matching asset in displayAssets for consistent color
-                  const displayAsset = displayAssets.find(a => a.symbol === allocation.symbol);
-                  const barColor = displayAsset?.color ?? allocation.color;
-                  const isLast = index === shieldedAllocations.length - 1;
+                // Find the matching asset in displayAssets for consistent color
+                const displayAsset = displayAssets.find(a => a.symbol === allocation.symbol);
+                const barColor = displayAsset?.color ?? allocation.color;
+                const isLast = index === shieldedAllocations.length - 1;
 
-                  return (
-                    <div
-                      key={`shielded-${allocation.symbol}-${index}`}
-                      className='absolute top-0 h-full rounded'
-                      style={{
-                        backgroundColor: barColor,
-                        width: `calc(${allocation.percentage}% - ${isLast ? '0px' : '4px'})`,
-                        left: `calc(${prevWidth}% + ${index * 4}px)`,
-                      }}
-                    />
-                  );
-                })}
-            </div>
+                return (
+                  <div
+                    key={`shielded-${allocation.symbol}-${index}`}
+                    className='absolute top-0 h-full rounded'
+                    style={{
+                      backgroundColor: barColor,
+                      width: `calc(${allocation.percentage}% - ${isLast ? '0px' : '4px'})`,
+                      left: `calc(${prevWidth}% + ${index * 4}px)`,
+                    }}
+                  />
+                );
+              })}
           </div>
-        </div>
-
-        {/* Public Assets Bar */}
-        <div className='flex items-center gap-2'>
-          <div className='w-16 text-xs font-normal text-neutral-400'>Public</div>
-          <div
-            className={`relative h-1.5 grow overflow-hidden rounded ${
-              publicAllocations.length === 0 ? 'bg-neutral-800' : ''
-            }`}
-          >
-            <div className='absolute top-0 left-0 h-full' style={{ width: `${publicBarWidth}%` }}>
-              {publicAllocations.length > 0 &&
-                publicAllocations.map((allocation, index) => {
-                  const prevWidth = publicAllocations
-                    .slice(0, index)
-                    .reduce((acc, item) => acc + (item.percentage / 100) * 100, 0);
-
-                  // Find the matching asset in displayAssets for consistent color
-                  const displayAsset = displayAssets.find(a => a.symbol === allocation.symbol);
-                  const barColor = displayAsset?.color ?? allocation.color;
-                  const isLast = index === publicAllocations.length - 1;
-
-                  return (
-                    <div
-                      key={`public-${allocation.symbol}`}
-                      className='absolute top-0 h-full rounded'
-                      style={{
-                        backgroundColor: barColor,
-                        width: `calc(${allocation.percentage}% - ${isLast ? '0px' : '4px'})`,
-                        left: `calc(${prevWidth}% + ${index * 4}px)`,
-                      }}
-                    />
-                  );
-                })}
-            </div>
-          </div>
-        </div>
-
-        {/* Asset Legend */}
-        <div className='mt-2 flex flex-wrap gap-4 pl-[72px]'>
-          {displayAssets.map(asset => (
-            <div key={asset.symbol} className='flex items-center gap-1'>
-              <div className='h-2 w-2 rounded-full' style={{ backgroundColor: asset.color }} />
-              <Text small color='text.primary'>
-                {asset.symbol}
-              </Text>
-              <Text small color='text.secondary'>
-                {Math.round(asset.percentage)}%
-              </Text>
-            </div>
-          ))}
         </div>
       </div>
-    </PortfolioCard>
+
+      {/* Public Assets Bar */}
+      <div className='flex items-center gap-2'>
+        <div className='w-16 text-xs font-normal text-neutral-400'>Public</div>
+        <div
+          className={`relative h-1.5 grow overflow-hidden rounded ${
+            publicAllocations.length === 0 ? 'bg-neutral-800' : ''
+          }`}
+        >
+          <div className='absolute top-0 left-0 h-full' style={{ width: `${publicBarWidth}%` }}>
+            {publicAllocations.length > 0 &&
+              publicAllocations.map((allocation, index) => {
+                const prevWidth = publicAllocations
+                  .slice(0, index)
+                  .reduce((acc, item) => acc + (item.percentage / 100) * 100, 0);
+
+                // Find the matching asset in displayAssets for consistent color
+                const displayAsset = displayAssets.find(a => a.symbol === allocation.symbol);
+                const barColor = displayAsset?.color ?? allocation.color;
+                const isLast = index === publicAllocations.length - 1;
+
+                return (
+                  <div
+                    key={`public-${allocation.symbol}`}
+                    className='absolute top-0 h-full rounded'
+                    style={{
+                      backgroundColor: barColor,
+                      width: `calc(${allocation.percentage}% - ${isLast ? '0px' : '4px'})`,
+                      left: `calc(${prevWidth}% + ${index * 4}px)`,
+                    }}
+                  />
+                );
+              })}
+          </div>
+        </div>
+      </div>
+
+      {/* Asset Legend */}
+      <div className='mt-2 flex flex-wrap gap-4 pl-[72px]'>
+        {displayAssets.map(asset => (
+          <div key={asset.symbol} className='flex items-center gap-1'>
+            <div className='h-2 w-2 rounded-full' style={{ backgroundColor: asset.color }} />
+            <Text small color='text.primary'>
+              {asset.symbol}
+            </Text>
+            <Text small color='text.secondary'>
+              {Math.round(asset.percentage)}%
+            </Text>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };
 
@@ -259,38 +256,35 @@ const SMALL_ASSET_THRESHOLD = 2;
 
 const LoadingBars = () => {
   return (
-    <PortfolioCard title={'Allocation'}>
-      {/* Asset distribution bar skeleton */}
-      <div className='mt-4 flex flex-col gap-4'>
-        <div className='flex items-center gap-2'>
-          <div className='w-16 text-xs text-neutral-400'>Shielded</div>
-          <div className='h-1.5 w-full'>
-            <Skeleton />
-          </div>
-        </div>
-
-        <div className='flex items-center gap-2'>
-          <div className='w-16 text-xs text-neutral-400'>Public</div>
-          <div className='h-1.5 w-full'>
-            <Skeleton />
-          </div>
-        </div>
-
-        {/* Legend skeleton */}
-        <div className='mt-2 flex flex-wrap gap-4 pl-[72px]'>
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className='flex items-center gap-2'>
-              <div className='h-2 w-2'>
-                <Skeleton />
-              </div>
-              <div className='h-4 w-20'>
-                <Skeleton />
-              </div>
-            </div>
-          ))}
+    <div className='flex flex-col gap-4'>
+      <div className='flex items-center gap-2'>
+        <div className='w-16 text-xs text-neutral-400'>Shielded</div>
+        <div className='h-1.5 w-full'>
+          <Skeleton />
         </div>
       </div>
-    </PortfolioCard>
+
+      <div className='flex items-center gap-2'>
+        <div className='w-16 text-xs text-neutral-400'>Public</div>
+        <div className='h-1.5 w-full'>
+          <Skeleton />
+        </div>
+      </div>
+
+      {/* Legend skeleton */}
+      <div className='mt-2 flex flex-wrap gap-4 pl-[72px]'>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className='flex items-center gap-2'>
+            <div className='h-2 w-2'>
+              <Skeleton />
+            </div>
+            <div className='h-4 w-20'>
+              <Skeleton />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };
 
@@ -521,9 +515,5 @@ const ConnectedButEmpty: React.FC = observer(() => {
     return null;
   }
 
-  return (
-    <PortfolioCard title={'Allocation'}>
-      <div className='flex flex-col gap-4 p-6'>{rows}</div>
-    </PortfolioCard>
-  );
+  return <div className='flex flex-col gap-4 p-6'>{rows}</div>;
 });

--- a/apps/veil/src/pages/portfolio/ui/assets-table.tsx
+++ b/apps/veil/src/pages/portfolio/ui/assets-table.tsx
@@ -1,5 +1,4 @@
 import { TableCell } from '@penumbra-zone/ui/TableCell';
-import { Card } from '@penumbra-zone/ui/Card';
 import { Text } from '@penumbra-zone/ui/Text';
 
 import { Density } from '@penumbra-zone/ui/Density';
@@ -10,94 +9,102 @@ import { useUnifiedAssets } from '../api/use-unified-assets.ts';
 import { useAssetPrices } from '../api/use-asset-prices.ts';
 import { AssetRow } from '@/pages/portfolio/ui/asset-row.tsx';
 import { PortfolioCard } from '@/pages/portfolio/ui/portfolio-card.tsx';
+import { ReactNode } from 'react';
+
+export const AssetsTableLayout = ({ children }: { children?: ReactNode }) => {
+  return (
+    <PortfolioCard
+      title={
+        <div className={'flex justify-between'}>
+          <Text as={'h4'} xxl color='text.primary'>
+            Assets
+          </Text>
+        </div>
+      }
+    >
+      {children}
+    </PortfolioCard>
+  );
+};
+
+const LoadingRow = () => {
+  return (
+    <div className='col-span-6 grid grid-cols-subgrid'>
+      <TableCell loading>
+        <div className='flex items-center gap-2'>
+          <div className='h-6 w-6 overflow-hidden rounded-full'>
+            <Skeleton />
+          </div>
+          <div className='h-5 w-20'>
+            <Skeleton />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell loading>
+        <div className='h-5 w-24'>
+          <Skeleton />
+        </div>
+      </TableCell>
+      <TableCell loading>
+        <div className='h-5 w-24'>
+          <Skeleton />
+        </div>
+      </TableCell>
+      <TableCell loading>
+        <div className='h-5 w-24'>
+          <Skeleton />
+        </div>
+      </TableCell>
+      <TableCell loading>
+        <div className='h-5 w-24'>
+          <Skeleton />
+        </div>
+      </TableCell>
+      <TableCell loading>
+        <div className='h-5 w-24'>
+          <Skeleton />
+        </div>
+      </TableCell>
+    </div>
+  );
+};
 
 const LoadingState = () => {
   return (
-    <Card>
-      <div className='p-3'>
-        <Text as={'h4'} large color='text.primary'>
-          Assets
-        </Text>
-
-        <Density compact>
-          <div className='grid grid-cols-[1fr_1fr_1fr_1fr_1fr_1fr] overflow-x-auto overflow-y-auto'>
-            <TableCell heading>Shielded Balance</TableCell>
-            <TableCell heading>Public Balance</TableCell>
-            <TableCell heading>Price</TableCell>
-            <TableCell heading>Shielded Value</TableCell>
-            <TableCell heading>Public Value</TableCell>
-            <TableCell heading>Total Value</TableCell>
-
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className='col-span-6 grid grid-cols-subgrid'>
-                <TableCell loading>
-                  <div className='flex items-center gap-2'>
-                    <div className='h-6 w-6 overflow-hidden rounded-full'>
-                      <Skeleton />
-                    </div>
-                    <div className='h-5 w-20'>
-                      <Skeleton />
-                    </div>
-                  </div>
-                </TableCell>
-                <TableCell loading>
-                  <div className='h-5 w-24'>
-                    <Skeleton />
-                  </div>
-                </TableCell>
-                <TableCell loading>
-                  <div className='h-5 w-24'>
-                    <Skeleton />
-                  </div>
-                </TableCell>
-                <TableCell loading>
-                  <div className='h-5 w-24'>
-                    <Skeleton />
-                  </div>
-                </TableCell>
-                <TableCell loading>
-                  <div className='h-5 w-24'>
-                    <Skeleton />
-                  </div>
-                </TableCell>
-                <TableCell loading>
-                  <div className='h-5 w-24'>
-                    <Skeleton />
-                  </div>
-                </TableCell>
-              </div>
-            ))}
-          </div>
-        </Density>
+    <Density compact>
+      <div className='grid grid-cols-[1fr_1fr_1fr_1fr_auto_auto_auto] overflow-x-auto overflow-y-auto'>
+        <TableCell heading>Shielded Balance</TableCell>
+        <TableCell heading>Public Balance</TableCell>
+        <TableCell heading>Price</TableCell>
+        <TableCell heading>Shielded Value</TableCell>
+        <TableCell heading>Public Value</TableCell>
+        <TableCell heading>Total Value</TableCell>
+        <TableCell heading>&nbsp;</TableCell>
       </div>
-    </Card>
+
+      {Array.from({ length: 6 }).map((_, i) => (
+        <LoadingRow key={i} />
+      ))}
+    </Density>
   );
 };
 
 const NotConnectedNotice = () => {
   return (
-    <div className='m-4 sm:m-0'>
-      <Card>
-        <div className='flex h-[400px] flex-col items-center justify-center gap-4'>
-          <Text color='text.secondary' small>
-            Connect wallet to see your assets
-          </Text>
-        </div>
-      </Card>
+    <div className='flex h-[400px] flex-col items-center justify-center gap-4'>
+      <Text color='text.secondary' small>
+        Connect wallet to see your assets
+      </Text>
     </div>
   );
 };
 
 const NoAssetsNotice = () => {
   return (
-    <div className='m-4 sm:m-0'>
-      <Card>
-        <div className='flex h-[400px] flex-col items-center justify-center gap-4'>
-          <Text color='text.secondary' small>
-            No assets found in your connected wallets
-          </Text>
-        </div>
-      </Card>
+    <div className='flex h-[400px] flex-col items-center justify-center gap-4'>
+      <Text color='text.secondary' small>
+        No assets found in your connected wallets
+      </Text>
     </div>
   );
 };
@@ -119,39 +126,29 @@ export const AssetsTable = observer(() => {
   }
 
   return (
-    <PortfolioCard
-      title={
-        <div className={'flex justify-between'}>
-          <Text as={'h4'} xxl color='text.primary'>
-            Assets
-          </Text>
-        </div>
-      }
-    >
-      <Density compact>
-        <div className='grid grid-cols-[1fr_1fr_1fr_1fr_auto_auto_auto] overflow-x-auto overflow-y-auto'>
-          <TableCell heading>Shielded Balance</TableCell>
-          <TableCell heading>Public Balance</TableCell>
-          <TableCell heading>Price</TableCell>
-          <TableCell heading>Shielded Value</TableCell>
-          <TableCell heading>Public Value</TableCell>
-          <TableCell heading>Total Value</TableCell>
-          <TableCell heading>&nbsp;</TableCell>
+    <Density compact>
+      <div className='grid grid-cols-[1fr_1fr_1fr_1fr_auto_auto_auto] overflow-x-auto overflow-y-auto'>
+        <TableCell heading>Shielded Balance</TableCell>
+        <TableCell heading>Public Balance</TableCell>
+        <TableCell heading>Price</TableCell>
+        <TableCell heading>Shielded Value</TableCell>
+        <TableCell heading>Public Value</TableCell>
+        <TableCell heading>Total Value</TableCell>
+        <TableCell heading>&nbsp;</TableCell>
 
-          {unifiedAssets.map((asset, index) => (
-            <AssetRow
-              key={asset.symbol}
-              asset={asset}
-              price={{
-                price: prices[asset.symbol]?.price ?? 0,
-                quoteSymbol: prices[asset.symbol]?.quoteSymbol ?? '-',
-              }}
-              isCosmosConnected={isCosmosConnected}
-              isLastRow={index === unifiedAssets.length - 1}
-            />
-          ))}
-        </div>
-      </Density>
-    </PortfolioCard>
+        {unifiedAssets.map((asset, index) => (
+          <AssetRow
+            key={asset.symbol}
+            asset={asset}
+            price={{
+              price: prices[asset.symbol]?.price ?? 0,
+              quoteSymbol: prices[asset.symbol]?.quoteSymbol ?? '-',
+            }}
+            isCosmosConnected={isCosmosConnected}
+            isLastRow={index === unifiedAssets.length - 1}
+          />
+        ))}
+      </div>
+    </Density>
   );
 });

--- a/apps/veil/src/widgets/footer/ui/footer.tsx
+++ b/apps/veil/src/widgets/footer/ui/footer.tsx
@@ -7,9 +7,15 @@ export const Footer = () => {
   const currentPath = useBasePath();
   const isInspectPage = currentPath === PagePath.Inspect;
 
+  if (!isInspectPage) {
+    return null;
+  }
+
   return (
     <footer className='mt-auto border-t border-t-other-solid-stroke px-6 py-4'>
-      <div className='flex justify-center'>{isInspectPage && <VeilVersion />}</div>
+      <div className='flex justify-center'>
+        <VeilVersion />
+      </div>
     </footer>
   );
 };

--- a/apps/veil/src/widgets/header/ui/connection.tsx
+++ b/apps/veil/src/widgets/header/ui/connection.tsx
@@ -1,4 +1,5 @@
 import { observer } from 'mobx-react-lite';
+import { Skeleton } from '@penumbra-zone/ui/Skeleton';
 import { connectionStore } from '@/shared/model/connection';
 import { ConnectButton } from '@/features/connect/connect-button';
 import { SubaccountSelector } from '@/widgets/header/ui/subaccount-selector';
@@ -8,6 +9,14 @@ export interface ConnectionProps {
 }
 
 export const Connection = observer(({ mobile }: ConnectionProps) => {
+  if (connectionStore.connectedLoading) {
+    return mobile ? null : (
+      <div className='h-12 w-28'>
+        <Skeleton />
+      </div>
+    );
+  }
+
   if (!connectionStore.connected) {
     return <ConnectButton variant={mobile ? 'mobile' : 'default'} />;
   }

--- a/apps/veil/src/widgets/shielding-ticker/index.tsx
+++ b/apps/veil/src/widgets/shielding-ticker/index.tsx
@@ -16,6 +16,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Image from 'next/image';
 import type { ShieldingDepositWithMeta } from '@/shared/api/server/shielding-deposits';
 import { getPortfolioPath, QueryParams } from '@/shared/const/pages';
+import { useAutoAnimate } from '@formkit/auto-animate/react';
 
 interface DepositItemProps {
   deposit: ShieldingDepositWithMeta;
@@ -133,6 +134,7 @@ const DepositItem = ({ deposit }: DepositItemProps) => {
 };
 
 export const ShieldingTicker = () => {
+  const [parent] = useAutoAnimate();
   const [isVisible, setIsVisible] = useState(true);
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -157,7 +159,7 @@ export const ShieldingTicker = () => {
 
   if (isLoading || !hasDeposits) {
     return (
-      <div className='w-full border-b border-other-solid-stroke'>
+      <div className='w-full'>
         <div className='container mx-auto flex max-w-[1136px] items-center justify-between px-4 py-3'>
           <div className='flex items-center gap-2'>
             <div className='h-2 w-2 animate-pulse rounded-full bg-green-400'></div>
@@ -176,12 +178,14 @@ export const ShieldingTicker = () => {
             Dismiss
           </Button>
         </div>
+
+        <div className='relative h-18 w-full py-3' />
       </div>
     );
   }
 
   return (
-    <div className='w-full border-b border-other-solid-stroke'>
+    <div className='w-full'>
       {/* Title and hide button row - constrained to container width */}
       <div className='container mx-auto flex max-w-[1136px] items-center justify-between px-4 py-3'>
         <div className='flex items-center gap-2'>
@@ -203,7 +207,7 @@ export const ShieldingTicker = () => {
       </div>
 
       {/* Full-width marquee area */}
-      <div className='relative w-full py-3'>
+      <div ref={parent} className='relative h-18 w-full py-3'>
         <Marquee pauseOnHover={true} speed={30} gradient={false} autoFill={true}>
           {deposits.map(deposit => (
             <DepositItem key={deposit.id} deposit={deposit} />


### PR DESCRIPTION
Closes #2598 

After looking at the #2598 issue, I found that the UX issue won't be fixed by adding new state in the connection store, rather the portfolio page needed a major rework to eliminate content layout shift and jumps.

In this PR, I used `connectedLoading` variable introduced by @cronokirby to render better connection states in the header and in the portfolio pages. Here's the final result in a video – compare it with [how it was before](https://github.com/user-attachments/assets/4477f7e7-a0eb-432e-89cd-da2f7147635a).

I also fixed css issues here and there while working on portfolio page.

https://github.com/user-attachments/assets/8b85176d-fc0c-4ff5-97be-3bc58106c95f

