### PR TITLE
Increase syncing modal timeout

### DIFF
--- a/apps/minifront/src/fetchers/status.ts
+++ b/apps/minifront/src/fetchers/status.ts
@@ -20,7 +20,7 @@ export async function* getStatusStream(
 ): AsyncGenerator<PlainMessage<StatusStreamResponse>> {
   for await (const item of penumbra
     .service(ViewService)
-    .statusStream({}, { timeoutMs: 15_000, ...opt })) {
+    .statusStream({}, { timeoutMs: 60_000, ...opt })) {
     yield toPlainMessage(item);
   }
 }


### PR DESCRIPTION
## Description of Changes

The syncing modal appears too aggressively, especially on dense blocks. This change increases the timeout from 15s to 60s as a conservative adjustment.

## Related Issue

https://github.com/penumbra-zone/web/issues/2254

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
