### PR TITLE
fix: rounding time pluralization

### DIFF
--- a/apps/veil/src/shared/utils/format-time.ts
+++ b/apps/veil/src/shared/utils/format-time.ts
@@ -2,7 +2,7 @@ import { pluralize } from '@/shared/utils/pluralize';
 
 export const formatTimeRemaining = (seconds: number): string => {
   if (seconds < 60) {
-    return pluralize(seconds, 'second', 'seconds');
+    return pluralize(Math.round(seconds), 'second', 'seconds');
   } else if (seconds < 3600) {
     const minutes = Math.floor(seconds / 60);
     return pluralize(minutes, 'minute', 'minutes');


### PR DESCRIPTION
## Description of Changes

rounds the remaining timer display to whole seconds when below 60 seconds.

## Related Issue

https://github.com/penumbra-zone/web/issues/2651

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
