### PR TITLE
fix dialogue regression in UI library 

### DIFF
--- a/packages/ui/src/Dialog/RadioItem.tsx
+++ b/packages/ui/src/Dialog/RadioItem.tsx
@@ -87,9 +87,9 @@ export const RadioItem = ({
           getAriaCheckedOutlineColorByActionType(actionType),
         )}
       >
-        <div className='flex w-full items-center gap-2'>
+        <div className='flex items-center gap-2'>
           {startAdornment}
-          <div className='flex w-[90%] flex-col'>
+          <div>
             <div className='flex items-center gap-1 whitespace-nowrap'>{title}</div>
             {descriptionText}
           </div>


### PR DESCRIPTION
## Description of Changes

reverses change in https://github.com/penumbra-zone/web/pull/2642 that introduced a regression in the voting dialogue in veil.

## Related Issue

references https://github.com/penumbra-zone/web/issues/2649

## Checklist Before Requesting Review

- [x] I have ensured that any relevant minifront changes do not cause the existing extension to break.
