### PR TITLE
fix: correctly apply subaccount filtering for historical votes in storage

### DIFF
--- a/.changeset/upset-ads-find.md
+++ b/.changeset/upset-ads-find.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-zone/storage': patch
+---
+
+correctly applies subaccount filtering in storage layer for LQT voting logic

--- a/packages/storage/src/indexed-db/index.ts
+++ b/packages/storage/src/indexed-db/index.ts
@@ -460,9 +460,10 @@ export class IndexedDb implements IndexedDbInterface {
       epoch.toString(),
     );
 
-    const filtered = subaccount
-      ? tournamentVotes.filter(vote => vote.subaccount === subaccount)
-      : tournamentVotes;
+    const filtered =
+      subaccount === undefined
+        ? tournamentVotes
+        : tournamentVotes.filter(vote => vote.subaccount === subaccount);
 
     return filtered.map(tournamentVote => ({
       incentivizedAsset: AssetId.fromJson(tournamentVote.incentivizedAsset, { typeRegistry }),


### PR DESCRIPTION
## Description of Changes

a conditional check in storage fails when subaccount is 0 (falsy in JS), causing it to evaluate to false and skip the filtering logic. This in turns returns the votes for each subaccount, so voting in one account will incorrectly evaluate each subaccount as already voted. This seems to have been an issue since the reactor in https://github.com/penumbra-zone/web/pull/2557 which exposed this issue. However, this appears to be an edge case that only arises when voting is initiated from a subaccount first, and then followed by an attempt to vote with the main account—rather than the other way around.

## Related Issue

https://github.com/penumbra-zone/web/issues/2648

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
